### PR TITLE
Fixed URL for "how to contribute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nonetheless we have snapshot builds already [available at CloudBees](https://ope
 
 If you are looking for support, please check out the [different support channels](https://github.com/openhab/openhab/wiki/Support-options-for-openHAB) that we provide.
 
-As any good open source project, openHAB welcomes any participation in the project. Read more in the [how to contribute](https://github.com/openhab/openhab2/CONTRIBUTING.md) guide.
+As any good open source project, openHAB welcomes any participation in the project. Read more in the [how to contribute](CONTRIBUTING.md) guide.
 
 If you are a developer and want to jump right into the sources and execute openHAB from within Eclipse, please have a look at the [IDE setup](https://github.com/openhab/openhab/wiki/IDE-Setup) procedures.
 


### PR DESCRIPTION
Simple URL fix. "how to contribute" URL in README.md was changed from broken absolute URL to working relative URL.
