### PR TITLE
[tradfri][WIP] Adds basic support for IKEA smart blinds FYRTUR and KADRILJ

### DIFF
--- a/bundles/org.openhab.binding.tradfri/README.md
+++ b/bundles/org.openhab.binding.tradfri/README.md
@@ -22,18 +22,20 @@ These are:
 | Non-Colour Controller           | 0x0820           | 0820       |
 | Non-Colour Scene Controller     | 0x0830           | 0830       |
 | Control Outlet                  | 0x0010           | 0010       |
+| Blind                           | 0x0999           | 0999       |
 
 The following matrix lists the capabilities (channels) for each of the supported lighting device types:
 
-| Thing type  | Brightness | Color | Color Temperature | Battery Level | Battery Low | Power |
-|-------------|:----------:|:-----:|:-----------------:|:-------------:|:-----------:|:-----:|
-|  0010       |            |       |                   |               |             |   X   |
-|  0100       |     X      |       |                   |               |             |       |
-|  0220       |     X      |       |         X         |               |             |       |
-|  0210       |            |   X   |         X         |               |             |       |
-|  0107       |            |       |                   |       X       |      X      |       |
-|  0820       |            |       |                   |       X       |      X      |       |
-|  0830       |            |       |                   |       X       |      X      |       |
+| Thing type  | Brightness | Color | Color Temperature | Battery Level | Battery Low | Power | Position |
+|-------------|:----------:|:-----:|:-----------------:|:-------------:|:-----------:|:-----:|:---------|
+|  0010       |            |       |                   |               |             |   X   |          |
+|  0100       |     X      |       |                   |               |             |       |          |
+|  0220       |     X      |       |         X         |               |             |       |          |
+|  0210       |            |   X   |         X         |               |             |       |          |
+|  0107       |            |       |                   |       X       |      X      |       |          |
+|  0820       |            |       |                   |       X       |      X      |       |          |
+|  0830       |            |       |                   |       X       |      X      |       |          |
+|  0999       |            |       |                   |       X       |      X      |       |     X    |
 
 ## Thing Configuration
 
@@ -60,14 +62,15 @@ The control outlet supports the `power` channel.
 
 Refer to the matrix above.
 
-| Channel Type ID   | Item Type | Description                                      |
-|-------------------|-----------|--------------------------------------------------|
-| brightness        | Dimmer    | The brightness of the bulb in percent            |
-| color_temperature | Dimmer    | color temperature from 0% = cold to 100% = warm  |
-| color             | Color     | full color                                       |
-| battery_level     | Number    | battery level (in %)                             |
-| battery_low       | Switch    | battery low warning (<=10% = ON, >10% = OFF)     |
-| power             | Switch    | power switch                                     |
+| Channel Type ID   | Item Type     | Description                                      |
+|-------------------|---------------|--------------------------------------------------|
+| brightness        | Dimmer        | The brightness of the bulb in percent            |
+| color_temperature | Dimmer        | color temperature from 0% = cold to 100% = warm  |
+| color             | Color         | full color                                       |
+| battery_level     | Number        | battery level (in %)                             |
+| battery_low       | Switch        | battery low warning (<=10% = ON, >10% = OFF)     |
+| power             | Switch        | power switch                                     |
+| position          | Rollershutter | position of the blind in percent                 |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriBindingConstants.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriBindingConstants.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added support for remote controller and motion sensor devices (read-only battery level)
+ * @author Manuel Raffel - Added support for blinds
  */
 public class TradfriBindingConstants {
 
@@ -40,6 +41,7 @@ public class TradfriBindingConstants {
     public static final ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "0820");
     public static final ThingTypeUID THING_TYPE_REMOTE_CONTROL = new ThingTypeUID(BINDING_ID, "0830");
     public static final ThingTypeUID THING_TYPE_MOTION_SENSOR = new ThingTypeUID(BINDING_ID, "0107");
+    public static final ThingTypeUID THING_TYPE_BLIND = new ThingTypeUID(BINDING_ID, "0999");
 
     public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_TEMP_LIGHT, THING_TYPE_COLOR_LIGHT)
@@ -47,6 +49,10 @@ public class TradfriBindingConstants {
 
     public static final Set<ThingTypeUID> SUPPORTED_PLUG_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(THING_TYPE_ONOFF_PLUG).collect(Collectors.toSet()));
