### PR TITLE
[wifiled] Fixing "Value must be between 0 and 100" error

### DIFF
--- a/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
+++ b/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/AbstractWiFiLEDDriver.java
@@ -131,6 +131,12 @@ public abstract class AbstractWiFiLEDDriver {
             int state = statusBytes[2] & 0xFF; // On/Off
             int program = statusBytes[3] & 0xFF;
             int programSpeed = statusBytes[5] & 0xFF;
+            
+            // On factory default the controller can be configured 
+            // with a value of 255 but max should be 31.
+            if (programSpeed > 31) {
+                programSpeed = 31;
+            }
 
             int red = statusBytes[6] & 0xFF;
             int green = statusBytes[7] & 0xFF;


### PR DESCRIPTION
Fix for issue: https://github.com/openhab/openhab2-addons/issues/2829

It can be that the value for programSpeed is 255 on a factory default controller. But the maximum should be 31 like expected in:

https://github.com/t1lt3rr0r/openhab2-addons/blob/58cd648d860f68e9c31d354bc544db2049808064/addons/binding/org.openhab.binding.wifiled/src/main/java/org/openhab/binding/wifiled/internal/handler/LEDStateDTO.java#L96

Signed-off-by: Jan Mollenhauer <janmo0904@gmail.com>