### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/sources/installation/compatibility.md
+++ b/docs/sources/installation/compatibility.md
@@ -27,7 +27,7 @@ This page is a community effort - please help filling the gaps and analysing pot
 | Epson Projector |  |  |  |  |  |
 | Exec |  |  |  |  |  |
 | Freebox |  |  |  |  |  |
-| Freeswitch | X |  |  |  | Seemingly works, but IllegalArgumentException thrown (state must not be null) by EventPublisherImpl.java:122. Further testing required  |
+| Freeswitch | X |  |  |  |  |
 | Fritz!Box |  |  |  |  |  |
 | Fritz AHA |  |  |  |  |  |
 | FS20 |  |  |  |  |  |


### PR DESCRIPTION
For information: 

18:57:32.098 ERROR o.f.esl.client.inbound.Client[:469] - Error caught notifying listener of event [EslEvent: name=[CHANNEL_CREATE] headers=2, eventHeaders=130, eventBody=0 lines.]
java.lang.IllegalArgumentException: The state must not be null!
    at org.eclipse.smarthome.core.internal.events.EventPublisherImpl.postUpdate(EventPublisherImpl.java:122)
    at org.eclipse.smarthome.core.internal.events.EventPublisherImpl.postUpdate(EventPublisherImpl.java:179)
    at org.openhab.core.events.EventPublisherDelegate.postUpdate(EventPublisherDelegate.java:63)
    at org.openhab.binding.freeswitch.internal.FreeswitchBinding.newCallItemUpdate(FreeswitchBinding.java:375)
    at org.openhab.binding.freeswitch.internal.FreeswitchBinding.handleNewCallEvent(FreeswitchBinding.java:275)
    at org.openhab.binding.freeswitch.internal.FreeswitchBinding.eventReceived(FreeswitchBinding.java:169)
    at org.freeswitch.esl.client.inbound.Client$3$2.run(Client.java:465)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
    at java.lang.Thread.run(Thread.java:722)
