### PR TITLE
[pjlinkdevice] Improvement: Projector lamp states as channels

### DIFF
--- a/bundles/org.openhab.binding.pjlinkdevice/README.md
+++ b/bundles/org.openhab.binding.pjlinkdevice/README.md
@@ -33,7 +33,7 @@ The *pjLinkDevice* thing type has the following parameters:
 | refreshPower          | enables polling of the power status. *Optional, the default value is false*                                                                                  |
 | refreshMute           | enables polling of the mute status. *Optional, the default value is false*                                                                                   |
 | refreshInputChannel   | enables polling of the selected input channel. *Optional, the default value is false*                                                                        |
-| refreshLampStatus     | enables polling of the lamp usage hours and activity. *Optional, the default value is false*                                                                 |
+| refreshLampState      | enables polling of the lamp usage hours and activity. *Optional, the default value is false*                                                                 |
 | autoReconnectInterval | seconds between connection retries when connection to the PJLink device has been lost, 0 means never retry, minimum 30s *Optional, the default value is 60*  |
 
 

--- a/bundles/org.openhab.binding.pjlinkdevice/README.md
+++ b/bundles/org.openhab.binding.pjlinkdevice/README.md
@@ -33,6 +33,7 @@ The *pjLinkDevice* thing type has the following parameters:
 | refreshPower          | enables polling of the power status. *Optional, the default value is false*                                                                                  |
 | refreshMute           | enables polling of the mute status. *Optional, the default value is false*                                                                                   |
 | refreshInputChannel   | enables polling of the selected input channel. *Optional, the default value is false*                                                                        |
+| refreshLampStatus     | enables polling of the lamp usage hours and activity. *Optional, the default value is false*                                                                 |
 | autoReconnectInterval | seconds between connection retries when connection to the PJLink device has been lost, 0 means never retry, minimum 30s *Optional, the default value is 60*  |
 
 
@@ -44,6 +45,8 @@ The *pjLinkDevice* thing type has the following parameters:
 | input             | Switches the input channel of the device  |
 | audioMute         | Mutes the device audio                    |
 | videoMute         | Mutes the device video                    |
+| lamp1Hours        | The hours lamp 1 has been in use          |
+| lamp1Active       | Shows if lamp 1 is in use                 |
 
 ## Full Example
 
