### PR TITLE
[Yeelight] Added support for YEELIGHT JIAOYUE 650 lamps

### DIFF
--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightBindingConstants.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightBindingConstants.java
@@ -29,6 +29,7 @@ public class YeelightBindingConstants {
     public static final ThingTypeUID THING_TYPE_CEILING = new ThingTypeUID(BINDING_ID, "ceiling");
     public static final ThingTypeUID THING_TYPE_CEILING1 = new ThingTypeUID(BINDING_ID, "ceiling1");
     public static final ThingTypeUID THING_TYPE_CEILING3 = new ThingTypeUID(BINDING_ID, "ceiling3");
+    public static final ThingTypeUID THING_TYPE_CEILING4 = new ThingTypeUID(BINDING_ID, "ceiling4");
     public static final ThingTypeUID THING_TYPE_DOLPHIN = new ThingTypeUID(BINDING_ID, "dolphin");
     public static final ThingTypeUID THING_TYPE_CTBULB = new ThingTypeUID(BINDING_ID, "ct_bulb");
     public static final ThingTypeUID THING_TYPE_WONDER = new ThingTypeUID(BINDING_ID, "wonder");

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactory.java
@@ -40,6 +40,7 @@ public class YeelightHandlerFactory extends BaseThingHandlerFactory {
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CEILING);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CEILING1);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CEILING3);
+        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CEILING4);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_DOLPHIN);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_CTBULB);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_WONDER);
@@ -63,7 +64,8 @@ public class YeelightHandlerFactory extends BaseThingHandlerFactory {
         } else if (thingTypeUID.equals(THING_TYPE_STRIPE)) {
             return new YeelightStripeHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_CEILING) || thingTypeUID.equals(THING_TYPE_CEILING1)
-                || thingTypeUID.equals(THING_TYPE_CEILING3) || thingTypeUID.equals(THING_TYPE_DESKLAMP)) {
+                || thingTypeUID.equals(THING_TYPE_CEILING3) || thingTypeUID.equals(THING_TYPE_CEILING4)
+                || thingTypeUID.equals(THING_TYPE_DESKLAMP)) {
             return new YeelightCeilingHandler(thing);
         } else {
             return null;

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/discovery/YeelightDiscoveryService.java
@@ -90,6 +90,8 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING, device.getDeviceId());
             case ceiling3:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING, device.getDeviceId());
+            case ceiling4:
+                return new ThingUID(YeelightBindingConstants.THING_TYPE_CEILING, device.getDeviceId());
             case color:
                 return new ThingUID(YeelightBindingConstants.THING_TYPE_WONDER, device.getDeviceId());
             case mono:
@@ -113,6 +115,8 @@ public class YeelightDiscoveryService extends AbstractDiscoveryService implement
                 return YeelightBindingConstants.THING_TYPE_CEILING1;
             case ceiling3:
                 return YeelightBindingConstants.THING_TYPE_CEILING3;
+            case ceiling4:
+                return YeelightBindingConstants.THING_TYPE_CEILING4;
             case color:
                 return YeelightBindingConstants.THING_TYPE_WONDER;
             case mono:

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/handler/YeelightHandlerBase.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/handler/YeelightHandlerBase.java
@@ -84,6 +84,8 @@ public abstract class YeelightHandlerBase extends BaseThingHandler
             return DeviceType.ceiling;
         } else if (typeUID.equals(THING_TYPE_CEILING3)) {
             return DeviceType.ceiling3;
+        } else if (typeUID.equals(THING_TYPE_CEILING4)) {
+            return DeviceType.ceiling4;
         } else if (typeUID.equals(THING_TYPE_WONDER)) {
             return DeviceType.color;
         } else if (typeUID.equals(THING_TYPE_DOLPHIN)) {

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/device/DeviceFactory.java
@@ -38,6 +38,8 @@ public class DeviceFactory {
                 return new CeilingDevice(id);
             case ceiling3:
                 return new CeilingDevice(id);
+            case ceiling4:
+                return new CeilingDevice(id);
             case color:
                 return new WonderDevice(id);
             case mono:
@@ -64,6 +66,9 @@ public class DeviceFactory {
                 device = new CeilingDevice(bulbInfo.get("id"));
                 break;
             case ceiling3:
+                device = new CeilingDevice(bulbInfo.get("id"));
+                break;
+            case ceiling4:
                 device = new CeilingDevice(bulbInfo.get("id"));
                 break;
             case color:

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/enums/DeviceType.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/enums/DeviceType.java
@@ -24,6 +24,7 @@ public enum DeviceType {
     ceiling,
     ceiling1,
     ceiling3,
+    ceiling4,
     stripe,
     desklamp
 }

--- a/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
+++ b/bundles/org.openhab.binding.yeelight/src/main/java/org/openhab/binding/yeelight/internal/lib/services/DeviceManager.java
@@ -272,6 +272,7 @@ public class DeviceManager {
             case ceiling:
             case ceiling1:
             case ceiling3:
+            case ceiling4:
                 return "Yeelight LED Ceiling";
             case color:
                 return "Yeelight Color LED Bulb";


### PR DESCRIPTION
Added support for YEELIGHT JIAOYUE 650 lamps - they show up in the network as 'ceiling4', so I added missing mappings for them - enums etc.