### PR TITLE
[airvisualnode] Refactor JSON parsing according to the new manufacturer format

### DIFF
--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/AirVisualNodeBindingConstants.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/AirVisualNodeBindingConstants.java
@@ -40,6 +40,8 @@ public class AirVisualNodeBindingConstants {
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_AQI_US = "aqi";
     public static final String CHANNEL_PM_25 = "pm_25";
+    public static final String CHANNEL_PM_10 = "pm_10";
+    public static final String CHANNEL_PM_01 = "pm_01";
     public static final String CHANNEL_TEMP_CELSIUS = "temperature";
     public static final String CHANNEL_TIMESTAMP = "timestamp";
     public static final String CHANNEL_USED_MEMORY = "used_memory";
@@ -55,6 +57,6 @@ public class AirVisualNodeBindingConstants {
     // List of all supported Channel ids
     public static final Set<String> SUPPORTED_CHANNEL_IDS = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(CHANNEL_CO2, CHANNEL_HUMIDITY, CHANNEL_AQI_US,
-                    CHANNEL_PM_25, CHANNEL_TEMP_CELSIUS, CHANNEL_BATTERY_LEVEL,
+                    CHANNEL_PM_25, CHANNEL_PM_10, CHANNEL_PM_01, CHANNEL_TEMP_CELSIUS, CHANNEL_BATTERY_LEVEL,
                     CHANNEL_WIFI_STRENGTH, CHANNEL_TIMESTAMP, CHANNEL_USED_MEMORY)));
 }

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/handler/AirVisualNodeHandler.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/handler/AirVisualNodeHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.airvisualnode.internal.config.AirVisualNodeConfig;
+import org.openhab.binding.airvisualnode.internal.json.Measurements;
 import org.openhab.binding.airvisualnode.internal.json.NodeData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,23 +199,33 @@ public class AirVisualNodeHandler extends BaseThingHandler {
         } else if (CHANNEL_WIFI_STRENGTH.equals(channelId)) {
             state = new DecimalType(BigDecimal.valueOf(Math.max(0, nodeData.getStatus().getWifiStrength()-1)).longValue());
         } else {
+
+            Measurements measurements = nodeData.getMeasurements().get(0);
             // Handle binding-specific channel IDs
             switch (channelId) {
                 case CHANNEL_CO2:
-                    state = new QuantityType<>(nodeData.getMeasurements().getCo2Ppm(), PARTS_PER_MILLION);
+                    state = new QuantityType<>(measurements.getCo2Ppm(), PARTS_PER_MILLION);
                     break;
                 case CHANNEL_HUMIDITY:
-                    state = new QuantityType<>(nodeData.getMeasurements().getHumidityRH(), PERCENT);
+                    state = new QuantityType<>(measurements.getHumidityRH(), PERCENT);
                     break;
                 case CHANNEL_AQI_US:
-                    state = new QuantityType<>(nodeData.getMeasurements().getPm25AQIUS(), ONE);
+                    state = new QuantityType<>(measurements.getPm25AQIUS(), ONE);
                     break;
                 case CHANNEL_PM_25:
                     // PM2.5 is in ug/m3
-                    state = new QuantityType<>(nodeData.getMeasurements().getPm25Ugm3(), MICRO(GRAM).divide(CUBIC_METRE));
+                    state = new QuantityType<>(measurements.getPm25Ugm3(), MICRO(GRAM).divide(CUBIC_METRE));
+                    break;
+                case CHANNEL_PM_10:
+                    // PM10 is in ug/m3
+                    state = new QuantityType<>(measurements.getPm10Ugm3(), MICRO(GRAM).divide(CUBIC_METRE));
+                    break;
+                case CHANNEL_PM_01:
+                    // PM0.1 is in ug/m3
+                    state = new QuantityType<>(measurements.getPm01Ugm3(), MICRO(GRAM).divide(CUBIC_METRE));
                     break;
                 case CHANNEL_TEMP_CELSIUS:
-                    state = new QuantityType<>(nodeData.getMeasurements().getTemperatureC(), CELSIUS);
+                    state = new QuantityType<>(measurements.getTemperatureC(), CELSIUS);
                     break;
                 case CHANNEL_TIMESTAMP:
                     // It seem the Node timestamp is Unix timestamp converted from UTC time plus timezone offset.

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Measurements.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Measurements.java
@@ -21,26 +21,45 @@ import com.google.gson.annotations.SerializedName;
  */
 public class Measurements {
 
+    @SerializedName("co2_ppm")
     private int co2Ppm;
+
     @SerializedName("humidity_RH")
     private int humidityRH;
+
     @SerializedName("pm25_AQICN")
     private int pm25AQICN;
+
     @SerializedName("pm25_AQIUS")
     private int pm25AQIUS;
+
+    @SerializedName("pm01_ugm3")
+    private float pm01Ugm3;
+
+    @SerializedName("pm25_ugm3")
     private float pm25Ugm3;
+
+    @SerializedName("pm10_ugm3")
+    private float pm10Ugm3;
+
     @SerializedName("temperature_C")
     private float temperatureC;
+
     @SerializedName("temperature_F")
     private float temperatureF;
+
     private int vocPpb;
 
-    public Measurements(int co2Ppm, int humidityRH, int pm25AQICN, int pm25AQIUS, float pm25Ugm3,
+    public Measurements(int co2Ppm, int humidityRH, int pm25AQICN, int pm25AQIUS,
+            float pm01Ugm3, float pm10Ugm3, float pm25Ugm3,
             float temperatureC, float temperatureF, int vocPpb) {
+
         this.co2Ppm = co2Ppm;
         this.humidityRH = humidityRH;
         this.pm25AQICN = pm25AQICN;
         this.pm25AQIUS = pm25AQIUS;
+        this.pm01Ugm3 = pm01Ugm3;
+        this.pm10Ugm3 = pm10Ugm3;
         this.pm25Ugm3 = pm25Ugm3;
         this.temperatureC = temperatureC;
         this.temperatureF = temperatureF;
@@ -77,6 +96,22 @@ public class Measurements {
 
     public void setPm25AQIUS(int pm25AQIUS) {
         this.pm25AQIUS = pm25AQIUS;
+    }
+
+    public float getPm01Ugm3() {
+        return pm01Ugm3;
+    }
+
+    public void setPm01Ugm3(float pm01Ugm3) {
+        this.pm01Ugm3 = pm01Ugm3;
+    }
+
+    public float getPm10Ugm3() {
+        return pm10Ugm3;
+    }
+
+    public void setPm10Ugm3(float pm10Ugm3) {
+        this.pm10Ugm3 = pm10Ugm3;
     }
 
     public float getPm25Ugm3() {

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/NodeData.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/NodeData.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.airvisualnode.internal.json;
 
+import java.util.List;
+
 /**
  * Top level object for AirVisual Node JSON data.
  *
@@ -20,13 +22,12 @@ package org.openhab.binding.airvisualnode.internal.json;
 public class NodeData {
 
     private DateAndTime dateAndTime;
-    private Measurements measurements;
+    private List<Measurements> measurements;
     private String serialNumber;
     private Settings settings;
     private Status status;
 
-    public NodeData(DateAndTime dateAndTime, Measurements measurements, String serialNumber, Settings settings,
-            Status status) {
+    public NodeData(DateAndTime dateAndTime, List<Measurements> measurements, String serialNumber, Settings settings, Status status) {
         this.dateAndTime = dateAndTime;
         this.measurements = measurements;
         this.serialNumber = serialNumber;
@@ -42,11 +43,11 @@ public class NodeData {
         this.dateAndTime = dateAndTime;
     }
 
-    public Measurements getMeasurements() {
+    public List<Measurements> getMeasurements() {
         return measurements;
     }
 
-    public void setMeasurements(Measurements measurements) {
+    public void setMeasurements(List<Measurements> measurements) {
         this.measurements = measurements;
     }
 

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/PowerSaving.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/PowerSaving.java
@@ -24,12 +24,17 @@ public class PowerSaving {
 
     @SerializedName("2slots")
     private List<PowerSavingTimeSlot> timeSlots = null;
+
     private String mode;
+
+    private long runningTime;
+
     @SerializedName("yes")
     private List<PowerSavingTime> times = null;
 
-    public PowerSaving(List<PowerSavingTimeSlot> timeSlots, String mode, List<PowerSavingTime> times) {
+    public PowerSaving(List<PowerSavingTimeSlot> timeSlots, String mode, long runningTime, List<PowerSavingTime> times) {
         this.mode = mode;
+        this.runningTime = runningTime;
         this.times = times;
         this.timeSlots = timeSlots;
     }
@@ -58,4 +63,11 @@ public class PowerSaving {
         this.mode = mode;
     }
 
+    public long getRunningTime() {
+        return runningTime;
+    }
+
+    public void setRunningTime(long runningTime) {
+        this.runningTime = runningTime;
+    }
 }

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/SensorLife.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/SensorLife.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.airvisualnode.internal.json;
+
+/**
+ * Sensor Usage/Life data
+ */
+public class SensorLife {
+
+    private long pm25;
+
+    public SensorLife(long pm25) {
+        this.pm25 = pm25;
+    }
+
+    public long getPm25() {
+        return pm25;
+    }
+
+    public void setPm25(long pm25) {
+        this.pm25 = pm25;
+    }
+}

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/SensorMode.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/SensorMode.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.airvisualnode.internal.json;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Sensor Operating Mode
+ */
+public class SensorMode {
+
+    private long customModeInterval;
+
+    private long mode;
+
+    public SensorMode(long customModeInterval, long mode) {
+        this.customModeInterval = customModeInterval;
+        this.mode = mode;
+    }
+
+    public long getCustomModeInterval() {
+        return customModeInterval;
+    }
+
+    public void setCustomModeInterval(long customModeInterval) {
+        this.customModeInterval = customModeInterval;
+    }
+
+    public long getMode() {
+        return mode;
+    }
+
+    public void setMode(long mode) {
+        this.mode = mode;
+    }
+}

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Settings.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Settings.java
@@ -19,6 +19,7 @@ package org.openhab.binding.airvisualnode.internal.json;
  */
 public class Settings {
 
+    private String followMode;
     private String followedStation;
     private boolean isAqiUsa;
     private boolean isConcentrationShowed;
@@ -30,12 +31,15 @@ public class Settings {
     private int lcdBrightness;
     private String nodeName;
     private PowerSaving powerSaving;
+    private SensorMode sensorMode;
     private String speedUnit;
     private String timezone;
 
-    public Settings(String followedStation, boolean isAqiUsa, boolean isConcentrationShowed, boolean isIndoor,
+    public Settings(String followMode, String followedStation, boolean isAqiUsa, boolean isConcentrationShowed, boolean isIndoor,
             boolean isLcdOn, boolean isNetworkTime, boolean isTemperatureCelsius, String language, int lcdBrightness,
-            String nodeName, PowerSaving powerSaving, String speedUnit, String timezone) {
+            String nodeName, PowerSaving powerSaving, SensorMode sensorMode, String speedUnit, String timezone) {
+
+        this.followMode = followMode;
         this.followedStation = followedStation;
         this.isAqiUsa = isAqiUsa;
         this.isConcentrationShowed = isConcentrationShowed;
@@ -47,8 +51,17 @@ public class Settings {
         this.lcdBrightness = lcdBrightness;
         this.nodeName = nodeName;
         this.powerSaving = powerSaving;
+        this.sensorMode = sensorMode;
         this.speedUnit = speedUnit;
         this.timezone = timezone;
+    }
+
+    public String getFollowMode() {
+        return followMode;
+    }
+
+    public void setFollowMode(String followMode) {
+        this.followMode = followMode;
     }
 
     public String getFollowedStation() {

--- a/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Status.java
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/java/org/openhab/binding/airvisualnode/internal/json/Status.java
@@ -22,19 +22,29 @@ public class Status {
     private String appVersion;
     private int battery;
     private long datetime;
+    private String deviceName;
+    private String ipAddress;
+    private String macAddress;
     private String model;
+    private SensorLife sensorLife;
     private String sensorPm25Serial;
     private int syncTime;
     private String systemVersion;
     private int usedMemory;
     private int wifiStrength;
 
-    public Status(String appVersion, int battery, long datetime, String model, String sensorPm25Serial, int syncTime,
-            String systemVersion, int usedMemory, int wifiStrength) {
+    public Status(String appVersion, int battery, long datetime, String deviceName,
+                  String ipAddress, String macAddress, String model, SensorLife sensorLife,
+                  String sensorPm25Serial, int syncTime, String systemVersion, int usedMemory,
+                  int wifiStrength) {
         this.appVersion = appVersion;
         this.battery = battery;
         this.datetime = datetime;
+        this.deviceName = deviceName;
+        this.ipAddress = ipAddress;
+        this.macAddress = macAddress;
         this.model = model;
+        this.sensorLife = sensorLife;
         this.sensorPm25Serial = sensorPm25Serial;
         this.syncTime = syncTime;
         this.systemVersion = systemVersion;
@@ -66,12 +76,44 @@ public class Status {
         this.datetime = datetime;
     }
 
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public void setDeviceName(String deviceName) {
+        this.deviceName = deviceName;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
     public String getModel() {
         return model;
     }
 
     public void setModel(String model) {
         this.model = model;
+    }
+
+    public SensorLife getSensorLife() {
+        return sensorLife;
+    }
+
+    public void setSensorLife(SensorLife sensorLife) {
+        this.sensorLife = sensorLife;
     }
 
     public String getSensorPm25Serial() {
@@ -113,5 +155,4 @@ public class Status {
     public void setWifiStrength(int wifiStrength) {
         this.wifiStrength = wifiStrength;
     }
-
 }

--- a/bundles/org.openhab.binding.airvisualnode/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -14,7 +14,9 @@
 			<channel id="co2" typeId="Co2" />
 			<channel id="humidity" typeId="Humidity" />
 			<channel id="aqi" typeId="Aqi" />
+			<channel id="pm_01" typeId="Pm_01" />
 			<channel id="pm_25" typeId="Pm_25" />
+			<channel id="pm_10" typeId="Pm_10" />
 			<channel id="temperature" typeId="Temperature" />
 			<channel id="timestamp" typeId="Timestamp" />
 			<channel id="used_memory" typeId="Used_memory" />
@@ -87,6 +89,20 @@
 		<item-type>Number:Density</item-type>
 		<label>PM2.5</label>
 		<description>PM2.5 level, µg/m&#179;</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
+	</channel-type>
+
+	<channel-type id="Pm_10">
+		<item-type>Number:Density</item-type>
+		<label>PM10</label>
+		<description>PM10 level, µg/m&#179;</description>
+		<state readOnly="true" pattern="%.1f %unit%" />
+	</channel-type>
+
+	<channel-type id="Pm_01">
+		<item-type>Number:Density</item-type>
+		<label>PM0.1</label>
+		<description>PM0.1 level, µg/m&#179;</description>
 		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 


### PR DESCRIPTION
The Airvisual Node/Pro has recently got new firmware (the hw is seemingly the same) and the new firmware uses a significantly changed JSON format in which measurements and device status is stored.

Without this fix, the binding cannot work with any of the AirVisual Node/Pro that has newer firmware. Very likely, the older hardware also gets the new firmware so none of the devices will work with the older version of the OpenHAB binding.

Fixes #4593 

Signed-off-by: András Soltész <soltesz.andras@gmail.com>