@@ -60,6 +63,8 @@ Switch Projector_Power "Projector Power"          { channel="pjLinkDevice:pjLink
 String Projector_Input "Projector Input"          { channel="pjLinkDevice:pjLinkDevice:MyProjector:input" }
 Switch Projector_AudioMute "Projector Audio Mute" { channel="pjLinkDevice:pjLinkDevice:MyProjector:audioMute" }
 Switch Projector_VideoMute "Projector Video Mute" { channel="pjLinkDevice:pjLinkDevice:MyProjector:videoMute" }
+Number Projector_Lamp1Hours "Projector lamp 1 used hours"   { channel="pjLinkDevice:pjLinkDevice:MyProjector:lamp1Hours" }
+Switch Projector_Lamp1Active "Projector lamp 1 active"      { channel="pjLinkDevice:pjLinkDevice:MyProjector:lamp1Active" }
 ```
 
 sample.sitemap:
@@ -71,6 +76,45 @@ sitemap sample label="Main Menu" {
     Selection item=Projector_Input
     Switch item=Projector_AudioMute
     Switch item=Projector_VideoMute
+    Switch item=Projector_Lamp1Active
+    Text item=Projector_Lamp1Hours
+  }
+}
+```
+
+### Multiple lamps
+
+Most of the time, there's just one lamp. In case a projector has more than one lamp, additional channels for those lamps can be configured.
+
+sample-lamp-2.things:
+
+```
+pjLinkDevice:pjLinkDevice:MyProjector [ ipAddress="192.168.178.10" ]
+{
+  Channels:
+    Type lampHours : lamp2Hours "Lamp 2 Hours" [
+        lampNumber=2
+    ]
+    Type lampActive : lamp2Active "Lamp 2 Active" [
+        lampNumber=2
+    ]
+}
+```
+
+sample-lamp-2.items:
+
+```
+Number Projector_Lamp2Hours "Projector lamp 2 used hours"   { channel="pjLinkDevice:pjLinkDevice:MyProjector:lamp2Hours" }
+Switch Projector_Lamp2Active "Projector lamp 2 active"      { channel="pjLinkDevice:pjLinkDevice:MyProjector:lamp2Active" }
+```
+
+sample-lamp-2.sitemap:
+
+```
+sitemap sample label="Main Menu" {
+  Frame  {
+    Switch item=Projector_Lamp2Active
+    Text item=Projector_Lamp2Hours
   }
 }
 ```

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceBindingConstants.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceBindingConstants.java
@@ -44,8 +44,6 @@ public class PJLinkDeviceBindingConstants {
   public static final String CHANNEL_INPUT = "input";
   public static final String CHANNEL_AUDIO_MUTE = "audioMute";
   public static final String CHANNEL_VIDEO_MUTE = "videoMute";
-  public static final String CHANNEL_LAMP_HOURS = "lampHours";
-  public static final String CHANNEL_LAMP_ACTIVE = "lampActive";
   public static final String CHANNEL_LAMP_1_HOURS = "lamp1Hours";
   public static final String CHANNEL_LAMP_1_ACTIVE = "lamp1Active";
 

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceBindingConstants.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceBindingConstants.java
@@ -28,14 +28,29 @@ public class PJLinkDeviceBindingConstants {
 
   private static final String BINDING_ID = "pjLinkDevice";
 
-  // List of all Thing Type UIDs
+  // List of all thing type UIDs
   public static final ThingTypeUID THING_TYPE_PJLINK = new ThingTypeUID(BINDING_ID, "pjLinkDevice");
 
-  // List of all Channel ids
+  // List of all channel type IDs
+  public static final String CHANNEL_TYPE_POWER = "power";
+  public static final String CHANNEL_TYPE_INPUT = "input";
+  public static final String CHANNEL_TYPE_AUDIO_MUTE = "audioMute";
+  public static final String CHANNEL_TYPE_VIDEO_MUTE = "videoMute";
+  public static final String CHANNEL_TYPE_LAMP_HOURS = "lampHours";
+  public static final String CHANNEL_TYPE_LAMP_ACTIVE = "lampActive";
+
+  // List of all channel IDs
   public static final String CHANNEL_POWER = "power";
   public static final String CHANNEL_INPUT = "input";
   public static final String CHANNEL_AUDIO_MUTE = "audioMute";
   public static final String CHANNEL_VIDEO_MUTE = "videoMute";
+  public static final String CHANNEL_LAMP_HOURS = "lampHours";
+  public static final String CHANNEL_LAMP_ACTIVE = "lampActive";
+  public static final String CHANNEL_LAMP_1_HOURS = "lamp1Hours";
+  public static final String CHANNEL_LAMP_1_ACTIVE = "lamp1Active";
+
+  // List of all channel parameter names
+  public static final String CHANNEL_PARAMETER_LAMP_NUMBER = "lampNumber";
 
   public static final int DEFAULT_PORT = 4352;
   public static final int DEFAULT_SCAN_TIMEOUT_SECONDS = 60;

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceConfiguration.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceConfiguration.java
@@ -31,6 +31,7 @@ public class PJLinkDeviceConfiguration {
   public boolean refreshPower;
   public boolean refreshMute;
   public boolean refreshInputChannel;
+  public boolean refreshLampState;
 
   public int autoReconnectInterval;
 }

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -205,7 +205,7 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
         case CHANNEL_TYPE_LAMP_ACTIVE:
         case CHANNEL_TYPE_LAMP_HOURS:
           if (command == RefreshType.REFRESH) {
-            List<LampState> lampStates = device.getLampStates();
+            List<LampState> lampStates = device.getLampStatesCached();
             // update all lamp related channels, as the response contains information about all of them
             for (Channel lampChannel : thing.getChannels()) {
               String lampChannelTypeId = getChannelTypeId(lampChannel.getUID());

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -235,7 +235,8 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
           }
           break;
         default:
-          logger.debug("unknown channel {}", channelUID.getId());
+          logger.debug("unknown channel {}", channelUID);
+          break;
       }
 
       logger.trace("Successfully handled command {} on channel {}", command, channelUID.getId());

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -258,7 +258,6 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
       return null;
     }
     ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
-    channel.getChannelTypeUID();
     if (channelTypeUID == null) {
       logger.debug("channelTypeUID for channel {} is null", channel);
       return null;

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -98,7 +98,7 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
 
   public void refresh(PJLinkDeviceConfiguration config) {
     // Do not poll if device is offline
-    if (PJLinkDeviceHandler.this.getThing().getStatusInfo().getStatus() != ThingStatus.ONLINE) {
+    if (PJLinkDeviceHandler.this.getThing().getStatus() != ThingStatus.ONLINE) {
       PJLinkDeviceHandler.this.logger.debug("Not polling device status because device is offline");
       // setup() will schedule a new refresh interval after successful reconnection, cancel this one
       this.clearRefreshInterval();
@@ -106,20 +106,18 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
     }
 
     PJLinkDeviceHandler.this.logger.debug("Polling device status...");
-    if (config.refreshPower && PJLinkDeviceHandler.this.getThing().getStatusInfo().getStatus() == ThingStatus.ONLINE) {
+    if (config.refreshPower && PJLinkDeviceHandler.this.getThing().getStatus() == ThingStatus.ONLINE) {
       PJLinkDeviceHandler.this.handleCommand(new ChannelUID(getThing().getUID(), CHANNEL_POWER), RefreshType.REFRESH);
     }
-    if (config.refreshMute && PJLinkDeviceHandler.this.getThing().getStatusInfo().getStatus() == ThingStatus.ONLINE) {
+    if (config.refreshMute && PJLinkDeviceHandler.this.getThing().getStatus() == ThingStatus.ONLINE) {
       // this updates both CHANNEL_AUDIO_MUTE and CHANNEL_VIDEO_MUTE
       PJLinkDeviceHandler.this.handleCommand(new ChannelUID(getThing().getUID(), CHANNEL_AUDIO_MUTE),
           RefreshType.REFRESH);
     }
-    if (config.refreshInputChannel
-        && PJLinkDeviceHandler.this.getThing().getStatusInfo().getStatus() == ThingStatus.ONLINE) {
+    if (config.refreshInputChannel && PJLinkDeviceHandler.this.getThing().getStatus() == ThingStatus.ONLINE) {
       PJLinkDeviceHandler.this.handleCommand(new ChannelUID(getThing().getUID(), CHANNEL_INPUT), RefreshType.REFRESH);
     }
-    if (config.refreshLampState
-        && PJLinkDeviceHandler.this.getThing().getStatusInfo().getStatus() == ThingStatus.ONLINE) {
+    if (config.refreshLampState && PJLinkDeviceHandler.this.getThing().getStatus() == ThingStatus.ONLINE) {
       // this updates both CHANNEL_LAMP_ACTIVE and CHANNEL_LAMP_HOURS
       PJLinkDeviceHandler.this.handleCommand(new ChannelUID(getThing().getUID(), CHANNEL_LAMP_1_HOURS),
           RefreshType.REFRESH);

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -249,7 +249,7 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
     }
   }
 
-  private @Nullable String getChannelTypeId(ChannelUID channelUID) throws ConfigurationException {
+  private @Nullable String getChannelTypeId(ChannelUID channelUID) {
     Channel channel = thing.getChannel(channelUID);
     if (channel == null) {
       logger.debug("channel is null");

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -139,7 +139,6 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
     logger.trace("Received command {} on channel {}", command, channelUID.getId());
     try {
       PJLinkDevice device = getDevice();
-      @Nullable
       String channelTypeId = getChannelTypeId(channelUID);
       if (channelTypeId == null) {
         logger.debug("unknown channel {}", channelUID);
@@ -251,7 +250,6 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
   }
 
   private @Nullable String getChannelTypeId(ChannelUID channelUID) throws ConfigurationException {
-    @Nullable
     Channel channel = thing.getChannel(channelUID);
     if (channel == null) {
       logger.debug("channel is null");

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,6 +42,8 @@ import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputInstr
 import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputListQueryCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputQueryCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputQueryResponse;
+import org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus.LampStatesCommand;
+import org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus.LampStatesResponse.LampState;
 import org.openhab.binding.pjlinkdevice.internal.device.command.mute.MuteInstructionCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.mute.MuteInstructionCommand.MuteInstructionChannel;
 import org.openhab.binding.pjlinkdevice.internal.device.command.mute.MuteInstructionCommand.MuteInstructionState;
@@ -326,9 +329,8 @@ public class PJLinkDevice {
         return new ErrorStatusQueryCommand(this).execute().getResult();
     }
 
-    public String getLampHours() throws ResponseException, IOException, AuthenticationException {
-        return new IdentificationCommand(this, IdentificationCommand.IdentificationProperty.LAMP_HOURS).execute()
-                .getResult();
+    public List<LampState> getLampStates() throws ResponseException, IOException, AuthenticationException {
+        return new LampStatesCommand(this).execute().getResult();
     }
 
     public String getOtherInformation() throws ResponseException, IOException, AuthenticationException {

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -77,6 +77,8 @@ public class PJLinkDevice {
     private final Logger logger = LoggerFactory.getLogger(PJLinkDevice.class);
     private String prefixForNextCommand = "";
     private @Nullable Instant socketCreatedOn;
+    private CachedCommand<LampStatesResponse> cachedLampHoursCommand = new CachedCommand<LampStatesResponse>(
+            new LampStatesCommand(this));
 
     public PJLinkDevice(int tcpPort, InetAddress ipAddress, @Nullable String adminPassword, int timeout) {
         this.tcpPort = tcpPort;
@@ -334,9 +336,6 @@ public class PJLinkDevice {
     public List<LampState> getLampStates() throws ResponseException, IOException, AuthenticationException {
         return new LampStatesCommand(this).execute().getResult();
     }
-
-    private CachedCommand<LampStatesResponse> cachedLampHoursCommand = new CachedCommand<LampStatesResponse>(
-            new LampStatesCommand(this));
 
     public List<LampState> getLampStatesCached() throws ResponseException, IOException, AuthenticationException {
         return cachedLampHoursCommand.execute().getResult();

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.pjlinkdevice.internal.device.command.AuthenticationException;
+import org.openhab.binding.pjlinkdevice.internal.device.command.CachedCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.ResponseException;
 import org.openhab.binding.pjlinkdevice.internal.device.command.authentication.AuthenticationCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.errorstatus.ErrorStatusQueryCommand;
@@ -43,6 +44,7 @@ import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputListQ
 import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputQueryCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.input.InputQueryResponse;
 import org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus.LampStatesCommand;
+import org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus.LampStatesResponse;
 import org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus.LampStatesResponse.LampState;
 import org.openhab.binding.pjlinkdevice.internal.device.command.mute.MuteInstructionCommand;
 import org.openhab.binding.pjlinkdevice.internal.device.command.mute.MuteInstructionCommand.MuteInstructionChannel;
@@ -331,6 +333,13 @@ public class PJLinkDevice {
 
     public List<LampState> getLampStates() throws ResponseException, IOException, AuthenticationException {
         return new LampStatesCommand(this).execute().getResult();
+    }
+
+    private CachedCommand<LampStatesResponse> cachedLampHoursCommand = new CachedCommand<LampStatesResponse>(
+            new LampStatesCommand(this));
+
+    public List<LampState> getLampStatesCached() throws ResponseException, IOException, AuthenticationException {
+        return cachedLampHoursCommand.execute().getResult();
     }
 
     public String getOtherInformation() throws ResponseException, IOException, AuthenticationException {

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CacheException.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CacheException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pjlinkdevice.internal.device.command;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception thrown whenever an error code or unexpected response is retrieved from the device.
+ *
+ * @author Nils Schnabel - Initial contribution
+ */
+@NonNullByDefault
+public class CacheException extends RuntimeException {
+  private static final long serialVersionUID = -3319800607314286998L;
+
+  public CacheException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
@@ -39,6 +39,7 @@ public class CachedCommand<ResponseType extends Response<?>> implements Command<
             try {
                 return this.cachedCommand.execute();
             } catch (ResponseException | IOException | AuthenticationException e) {
+                // wrap exception into RuntimeException to unwrap again later in CachedCommand.execute()
                 throw new RuntimeException(e);
             }
         });
@@ -56,6 +57,7 @@ public class CachedCommand<ResponseType extends Response<?>> implements Command<
             }
             return result;
         } catch (RuntimeException e) {
+            // try to unwrap RuntimeException thrown in ExpiringCache
             Throwable cause = e.getCause();
             if (cause instanceof ResponseException) {
                 throw (ResponseException) cause;

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
 
 /**
- * Basic command interface allowing to execute the command.
+ * CachedCommand wraps any command and caches its response for a configurable period of time.
  *
  * @author Nils Schnabel - Initial contribution
  */

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/CachedCommand.java
@@ -40,7 +40,7 @@ public class CachedCommand<ResponseType extends Response<?>> implements Command<
                 return this.cachedCommand.execute();
             } catch (ResponseException | IOException | AuthenticationException e) {
                 // wrap exception into RuntimeException to unwrap again later in CachedCommand.execute()
-                throw new RuntimeException(e);
+                throw new CacheException(e);
             }
         });
     }
@@ -56,7 +56,7 @@ public class CachedCommand<ResponseType extends Response<?>> implements Command<
                 throw new ResponseException("Cached value is null");
             }
             return result;
-        } catch (RuntimeException e) {
+        } catch (CacheException e) {
             // try to unwrap RuntimeException thrown in ExpiringCache
             Throwable cause = e.getCause();
             if (cause instanceof ResponseException) {

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
@@ -34,7 +34,6 @@ public class LampStatesCommand extends AbstractCommand<LampStatesRequest, LampSt
   @Override
   protected LampStatesRequest createRequest() {
     return new LampStatesRequest();
-
   }
 
   @Override

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesCommand.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus;
+
+import org.openhab.binding.pjlinkdevice.internal.device.PJLinkDevice;
+import org.openhab.binding.pjlinkdevice.internal.device.command.AbstractCommand;
+import org.openhab.binding.pjlinkdevice.internal.device.command.ResponseException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This command is used for retrieving device information as described in
+ * <a href="https://pjlink.jbmia.or.jp/english/data_cl2/PJLink_5-1.pdf">[PJLinkSpec]</a> chapters:
+ * 4.8. Lamp number/ lighting hour query
+ *
+ * @author Nils Schnabel - Initial contribution
+ */
+@NonNullByDefault
+public class LampStatesCommand extends AbstractCommand<LampStatesRequest, LampStatesResponse> {
+  public LampStatesCommand(PJLinkDevice pjLinkDevice) {
+    super(pjLinkDevice);
+  }
+
+  @Override
+  protected LampStatesRequest createRequest() {
+    return new LampStatesRequest();
+
+  }
+
+  @Override
+  protected LampStatesResponse parseResponse(String response) throws ResponseException {
+    return new LampStatesResponse(response);
+  }
+
+}

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesRequest.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesRequest.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesRequest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus;
+
+import org.openhab.binding.pjlinkdevice.internal.device.command.Request;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The request part of {@link LampStatesCommand}
+ *
+ * @author Nils Schnabel - Initial contribution
+ */
+@NonNullByDefault
+public class LampStatesRequest implements Request {
+  @Override
+  public String getRequestString() {
+    return "%1LAMP ?";
+  }
+}

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class LampStatesResponse extends PrefixedResponse<List<LampStatesResponse.LampState>> {
+  @NonNullByDefault
   public class LampState {
     private boolean active;
     private int lampHours;

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/lampstatus/LampStatesResponse.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pjlinkdevice.internal.device.command.lampstatus;
+
+import org.openhab.binding.pjlinkdevice.internal.device.command.PrefixedResponse;
+import org.openhab.binding.pjlinkdevice.internal.device.command.ResponseException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The response part of {@link LampStatesCommand}
+ *
+ * @author Nils Schnabel - Initial contribution
+ */
+@NonNullByDefault
+public class LampStatesResponse extends PrefixedResponse<List<LampStatesResponse.LampState>> {
+  public class LampState {
+    private boolean active;
+    private int lampHours;
+
+    public LampState(boolean active, int lampHours) {
+      this.active = active;
+      this.lampHours = lampHours;
+    }
+
+    public int getLampHours() {
+      return lampHours;
+    }
+
+    public boolean isActive() {
+      return active;
+    }
+  }
+
+  public LampStatesResponse(String response) throws ResponseException {
+    super("LAMP=", response);
+  }
+
+  @Override
+  protected List<LampStatesResponse.LampState> parseResponseWithoutPrefix(String responseWithoutPrefix)
+      throws ResponseException {
+    List<LampStatesResponse.LampState> result = new ArrayList<LampStatesResponse.LampState>();
+    LinkedList<String> queue = new LinkedList<String>(Arrays.asList(responseWithoutPrefix.split(" ")));
+    while (!queue.isEmpty()) {
+      try {
+        int lampHours = Integer.parseInt(queue.remove());
+        boolean active = Integer.parseInt(queue.remove()) == 1;
+        result.add(new LampState(active, lampHours));
+      } catch (NoSuchElementException | NumberFormatException e) {
+        throw new ResponseException("Lamp status response could not be parsed", e);
+      }
+    }
+    return result;
+  }
+
+}

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/discovery/AbstractDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/discovery/AbstractDiscoveryParticipant.java
@@ -23,16 +23,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.pjlinkdevice.internal.PJLinkDeviceBindingConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Discovery of PJLink devices. Checks IP addresses in parallel processing.
@@ -48,7 +46,7 @@ public abstract class AbstractDiscoveryParticipant extends AbstractDiscoveryServ
   private Integer scannedIPcount = 0;
   private @Nullable ExecutorService executorService = null;
 
-  public AbstractDiscoveryParticipant(Set<@NonNull ThingTypeUID> supportedThingTypes, int timeout,
+  public AbstractDiscoveryParticipant(Set<ThingTypeUID> supportedThingTypes, int timeout,
       boolean backgroundDiscoveryEnabledByDefault) throws IllegalArgumentException {
     super(supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault);
   }

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -95,7 +95,7 @@
 		<item-type>Number</item-type>
 		<label>Lamp hours</label>
 		<description>How long the lamp has been in use (in hours)</description>
-		<state readOnly="true" />
+		<state readOnly="true" pattern="%d h" />
 		<config-description>
 			<parameter name="lampNumber" type="integer" min="1" max="8">
 				<label>Lamp number</label>

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,8 @@
 			<channel id="input" typeId="input" />
 			<channel id="audioMute" typeId="audioMute" />
 			<channel id="videoMute" typeId="videoMute" />
+			<channel id="lamp1Hours" typeId="lampHours" />
+			<channel id="lamp1Active" typeId="lampActive" />
 		</channels>
 
 		<config-description>
@@ -56,6 +58,11 @@
 				<description>Seconds between connection retries when connection to the PJLink device has been lost, 0 means never retry, minimum 30s</description>
 				<default>60</default>
 			</parameter>
+			<parameter name="refreshLampState" type="boolean">
+				<default>false</default>
+				<label>Poll for lamp state</label>
+				<description>Enable polling for the lamp state. Only considered if the refresh interval is greater than zero.</description>
+			</parameter>
 		</config-description>
 
 	</thing-type>
@@ -84,4 +91,31 @@
 		<description>Select the video mute status</description>
 	</channel-type>
 
+	<channel-type id="lampHours">
+		<item-type>Number</item-type>
+		<label>Lamp hours</label>
+		<description>How long the lamp has been in use (in hours)</description>
+		<state readOnly="true" />
+		<config-description>
+			<parameter name="lampNumber" type="integer" min="1" max="8">
+				<label>Lamp number</label>
+				<description>Show used hours for this lamp</description>
+				<default>1</default>
+			</parameter>
+		</config-description>
+	</channel-type>
+
+	<channel-type id="lampActive">
+		<item-type>Switch</item-type>
+		<label>Lamp active</label>
+		<description>Is the lamp in use?</description>
+		<state readOnly="true" />
+		<config-description>
+			<parameter name="lampNumber" type="integer" min="1" max="8">
+				<label>Lamp number</label>
+				<description>Show activity for this lamp</description>
+				<default>1</default>
+			</parameter>
+		</config-description>
+	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -60,7 +60,7 @@
 			</parameter>
 			<parameter name="refreshLampState" type="boolean">
 				<default>false</default>
-				<label>Poll for lamp state</label>
+				<label>Poll for Lamp State</label>
 				<description>Enable polling for the lamp state. Only considered if the refresh interval is greater than zero.</description>
 			</parameter>
 		</config-description>
@@ -93,12 +93,12 @@
 
 	<channel-type id="lampHours">
 		<item-type>Number</item-type>
-		<label>Lamp hours</label>
+		<label>Lamp Hours</label>
 		<description>How long the lamp has been in use (in hours)</description>
 		<state readOnly="true" pattern="%d h" />
 		<config-description>
 			<parameter name="lampNumber" type="integer" min="1" max="8">
-				<label>Lamp number</label>
+				<label>Lamp Number</label>
 				<description>Show used hours for this lamp</description>
 				<default>1</default>
 			</parameter>
@@ -107,12 +107,12 @@
 
 	<channel-type id="lampActive">
 		<item-type>Switch</item-type>
-		<label>Lamp active</label>
+		<label>Lamp Active</label>
 		<description>Is the lamp in use?</description>
 		<state readOnly="true" />
 		<config-description>
 			<parameter name="lampNumber" type="integer" min="1" max="8">
-				<label>Lamp number</label>
+				<label>Lamp Number</label>
 				<description>Show activity for this lamp</description>
 				<default>1</default>
 			</parameter>


### PR DESCRIPTION
As [discussed in the initial contribution of this binding](https://github.com/openhab/openhab2-addons/pull/3834#discussion_r304840795) with @lolodomo, it could be useful to the user to have lamp usage hours as a channel instead of a property.

This PR addresses this issue by adding configurable channels for the lamp channels.
There is one preconfigured channel for lamp 1 (which should be available in most devices), if a device has more lamps additional channels can be configured.