### PR TITLE
Fixed issue #49

### DIFF
--- a/distribution/openhabhome/runtime/etc/logback.xml
+++ b/distribution/openhabhome/runtime/etc/logback.xml
@@ -47,6 +47,8 @@
 
  	<!-- temporary workaround for https://github.com/openhab/jmdns/issues/12 -->
     <logger name="javax.jmdns" level="OFF"/>
+    <logger name="javax.jmdns.impl" level="OFF"/>
+    <logger name="javax.jmdns.impl.constants" level="OFF"/>
     
 	<root level="WARN">
 		<appender-ref ref="FILE" />

--- a/distribution/openhabhome/runtime/etc/logback_debug.xml
+++ b/distribution/openhabhome/runtime/etc/logback_debug.xml
@@ -40,6 +40,8 @@
     <logger name="org.jupnp" level="ERROR"/>
  	<!-- temporary workaround for https://github.com/openhab/jmdns/issues/12 -->
     <logger name="javax.jmdns" level="OFF"/>
+    <logger name="javax.jmdns.impl" level="OFF"/>
+    <logger name="javax.jmdns.impl.constants" level="OFF"/>
 
 	<root level="INFO">
 		<appender-ref ref="FILE" />


### PR DESCRIPTION
- disable more logging for jmDNS when running latest Apple devices in
  home network

Signed-off-by: Jochen Hiller jo.hiller@googlemail.com
