### PR TITLE
[hue] Add channel to the hue bridge to activate predefined scenes

### DIFF
--- a/bundles/org.openhab.binding.hue/README.md
+++ b/bundles/org.openhab.binding.hue/README.md
@@ -183,7 +183,7 @@ The devices support some of the following channels:
 | status            | Number             | This channel save status state for a CLIP sensor.                                                                                       | 0840                                |
 | last_updated      | DateTime           | This channel the date and time when the sensor was last updated.                                                                        | 0820, 0830, 0840, 0850, 0106, 0107, 0302|
 | battery_level     | Number             | This channel shows the battery level.                                                                                                   | 0820, 0106, 0107, 0302             |
-| battery_low       | Switch             | This channel indicates whether the battery is low or not.                                                                               | 0820, 0106, 0107, 0302             |
+| battery_low       | Switch             | This channel indicates whether the battery is low or not.                                                                               | 0820, 0106, 0107, 0302  |
 
 ### Trigger Channels
 
@@ -224,6 +224,17 @@ The `tap_switch_event` can trigger one of the following events:
 | Button 3 | Button 3 | 17    |
 | Button 4 | Button 4 | 18    |
 
+### Scene Channel
+
+The bridge itself supports a channel to activate scenes:
+
+| Channel Type ID | Item Type | Description |
+| --------------- | --------- | ----------- |
+| scene             | String             | This channel activates the scene with the given ID String. | 
+
+The scenes are identified by an ID String that is assigned by the Hue bridge. These must be aquired directly from [Hue REST API](https://developers.meethue.com/develop/hue-api/).
+
+This channel can then be used in the sitemap, for example as a switch or selection.
 
 ## Rule Actions
 
@@ -301,6 +312,9 @@ Switch   MotionSensorLowBattery   { channel="hue:0107:1:motion-sensor:battery_lo
 
 // Temperature Sensor
 Number:Temperature TemperatureSensorTemperature { channel="hue:0302:temperature-sensor:temperature" }
+
+// Scenes
+String LightScene { channel="hue:bridge:1:scene"}
 ```
 
 Note: The bridge ID is in this example **1** but can be different in each system.
@@ -336,6 +350,9 @@ sitemap demo label="Main Menu"
         Text item=MotionSensorLastUpdate
         Text item=MotionSensorBatteryLevel
         Switch item=MotionSensorLowBattery
+
+        // Light Scenes
+        Switch item=LightScene label="Scene []" mappings=[abcdefgh1234567="Relax", ABCDEFGH1234567="Concentrate"]
     }
 }
 ```

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -75,6 +75,7 @@ public class HueBindingConstants {
     public static final String CHANNEL_DAYLIGHT = "daylight";
     public static final String CHANNEL_STATUS = "status";
     public static final String CHANNEL_FLAG = "flag";
+    public static final String CHANNEL_SCENE = "scene";
 
     // List all triggers
     public static final String EVENT_DIMMER_SWITCH = "dimmer_switch_event";
@@ -86,7 +87,7 @@ public class HueBindingConstants {
     public static final String PROTOCOL = "protocol";
     public static final String USER_NAME = "userName";
 
-    // Light config properties
+    // Light and sensor config properties
     public static final String LIGHT_ID = "lightId";
     public static final String SENSOR_ID = "sensorId";
     public static final String PRODUCT_NAME = "productName";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBridge.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBridge.java
@@ -605,13 +605,12 @@ public class HueBridge {
      * @throws UnauthorizedException thrown if the user no longer exists
      * @throws EntityNotAvailableException thrown if the specified group no longer exists
      */
-    public void setGroupState(Group group, StateUpdate update) throws IOException, ApiException {
+    public CompletableFuture<Result> setGroupState(Group group, StateUpdate update) {
         requireAuthentication();
 
         String body = update.toJson();
-        Result result = http.put(getRelativeURL("groups/" + enc(group.getId()) + "/action"), body);
-
-        handleErrors(result);
+        return http.putAsync(getRelativeURL("groups/" + enc(group.getId()) + "/action"), body, update.getMessageDelay(),
+                scheduler);
     }
 
     /**
@@ -850,6 +849,17 @@ public class HueBridge {
         Result result = http.delete(getRelativeURL("schedules/" + enc(schedule.getId())));
 
         handleErrors(result);
+    }
+
+    /**
+     * Activate scene to all lights that belong to the scene.
+     *
+     * @param id the scene to be activated
+     * @throws IOException if the bridge cannot be reached
+     */
+    public CompletableFuture<Result> activateScene(String id) {
+        Group allLightsGroup = new Group();
+        return setGroupState(allLightsGroup, new StateUpdate().setScene(id));
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueObject.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueObject.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import com.google.gson.reflect.TypeToken;
 
 /**
- * Basic light information.
+ * Basic hue object information.
  *
  * @author Q42 - Initial contribution
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueThingHandlerFactory.java
@@ -59,6 +59,7 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.hue")
 public class HueThingHandlerFactory extends BaseThingHandlerFactory {
+
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(
             Stream.of(HueBridgeHandler.SUPPORTED_THING_TYPES.stream(), HueLightHandler.SUPPORTED_THING_TYPES.stream(),
                     DimmerSwitchHandler.SUPPORTED_THING_TYPES.stream(), TapSwitchHandler.SUPPORTED_THING_TYPES.stream(),

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
@@ -218,4 +218,15 @@ public class StateUpdate extends ConfigUpdate {
         commands.add(new Command("status", status));
         return this;
     }
+
+    /**
+     * Recall the given scene.
+     *
+     * @param sceneId Identifier of the scene
+     * @return this object for chaining calls
+     */
+    public StateUpdate setScene(String sceneId) {
+        commands.add(new Command("scene", sceneId));
+        return this;
+    }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -53,7 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link HueBridgeServiceTracker} tracks for hue lights which are connected
+ * The {@link HueBridgeServiceTracker} tracks for hue lights and sensors which are connected
  * to a paired hue bridge. The default search time for hue is 60 seconds.
  *
  * @author Kai Kreuzer - Initial contribution

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -83,7 +83,7 @@ public interface HueClient {
      * Get the light by its ID.
      *
      * @param lightId the light ID
-     * @return the full light representation of {@code null} if it could not be found
+     * @return the full light representation or {@code null} if it could not be found
      */
     @Nullable
     FullLight getLightById(String lightId);
@@ -92,7 +92,7 @@ public interface HueClient {
      * Get the sensor by its ID.
      *
      * @param sensorId the sensor ID
-     * @return the full sensor representation of {@code null} if it could not be found
+     * @return the full sensor representation or {@code null} if it could not be found
      */
     @Nullable
     FullSensor getSensorById(String sensorId);
@@ -137,4 +137,11 @@ public interface HueClient {
      * @param stateUpdate the state update
      */
     void updateGroupState(FullGroup group, StateUpdate stateUpdate);
+
+    /**
+     * Activate scene to all lights that belong to the scene.
+     *
+     * @param id the ID of the scene to activate
+     */
+    void activateScene(String id);
 }

--- a/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/bridge.xml
@@ -8,6 +8,10 @@
 		<label>Hue Bridge</label>
 		<description>The Hue bridge represents the Philips Hue bridge.</description>
 
+		<channels>
+			<channel id="scene" typeId="scene" />
+		</channels>
+
 		<properties>
 			<property name="vendor">Philips</property>
 		</properties>

--- a/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/ESH-INF/thing/channels.xml
@@ -212,5 +212,11 @@
 		<label>Flag</label>
 		<description>Flag of CLIP sensor.</description>
 	</channel-type>
-
+	
+	<!-- Scene Channel -->
+	<channel-type id="scene">
+		<item-type>String</item-type>
+		<label>Scene</label>
+		<description>The scene channel allows activating a scene to all lights that belong to the scene.</description>
+	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
I think the ability to activate scenes is really essential for hues. Although I've seen some tutorials on how to do this, none of them seem really none-trivial to me. I know that you can create the scenes as rules, but the scenes creator in the hue app is very convenient in my opinion.

As an intermediate solutation, this does not retrieve the list of available scenes, so the user have to provide the scene IDs in e.g. a switch control. (Also haven't written any intergration test yet, as I am quite unfamiliar with the setup.)

The concept is to add the hue as a separate gateway thing to control functionatlities that goes beyond that of a bridge. This approach is taken from the Mi Home addon.

