### PR TITLE
Add additional CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,7 +37,7 @@
 /addons/binding/org.openhab.binding.freebox/ @clinique
 /addons/binding/org.openhab.binding.fronius/ @trokohl
 /addons/binding/org.openhab.binding.ftpupload/ @paulianttila
-/addons/binding/org.openhab.binding.gardena/ @paulianttila
+/addons/binding/org.openhab.binding.gardena/ @gerrieg
 /addons/binding/org.openhab.binding.globalcache/ @mhilbush
 /addons/binding/org.openhab.binding.gpstracker/ @gbicskei
 /addons/binding/org.openhab.binding.groheondus/ @FlorianSW


### PR DESCRIPTION
Here are some more entries for the CODEOWNERS file mainly based on initial contributions.