### PR TITLE
[rfxcom] Receive-only devices

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/config/RFXComDeviceConfiguration.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/config/RFXComDeviceConfiguration.java
@@ -19,12 +19,14 @@ package org.openhab.binding.rfxcom.internal.config;
  */
 
 public class RFXComDeviceConfiguration {
+    public static final String RECIEVE_ONLY_LABEL = "receiveOnly";
     public static final String DEVICE_ID_LABEL = "deviceId";
     public static final String SUB_TYPE_LABEL = "subType";
     public static final String PULSE_LABEL = "pulse";
     public static final String ON_COMMAND_ID_LABEL = "onCommandId";
     public static final String OFF_COMMAND_ID_LABEL = "offCommandId";
 
+    public boolean receiveOnly;
     public String deviceId;
     public String subType;
     public Integer pulse;

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComHandler.java
@@ -65,6 +65,8 @@ public class RFXComHandler extends BaseThingHandler implements DeviceMessageList
         if (bridgeHandler != null) {
             if (command instanceof RefreshType) {
                 logger.trace("Received unsupported Refresh command");
+            } else if (config.receiveOnly){
+                logger.trace("Ignored command for receive-only device");
             } else {
                 try {
                     PacketType packetType = RFXComMessageFactory

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/currentenergy.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/currentenergy.xml
@@ -25,6 +25,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 47104</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/datetime.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/datetime.xml
@@ -22,6 +22,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Device id, example 47360</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/energy.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/energy.xml
@@ -25,6 +25,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 5693</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/humidity.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/humidity.xml
@@ -23,6 +23,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 5693</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting1.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting1.xml
@@ -22,6 +22,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Device Id. House code + unit code, separated by dot. Example A.1</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting2.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting2.xml
@@ -22,6 +22,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Remote/switch/unit Id + unit code, separated by dot. Example 8773718.10</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting4.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting4.xml
@@ -21,6 +21,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Device Id. Example 3456</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting5.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting5.xml
@@ -23,6 +23,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Remote/switch/unit Id + unit code, separated by dot. Example 10001.1</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting6.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/lighting6.xml
@@ -21,6 +21,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Remote/switch/unit Id + group code + unit code, separated by dot. Example 100.A.1</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/rain.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/rain.xml
@@ -23,6 +23,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 56923</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/rfy.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/rfy.xml
@@ -30,6 +30,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>false</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Unit Id + unit code, separated by dot. Example 100.1</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/security1.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/security1.xml
@@ -25,6 +25,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Remote/sensor Id. Example 10001</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperature.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperature.xml
@@ -22,6 +22,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 56923</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturehumidity.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturehumidity.xml
@@ -24,6 +24,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 56923</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturehumiditybarometric.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturehumiditybarometric.xml
@@ -26,6 +26,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 59648</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturerain.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/temperaturerain.xml
@@ -23,6 +23,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 56923</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/thermostat1.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/thermostat1.xml
@@ -22,6 +22,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 56923</description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/wind.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/wind.xml
@@ -35,6 +35,11 @@
 		</channels>
 
 		<config-description>
+			<parameter name="receiveOnly" type="boolean" required="true">
+				<label>Receive only?</label>
+				<description>Set to disable all attempts to transmit to this device.</description>
+				<default>true</default>
+			</parameter>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
 				<description>Sensor Id. Example 2983</description>


### PR DESCRIPTION
Add thing config options to allow a device to be set receive-only. Many
sensors and wireless switches fall into this category and sending to
them is simply a waste of time. This is especially a problem when
persistence is trying to restore state as the wasted work means it may
take many seconds or even minutes before sanity is restored.

Closes #2287

Signed-off-by: Mike Jagdis <mjagdis@eris-associates.co.uk> (github: mjagdis)