### PR TITLE
[MiHome] fixed Xiaomi Mi Smart Cube actions description #1 

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/sensor_cube.xml
+++ b/addons/binding/org.openhab.binding.mihome/ESH-INF/thing/sensor_cube.xml
@@ -10,7 +10,7 @@
 		</supported-bridge-type-refs>
 		<label>Xiaomi Mi Smart Cube</label>
 		<description>Multifunctional controller equipped with an accelerometer and a gyroscope. Triggers the following
-			actions: move, rotate, rotate, flip 90, flip 180, tap twice, shake air, free fall, alert.</description>
+			actions: move, rotate right, rotate left, flip 90, flip 180, tap twice, shake air, free fall, alert.</description>
 		<channels>
 			<channel id="action" typeId="cubeAction"></channel>
 			<channel id="lastAction" typeId="lastAction"></channel>


### PR DESCRIPTION
the actions `ROTATE_RIGHT` and `ROTATE_LEFT` where both described as `rotate`, which I would consider a typo and misleading for users.