+
+        public static final Set<ThingTypeUID> SUPPORTED_BLIND_TYPES_UIDS = Collections
+                .unmodifiableSet(Stream.of(THING_TYPE_BLIND).collect(Collectors.toSet()));
+
 
     // List of all Gateway Configuration Properties
     public static final String GATEWAY_CONFIG_HOST = "host";
@@ -64,12 +70,14 @@ public class TradfriBindingConstants {
     public static final String CHANNEL_BRIGHTNESS = "brightness";
     public static final String CHANNEL_COLOR_TEMPERATURE = "color_temperature";
     public static final String CHANNEL_COLOR = "color";
+    public static final String CHANNEL_POSITION = "position";
     public static final String CHANNEL_BATTERY_LEVEL = "battery_level";
     public static final String CHANNEL_BATTERY_LOW = "battery_low";
 
     // IPSO Objects
     public static final String DEVICES = "15001";
     public static final String AUTH_PATH = "9063";
+    public static final String BLIND = "15015";
     public static final String CLIENT_IDENTITY_PROPOSED = "9090";
     public static final String COLOR = "5706";
     public static final String COLOR_X = "5709";
@@ -135,6 +143,7 @@ public class TradfriBindingConstants {
     public static final String OTA_UPDATE_STATE = "9054";
     public static final String PLUG = "3312";
     public static final String POWER_FACTOR = "5820";
+    public static final String POSITION = "5536";
     public static final String REACHABILITY_STATE = "9019";
     public static final String REBOOT = "9030";
     public static final String REPEAT_DAYS = "9041";
@@ -175,6 +184,7 @@ public class TradfriBindingConstants {
     public static final String TYPE_LIGHT = "2";
     public static final String TYPE_PLUG = "3";
     public static final String TYPE_SENSOR = "4";
+    public static final String TYPE_BLIND = "7";
     public static final String DEVICE_VENDOR = "0";
     public static final String DEVICE_MODEL = "1";
     public static final String DEVICE_FIRMWARE = "3";

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriHandlerFactory.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriHandlerFactory.java
@@ -35,6 +35,7 @@ import org.openhab.binding.tradfri.internal.discovery.TradfriDiscoveryService;
 import org.openhab.binding.tradfri.internal.handler.TradfriControllerHandler;
 import org.openhab.binding.tradfri.internal.handler.TradfriGatewayHandler;
 import org.openhab.binding.tradfri.internal.handler.TradfriLightHandler;
+import org.openhab.binding.tradfri.internal.handler.TradfriBlindHandler;
 import org.openhab.binding.tradfri.internal.handler.TradfriPlugHandler;
 import org.openhab.binding.tradfri.internal.handler.TradfriSensorHandler;
 import org.osgi.framework.ServiceRegistration;
@@ -45,6 +46,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added support for remote controller and motion sensor devices (read-only battery level)
+ * @author Manuel Raffel - Added support for blinds
  */
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.tradfri")
 @NonNullByDefault
@@ -52,7 +54,7 @@ public class TradfriHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
             .of(Stream.of(GATEWAY_TYPE_UID), SUPPORTED_LIGHT_TYPES_UIDS.stream(),
-                    SUPPORTED_CONTROLLER_TYPES_UIDS.stream(), SUPPORTED_PLUG_TYPES_UIDS.stream())
+                    SUPPORTED_CONTROLLER_TYPES_UIDS.stream(), SUPPORTED_PLUG_TYPES_UIDS.stream(), SUPPORTED_BLIND_TYPES_UIDS.stream())
             .reduce(Stream::concat).orElseGet(Stream::empty).collect(Collectors.toSet());
 
     private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
@@ -74,6 +76,8 @@ public class TradfriHandlerFactory extends BaseThingHandlerFactory {
             return new TradfriControllerHandler(thing);
         } else if (THING_TYPE_MOTION_SENSOR.equals(thingTypeUID)) {
             return new TradfriSensorHandler(thing);
+        } else if (THING_TYPE_BLIND.equals(thingTypeUID)) {
+            return new TradfriBlindHandler(thing);
         } else if (SUPPORTED_LIGHT_TYPES_UIDS.contains(thingTypeUID)) {
             return new TradfriLightHandler(thing);
         } else if (SUPPORTED_PLUG_TYPES_UIDS.contains(thingTypeUID)) {

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -43,6 +43,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added support for remote controller and motion sensor devices (read-only battery level)
  * @author Andre Fuechsel - fixed the results removal
+ * @author Manuel Raffel - Added support for blinds
  */
 @NonNullByDefault
 public class TradfriDiscoveryService extends AbstractDiscoveryService implements DeviceUpdateListener {
@@ -118,6 +119,9 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
                     if (thingType == null) {
                         thingType = THING_TYPE_DIMMABLE_LIGHT;
                     }
+                    thingId = new ThingUID(thingType, bridge, Integer.toString(id));
+                } else if(TYPE_BLIND.equals(type) && data.has(BLIND)) {
+                    ThingTypeUID thingType = THING_TYPE_BLIND;
                     thingId = new ThingUID(thingType, bridge, Integer.toString(id));
                 } else if (TYPE_PLUG.equals(type) && data.has(PLUG)) {
                     // Smart plug

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriBlindHandler.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriBlindHandler.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tradfri.internal.handler;
+
+import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.tradfri.internal.model.TradfriBlindData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+
+/**
+ * The {@link TradfriBlindHandler} is responsible for handling commands for individual blinds.
+ *
+ * @author Manuel Raffel - Initial contribution
+ */
+@NonNullByDefault
+public class TradfriBlindHandler extends TradfriThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(TradfriBlindHandler.class);
+
+    // keeps track of the current state for handling of stop/move
+    private @Nullable TradfriBlindData state;
+
+    public TradfriBlindHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void onUpdate(JsonElement data) {
+        if (active && !(data.isJsonNull())) {
+            TradfriBlindData state = new TradfriBlindData(data);
+            updateStatus(state.getReachabilityStatus() ? ThingStatus.ONLINE : ThingStatus.OFFLINE);
+
+            PercentType position = state.getPosition();
+            if (position != null) {
+                updateState(CHANNEL_POSITION, position);
+            }
+
+            DecimalType batteryLevel = state.getBatteryLevel();
+            if (batteryLevel != null) {
+                updateState(CHANNEL_BATTERY_LEVEL, batteryLevel);
+            }
+
+            OnOffType batteryLow = state.getBatteryLow();
+            if (batteryLow != null) {
+                updateState(CHANNEL_BATTERY_LOW, batteryLow);
+            }
+
+            updateDeviceProperties(state);
+
+            this.state = state;
+
+            logger.debug(
+                    "Updating thing for blindId {} to state {position: {}, firmwareVersion: {}, modelId: {}, vendor: {}}",
+                    state.getDeviceId(), position, state.getFirmwareVersion(), state.getModelId(),
+                    state.getVendor());
+        }
+    }
+
+    private void setPosition(PercentType percent) {
+        TradfriBlindData data = new TradfriBlindData();
+        data.setPosition(percent);
+        set(data.getJsonString());
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (active) {
+            if (command instanceof RefreshType) {
+                logger.debug("Refreshing channel {}", channelUID);
+                coapClient.asyncGet(this);
+                return;
+            }
+
+            switch (channelUID.getId()) {
+                case CHANNEL_POSITION:
+                    handlePositionCommand(command);
+                    break;
+                default:
+                    logger.error("Unknown channel UID {}", channelUID);
+            }
+        }
+    }
+
+    private void handlePositionCommand(Command command) {
+        if (command instanceof PercentType) {
+            setPosition((PercentType) command);
+        } else if (command instanceof StopMoveType) {
+            final TradfriBlindData state = this.state;
+            if (state != null && state.getPosition() != null) {
+                if(StopMoveType.STOP.equals(command)) {
+                    // setPosition(state.getPosition());
+                } else {
+                    // (what) TODO (?)
+                }            
+            } else {
+                logger.debug("Cannot handle stop/move as current state is not known.");
+            }
+        } else if (command instanceof UpDownType) {
+            if (UpDownType.UP.equals(command)) {
+                setPosition(PercentType.ZERO);
+            } else {
+                setPosition(PercentType.HUNDRED);
+            }
+        } else {
+            logger.debug("Cannot handle command {} for channel {}", command, CHANNEL_POSITION);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/model/TradfriBlindData.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/model/TradfriBlindData.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.tradfri.internal.model;
+
+import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.PercentType;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * The {@link TradfriBlindData} class is a Java wrapper for the raw JSON data about the blinds state.
+ *
+ * @author Manuel Raffel - Initial contribution
+ */
+@NonNullByDefault
+public class TradfriBlindData extends TradfriWirelessDeviceData {
+    public TradfriBlindData() {
+        super(BLIND);
+    }
+
+    public TradfriBlindData(JsonElement json) {
+        super(BLIND, json);
+    }
+
+    public TradfriBlindData setPosition(PercentType position) {
+        attributes.add(POSITION, new JsonPrimitive(position.intValue()));
+        return this;
+    }
+
+    public @Nullable PercentType getPosition() {
+        PercentType result = null;
+
+        JsonElement position = attributes.get(POSITION);
+        if (position != null) {
+            result = new PercentType(position.getAsInt());
+        }
+
+        return result;
+    }
+
+    public String getJsonString() {
+        return root.toString();
+    }
+}

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/i18n/tradfri_de.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/i18n/tradfri_de.properties
@@ -1,25 +1,25 @@
 # binding
-binding.tradfri.name = TR√ÖDFRI Binding
-binding.tradfri.description = Dieses Binding integriert das IKEA TR√ÖDFRI System. Durch dieses k√∂nnen die TR√ÖDFRI Lampen und Leuchten gesteuert werden. 
+binding.tradfri.name = TR≈DFRI Binding
+binding.tradfri.description = Dieses Binding integriert das IKEA TR≈DFRI System. Durch dieses kˆnnen die TR≈DFRI Lampen und Leuchten gesteuert werden. 
 
 # bridge types
-thing-type.tradfri.gateway.label = TR√ÖDFRI Gateway
-thing-type.tradfri.gateway.description = IKEA TR√ÖDFRI Gateway/zentrale Steuereinheit.
+thing-type.tradfri.gateway.label = TR≈DFRI Gateway
+thing-type.tradfri.gateway.description = IKEA TR≈DFRI Gateway/zentrale Steuereinheit.
 
 # bridge type configuration
 bridge-type.config.tradfri.gateway.host.label = IP-Adresse
-bridge-type.config.tradfri.gateway.host.description = Lokale IP-Adresse oder Hostname des TR√ÖDFRI Gateway.
+bridge-type.config.tradfri.gateway.host.description = Lokale IP-Adresse oder Hostname des TR≈DFRI Gateway.
 bridge-type.config.tradfri.gateway.port.label = Port
-bridge-type.config.tradfri.gateway.port.description = Port des TR√ÖDFRI Gateway.
+bridge-type.config.tradfri.gateway.port.description = Port des TR≈DFRI Gateway.
 bridge-type.config.tradfri.gateway.code.label = Security Code
-bridge-type.config.tradfri.gateway.code.description = Security Code zur Authentifizierung am TR√ÖDFRI Gateway. Befindet sich unterhalb des TR√ÖDFRI Gateway.
+bridge-type.config.tradfri.gateway.code.description = Security Code zur Authentifizierung am TR≈DFRI Gateway. Befindet sich unterhalb des TR≈DFRI Gateway.
 
 # thing types
-thing-type.tradfri.0100.label = Dimmbare Lampe (wei√ü)
+thing-type.tradfri.0100.label = Dimmbare Lampe (weiﬂ)
 thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
 thing-type.tradfri.0210.label = Farbspektrum Lampe
 thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
-thing-type.tradfri.0220.label = Farbtemperatur Lampe (wei√ü)
+thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiﬂ)
 thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
 thing-type.tradfri.0107.label = Funk-Bewegungsmelder
 thing-type.tradfri.0107.description = Der Funk-Bewegungsmelder liefert Daten wie z.B. die Batterieladung.
@@ -28,18 +28,18 @@ thing-type.tradfri.0820.description = Der Kabellose Dimmer liefert Daten wie z.B
 thing-type.tradfri.0830.label = Fernbedienung
 thing-type.tradfri.0830.description = Die Fernbedienung liefert Daten wie z.B. die Batterieladung.
 thing-type.tradfri.0999.label = Rollo
-thing-type.tradfri.0999.description = Akkubetriebene Rollo mit einstellbarer Position. Liefert au√üerdem Daten wie z.B. die Akkuladung.
+thing-type.tradfri.0999.description = Akkubetriebene Rollo mit einstellbarer Position. Liefert auﬂerdem Daten wie z.B. die Akkuladung.
 
 # thing types config
-thing-type.config.tradfri.device.id.label = ID des Ger√§tes
-thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger√§tes.
+thing-type.config.tradfri.device.id.label = ID des Ger‰tes
+thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger‰tes.
 
 # channel types
 channel-type.tradfri.brightness.label = Helligkeit
-channel-type.tradfri.brightness.description = Erm√∂glicht die Steuerung der Helligkeit. Erm√∂glicht ebenfalls die Lampe ein- und auszuschalten.
+channel-type.tradfri.brightness.description = Ermˆglicht die Steuerung der Helligkeit. Ermˆglicht ebenfalls die Lampe ein- und auszuschalten.
 channel-type.tradfri.color_temperature.label = Farbtemperatur
-channel-type.tradfri.color_temperature.description = Erm√∂glicht die Steuerung der Farbtemperatur. Von Tageslichtwei√ü (0) bis Warmwei√ü (100).
+channel-type.tradfri.color_temperature.description = Ermˆglicht die Steuerung der Farbtemperatur. Von Tageslichtweiﬂ (0) bis Warmweiﬂ (100).
 channel-type.tradfri.color.label = Farbe
-channel-type.tradfri.color.description = Erm√∂glicht die Steuerung der Farbe.
+channel-type.tradfri.color.description = Ermˆglicht die Steuerung der Farbe.
 channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Erm√∂glicht die Steuerung der Position von Offen (0) bis Geschlossen (100).
+channel-type.tradfri.position.description = Ermˆglicht die Steuerung der Position von Offen (0) bis Geschlossen (100).

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/i18n/tradfri_de.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/i18n/tradfri_de.properties
@@ -1,25 +1,25 @@
 # binding
-binding.tradfri.name = TR≈DFRI Binding
-binding.tradfri.description = Dieses Binding integriert das IKEA TR≈DFRI System. Durch dieses kˆnnen die TR≈DFRI Lampen und Leuchten gesteuert werden. 
+binding.tradfri.name = TR√ÖDFRI Binding
+binding.tradfri.description = Dieses Binding integriert das IKEA TR√ÖDFRI System. Durch dieses k√∂nnen die TR√ÖDFRI Lampen und Leuchten gesteuert werden. 
 
 # bridge types
-thing-type.tradfri.gateway.label = TR≈DFRI Gateway
-thing-type.tradfri.gateway.description = IKEA TR≈DFRI Gateway/zentrale Steuereinheit.
+thing-type.tradfri.gateway.label = TR√ÖDFRI Gateway
+thing-type.tradfri.gateway.description = IKEA TR√ÖDFRI Gateway/zentrale Steuereinheit.
 
 # bridge type configuration
 bridge-type.config.tradfri.gateway.host.label = IP-Adresse
-bridge-type.config.tradfri.gateway.host.description = Lokale IP-Adresse oder Hostname des TR≈DFRI Gateway.
+bridge-type.config.tradfri.gateway.host.description = Lokale IP-Adresse oder Hostname des TR√ÖDFRI Gateway.
 bridge-type.config.tradfri.gateway.port.label = Port
-bridge-type.config.tradfri.gateway.port.description = Port des TR≈DFRI Gateway.
+bridge-type.config.tradfri.gateway.port.description = Port des TR√ÖDFRI Gateway.
 bridge-type.config.tradfri.gateway.code.label = Security Code
-bridge-type.config.tradfri.gateway.code.description = Security Code zur Authentifizierung am TR≈DFRI Gateway. Befindet sich unterhalb des TR≈DFRI Gateway.
+bridge-type.config.tradfri.gateway.code.description = Security Code zur Authentifizierung am TR√ÖDFRI Gateway. Befindet sich unterhalb des TR√ÖDFRI Gateway.
 
 # thing types
-thing-type.tradfri.0100.label = Dimmbare Lampe (weiﬂ)
+thing-type.tradfri.0100.label = Dimmbare Lampe (wei√ü)
 thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
 thing-type.tradfri.0210.label = Farbspektrum Lampe
 thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
-thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiﬂ)
+thing-type.tradfri.0220.label = Farbtemperatur Lampe (wei√ü)
 thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
 thing-type.tradfri.0107.label = Funk-Bewegungsmelder
 thing-type.tradfri.0107.description = Der Funk-Bewegungsmelder liefert Daten wie z.B. die Batterieladung.
@@ -27,15 +27,19 @@ thing-type.tradfri.0820.label = Kabelloser Dimmer
 thing-type.tradfri.0820.description = Der Kabellose Dimmer liefert Daten wie z.B. die Batterieladung.
 thing-type.tradfri.0830.label = Fernbedienung
 thing-type.tradfri.0830.description = Die Fernbedienung liefert Daten wie z.B. die Batterieladung.
+thing-type.tradfri.0999.label = Rollo
+thing-type.tradfri.0999.description = Akkubetriebene Rollo mit einstellbarer Position. Liefert au√üerdem Daten wie z.B. die Akkuladung.
 
 # thing types config
-thing-type.config.tradfri.device.id.label = ID des Ger‰tes
-thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger‰tes.
+thing-type.config.tradfri.device.id.label = ID des Ger√§tes
+thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger√§tes.
 
 # channel types
 channel-type.tradfri.brightness.label = Helligkeit
-channel-type.tradfri.brightness.description = Ermˆglicht die Steuerung der Helligkeit. Ermˆglicht ebenfalls die Lampe ein- und auszuschalten.
+channel-type.tradfri.brightness.description = Erm√∂glicht die Steuerung der Helligkeit. Erm√∂glicht ebenfalls die Lampe ein- und auszuschalten.
 channel-type.tradfri.color_temperature.label = Farbtemperatur
-channel-type.tradfri.color_temperature.description = Ermˆglicht die Steuerung der Farbtemperatur. Von Tageslichtweiﬂ (0) bis Warmweiﬂ (100).
+channel-type.tradfri.color_temperature.description = Erm√∂glicht die Steuerung der Farbtemperatur. Von Tageslichtwei√ü (0) bis Warmwei√ü (100).
 channel-type.tradfri.color.label = Farbe
-channel-type.tradfri.color.description = Ermˆglicht die Steuerung der Farbe.
+channel-type.tradfri.color.description = Erm√∂glicht die Steuerung der Farbe.
+channel-type.tradfri.position.label = Position
+channel-type.tradfri.position.description = Erm√∂glicht die Steuerung der Position von Offen (0) bis Geschlossen (100).

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -137,6 +137,25 @@
 		<config-description-ref uri="thing-type:tradfri:device" />
 	</thing-type>
 
+	<thing-type id="0999">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+
+		<label>Blind</label>
+		<description>A blind that can be moved up and down. Also reports current battery level.</description>
+
+		<channels>
+			<channel id="position" typeId="position" />
+			<channel id="battery_level" typeId="system.battery-level" />
+			<channel id="battery_low" typeId="system.low-battery" />
+		</channels>
+
+		<representation-property>id</representation-property>
+
+		<config-description-ref uri="thing-type:tradfri:device" />
+	</thing-type>
+
 	<channel-type id="brightness">
 		<item-type>Dimmer</item-type>
 		<label>Brightness</label>
@@ -144,6 +163,16 @@
 		<category>DimmableLight</category>
 		<tags>
 			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="position">
+		<item-type>Rollershutter</item-type>
+		<label>Position</label>
+		<description>Control the position of the blind in percent from 0 (open) to 100 (closed).</description>
+		<category>Rollershutter</category>
+		<tags>
+			<tag>WindowCovering</tag>
 		</tags>
 	</channel-type>
 


### PR DESCRIPTION
Recently, IKEA released two new, rechargeable smart blinds "FYRTUR" and "KADRILJ" (first one is lightproof, second one slightly translucent). The changes in this PR add basic support for those blinds to the binding with the possibility to open and close the blinds as well as set the to a specific position (percentage between 0 and 100). Furthermore, the current battery level of the blind is exposed and also the "battery low" status which is triggered if the level is below 10 percent. 

The PR is marked [WIP] because the new thing is of type "Rollershutter" and therefore should support Stop/Move commands as well, which have not been implemented yet. Maybe someone can figure this out faster than me. Also, I guess the additions and adjustments of the README and language files could be better. As "blinds" are not mentioned in the "ZigBee LightLink" document, which apparently is the source for all thing type ids, a temporary id of "0999" was used for them. A final id needs to be figured out somehow.