### PR TITLE
[sunspec] Modbus: SunSpec bundle basic version initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -174,6 +174,7 @@
 /bundles/org.openhab.binding.sonyprojector/ @lolodomo
 /bundles/org.openhab.binding.spotify/ @Hilbrand
 /bundles/org.openhab.binding.squeezebox/ @digitaldan @mhilbush
+/bundles/org.openhab.binding.modbus.sunspec/ @mrbig
 /bundles/org.openhab.binding.synopanalyzer/ @clinique
 /bundles/org.openhab.binding.systeminfo/ @svilenvul
 /bundles/org.openhab.binding.tado/ @dfrommi

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -866,6 +866,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.modbus.sunspec</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.synopanalyzer</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.modbus.sunspec/.classpath
+++ b/bundles/org.openhab.binding.modbus.sunspec/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.modbus.sunspec/.project
+++ b/bundles/org.openhab.binding.modbus.sunspec/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.modbus.sunspec</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.modbus.sunspec/NOTICE
+++ b/bundles/org.openhab.binding.modbus.sunspec/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -90,13 +90,13 @@ Different things support a subset of the following groups.
 
 This group contains general operational information about the device.
 
-| Channel ID           | Item Type | Description                                                         |
-|----------------------|-----------|---------------------------------------------------------------------|
-| cabinet-temperature  | Number    | Temperature of the cabinet if supported in Celsius                  |
-| heatsink-temperature | Number    | Device heat sink temperature in Celsius                             |
-| transformer-temperature | Number    | Temperature of the transformer in Celsius                        |
-| other-temperature    | Number    | Any other temperature reading not covered by the above items if available. Celsius |
-| status               | Number    | Device status: 1=Off, 2=Sleeping/night mode, 4=On - producing power |
+| Channel ID              | Item Type             | Description                                                                        |
+|-------------------------|-----------------------|------------------------------------------------------------------------------------|
+| cabinet-temperature     | Number:Temperature    | Temperature of the cabinet if supported in Celsius                                 |
+| heatsink-temperature    | Number:Temperature    | Device heat sink temperature in Celsius                                            |
+| transformer-temperature | Number:Temperature    | Temperature of the transformer in Celsius                                          |
+| other-temperature       | Number:Temperature    | Any other temperature reading not covered by the above items if available. Celsius |
+| status                  | String                | Device status: OFF=Off, SLEEP=Sleeping/night mode, ON=On - producing power         |
 
 Supported by: all inverter things
 
@@ -107,15 +107,15 @@ Supported by: all inverter things
 This group contains summarized values for the AC side of the inverter.
 Even if the inverter supports multiple phases this group will appear only once.
 
-| Channel ID           | Item Type | Description                                                         |
-|----------------------|-----------|---------------------------------------------------------------------|
-| ac-total-current     | Number    | Total AC current over all phases in Amperes                         |
-| ac-power             | Number    | Actual AC power over all phases in Watts                            |
-| ac-frequency         | Number    | Actual grid frequency                                               |
-| ac-apparent-power    | Number    | Actual AC apparent power                                            |
-| ac-reactive-power    | Number    | Actual AC reactive power                                            |
-| ac-power-factor      | Number    | Actual AC power factor (%)                                          |
-| ac-lifetime-energy   | Number    | Ac lifetime energy production for this device in WattHours          |
+| Channel ID           | Item Type              | Description                                                         |
+|----------------------|------------------------|---------------------------------------------------------------------|
+| ac-total-current     | Number:ElectricCurrent | Total AC current over all phases in Amperes                         |
+| ac-power             | Number:Power           | Actual AC power over all phases in Watts                            |
+| ac-frequency         | Number:Frequency       | Actual grid frequency                                               |
+| ac-apparent-power    | Number:Power           | Actual AC apparent power                                            |
+| ac-reactive-power    | Number:Power           | Actual AC reactive power                                            |
+| ac-power-factor      | Number:Dimensionless   | Actual AC power factor (%)                                          |
+| ac-lifetime-energy   | Number:Energy          | AC lifetime energy production for this device in WattHours          |
 
 Supported by: all inverter things
 
@@ -124,24 +124,24 @@ Supported by: all inverter things
 
 This group contains summarized values for the power meter over all phases.
 
-| Channel ID                           | Item Type | Description                                                         |
-|--------------------------------------|-----------|---------------------------------------------------------------------|
-| ac-total-current                     | Number    | Total AC current over all phases in Amperes                         |
-| ac-average-voltage-to-n              | Number    | Average Line to Neutral AC Voltage over all phases                  |
-| ac-average-voltage-to-next           | Number    | Average Line to Line AC Voltage  over all phases                    |
-| ac-frequency                         | Number    | Actual grid frequency                                               |
-| ac-total-real-power                  | Number    | Total Real Power over all phases(W)                                 |
-| ac-total-apparent-power              | Number    | Total Apparent Power over all phases (W)                            |
-| ac-total-reactive-power              | Number    | Total Reactive Power over all phases (W)                            |
-| ac-average-power-factor              | Number    | Average AC Power Factor over all phases (%)                         |
-| ac-total-exported-real-energy        | Number    | Total Real Energy Exported over all phases (Wh)                     |
-| ac-total-imported-real-energy        | Number    | Total Real Energy Imported  over all phases (Wh)                    |
-| ac-total-exported-apparent-energy    | Number    | Total Apparent Energy Exported over all phases (VAh)                |
-| ac-total-imported-apparent-energy    | Number    | Total Apparent Energy Imported over all phases (VAh)                |
-| ac-total-imported-reactive-energy-q1 | Number    | Total Reactive Energy Imported Quadrant 1 over all phases (VARh)    |
-| ac-total-imported-reactive-energy-q2 | Number    | Total Reactive Energy Imported Quadrant 2 over all phases (VARh)    |
-| ac-total-exported-reactive-energy-q3 | Number    | Total Reactive Energy Exported Quadrant 3 over all phases (VARh)    |
-| ac-total-exported-reactive-energy-q4 | Number    | Total Reactive Energy Exported Quadrant 4 over all phases (VARh)    |
+| Channel ID                           | Item Type                | Description                                                         |
+|--------------------------------------|--------------------------|---------------------------------------------------------------------|
+| ac-total-current                     | Number:ElectricCurrent   | Total AC current over all phases in Amperes                         |
+| ac-average-voltage-to-n              | Number:ElectricPotential | Average Line to Neutral AC Voltage over all phases                  |
+| ac-average-voltage-to-next           | Number:ElectricPotential | Average Line to Line AC Voltage  over all phases                    |
+| ac-frequency                         | Number:Frequency         | Actual grid frequency                                               |
+| ac-total-real-power                  | Number:Power             | Total Real Power over all phases(W)                                 |
+| ac-total-apparent-power              | Number:Power             | Total Apparent Power over all phases (W)                            |
+| ac-total-reactive-power              | Number:Power             | Total Reactive Power over all phases (W)                            |
+| ac-average-power-factor              | Number:Dimensionless     | Average AC Power Factor over all phases (%)                         |
+| ac-total-exported-real-energy        | Number:Energy            | Total Real Energy Exported over all phases (Wh)                     |
+| ac-total-imported-real-energy        | Number:Energy            | Total Real Energy Imported  over all phases (Wh)                    |
+| ac-total-exported-apparent-energy    | Number:Energy            | Total Apparent Energy Exported over all phases (VAh)                |
+| ac-total-imported-apparent-energy    | Number:Energy            | Total Apparent Energy Imported over all phases (VAh)                |
+| ac-total-imported-reactive-energy-q1 | Number:Energy            | Total Reactive Energy Imported Quadrant 1 over all phases (VARh)    |
+| ac-total-imported-reactive-energy-q2 | Number:Energy            | Total Reactive Energy Imported Quadrant 2 over all phases (VARh)    |
+| ac-total-exported-reactive-energy-q3 | Number:Energy            | Total Reactive Energy Exported Quadrant 3 over all phases (VARh)    |
+| ac-total-exported-reactive-energy-q4 | Number:Energy            | Total Reactive Energy Exported Quadrant 4 over all phases (VARh)    |
 
 Supported by: all meter things
 
@@ -159,11 +159,11 @@ acPhaseB: available for inverter-slit-phase and inverter-three-phase type invert
 
 acPhaseC: available only for inverter-three-phase type inverters.
 
-| Channel ID           | Item Type | Description                                                         |
-|----------------------|-----------|---------------------------------------------------------------------|
-| ac-phase-current     | Number    | Actual current over this phase in Watts                             |
-| ac-voltage-to-next   | Number    | Voltage of this phase relative to the next phase, or to the ground in case of single phase inverter. Note: some single phase SolarEdge inverters incorrectly use this value to report the voltage to neutral value|
-| ac-voltage-to-n      | Number    | Voltage of this phase relative to the ground                        |
+| Channel ID           | Item Type                | Description                                                         |
+|----------------------|--------------------------|---------------------------------------------------------------------|
+| ac-phase-current     | Number:ElectricCurrent   | Actual current over this phase in Watts                             |
+| ac-voltage-to-next   | Number:ElectricPotential | Voltage of this phase relative to the next phase, or to the ground in case of single phase inverter. Note: some single phase SolarEdge inverters incorrectly use this value to report the voltage to neutral value|
+| ac-voltage-to-n      | Number:ElectricPotential | Voltage of this phase relative to the ground                        |
 
 Supported by: all inverter things
 
@@ -179,23 +179,23 @@ acPhaseB: available for meter-split-phase, meter-wye-phase and meter-delta-phase
 acPhaseC: available only for meter-wye-phase and meter-delta-phase meters type inverters.
 
 
-| Channel ID                     | Item Type | Description                                                         |
-|--------------------------------|-----------|---------------------------------------------------------------------|
-| ac-phase-current               | Number    | Actual current over this line in Watts                              |
-| ac-voltage-to-n                | Number    | Voltage of this line relative to the neutral line                   |
-| ac-voltage-to-next             | Number    | Voltage of this line relative to the next line                      |
-| ac-real-power                  | Number    | AC Real Power value (W)                                             |
-| ac-apparent-power              | Number    | AC Apparent Power value                                             |
-| ac-reactive-power              | Number    | AC Reactive Power value                                             |
-| ac-power-factor                | Number    | AC Power Factor (%)                                                 |
-| ac-exported-real-energy        | Number    | Real Energy Exported (Wh                                            |
-| ac-imported-real-energy        | Number    | Real Energy Imported (Wh)                                           |
-| ac-exported-apparent-energy    | Number    | Apparent Energy Exported (VAh)                                      |
-| ac-imported-apparent-energy    | Number    | Apparent Energy Imported (VAh)                                      |
-| ac-imported-reactive-energy-q1 | Number    | Reactive Energy Imported Quadrant 1 (VARh)                          |
-| ac-imported-reactive-energy-q2 | Number    | Reactive Energy Imported Quadrant 2 (VARh)                          |
-| ac-exported-reactive-energy-q3 | Number    | Reactive Energy Exported Quadrant 3 (VARh)                          |
-| ac-exported-reactive-energy-q4 | Number    | Reactive Energy Exported Quadrant 4 (VARh)                          |
+| Channel ID                     | Item Type                | Description                                                         |
+|--------------------------------|--------------------------|---------------------------------------------------------------------|
+| ac-phase-current               | Number:ElectricCurrent   | Actual current over this line in Watts                              |
+| ac-voltage-to-n                | Number:ElectricPotential | Voltage of this line relative to the neutral line                   |
+| ac-voltage-to-next             | Number:ElectricPotential | Voltage of this line relative to the next line                      |
+| ac-real-power                  | Number:Power             | AC Real Power value (W)                                             |
+| ac-apparent-power              | Number:Power             | AC Apparent Power value                                             |
+| ac-reactive-power              | Number:Power             | AC Reactive Power value                                             |
+| ac-power-factor                | Number:Dimensionless     | AC Power Factor (%)                                                 |
+| ac-exported-real-energy        | Number:Energy            | Real Energy Exported (Wh                                            |
+| ac-imported-real-energy        | Number:Energy            | Real Energy Imported (Wh)                                           |
+| ac-exported-apparent-energy    | Number:Energy            | Apparent Energy Exported (VAh)                                      |
+| ac-imported-apparent-energy    | Number:Energy            | Apparent Energy Imported (VAh)                                      |
+| ac-imported-reactive-energy-q1 | Number:Energy            | Reactive Energy Imported Quadrant 1 (VARh)                          |
+| ac-imported-reactive-energy-q2 | Number:Energy            | Reactive Energy Imported Quadrant 2 (VARh)                          |
+| ac-exported-reactive-energy-q3 | Number:Energy            | Reactive Energy Exported Quadrant 3 (VARh)                          |
+| ac-exported-reactive-energy-q4 | Number:Energy            | Reactive Energy Exported Quadrant 4 (VARh)                          |
 
 
 Supported by: all meter things
@@ -205,11 +205,11 @@ Supported by: all meter things
 This group contains summarized data for the DC side of the inverter.
 DC information is summarized even if the inverter has multiple strings.
 
-| Channel ID           | Item Type | Description                                                         |
-|----------------------|-----------|---------------------------------------------------------------------|
-| dc-current           | Number    | Actual DC current in Amperes                                        |
-| dc-voltage           | Number    | Actual DC voltage                                                   |
-| dc-power             | Number    | Actual DC power produced                                            |
+| Channel ID           | Item Type                | Description                                                         |
+|----------------------|--------------------------|---------------------------------------------------------------------|
+| dc-current           | Number:ElectricCurrent   | Actual DC current in Amperes                                        |
+| dc-voltage           | Number:ElectricPotential | Actual DC voltage                                                   |
+| dc-power             | Number:Power             | Actual DC power produced                                            |
 
 Supported by: all inverter things
 

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -2,13 +2,15 @@
 
 This bundle is an extension for the Modbus binding to support the SunSpec protocol.
 
-SunSpec is a format for inverters and smart meters to communicate over the Modbus protocol. It defines how common parameters like AC/DC voltage and current, lifetime produced energy, device temperature etc can be read from the device.
+SunSpec is a format for inverters and smart meters to communicate over the Modbus protocol.
+It defines how common parameters like AC/DC voltage and current, lifetime produced energy, device temperature etc can be read from the device.
 
-SunSpec is supported by several manufacturers like ABB, Fronius, LG, SMA, SolarEdge, Schneider Electric. For a list of certified products see this page: https://sunspec.org/sunspec-certified-products/
+SunSpec is supported by several manufacturers like ABB, Fronius, LG, SMA, SolarEdge, Schneider Electric.
+For a list of certified products see this page: https://sunspec.org/sunspec-certified-products/
 
 # IMPORTANT: under merge
 
-** IMPORTANT: this version of this bundle is being merged into OpenHAB. This will be done in small steps - this means that not everything in this readme is supported at the moment **
+** IMPORTANT: this version of this bundle is being merged into openHAB. This will be done in small steps - this means that not everything in this readme is supported at the moment **
 
 Currently supported features are:
 
@@ -19,7 +21,8 @@ Currently supported features are:
 
 ## Supported Things
 
-This bundle adds the following thing types to the Modbus binding. Note, that the things will show up under the Modbus binding.
+This bundle adds the following thing types to the Modbus binding.
+Note, that the things will show up under the Modbus binding.
 
 | Thing                 | Description                                                           |
 |-----------------------|-----------------------------------------------------------------------|
@@ -35,13 +38,18 @@ This bundle adds the following thing types to the Modbus binding. Note, that the
 
 ## Binding Configuration
 
-This bundle requires the OpenHAB 2 compatible Modbus binding to be installed. Please refer to the Modbus binding configuration. This addon does not require any additional configuration.
+This bundle requires the openHAB 2 compatible Modbus binding to be installed.
+Please refer to the Modbus binding configuration.
+This addon does not require any additional configuration.
 
 ## Thing Configuration
 
-You need first to set up either a TCP or a Serial Modbus bridge according to the Modbus documentation. Things in this bundle will use the selected bridge to connect to the device.
+You need first to set up either a TCP or a Serial Modbus bridge according to the Modbus documentation.
+Things in this bundle will use the selected bridge to connect to the device.
 
-The preferred way to add new things is by using the discovery feature. This way the bundle will automatically detect if the Modbus bridge supports the SunSpec protocol and if so what type of models are available. It will automatically detect the register addresses for each model.
+The preferred way to add new things is by using the discovery feature.
+This way the bundle will automatically detect if the Modbus bridge supports the SunSpec protocol and if so what type of models are available.
+It will automatically detect the register addresses for each model.
 
 ### Auto discovering things
 
@@ -59,7 +67,9 @@ Bridge modbus:tcp:bridge [ host="10.0.0.2", port=502, id=1, enableDiscovery=true
 
 ### Adding things manually
 
-If you decide to add a thing manually then first you have to find out the start address of the model block and the length of it. While the length is usually fixed the address isn't. Please refer to your device's vendor documentation how model blocks are laid for your equipment.
+If you decide to add a thing manually then first you have to find out the start address of the model block and the length of it.
+While the length is usually fixed the address isn't.
+Please refer to your device's vendor documentation how model blocks are laid for your equipment.
 
 The following parameters are valid for all thing types:
 
@@ -73,13 +83,14 @@ The following parameters are valid for all thing types:
 
 ## Channels
 
-Channels are grouped into channel groups. Different things support a subset of the following groups.
+Channels are grouped into channel groups.
+Different things support a subset of the following groups.
 
 ### Device information group (deviceInformation)
 
 This group contains general operational information about the device.
 
-| Channel Type ID      | Item Type | Description                                                         |
+| Channel ID           | Item Type | Description                                                         |
 |----------------------|-----------|---------------------------------------------------------------------|
 | cabinet-temperature  | Number    | Temperature of the cabinet if supported in Celsius                  |
 | heatsink-temperature | Number    | Device heat sink temperature in Celsius                             |
@@ -93,9 +104,10 @@ Supported by: all inverter things
 
 #### inverters
 
-This group contains summarized values for the AC side of the inverter. Even if the inverter supports multiple phases this group will appear only once.
+This group contains summarized values for the AC side of the inverter.
+Even if the inverter supports multiple phases this group will appear only once.
 
-| Channel Type ID      | Item Type | Description                                                         |
+| Channel ID           | Item Type | Description                                                         |
 |----------------------|-----------|---------------------------------------------------------------------|
 | ac-total-current     | Number    | Total AC current over all phases in Amperes                         |
 | ac-power             | Number    | Actual AC power over all phases in Watts                            |
@@ -112,7 +124,7 @@ Supported by: all inverter things
 
 This group contains summarized values for the power meter over all phases.
 
-| Channel Type ID                      | Item Type | Description                                                         |
+| Channel ID                           | Item Type | Description                                                         |
 |--------------------------------------|-----------|---------------------------------------------------------------------|
 | ac-total-current                     | Number    | Total AC current over all phases in Amperes                         |
 | ac-average-voltage-to-n              | Number    | Average Line to Neutral AC Voltage over all phases                  |
@@ -138,7 +150,8 @@ Supported by: all meter things
 
 #### inverters
 
-This group describes values for a single phase of the inverter. There can be a maximum of three of this group named:
+This group describes values for a single phase of the inverter.
+There can be a maximum of three of this group named:
 
 acPhaseA: available for all inverter types
 
@@ -146,7 +159,7 @@ acPhaseB: available for inverter-slit-phase and inverter-three-phase type invert
 
 acPhaseC: available only for inverter-three-phase type inverters.
 
-| Channel Type ID      | Item Type | Description                                                         |
+| Channel ID           | Item Type | Description                                                         |
 |----------------------|-----------|---------------------------------------------------------------------|
 | ac-phase-current     | Number    | Actual current over this phase in Watts                             |
 | ac-voltage-to-next   | Number    | Voltage of this phase relative to the next phase, or to the ground in case of single phase inverter. Note: some single phase SolarEdge inverters incorrectly use this value to report the voltage to neutral value|
@@ -156,7 +169,8 @@ Supported by: all inverter things
 
 #### meters
 
-This group holds values for a given line of the meter. There can be a maximum of three of this group named:
+This group holds values for a given line of the meter.
+There can be a maximum of three of this group named:
 
 acPhaseA: available for all meter types
 
@@ -165,7 +179,7 @@ acPhaseB: available for meter-split-phase, meter-wye-phase and meter-delta-phase
 acPhaseC: available only for meter-wye-phase and meter-delta-phase meters type inverters.
 
 
-| Channel Type ID                | Item Type | Description                                                         |
+| Channel ID                     | Item Type | Description                                                         |
 |--------------------------------|-----------|---------------------------------------------------------------------|
 | ac-phase-current               | Number    | Actual current over this line in Watts                              |
 | ac-voltage-to-n                | Number    | Voltage of this line relative to the neutral line                   |
@@ -188,9 +202,10 @@ Supported by: all meter things
 
 ### DC general group
 
-This group contains summarized data for the DC side of the inverter. DC information is summarized even if the inverter has multiple strings.
+This group contains summarized data for the DC side of the inverter.
+DC information is summarized even if the inverter has multiple strings.
 
-| Channel Type ID      | Item Type | Description                                                         |
+| Channel ID           | Item Type | Description                                                         |
 |----------------------|-----------|---------------------------------------------------------------------|
 | dc-current           | Number    | Actual DC current in Amperes                                        |
 | dc-voltage           | Number    | Actual DC voltage                                                   |
@@ -201,15 +216,20 @@ Supported by: all inverter things
 
 ## Full Example
 
-To configure a SunSpec inverter you have to set up a Modbus bridge with the connection parameters. The Modbus binding supports both TCP and Serial connections please choose the one that's appropriate for you. Please enable discovery on the bridge.
+To configure a SunSpec inverter you have to set up a Modbus bridge with the connection parameters.
+The Modbus binding supports both TCP and Serial connections please choose the one that's appropriate for you.
+Please enable discovery on the bridge.
 
-Textual configuration is optional, you can set up everything using PaperUI. After adding the Modbus bridge and enabling discovery a scan will be initiated and if the device supports SunSpec then the known models will be added to the inbox with correct address configuration.
+Textual configuration is optional, you can set up everything using PaperUI.
+After adding the Modbus bridge and enabling discovery a scan will be initiated and if the device supports SunSpec then the known models will be added to the inbox with correct address configuration.
 
 ### Thing Configuration
 
-The preferred way to add a SunSpec compatible Thing is through auto-discovery. Whoever if the auto-discovery would not work, advanced users could set up the thing through the config file.
+The preferred way to add a SunSpec compatible Thing is through auto-discovery.
+Whoever if the auto-discovery would not work, advanced users could set up the thing through the config file.
 
-Please note that the nested bridge configuration does not work at the moment. Use the following flat format to set up the bridge and the inverter thing:
+Please note that the nested bridge configuration does not work at the moment.
+Use the following flat format to set up the bridge and the inverter thing:
 
 ```
 Bridge modbus:tcp:bridge [ host="hostname|ip", port=502, id=1, enableDiscovery=true ]
@@ -244,25 +264,34 @@ Number Inverter_AC1_A "AC Current Phase 1 [%0.2f A]" {channel="modbus:inverter-s
 
 ### SolarEdge
 
-Newer models of SolarEdge inverters can be monitored over TCP, but you need to enable support in the inverter first. Refer to the "Modbus over TCP Configuration" chapter in this documentation: https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf
+Newer models of SolarEdge inverters can be monitored over TCP, but you need to enable support in the inverter first.
+Refer to the "Modbus over TCP Configuration" chapter in this documentation: https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf
 
 Modbus connection is limited to a single client at a time, so make sure no other clients are using the port.
 
 ## For Developers
 
-SunSpec is a big specification with many different type of devices. If you own or have access to an appliance that is not supported at the moment then your help is welcome.
+SunSpec is a big specification with many different type of devices.
+If you own or have access to an appliance that is not supported at the moment then your help is welcome.
 
 If you want to extend the bundle yourself, you have to do the followings:
 
- - Define your thing type, channel types and channel groups according to openHAB development practices. You can look at the meter and inverter types to get ideas how you can avoid repeating the same configuration over and over.
+ - Define your thing type, channel types and channel groups according to openHAB development practices.
+ You can look at the meter and inverter types to get ideas how you can avoid repeating the same configuration over and over.
  
- - Extend the `AbstractSunSpecHandler` and implement the handlePolledData method. This method will be regularly called with the register data read from the appliance. The method should parse the data and update the channels with them.
+ - Extend the `AbstractSunSpecHandler` and implement the handlePolledData method.
+ This method will be regularly called with the register data read from the appliance.
+ The method should parse the data and update the channels with them.
 
- - The preferred way to parse the raw data is to write a parser for you model block type. Your class should implement the `SunspecParser` class and it is preferred to extend the `AbstractBaseParser` class. This base class has methods to accurately extract fields from the register array.
+ - The preferred way to parse the raw data is to write a parser for you model block type.
+ Your class should implement the `SunspecParser` class and it is preferred to extend the `AbstractBaseParser` class.
+ This base class has methods to accurately extract fields from the register array.
 
- - The parser should only retrieve the data from the register array and return them in a block descriptor class. Scaling and other higher level transformation should be done by the handler itself.
+ - The parser should only retrieve the data from the register array and return them in a block descriptor class.
+ Scaling and other higher level transformation should be done by the handler itself.
  
- - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`. This is enough for our discovery process to include your thing type in the results.
+ - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`.
+ This is enough for our discovery process to include your thing type in the results.
 
 If you have questions or need help don't hesitate to contact us.
  

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -207,6 +207,8 @@ Textual configuration is optional, you can set up everything using PaperUI. Afte
 
 ### Thing Configuration
 
+The preferred way to add a SunSpec compatible Thing is through auto-discovery. Whoever if the auto-discovery would not work, advanced users could set up the thing through the config file.
+
 Please note that the nested bridge configuration does not work at the moment. Use the following flat format to set up the bridge and the inverter thing:
 
 ```
@@ -258,9 +260,9 @@ If you want to extend the bundle yourself, you have to do the followings:
 
  - The preferred way to parse the raw data is to write a parser for you model block type. Your class should implement the `SunspecParser` class and it is preferred to extend the `AbstractBaseParser` class. This base class has methods to accurately extract fields from the register array.
 
- - The parser should only retrieve the data from the register array and return them in a block descriptor class that extends the `AbstractSunSpecMessageBlock`. Scaling and other higher level transformation should be done by the handler itself.
+ - The parser should only retrieve the data from the register array and return them in a block descriptor class. Scaling and other higher level transformation should be done by the handler itself.
  
  - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`. This is enough for our discovery process to include your thing type in the results.
 
- If you have questions or need help don't hesitate to contact us.
+If you have questions or need help don't hesitate to contact us.
  

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -293,5 +293,5 @@ If you want to extend the bundle yourself, you have to do the followings:
  - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`. This is enough for our discovery process to include your thing type in the results.
 
 
-If you have questions or need help don't hesitate to contact us.
+If you have questions or need help don't hesitate to contact us over the OpenHAB community forums and github pages.
  

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -27,7 +27,7 @@ Note, that the things will show up under the Modbus binding.
 | Thing                 | Description                                                           |
 |-----------------------|-----------------------------------------------------------------------|
 | inverter-single-phase | For simple, single phase inverters                                    |
-| inverter-split-phase  | Split phase inverters (Japanese grind and 240V grid in North America) |
+| inverter-split-phase  | Split phase inverters (Japanese grid and 240V grid in North America)  |
 | inverter-three-phase  | Three phase inverters                                                 |
 | meter-single-phase    | Single phase meters (AN or AB)                                        |
 | meter-split-phase     | Split single phase meters (ABN)                                       |

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -1,0 +1,266 @@
+# Modbus: SunSpec Bundle
+
+This bundle is an extension for the Modbus binding to support the SunSpec protocol.
+
+SunSpec is a format for inverters and smart meters to communicate over the Modbus protocol. It defines how common parameters like AC/DC voltage and current, lifetime produced energy, device temperature etc can be read from the device.
+
+SunSpec is supported by several manufacturers like ABB, Fronius, LG, SMA, SolarEdge, Schneider Electric. For a list of certified products see this page: https://sunspec.org/sunspec-certified-products/
+
+# IMPORTANT: under merge
+
+** IMPORTANT: this version of this bundle is being merged into OpenHAB. This will be done in small steps - this means that not everything in this readme is supported at the moment **
+
+Currently supported features are:
+
+* basic values of single phase inverters without auto-discovery
+
+ For the complete version of this bundle please contact me!
+
+
+## Supported Things
+
+This bundle adds the following thing types to the Modbus binding. Note, that the things will show up under the Modbus binding.
+
+| Thing                 | Description                                                           |
+|-----------------------|-----------------------------------------------------------------------|
+| inverter-single-phase | For simple, single phase inverters                                    |
+| inverter-split-phase  | Split phase inverters (Japanese grind and 240V grid in North America) |
+| inverter-three-phase  | Three phase inverters                                                 |
+| meter-single-phase    | Single phase meters (AN or AB)                                        |
+| meter-split-phase     | Split single phase meters (ABN)                                       |
+| meter-wye-phase       | Wye connected three phase meters (ABCN)                               |
+| meter-delta-phase     | Delta connected three phase meters (ABC)                              |
+
+
+
+## Binding Configuration
+
+This bundle requires the OpenHAB 2 compatible Modbus binding to be installed. Please refer to the Modbus binding configuration. This addon does not require any additional configuration.
+
+## Thing Configuration
+
+You need first to set up either a TCP or a Serial Modbus bridge according to the Modbus documentation. Things in this bundle will use the selected bridge to connect to the device.
+
+The preferred way to add new things is by using the discovery feature. This way the bundle will automatically detect if the Modbus bridge supports the SunSpec protocol and if so what type of models are available. It will automatically detect the register addresses for each model.
+
+### Auto discovering things
+
+This bingind fully supports modbus auto discovery, that means all supported profiles should appear in the inbox once you connect your device.
+
+Auto discovery is turned off by default in the modbus binding so you have to enable it manually.
+
+You can add `enableDiscovery=true` attribute to your bridge config, or you can enable it in the paper ui under the modbus tcp|serial slave thing.
+
+A typical bridge configuration would looke like this:
+
+```
+Bridge modbus:tcp:bridge [ host="10.0.0.2", port=502, id=1, enableDiscovery=true ]
+```
+
+### Adding things manually
+
+If you decide to add a thing manually then first you have to find out the start address of the model block and the length of it. While the length is usually fixed the address isn't. Please refer to your device's vendor documentation how model blocks are laid for your equipment.
+
+The following parameters are valid for all thing types:
+
+| Parameter | Type    | Required | Default if ommitted | Description                             |
+|-----------|---------|----------|---------------------|-----------------------------------------|
+| address   | integer | yes      | N/A                 | Start address of the model block.       |
+| length    | integer | yes      | N/A                 | Length of the model block. Setting this too short could cause problems during parsing |
+| refresh   | integer | no       | 5                   | Poll inteval in seconds. Increase this if you encounter connection errors |
+| maxTries  | integer | no       | 3                   | Number of retries when before giving up reading from this thing. |
+
+
+## Channels
+
+Channels are grouped into channel groups. Different things support a subset of the following groups.
+
+### Device information group (deviceInformation)
+
+This group contains general operational information about the device.
+
+| Channel Type ID      | Item Type | Description                                                         |
+|----------------------|-----------|---------------------------------------------------------------------|
+| cabinet-temperature  | Number    | Temperature of the cabinet if supported in Celsius                  |
+| heatsink-temperature | Number    | Device heat sink temperature in Celsius                             |
+| transformer-temperature | Number    | Temperature of the transformer in Celsius                        |
+| other-temperature    | Number    | Any other temperature reading not covered by the above items if available. Celsius |
+| status               | Number    | Device status: 1=Off, 2=Sleeping/night mode, 4=On - producing power |
+
+Supported by: all inverter things
+
+### AC summary group (acGeneral)
+
+#### inverters
+
+This group contains summarized values for the AC side of the inverter. Even if the inverter supports multiple phases this group will appear only once.
+
+| Channel Type ID      | Item Type | Description                                                         |
+|----------------------|-----------|---------------------------------------------------------------------|
+| ac-total-current     | Number    | Total AC current over all phases in Amperes                         |
+| ac-power             | Number    | Actual AC power over all phases in Watts                            |
+| ac-frequency         | Number    | Actual grid frequency                                               |
+| ac-apparent-power    | Number    | Actual AC apparent power                                            |
+| ac-reactive-power    | Number    | Actual AC reactive power                                            |
+| ac-power-factor      | Number    | Actual AC power factor (%)                                          |
+| ac-lifetime-energy   | Number    | Ac lifetime energy production for this device in WattHours          |
+
+Supported by: all inverter things
+
+
+#### meters
+
+This group contains summarized values for the power meter over all phases.
+
+| Channel Type ID                      | Item Type | Description                                                         |
+|--------------------------------------|-----------|---------------------------------------------------------------------|
+| ac-total-current                     | Number    | Total AC current over all phases in Amperes                         |
+| ac-average-voltage-to-n              | Number    | Average Line to Neutral AC Voltage over all phases                  |
+| ac-average-voltage-to-next           | Number    | Average Line to Line AC Voltage  over all phases                    |
+| ac-frequency                         | Number    | Actual grid frequency                                               |
+| ac-total-real-power                  | Number    | Total Real Power over all phases(W)                                 |
+| ac-total-apparent-power              | Number    | Total Apparent Power over all phases (W)                            |
+| ac-total-reactive-power              | Number    | Total Reactive Power over all phases (W)                            |
+| ac-average-power-factor              | Number    | Average AC Power Factor over all phases (%)                         |
+| ac-total-exported-real-energy        | Number    | Total Real Energy Exported over all phases (Wh)                     |
+| ac-total-imported-real-energy        | Number    | Total Real Energy Imported  over all phases (Wh)                    |
+| ac-total-exported-apparent-energy    | Number    | Total Apparent Energy Exported over all phases (VAh)                |
+| ac-total-imported-apparent-energy    | Number    | Total Apparent Energy Imported over all phases (VAh)                |
+| ac-total-imported-reactive-energy-q1 | Number    | Total Reactive Energy Imported Quadrant 1 over all phases (VARh)    |
+| ac-total-imported-reactive-energy-q2 | Number    | Total Reactive Energy Imported Quadrant 2 over all phases (VARh)    |
+| ac-total-exported-reactive-energy-q3 | Number    | Total Reactive Energy Exported Quadrant 3 over all phases (VARh)    |
+| ac-total-exported-reactive-energy-q4 | Number    | Total Reactive Energy Exported Quadrant 4 over all phases (VARh)    |
+
+Supported by: all meter things
+
+
+### AC phase specific group
+
+#### inverters
+
+This group describes values for a single phase of the inverter. There can be a maximum of three of this group named:
+
+acPhaseA: available for all inverter types
+
+acPhaseB: available for inverter-slit-phase and inverter-three-phase type inverters
+
+acPhaseC: available only for inverter-three-phase type inverters.
+
+| Channel Type ID      | Item Type | Description                                                         |
+|----------------------|-----------|---------------------------------------------------------------------|
+| ac-phase-current     | Number    | Actual current over this phase in Watts                             |
+| ac-voltage-to-next   | Number    | Voltage of this phase relative to the next phase, or to the ground in case of single phase inverter. Note: some single phase SolarEdge inverters incorrectly use this value to report the voltage to neutral value|
+| ac-voltage-to-n      | Number    | Voltage of this phase relative to the ground                        |
+
+Supported by: all inverter things
+
+#### meters
+
+This group holds values for a given line of the meter. There can be a maximum of three of this group named:
+
+acPhaseA: available for all meter types
+
+acPhaseB: available for meter-split-phase, meter-wye-phase and meter-delta-phase meters
+
+acPhaseC: available only for meter-wye-phase and meter-delta-phase meters type inverters.
+
+
+| Channel Type ID                | Item Type | Description                                                         |
+|--------------------------------|-----------|---------------------------------------------------------------------|
+| ac-phase-current               | Number    | Actual current over this line in Watts                              |
+| ac-voltage-to-n                | Number    | Voltage of this line relative to the neutral line                   |
+| ac-voltage-to-next             | Number    | Voltage of this line relative to the next line                      |
+| ac-real-power                  | Number    | AC Real Power value (W)                                             |
+| ac-apparent-power              | Number    | AC Apparent Power value                                             |
+| ac-reactive-power              | Number    | AC Reactive Power value                                             |
+| ac-power-factor                | Number    | AC Power Factor (%)                                                 |
+| ac-exported-real-energy        | Number    | Real Energy Exported (Wh                                            |
+| ac-imported-real-energy        | Number    | Real Energy Imported (Wh)                                           |
+| ac-exported-apparent-energy    | Number    | Apparent Energy Exported (VAh)                                      |
+| ac-imported-apparent-energy    | Number    | Apparent Energy Imported (VAh)                                      |
+| ac-imported-reactive-energy-q1 | Number    | Reactive Energy Imported Quadrant 1 (VARh)                          |
+| ac-imported-reactive-energy-q2 | Number    | Reactive Energy Imported Quadrant 2 (VARh)                          |
+| ac-exported-reactive-energy-q3 | Number    | Reactive Energy Exported Quadrant 3 (VARh)                          |
+| ac-exported-reactive-energy-q4 | Number    | Reactive Energy Exported Quadrant 4 (VARh)                          |
+
+
+Supported by: all meter things
+
+### DC general group
+
+This group contains summarized data for the DC side of the inverter. DC information is summarized even if the inverter has multiple strings.
+
+| Channel Type ID      | Item Type | Description                                                         |
+|----------------------|-----------|---------------------------------------------------------------------|
+| dc-current           | Number    | Actual DC current in Amperes                                        |
+| dc-voltage           | Number    | Actual DC voltage                                                   |
+| dc-power             | Number    | Actual DC power produced                                            |
+
+Supported by: all inverter things
+
+
+## Full Example
+
+To configure a SunSpec inverter you have to set up a Modbus bridge with the connection parameters. The Modbus binding supports both TCP and Serial connections please choose the one that's appropriate for you. Please enable discovery on the bridge.
+
+Textual configuration is optional, you can set up everything using PaperUI. After adding the Modbus bridge and enabling discovery a scan will be initiated and if the device supports SunSpec then the known models will be added to the inbox with correct address configuration.
+
+### Thing Configuration
+
+Please note that the nested bridge configuration does not work at the moment. Use the following flat format to set up the bridge and the inverter thing:
+
+```
+Bridge modbus:tcp:bridge [ host="hostname|ip", port=502, id=1, enableDiscovery=true ]
+Thing modbus:inverter-single-phase:bridge:se4000h "SE4000h" (modbus:tcp:modbusbridge) [ address=40069, length=52, refresh=15 ]
+```
+
+Note: make sure that refresh, port and id values are numerical, without quotes.
+
+### Item Configuration
+
+```
+Number Inverter_Temperature "Temperature [%.1f C]"  {channel="modbus:inverter-single-phase:bridge:se4000h:deviceInformation#heatsink-temperature"}
+
+Number Inverter_AC_Power "AC Power [%d W]" {channel="modbus:inverter-single-phase:bridge:se4000h:acGeneral#ac-power"}
+
+Number Inverter_AC1_A "AC Current Phase 1 [%0.2f A]" {channel="modbus:inverter-single-phase:bridge:se4000h:acPhaseA#ac-phase-current"}
+
+```
+
+### Sitemap Configuration
+
+```
+                        Text item=Inverter_Temperature
+                        Text item=Inverter_AC_Current
+                        Text item=Inverter_AC_Power
+                        Chart item=Inverter_Temperature period=D refresh=600000
+                        Chart item=Inverter_AC_Power period=D refresh=30000
+
+```
+
+## Vendor specific information
+
+### SolarEdge
+
+Newer models of SolarEdge inverters can be monitored over TCP, but you need to enable support in the inverter first. Refer to the "Modbus over TCP Configuration" chapter in this documentation: https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf
+
+Modbus connection is limited to a single client at a time, so make sure no other clients are using the port.
+
+## For Developers
+
+SunSpec is a big specification with many different type of devices. If you own or have access to an appliance that is not supported at the moment then your help is welcome.
+
+If you want to extend the bundle yourself, you have to do the followings:
+
+ - Define your thing type, channel types and channel groups according to openHAB development practices. You can look at the meter and inverter types to get ideas how you can avoid repeating the same configuration over and over.
+ 
+ - Extend the `AbstractSunSpecHandler` and implement the handlePolledData method. This method will be regularly called with the register data read from the appliance. The method should parse the data and update the channels with them.
+
+ - The preferred way to parse the raw data is to write a parser for you model block type. Your class should implement the `SunspecParser` class and it is preferred to extend the `AbstractBaseParser` class. This base class has methods to accurately extract fields from the register array.
+
+ - The parser should only retrieve the data from the register array and return them in a block descriptor class that extends the `AbstractSunSpecMessageBlock`. Scaling and other higher level transformation should be done by the handler itself.
+ 
+ - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`. This is enough for our discovery process to include your thing type in the results.
+
+ If you have questions or need help don't hesitate to contact us.
+ 

--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -290,8 +290,8 @@ If you want to extend the bundle yourself, you have to do the followings:
  - The parser should only retrieve the data from the register array and return them in a block descriptor class.
  Scaling and other higher level transformation should be done by the handler itself.
  
- - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`.
- This is enough for our discovery process to include your thing type in the results.
+ - To include your block type in auto discovery you have to add its id to the `SUPPORTED_THING_TYPES_UIDS` map in `SunSpecConstants`. This is enough for our discovery process to include your thing type in the results.
+
 
 If you have questions or need help don't hesitate to contact us.
  

--- a/bundles/org.openhab.binding.modbus.sunspec/pom.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.openhab.addons.bundles</groupId>
+		<artifactId>org.openhab.addons.reactor.bundles</artifactId>
+		<version>2.5.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.openhab.binding.modbus.sunspec</artifactId>
+
+	<name>openHAB Add-ons :: Bundles :: SunSpec Bundle</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.openhab.addons.bundles</groupId>
+			<artifactId>org.openhab.binding.modbus</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openhab.addons.bundles</groupId>
+			<artifactId>org.openhab.io.transport.modbus</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/bundles/org.openhab.binding.modbus.sunspec/pom.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab.addons.bundles</groupId>
         <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.openhab.binding.modbus.sunspec</artifactId>

--- a/bundles/org.openhab.binding.modbus.sunspec/pom.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab.addons.bundles</groupId>
         <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-        <version>2.5.3-SNAPSHOT</version>
+        <version>2.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.openhab.binding.modbus.sunspec</artifactId>

--- a/bundles/org.openhab.binding.modbus.sunspec/pom.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.openhab.addons.bundles</groupId>
-		<artifactId>org.openhab.addons.reactor.bundles</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>org.openhab.addons.bundles</groupId>
+        <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+        <version>2.5.2-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>org.openhab.binding.modbus.sunspec</artifactId>
+    <artifactId>org.openhab.binding.modbus.sunspec</artifactId>
 
-	<name>openHAB Add-ons :: Bundles :: SunSpec Bundle</name>
+    <name>openHAB Add-ons :: Bundles :: SunSpec Bundle</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.openhab.addons.bundles</groupId>
-			<artifactId>org.openhab.binding.modbus</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.openhab.addons.bundles</groupId>
-			<artifactId>org.openhab.io.transport.modbus</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.openhab.addons.bundles</groupId>
+            <artifactId>org.openhab.binding.modbus</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.addons.bundles</groupId>
+            <artifactId>org.openhab.io.transport.modbus</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.modbus.sunspec-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>file:${basedirRoot}/bundles/org.openhab.binding.modbus/target/feature/feature.xml</repository>
+
+    <feature name="openhab-binding-modbus-sunspec" description="SunSpec Bundle" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-binding-modbus</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.sunspec/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/InverterStatus.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/InverterStatus.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal;
+
+/**
+ * Possible values for an inverter's status field
+ *
+ * @author Nagy Attila Gábor - Initial contribution
+ */
+public enum InverterStatus {
+
+    OFF(1),
+    SLEEP(2),
+    ON(4),
+    UNKNOWN(-1);
+
+    private final int code;
+
+    InverterStatus(int code) {
+        this.code = code;
+    }
+
+    public int code() {
+        return this.code;
+    }
+
+    public static InverterStatus getByCode(int code) {
+        switch (code) {
+            case 1:
+                return InverterStatus.OFF;
+            case 2:
+                return InverterStatus.SLEEP;
+            case 4:
+                return InverterStatus.ON;
+            default:
+                return InverterStatus.UNKNOWN;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link SunSpecConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Nagy Attila Gábor - Initial contribution
+ */
+@NonNullByDefault
+public class SunSpecConfiguration {
+
+    /**
+     * Refresh interval in seconds
+     */
+    private long refresh;
+
+    private int maxTries = 3;// backwards compatibility and tests
+
+    /**
+     * Base address of the block to parse. Only used at manual setup
+     */
+    private int address;
+
+    /**
+     * Length of the block to parse. Only used at manual setup
+     */
+    private int length;
+
+    public Integer getAddress() {
+        return address;
+    }
+
+    public void setAddress(Integer address) {
+        this.address = address;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+    /**
+     * Gets refresh period in milliseconds
+     */
+    public long getRefreshMillis() {
+        return refresh * 1000;
+    }
+
+    /**
+     * Sets refresh period in milliseconds
+     */
+    public void setRefreshMillis(long refresh) {
+        this.refresh = refresh / 1000;
+    }
+
+    public int getMaxTries() {
+        return maxTries;
+    }
+
+    public void setMaxTries(int maxTries) {
+        this.maxTries = maxTries;
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
@@ -39,19 +39,19 @@ public class SunSpecConfiguration {
      */
     private int length;
 
-    public Integer getAddress() {
+    public int getAddress() {
         return address;
     }
 
-    public void setAddress(Integer address) {
+    public void setAddress(int address) {
         this.address = address;
     }
 
-    public Integer getLength() {
+    public int getLength() {
         return length;
     }
 
-    public void setLength(Integer length) {
+    public void setLength(int length) {
         this.length = length;
     }
 
@@ -60,13 +60,6 @@ public class SunSpecConfiguration {
      */
     public long getRefreshMillis() {
         return refresh * 1000;
-    }
-
-    /**
-     * Sets refresh period in milliseconds
-     */
-    public void setRefreshMillis(long refresh) {
-        this.refresh = refresh / 1000;
     }
 
     public int getMaxTries() {

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConfiguration.java
@@ -25,48 +25,24 @@ public class SunSpecConfiguration {
     /**
      * Refresh interval in seconds
      */
-    private long refresh;
+    public long refresh = 60;
 
-    private int maxTries = 3;// backwards compatibility and tests
+    public int maxTries = 3;// backwards compatibility and tests
 
     /**
      * Base address of the block to parse. Only used at manual setup
      */
-    private int address;
+    public int address;
 
     /**
      * Length of the block to parse. Only used at manual setup
      */
-    private int length;
-
-    public int getAddress() {
-        return address;
-    }
-
-    public void setAddress(int address) {
-        this.address = address;
-    }
-
-    public int getLength() {
-        return length;
-    }
-
-    public void setLength(int length) {
-        this.length = length;
-    }
+    public int length;
 
     /**
      * Gets refresh period in milliseconds
      */
     public long getRefreshMillis() {
         return refresh * 1000;
-    }
-
-    public int getMaxTries() {
-        return maxTries;
-    }
-
-    public void setMaxTries(int maxTries) {
-        this.maxTries = maxTries;
     }
 }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.openhab.binding.modbus.ModbusBindingConstants;
+
+/**
+ * The {@link SunSpecConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Nagy Attila Gábor - Initial contribution
+ */
+@NonNullByDefault
+public class SunSpecConstants {
+
+    private static final String BINDING_ID = ModbusBindingConstants.BINDING_ID;
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_INVERTER_SINGLE_PHASE = new ThingTypeUID(BINDING_ID,
+            "inverter-single-phase");
+
+    // Block types
+    public static final int COMMON_BLOCK = 1;
+    public static final int INVERTER_SINGLE_PHASE = 101;
+
+    /**
+     * Map of the supported thing type uids, with their block type id
+     */
+    public static final Map<Integer, ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashMap<>();
+    static {
+        SUPPORTED_THING_TYPES_UIDS.put(INVERTER_SINGLE_PHASE, THING_TYPE_INVERTER_SINGLE_PHASE);
+    }
+
+    // properties
+    public static final String PROPERTY_VENDOR = "vendor";
+    public static final String PROPERTY_MODEL = "model";
+    public static final String PROPERTY_VERSION = "version";
+    public static final String PROPERTY_PHASE_COUNT = "phaseCount";
+    public static final String PROPERTY_SERIAL_NUMBER = "serialNumber";
+    public static final String PROPERTY_BLOCK_ADDRESS = "blockAddress";
+    public static final String PROPERTY_BLOCK_LENGTH = "blockLength";
+    public static final String PROPERTY_UNIQUE_ADDRESS = "uniqueAddress";
+
+    // Channel group ids
+    public static final String GROUP_DEVICE_INFO = "deviceInformation";
+    public static final String GROUP_AC_GENERAL = "acGeneral";
+
+    // List of all Channel ids in device information group
+    public static final String CHANNEL_PHASE_CONFIGURATION = "phase-configuration";
+    public static final String CHANNEL_CABINET_TEMPERATURE = "cabinet-temperature";
+    public static final String CHANNEL_HEATSINK_TEMPERATURE = "heatsink-temperature";
+    public static final String CHANNEL_TRANSFORMER_TEMPERATURE = "transformer-temperature";
+    public static final String CHANNEL_OTHER_TEMPERATURE = "other-temperature";
+    public static final String CHANNEL_STATUS = "status";
+
+    // List of channel ids in AC general group for inverter
+    public static final String CHANNEL_AC_TOTAL_CURRENT = "ac-total-current";
+    public static final String CHANNEL_AC_POWER = "ac-power";
+    public static final String CHANNEL_AC_FREQUENCY = "ac-frequency";
+    public static final String CHANNEL_AC_APPARENT_POWER = "ac-apparent-power";
+    public static final String CHANNEL_AC_REACTIVE_POWER = "ac-reactive-power";
+    public static final String CHANNEL_AC_POWER_FACTOR = "ac-power-factor";
+    public static final String CHANNEL_AC_LIFETIME_ENERGY = "ac-lifetime-energy";
+
+    // Expected SunSpec ID This is a magic constant to distinguish SunSpec compatible
+    // devices from other modbus devices
+    public static final long SUNSPEC_ID = 0x53756e53;
+    // Size of SunSpect ID in words
+    public static final int SUNSPEC_ID_SIZE = 2;
+    // Size of any block header in words
+    public static final int MODEL_HEADER_SIZE = 2;
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.modbus.sunspec.internal;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -41,10 +41,8 @@ public class SunSpecConstants {
     /**
      * Map of the supported thing type uids, with their block type id
      */
-    public static final Map<Integer, ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashMap<>();
-    static {
-        SUPPORTED_THING_TYPES_UIDS.put(INVERTER_SINGLE_PHASE, THING_TYPE_INVERTER_SINGLE_PHASE);
-    }
+    public static final Map<Integer, ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .singletonMap(INVERTER_SINGLE_PHASE, THING_TYPE_INVERTER_SINGLE_PHASE);
 
     // properties
     public static final String PROPERTY_VENDOR = "vendor";

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
@@ -64,7 +64,6 @@ public class SunSpecHandlerFactory extends BaseThingHandlerFactory {
      */
     @Activate
     public SunSpecHandlerFactory(@Reference ModbusManager manager) {
-
         this.manager = manager;
     }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal;
+
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.THING_TYPE_INVERTER_SINGLE_PHASE;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.modbus.sunspec.internal.handler.InverterHandler;
+import org.openhab.io.transport.modbus.ModbusManager;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SunSpecHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Nagy Attila Gábor - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.sunspec", service = ThingHandlerFactory.class)
+public class SunSpecHandlerFactory extends BaseThingHandlerFactory {
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(SunSpecHandlerFactory.class);
+
+    /**
+     * Reference to the modbus manager
+     */
+    private Optional<ModbusManager> manager = Optional.empty();
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();
+    static {
+        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_INVERTER_SINGLE_PHASE);
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (manager.isPresent()) {
+            if (thingTypeUID.equals(THING_TYPE_INVERTER_SINGLE_PHASE)) {
+                return new InverterHandler(thing, () -> manager.get());
+            }
+        } else {
+            logger.debug("Modbus manager not found, can't continue");
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Setter to accept the ModbusManager
+     *
+     * @param manager the modbus manager from org.openhab.io.transport.modbus package
+     */
+    @Reference(service = ModbusManager.class, cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.STATIC, unbind = "unsetManager")
+    public void setManager(ModbusManager manager) {
+        logger.debug("Setting manager: {}", manager);
+        this.manager = Optional.of(manager);
+    }
+
+    /**
+     * Remove the modbus manager
+     *
+     * @param manager the modbus manager from org.openhab.io.transport.modbus package
+     */
+    public void unsetManager(ModbusManager manager) {
+        this.manager = Optional.empty();
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
@@ -14,7 +14,7 @@ package org.openhab.binding.modbus.sunspec.internal;
 
 import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.THING_TYPE_INVERTER_SINGLE_PHASE;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -52,10 +52,8 @@ public class SunSpecHandlerFactory extends BaseThingHandlerFactory {
      */
     private ModbusManager manager;
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();
-    static {
-        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_INVERTER_SINGLE_PHASE);
-    }
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .singleton(THING_TYPE_INVERTER_SINGLE_PHASE);
 
     /**
      * This factory needs a reference to the ModbusManager wich is provided

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -25,12 +25,12 @@ public class InverterModelBlock {
     /**
      * Type of inverter (single phase, split phase, three phase)
      */
-    public int phaseConfiguration;
+    public Integer phaseConfiguration;
 
     /**
      * Length of the block in 16bit words
      */
-    public int length;
+    public Integer length;
 
     /**
      * AC Total Current value

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.dto;
+
+import java.util.Optional;
+
+/**
+ * Model for SunSpec compatible inverter data
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+public class InverterModelBlock {
+
+    /**
+     * Type of inverter (single phase, split phase, three phase)
+     */
+    public int phaseConfiguration;
+
+    /**
+     * Length of the block in 16bit words
+     */
+    public int length;
+
+    /**
+     * AC Total Current value
+     */
+    public Integer acCurrentTotal;
+
+    /**
+     * AC Current scale factor
+     */
+    public Short acCurrentSF;
+
+    /**
+     * AC Power value
+     */
+    public Short acPower;
+
+    /**
+     * AC Power scale factor
+     */
+    public Short acPowerSF;
+
+    /**
+     * AC Frequency value
+     */
+    public Integer acFrequency;
+
+    /**
+     * AC Frequency scale factor
+     */
+    public Short acFrequencySF;
+
+    /**
+     * Apparent power
+     */
+    public Optional<Short> acApparentPower;
+
+    /**
+     * Apparent power scale factor
+     */
+    public Optional<Short> acApparentPowerSF;
+
+    /**
+     * Reactive power
+     */
+    public Optional<Short> acReactivePower;
+
+    /**
+     * Reactive power scale factor
+     */
+    public Optional<Short> acReactivePowerSF;
+
+    /**
+     * Power factor
+     */
+    public Optional<Short> acPowerFactor;
+
+    /**
+     * Power factor scale factor
+     */
+    public Optional<Short> acPowerFactorSF;
+
+    /**
+     * AC Lifetime Energy production
+     */
+    public Long acEnergyLifetime;
+
+    /**
+     * AC Lifetime Energy scale factor
+     */
+    public Short acEnergyLifetimeSF;
+
+    /**
+     * Cabinet temperature
+     */
+    public Short temperatureCabinet;
+
+    /**
+     * Heat sink temperature
+     */
+    public Optional<Short> temperatureHeatsink;
+
+    /**
+     * Transformer temperature
+     */
+    public Optional<Short> temperatureTransformer;
+
+    /**
+     * Other temperature
+     */
+    public Optional<Short> temperatureOther;
+
+    /**
+     * Heat sink temperature scale factor
+     */
+    public Short temperatureSF;
+
+    /**
+     * Current operating state
+     */
+    public Integer status;
+
+    /**
+     * Vendor defined operating state or error code
+     */
+    public Optional<Integer> statusVendor;
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/ModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/ModelBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/ModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/ModelBlock.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.dto;
+
+/**
+ * Descriptor for a model block found on the device
+ * This DTO contains only the metadata required to
+ * address the block at the modbus register space
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ */
+public class ModelBlock {
+
+    /**
+     * Base address of this block in 16bit words
+     */
+    public int address;
+
+    /**
+     * Length of this block in 16bit words
+     */
+    public int length;
+
+    /**
+     * Module identifier
+     */
+    public int moduleID;
+
+    @Override
+    public String toString() {
+        return String.format("ModelBlock type=%d address=%d length=%d", moduleID, address, length);
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -98,7 +98,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     /**
      * Reference to the modbus manager
      */
-    protected ModbusManager managerRef;
+    protected final ModbusManager managerRef;
 
     /**
      * Instances of this handler should get a reference to the modbus manager
@@ -252,7 +252,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     /**
      * Get a reference to the modbus endpoint
      */
-    @SuppressWarnings("null")
     private void connectEndpoint() {
         if (endpoint.isPresent()) {
             return;
@@ -260,6 +259,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
 
         ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
         if (slaveEndpointThingHandler == null) {
+            @SuppressWarnings("null")
             String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
                     String.format("Bridge '%s' is offline", label));
@@ -283,8 +283,10 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         }
 
         if (!endpoint.isPresent()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, String.format(
-                    "Bridge '%s' not completely initialized", Optional.ofNullable(getBridge()).map(b -> b.getLabel())));
+            @SuppressWarnings("null")
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' not completely initialized", label));
             logger.debug("Bridge not initialized fully (no endpoint) -- aborting init for {}", this);
             return;
         }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -18,9 +18,12 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.measure.Unit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -421,6 +424,17 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     }
 
     /**
+     * Returns the channel UID for the specified group and channel id
+     * 
+     * @param string the channel group
+     * @param string the channel id in that group
+     * @return the globally unique channel uid
+     */
+    ChannelUID channelUID(String group, String id) {
+        return new ChannelUID(getThing().getUID(), group, id);
+    }
+
+    /**
      * Returns value multiplied by the 10 on the power of scaleFactory
      *
      * @param value the value to alter
@@ -446,5 +460,33 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             return new DecimalType(value.longValue());
         }
         return new DecimalType(BigDecimal.valueOf(value.longValue(), scaleFactor * -1));
+    }
+
+    /**
+     * Returns value multiplied by the 10 on the power of scaleFactory
+     *
+     * @param value the value to alter
+     * @param scaleFactor the scale factor to use (may be negative)
+     * @return the scaled value as a DecimalType
+     */
+    protected State getScaled(Optional<? extends Number> value, Optional<Short> scaleFactor, Unit<?> unit) {
+        if (!value.isPresent() || !scaleFactor.isPresent()) {
+            return UnDefType.UNDEF;
+        }
+        return getScaled(value.get().longValue(), scaleFactor.get(), unit);
+    }
+
+    /**
+     * Returns value multiplied by the 10 on the power of scaleFactory
+     *
+     * @param value the value to alter
+     * @param scaleFactor the scale factor to use (may be negative)
+     * @return the scaled value as a DecimalType
+     */
+    protected State getScaled(Number value, Short scaleFactor, Unit<?> unit) {
+        if (scaleFactor == 1) {
+            return new QuantityType<>(value.longValue(), unit);
+        }
+        return new QuantityType<>(BigDecimal.valueOf(value.longValue(), scaleFactor * -1), unit);
     }
 }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.PROPE
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -101,7 +100,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     /**
      * Reference to the modbus manager
      */
-    protected Supplier<ModbusManager> managerRef;
+    protected ModbusManager managerRef;
 
     /**
      * Instances of this handler should get a reference to the modbus manager
@@ -109,7 +108,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * @param thing the thing to handle
      * @param managerRef the modbus manager
      */
-    public AbstractSunSpecHandler(Thing thing, Supplier<ModbusManager> managerRef) {
+    public AbstractSunSpecHandler(Thing thing, ModbusManager managerRef) {
         super(thing);
         this.managerRef = managerRef;
     }
@@ -346,7 +345,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             }
         }));
 
-        managerRef.get().registerRegularPoll(pollTask.get(), config.get().getRefreshMillis(), 1000);
+        managerRef.registerRegularPoll(pollTask.get(), config.get().getRefreshMillis(), 1000);
     }
 
     /**
@@ -377,7 +376,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         }
 
         logger.debug("Unregistering polling from ModbusManager");
-        managerRef.get().unregisterRegularPoll(pollTask.get());
+        managerRef.unregisterRegularPoll(pollTask.get());
 
         pollTask = Optional.empty();
     }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -271,12 +271,12 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             slaveId = slaveEndpointThingHandler.getSlaveId();
 
             @Nullable
-            ModbusSlaveEndpoint _endpoint = slaveEndpointThingHandler.asSlaveEndpoint();
+            ModbusSlaveEndpoint optionalEndpoint = slaveEndpointThingHandler.asSlaveEndpoint();
 
-            if (_endpoint == null) {
+            if (optionalEndpoint == null) {
                 endpoint = Optional.empty();
             } else {
-                endpoint = Optional.of(_endpoint);
+                endpoint = Optional.of(optionalEndpoint);
             }
         } catch (EndpointNotInitializedException e) {
             // this will be handled below as endpoint remains null
@@ -288,7 +288,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             logger.debug("Bridge not initialized fully (no endpoint) -- aborting init for {}", this);
             return;
         }
-
     }
 
     /**
@@ -324,7 +323,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             @Override
             public void onRegisters(@Nullable ModbusReadRequestBlueprint request,
                     @Nullable ModbusRegisterArray registers) {
-
                 if (registers == null) {
                     logger.info("Received empty register array on poll");
                     return;
@@ -335,7 +333,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
                 if (getThing().getStatus() != ThingStatus.ONLINE) {
                     updateStatus(ThingStatus.ONLINE);
                 }
-
             }
 
             @Override
@@ -350,14 +347,13 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         }));
 
         managerRef.get().registerRegularPoll(pollTask.get(), config.get().getRefreshMillis(), 1000);
-
     }
 
     /**
      * This method should handle incoming poll data, and update the channels
      * with the values received
      */
-    abstract protected void handlePolledData(ModbusRegisterArray registers);
+    protected abstract void handlePolledData(ModbusRegisterArray registers);
 
     @Override
     public synchronized void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
@@ -384,7 +380,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         managerRef.get().unregisterRegularPoll(pollTask.get());
 
         pollTask = Optional.empty();
-
     }
 
     /**

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -296,9 +296,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * Remove the endpoint if exists
      */
     private void unregisterEndpoint() {
-        if (endpoint.isPresent()) {
-            endpoint = Optional.empty();
-        }
+        endpoint = Optional.empty();
     }
 
     /**

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -78,20 +78,17 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     /**
      * Configuration instance
      */
-    @Nullable
-    protected SunSpecConfiguration config = null;
+    protected @Nullable SunSpecConfiguration config = null;
 
     /**
      * This is the task used to poll the device
      */
-    @Nullable
-    private volatile PollTask pollTask = null;
+    private volatile @Nullable PollTask pollTask = null;
 
     /**
      * This is the slave endpoint we're connecting to
      */
-    @Nullable
-    protected volatile ModbusSlaveEndpoint endpoint = null;
+    protected volatile @Nullable ModbusSlaveEndpoint endpoint = null;
 
     /**
      * This is the slave id, we store this once initialization is complete
@@ -325,7 +322,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             public void onRegisters(@Nullable ModbusReadRequestBlueprint request,
                     @Nullable ModbusRegisterArray registers) {
                 if (registers == null) {
-                    logger.info("Received empty register array on poll");
+                    logger.debug("Received empty register array on poll");
                     return;
                 }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -1,0 +1,457 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.handler;
+
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.PROPERTY_UNIQUE_ADDRESS;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.sunspec.internal.SunSpecConfiguration;
+import org.openhab.binding.modbus.sunspec.internal.dto.ModelBlock;
+import org.openhab.io.transport.modbus.BasicModbusReadRequestBlueprint;
+import org.openhab.io.transport.modbus.BasicPollTaskImpl;
+import org.openhab.io.transport.modbus.BitArray;
+import org.openhab.io.transport.modbus.ModbusManager;
+import org.openhab.io.transport.modbus.ModbusReadCallback;
+import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.io.transport.modbus.PollTask;
+import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AbstractSunSpecHandler} is the base class for any sunspec handlers
+ * Common things are handled here:
+ *
+ * - loads the configuration either from the configuration file or
+ * from the properties that have been set by the auto discovery
+ * - sets up a regular poller to the device
+ * - handles incoming messages from the device:
+ * - common properties are parsed and published
+ * - other values are submitted to child implementations
+ * - handles disposal of the device by removing any handlers
+ * - implements some tool methods
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AbstractSunSpecHandler extends BaseThingHandler {
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(AbstractSunSpecHandler.class);
+
+    /**
+     * Configuration instance
+     */
+    protected Optional<SunSpecConfiguration> config = Optional.empty();
+
+    /**
+     * This is the task used to poll the device
+     */
+    private volatile Optional<PollTask> pollTask = Optional.empty();
+
+    /**
+     * This is the slave endpoint we're connecting to
+     */
+    protected volatile Optional<ModbusSlaveEndpoint> endpoint = Optional.empty();
+
+    /**
+     * This is the slave id, we store this once initialization is complete
+     */
+    private volatile int slaveId;
+
+    /**
+     * Set to true after we're disposed
+     */
+    private volatile boolean disposed = false;
+
+    /**
+     * Reference to the modbus manager
+     */
+    protected Supplier<ModbusManager> managerRef;
+
+    /**
+     * Instances of this handler should get a reference to the modbus managet
+     *
+     * @param thing the thing to handle
+     * @param managerRef the modbus manager
+     */
+    public AbstractSunSpecHandler(Thing thing, Supplier<ModbusManager> managerRef) {
+        super(thing);
+        this.managerRef = managerRef;
+    }
+
+    /**
+     * Handle incoming commands. This binding is read-only be default
+     */
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // Currently we do not support any commands
+    }
+
+    /**
+     * Initialization:
+     * Load the config object of the block
+     * Connect to the slave bridge
+     * Start the periodic polling
+     */
+    @Override
+    public void initialize() {
+        config = Optional.of(getConfigAs(SunSpecConfiguration.class));
+
+        disposed = false;
+
+        connectEndpoint();
+        logger.debug("Initializing thing with properties: {}", thing.getProperties());
+
+        if (!endpoint.isPresent() || !config.isPresent()) {
+            logger.debug("Invalid enpoint/config/manager ref for sunspec handler");
+            return;
+        }
+
+        Optional<ModelBlock> mainBlock = getAddressFromConfig();
+        if (mainBlock.isPresent()) {
+            publishUniqueAddress(mainBlock.get());
+            updateStatus(ThingStatus.UNKNOWN);
+            registerPollTask(mainBlock.get());
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "SunSpec item should either have the address and length configuration set or should been created by auto discovery");
+            return;
+        }
+    }
+
+    /**
+     * Load configuration from main configuration
+     */
+    private Optional<ModelBlock> getAddressFromConfig() {
+        if (!config.isPresent()) {
+            return Optional.empty();
+        }
+        ModelBlock block = new ModelBlock();
+        block.address = config.get().getAddress();
+        block.length = config.get().getLength();
+        return Optional.of(block);
+    }
+
+    /**
+     * Publish the unique address property if it has not been set before
+     */
+    private void publishUniqueAddress(ModelBlock block) {
+        Map<String, String> properties = getThing().getProperties();
+        if (properties.containsKey(PROPERTY_UNIQUE_ADDRESS) && !properties.get(PROPERTY_UNIQUE_ADDRESS).isEmpty()) {
+            logger.debug("Current unique address is: {}", properties.get(PROPERTY_UNIQUE_ADDRESS));
+            return;
+        }
+
+        ModbusEndpointThingHandler handler = getEndpointThingHandler();
+        if (handler == null) {
+            return;
+        }
+        getThing().setProperty(PROPERTY_UNIQUE_ADDRESS, handler.getUID().getAsString() + ":" + block.address);
+    }
+
+    /**
+     * Dispose the binding correctly
+     */
+    @Override
+    public synchronized void dispose() {
+        dispose(Optional.empty());
+    }
+
+    /**
+     * Dispose the binding correctly
+     *
+     * @param reason status detail to be set
+     */
+    private synchronized void dispose(Optional<ThingStatusDetail> reason) {
+        logger.debug("dispose()");
+        // Mark handler as disposed as soon as possible to halt processing of callbacks
+        disposed = true;
+        unregisterPollTask();
+        unregisterEndpoint();
+        if (reason.isPresent()) {
+            updateStatus(ThingStatus.OFFLINE, reason.get());
+        } else {
+            updateStatus(ThingStatus.OFFLINE);
+        }
+    }
+
+    /**
+     * Returns the current slave id from the bridge
+     */
+    public int getSlaveId() {
+        return slaveId;
+    }
+
+    /**
+     * Get the endpoint handler from the bridge this handler is connected to
+     * Checks that we're connected to the right type of bridge
+     *
+     * @return the endpoint handler or null if the bridge does not exist
+     */
+    private @Nullable ModbusEndpointThingHandler getEndpointThingHandler() {
+        Bridge bridge = getBridge();
+        if (bridge == null) {
+            logger.debug("Bridge is null");
+            return null;
+        }
+        if (bridge.getStatus() != ThingStatus.ONLINE) {
+            logger.debug("Bridge is not online");
+            return null;
+        }
+
+        ThingHandler handler = bridge.getHandler();
+        if (handler == null) {
+            logger.debug("Bridge handler is null");
+            return null;
+        }
+
+        if (handler instanceof ModbusEndpointThingHandler) {
+            ModbusEndpointThingHandler slaveEndpoint = (ModbusEndpointThingHandler) handler;
+            return slaveEndpoint;
+        } else {
+            logger.debug("Unexpected bridge handler: {}", handler);
+            throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Get a reference to the modbus endpoint
+     */
+    @SuppressWarnings("null")
+    private synchronized void connectEndpoint() {
+        if (endpoint.isPresent()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+            throw new IllegalStateException("endpoint should be unregistered before registering a new one!");
+        }
+
+        ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
+        if (slaveEndpointThingHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, String.format("Bridge '%s' is offline",
+                    Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>")));
+            logger.debug("No bridge handler available -- aborting init for {}", this);
+            return;
+        }
+
+        try {
+            slaveId = slaveEndpointThingHandler.getSlaveId();
+
+            @Nullable
+            ModbusSlaveEndpoint _endpoint = slaveEndpointThingHandler.asSlaveEndpoint();
+
+            if (_endpoint == null) {
+                endpoint = Optional.empty();
+            } else {
+                endpoint = Optional.of(_endpoint);
+            }
+        } catch (EndpointNotInitializedException e) {
+            // this will be handled below as endpoint remains null
+        }
+
+        if (!endpoint.isPresent()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, String.format(
+                    "Bridge '%s' not completely initialized", Optional.ofNullable(getBridge()).map(b -> b.getLabel())));
+            logger.debug("Bridge not initialized fully (no endpoint) -- aborting init for {}", this);
+            return;
+        }
+
+    }
+
+    /**
+     * Remove the endpoint if exists
+     */
+    private synchronized void unregisterEndpoint() {
+        if (endpoint.isPresent()) {
+            endpoint = Optional.empty();
+        }
+    }
+
+    /**
+     * Register poll task
+     * This is where we set up our regular poller
+     */
+    private synchronized void registerPollTask(ModelBlock mainBlock) {
+        if (pollTask.isPresent()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+            throw new IllegalStateException("pollTask should be unregistered before registering a new one!");
+        }
+        if (!config.isPresent() || !endpoint.isPresent()) {
+            throw new IllegalStateException("registerPollTask called without proper configuration");
+        }
+
+        logger.debug("Setting up regular polling");
+
+        BasicModbusReadRequestBlueprint request = new BasicModbusReadRequestBlueprint(getSlaveId(),
+                ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, mainBlock.address, mainBlock.length,
+                config.get().getMaxTries());
+
+        pollTask = Optional.of(new BasicPollTaskImpl(endpoint.get(), request, new ModbusReadCallback() {
+
+            @Override
+            public void onRegisters(@Nullable ModbusReadRequestBlueprint request,
+                    @Nullable ModbusRegisterArray registers) {
+
+                if (registers == null) {
+                    logger.info("Received empty register array on poll");
+                    return;
+                }
+
+                handlePolledData(registers);
+
+                if (getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+
+            }
+
+            @Override
+            public void onError(@Nullable ModbusReadRequestBlueprint request, @Nullable Exception error) {
+                handleError(error);
+            }
+
+            @Override
+            public void onBits(@Nullable ModbusReadRequestBlueprint request, @Nullable BitArray bits) {
+                // don't care, we don't expect this result
+            }
+        }));
+
+        managerRef.get().registerRegularPoll(pollTask.get(), config.get().getRefreshMillis(), 1000);
+
+    }
+
+    /**
+     * This method should handle incoming poll data, and update the channels
+     * with the values received
+     */
+    abstract protected void handlePolledData(ModbusRegisterArray registers);
+
+    @Override
+    public synchronized void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        logger.debug("bridgeStatusChanged for {}. Reseting handler", this.getThing().getUID());
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE && getThing().getStatus() == ThingStatus.OFFLINE) {
+            initialize();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
+            dispose(Optional.of(ThingStatusDetail.BRIDGE_OFFLINE));
+        }
+    }
+
+    /**
+     * Unregister poll task.
+     *
+     * No-op in case no poll task is registered, or if the initialization is incomplete.
+     */
+    private synchronized void unregisterPollTask() {
+        logger.trace("unregisterPollTask()");
+        if (!pollTask.isPresent()) {
+            return;
+        }
+
+        logger.debug("Unregistering polling from ModbusManager");
+        managerRef.get().unregisterRegularPoll(pollTask.get());
+
+        pollTask = Optional.empty();
+
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    protected void handleError(@Nullable Exception error) {
+        // Ignore all incoming data and errors if configuration is not correct
+        if (hasConfigurationError() || disposed) {
+            return;
+        }
+        String msg = "";
+        String cls = "";
+        if (error != null) {
+            cls = error.getClass().getName();
+            msg = error.getMessage();
+        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                String.format("Error with read: %s: %s", cls, msg));
+    }
+
+    /**
+     * Returns true, if we're in a CONFIGURATION_ERROR state
+     *
+     * @return
+     */
+    protected boolean hasConfigurationError() {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        return statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR;
+    }
+
+    /**
+     * Reset communication status to ONLINE if we're in an OFFLINE state
+     */
+    protected void resetCommunicationError() {
+        ThingStatusInfo statusInfo = thing.getStatusInfo();
+        if (ThingStatus.OFFLINE.equals(statusInfo.getStatus())
+                && ThingStatusDetail.COMMUNICATION_ERROR.equals(statusInfo.getStatusDetail())) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    /**
+     * Returns value multiplied by the 10 on the power of scaleFactory
+     *
+     * @param value the value to alter
+     * @param scaleFactor the scale factor to use (may be negative)
+     * @return the scaled value as a DecimalType
+     */
+    protected State getScaled(Optional<? extends Number> value, Optional<Short> scaleFactor) {
+        if (!value.isPresent() || !scaleFactor.isPresent()) {
+            return UnDefType.UNDEF;
+        }
+        return getScaled(value.get().longValue(), scaleFactor.get());
+    }
+
+    /**
+     * Returns value multiplied by the 10 on the power of scaleFactory
+     *
+     * @param value the value to alter
+     * @param scaleFactor the scale factor to use (may be negative)
+     * @return the scaled value as a DecimalType
+     */
+    protected State getScaled(Number value, Short scaleFactor) {
+        if (scaleFactor == 1) {
+            return new DecimalType(value.longValue());
+        }
+        return new DecimalType(BigDecimal.valueOf(value.longValue(), scaleFactor * -1));
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -104,7 +104,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     protected Supplier<ModbusManager> managerRef;
 
     /**
-     * Instances of this handler should get a reference to the modbus managet
+     * Instances of this handler should get a reference to the modbus manager
      *
      * @param thing the thing to handle
      * @param managerRef the modbus manager
@@ -115,7 +115,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     }
 
     /**
-     * Handle incoming commands. This binding is read-only be default
+     * Handle incoming commands. This binding is read-only by default
      */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -172,8 +172,8 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             return Optional.empty();
         }
         ModelBlock block = new ModelBlock();
-        block.address = config.get().getAddress();
-        block.length = config.get().getLength();
+        block.address = config.get().address;
+        block.length = config.get().length;
         return Optional.of(block);
     }
 
@@ -316,7 +316,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
 
         BasicModbusReadRequestBlueprint request = new BasicModbusReadRequestBlueprint(getSlaveId(),
                 ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, mainBlock.address, mainBlock.length,
-                config.get().getMaxTries());
+                config.get().maxTries);
 
         pollTask = Optional.of(new BasicPollTaskImpl(endpoint.get(), request, new ModbusReadCallback() {
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -245,7 +245,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
             return slaveEndpoint;
         } else {
             logger.debug("Unexpected bridge handler: {}", handler);
-            throw new IllegalStateException();
+            return null;
         }
     }
 
@@ -260,9 +260,10 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
 
         ModbusEndpointThingHandler slaveEndpointThingHandler = getEndpointThingHandler();
         if (slaveEndpointThingHandler == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, String.format("Bridge '%s' is offline",
-                    Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>")));
-            logger.debug("No bridge handler available -- aborting init for {}", this);
+            String label = Optional.ofNullable(getBridge()).map(b -> b.getLabel()).orElse("<null>");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    String.format("Bridge '%s' is offline", label));
+            logger.debug("No bridge handler available -- aborting init for {}", label);
             return;
         }
 
@@ -292,7 +293,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     /**
      * Remove the endpoint if exists
      */
-    private synchronized void unregisterEndpoint() {
+    private void unregisterEndpoint() {
         if (endpoint.isPresent()) {
             endpoint = Optional.empty();
         }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -252,7 +252,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * Get a reference to the modbus endpoint
      */
     @SuppressWarnings("null")
-    private synchronized void connectEndpoint() {
+    private void connectEndpoint() {
         if (endpoint.isPresent()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
             throw new IllegalStateException("endpoint should be unregistered before registering a new one!");

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -355,7 +355,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
     protected abstract void handlePolledData(ModbusRegisterArray registers);
 
     @Override
-    public synchronized void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         super.bridgeStatusChanged(bridgeStatusInfo);
 
         logger.debug("Thing status changed to {}", this.getThing().getStatus().name());
@@ -425,7 +425,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
 
     /**
      * Returns the channel UID for the specified group and channel id
-     * 
+     *
      * @param string the channel group
      * @param string the channel id in that group
      * @return the globally unique channel uid

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.modbus.sunspec.internal.handler;
 
+import static org.eclipse.smarthome.core.library.unit.SIUnits.CELSIUS;
+import static org.eclipse.smarthome.core.library.unit.SmartHomeUnits.*;
 import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
 
 import java.util.Optional;
@@ -66,43 +68,44 @@ public class InverterHandler extends AbstractSunSpecHandler {
         InverterModelBlock block = parser.parse(registers);
 
         // Device information group
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_CABINET_TEMPERATURE),
-                getScaled(block.temperatureCabinet, block.temperatureSF));
+        updateState(channelUID(GROUP_DEVICE_INFO, CHANNEL_CABINET_TEMPERATURE),
+                getScaled(block.temperatureCabinet, block.temperatureSF, CELSIUS));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_HEATSINK_TEMPERATURE),
-                getScaled(block.temperatureHeatsink, Optional.of(block.temperatureSF)));
+        updateState(channelUID(GROUP_DEVICE_INFO, CHANNEL_HEATSINK_TEMPERATURE),
+                getScaled(block.temperatureHeatsink, Optional.of(block.temperatureSF), CELSIUS));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_TRANSFORMER_TEMPERATURE),
-                getScaled(block.temperatureTransformer, Optional.of(block.temperatureSF)));
+        updateState(channelUID(GROUP_DEVICE_INFO, CHANNEL_TRANSFORMER_TEMPERATURE),
+                getScaled(block.temperatureTransformer, Optional.of(block.temperatureSF), CELSIUS));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_OTHER_TEMPERATURE),
-                getScaled(block.temperatureOther, Optional.of(block.temperatureSF)));
+        updateState(channelUID(GROUP_DEVICE_INFO, CHANNEL_OTHER_TEMPERATURE),
+                getScaled(block.temperatureOther, Optional.of(block.temperatureSF), CELSIUS));
 
         InverterStatus status = InverterStatus.getByCode(block.status);
         updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_STATUS),
                 status == null ? UnDefType.UNDEF : new StringType(status.name()));
 
         // AC General group
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_TOTAL_CURRENT),
-                getScaled(block.acCurrentTotal, block.acCurrentSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_TOTAL_CURRENT),
+                getScaled(block.acCurrentTotal, block.acCurrentSF, AMPERE));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_POWER),
-                getScaled(block.acPower, block.acPowerSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER), getScaled(block.acPower, block.acPowerSF, WATT));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_FREQUENCY),
-                getScaled(block.acFrequency, block.acFrequencySF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_FREQUENCY),
+                getScaled(block.acFrequency, block.acFrequencySF, HERTZ));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_APPARENT_POWER),
-                getScaled(block.acApparentPower, block.acApparentPowerSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_APPARENT_POWER),
+                getScaled(block.acApparentPower, block.acApparentPowerSF)); // TODO: VA currently not supported, see:
+                                                                            // https://github.com/openhab/openhab-core/pull/1347
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_REACTIVE_POWER),
-                getScaled(block.acReactivePower, block.acReactivePowerSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_REACTIVE_POWER),
+                getScaled(block.acReactivePower, block.acReactivePowerSF)); // TODO: var currently not supported, see:
+                                                                            // https://github.com/openhab/openhab-core/pull/1347
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
-                getScaled(block.acPowerFactor, block.acPowerFactorSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
+                getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));
 
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
-                getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF));
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
+                getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF, WATT_HOUR));
 
         resetCommunicationError();
     }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.modbus.sunspec.internal.handler;
 import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -48,7 +47,7 @@ public class InverterHandler extends AbstractSunSpecHandler {
      */
     private final Logger logger = LoggerFactory.getLogger(InverterHandler.class);
 
-    public InverterHandler(Thing thing, Supplier<ModbusManager> managerRef) {
+    public InverterHandler(Thing thing, ModbusManager managerRef) {
         super(thing, managerRef);
     }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -94,12 +94,14 @@ public class InverterHandler extends AbstractSunSpecHandler {
                 getScaled(block.acFrequency, block.acFrequencySF, HERTZ));
 
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_APPARENT_POWER),
-                getScaled(block.acApparentPower, block.acApparentPowerSF)); // TODO: VA currently not supported, see:
-                                                                            // https://github.com/openhab/openhab-core/pull/1347
+                getScaled(block.acApparentPower, block.acApparentPowerSF, WATT)); // TODO: VA currently not supported,
+                                                                                  // see:
+                                                                                  // https://github.com/openhab/openhab-core/pull/1347
 
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_REACTIVE_POWER),
-                getScaled(block.acReactivePower, block.acReactivePowerSF)); // TODO: var currently not supported, see:
-                                                                            // https://github.com/openhab/openhab-core/pull/1347
+                getScaled(block.acReactivePower, block.acReactivePowerSF, WATT)); // TODO: var currently not supported,
+                                                                                  // see:
+                                                                                  // https://github.com/openhab/openhab-core/pull/1347
 
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
                 getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -17,10 +17,11 @@ import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.modbus.sunspec.internal.InverterStatus;
 import org.openhab.binding.modbus.sunspec.internal.dto.InverterModelBlock;
 import org.openhab.binding.modbus.sunspec.internal.parser.InverterModelParser;
 import org.openhab.io.transport.modbus.ModbusManager;
@@ -77,9 +78,9 @@ public class InverterHandler extends AbstractSunSpecHandler {
         updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_OTHER_TEMPERATURE),
                 getScaled(block.temperatureOther, Optional.of(block.temperatureSF)));
 
-        Integer status = block.status;
+        InverterStatus status = InverterStatus.getByCode(block.status);
         updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_STATUS),
-                status == null ? UnDefType.UNDEF : new DecimalType(status));
+                status == null ? UnDefType.UNDEF : new StringType(status.name()));
 
         // AC General group
         updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_TOTAL_CURRENT),

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.handler;
+
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.modbus.sunspec.internal.dto.InverterModelBlock;
+import org.openhab.binding.modbus.sunspec.internal.parser.InverterModelParser;
+import org.openhab.io.transport.modbus.ModbusManager;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link InverterHandler} is responsible for handling commands, which are
+ * sent to an inverter and publishing the received values to OpenHAB.
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ */
+@NonNullByDefault
+public class InverterHandler extends AbstractSunSpecHandler {
+
+    /**
+     * Parser used to convert incoming raw messages into model blocks
+     */
+    private InverterModelParser parser = new InverterModelParser();
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(InverterHandler.class);
+
+    public InverterHandler(Thing thing, Supplier<ModbusManager> managerRef) {
+        super(thing, managerRef);
+    }
+
+    /**
+     *
+     */
+    @Override
+    protected void handlePolledData(ModbusRegisterArray registers) {
+        logger.trace("Model block received, size: {}", registers.size());
+
+        InverterModelBlock block = parser.parse(registers);
+
+        // Device information group
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_CABINET_TEMPERATURE),
+                getScaled(block.temperatureCabinet, block.temperatureSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_HEATSINK_TEMPERATURE),
+                getScaled(block.temperatureHeatsink, Optional.of(block.temperatureSF)));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_TRANSFORMER_TEMPERATURE),
+                getScaled(block.temperatureTransformer, Optional.of(block.temperatureSF)));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_OTHER_TEMPERATURE),
+                getScaled(block.temperatureOther, Optional.of(block.temperatureSF)));
+
+        Integer status = block.status;
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_STATUS),
+                status == null ? UnDefType.UNDEF : new DecimalType(status));
+
+        // AC General group
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_TOTAL_CURRENT),
+                getScaled(block.acCurrentTotal, block.acCurrentSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_POWER),
+                getScaled(block.acPower, block.acPowerSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_FREQUENCY),
+                getScaled(block.acFrequency, block.acFrequencySF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_APPARENT_POWER),
+                getScaled(block.acApparentPower, block.acApparentPowerSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_REACTIVE_POWER),
+                getScaled(block.acReactivePower, block.acReactivePowerSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
+                getScaled(block.acPowerFactor, block.acPowerFactorSF));
+
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
+                getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF));
+
+        resetCommunicationError();
+
+    }
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -53,7 +53,11 @@ public class InverterHandler extends AbstractSunSpecHandler {
     }
 
     /**
-     *
+     * This method is called each time new data has been polled from the modbus slave
+     * The register array is first parsed, then each of the channels are updated
+     * to the new values
+     * 
+     * @param registers byte array read from the modbus slave
      */
     @Override
     protected void handlePolledData(ModbusRegisterArray registers) {

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -101,7 +101,6 @@ public class InverterHandler extends AbstractSunSpecHandler {
                 getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF));
 
         resetCommunicationError();
-
     }
 
 }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -41,7 +41,7 @@ public class InverterHandler extends AbstractSunSpecHandler {
     /**
      * Parser used to convert incoming raw messages into model blocks
      */
-    private InverterModelParser parser = new InverterModelParser();
+    private final InverterModelParser parser = new InverterModelParser();
 
     /**
      * Logger instance
@@ -56,7 +56,7 @@ public class InverterHandler extends AbstractSunSpecHandler {
      * This method is called each time new data has been polled from the modbus slave
      * The register array is first parsed, then each of the channels are updated
      * to the new values
-     * 
+     *
      * @param registers byte array read from the modbus slave
      */
     @Override

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
@@ -87,7 +87,6 @@ public class AbstractBaseParser {
     protected Optional<Long> extractOptionalAcc32(ModbusRegisterArray raw, int index) {
         return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT32).map(DecimalType::longValue)
                 .filter(value -> value != 0);
-
     }
 
     /**
@@ -100,7 +99,6 @@ public class AbstractBaseParser {
      */
     protected Long extractAcc32(ModbusRegisterArray raw, int index, long def) {
         return extractOptionalAcc32(raw, index).orElse(def);
-
     }
 
     /**
@@ -113,7 +111,6 @@ public class AbstractBaseParser {
     protected Optional<Short> extractOptionalSunSSF(ModbusRegisterArray raw, int index) {
         return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT16).map(DecimalType::shortValue)
                 .filter(value -> value != (short) 0x8000);
-
     }
 
     /**
@@ -125,6 +122,5 @@ public class AbstractBaseParser {
      */
     protected Short extractSunSSF(ModbusRegisterArray raw, int index) {
         return extractOptionalSunSSF(raw, index).orElse((short) 1);
-
     }
 }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.parser;
+
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.openhab.io.transport.modbus.ModbusBitUtilities;
+import org.openhab.io.transport.modbus.ModbusConstants.ValueType;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Base class for parsers with some helper methods
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class AbstractBaseParser {
+
+    /**
+     * Extract an optional int16 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Short> extractOptionalInt16(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT16).map(DecimalType::shortValue)
+                .filter(value -> value != (short) 0x8000);
+    }
+
+    /**
+     * Extract a mandatory int16 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @param def the default value
+     * @return the parsed value or the default if the field is not implemented
+     */
+    protected Short extractInt16(ModbusRegisterArray raw, int index, short def) {
+        return extractOptionalInt16(raw, index).orElse(def);
+    }
+
+    /**
+     * Extract an optional uint16 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Integer> extractOptionalUInt16(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT16).map(DecimalType::intValue)
+                .filter(value -> value != 0xffff);
+    }
+
+    /**
+     * Extract a mandatory uint16 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @param def the default value
+     * @return the parsed value or the default if the field is not implemented
+     */
+    protected Integer extractUInt16(ModbusRegisterArray raw, int index, int def) {
+        return extractOptionalUInt16(raw, index).orElse(def);
+    }
+
+    /**
+     * Extract an optional acc32 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Long> extractOptionalAcc32(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT32).map(DecimalType::longValue)
+                .filter(value -> value != 0);
+
+    }
+
+    /**
+     * Extract a mandatory acc32 value
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @param def the default value
+     * @return the parsed value or default if the field is not implemented
+     */
+    protected Long extractAcc32(ModbusRegisterArray raw, int index, long def) {
+        return extractOptionalAcc32(raw, index).orElse(def);
+
+    }
+
+    /**
+     * Extract an optional scale factor
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @return the parsed value or empty if the field is not implemented
+     */
+    protected Optional<Short> extractOptionalSunSSF(ModbusRegisterArray raw, int index) {
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT16).map(DecimalType::shortValue)
+                .filter(value -> value != (short) 0x8000);
+
+    }
+
+    /**
+     * Extract an mandatory scale factor
+     *
+     * @param raw the register array to extract from
+     * @param index the address of the field
+     * @return the parsed value or 1 if the field is not implemented
+     */
+    protected Short extractSunSSF(ModbusRegisterArray raw, int index) {
+        return extractOptionalSunSSF(raw, index).orElse((short) 1);
+
+    }
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.sunspec.internal.SunSpecConstants;
+import org.openhab.binding.modbus.sunspec.internal.dto.InverterModelBlock;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * Parses inverter modbus data into an InverterModelBlock
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class InverterModelParser extends AbstractBaseParser implements SunspecParser<InverterModelBlock> {
+
+    @Override
+    public InverterModelBlock parse(ModbusRegisterArray raw) {
+        InverterModelBlock block = new InverterModelBlock();
+
+        block.phaseConfiguration = extractUInt16(raw, 0, SunSpecConstants.INVERTER_SINGLE_PHASE);
+
+        block.length = extractUInt16(raw, 1, raw.size());
+
+        block.acCurrentTotal = extractUInt16(raw, 2, 0);
+
+        block.acCurrentSF = extractSunSSF(raw, 6);
+
+        block.acPower = extractInt16(raw, 14, (short) 0);
+
+        block.acPowerSF = extractSunSSF(raw, 15);
+
+        block.acFrequency = extractUInt16(raw, 16, 0);
+
+        block.acFrequencySF = extractSunSSF(raw, 17);
+
+        block.acApparentPower = extractOptionalInt16(raw, 18);
+
+        block.acApparentPowerSF = extractOptionalSunSSF(raw, 19);
+
+        block.acReactivePower = extractOptionalInt16(raw, 20);
+
+        block.acReactivePowerSF = extractOptionalSunSSF(raw, 21);
+
+        block.acPowerFactor = extractOptionalInt16(raw, 22);
+
+        block.acPowerFactorSF = extractOptionalSunSSF(raw, 23);
+
+        block.acEnergyLifetime = extractAcc32(raw, 24, 0);
+
+        block.acEnergyLifetimeSF = extractSunSSF(raw, 26);
+
+        block.temperatureCabinet = extractInt16(raw, 33, (short) 0);
+
+        block.temperatureHeatsink = extractOptionalInt16(raw, 34);
+
+        block.temperatureTransformer = extractOptionalInt16(raw, 35);
+
+        block.temperatureOther = extractOptionalInt16(raw, 36);
+
+        block.temperatureSF = extractSunSSF(raw, 37);
+
+        block.status = extractUInt16(raw, 38, 1);
+
+        block.statusVendor = extractOptionalUInt16(raw, 39);
+
+        return block;
+    }
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -31,49 +31,27 @@ public class InverterModelParser extends AbstractBaseParser implements SunspecPa
         InverterModelBlock block = new InverterModelBlock();
 
         block.phaseConfiguration = extractUInt16(raw, 0, SunSpecConstants.INVERTER_SINGLE_PHASE);
-
         block.length = extractUInt16(raw, 1, raw.size());
-
         block.acCurrentTotal = extractUInt16(raw, 2, 0);
-
         block.acCurrentSF = extractSunSSF(raw, 6);
-
         block.acPower = extractInt16(raw, 14, (short) 0);
-
         block.acPowerSF = extractSunSSF(raw, 15);
-
         block.acFrequency = extractUInt16(raw, 16, 0);
-
         block.acFrequencySF = extractSunSSF(raw, 17);
-
         block.acApparentPower = extractOptionalInt16(raw, 18);
-
         block.acApparentPowerSF = extractOptionalSunSSF(raw, 19);
-
         block.acReactivePower = extractOptionalInt16(raw, 20);
-
         block.acReactivePowerSF = extractOptionalSunSSF(raw, 21);
-
         block.acPowerFactor = extractOptionalInt16(raw, 22);
-
         block.acPowerFactorSF = extractOptionalSunSSF(raw, 23);
-
         block.acEnergyLifetime = extractAcc32(raw, 24, 0);
-
         block.acEnergyLifetimeSF = extractSunSSF(raw, 26);
-
         block.temperatureCabinet = extractInt16(raw, 33, (short) 0);
-
         block.temperatureHeatsink = extractOptionalInt16(raw, 34);
-
         block.temperatureTransformer = extractOptionalInt16(raw, 35);
-
         block.temperatureOther = extractOptionalInt16(raw, 36);
-
         block.temperatureSF = extractSunSSF(raw, 37);
-
         block.status = extractUInt16(raw, 38, 1);
-
         block.statusVendor = extractOptionalUInt16(raw, 39);
 
         return block;

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
@@ -38,5 +38,5 @@ public interface SunspecParser<T> {
      * This method should parser an incoming register array and
      * return a not-null sunspec block
      */
-    public T parse(ModbusRegisterArray raw);
+    T parse(ModbusRegisterArray raw);
 }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/SunspecParser.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.parser;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+
+/**
+ * General interface for sunspec parsers
+ *
+ * Parsers are responsible to take the raw register array
+ * that was read from the device and to parse them into a SunSpecMessageBlock
+ * They should parse all reasonable fields into separate properties
+ * in the message block.
+ *
+ * Fields with unsupported values should be parsed as null values.
+ *
+ * In no way should a parser handle value scaling or device specific
+ * workarounds. These should be done in the handler.
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+@NonNullByDefault
+public interface SunspecParser<T> {
+
+    /**
+     * This method should parser an incoming register array and
+     * return a not-null sunspec block
+     */
+    public T parse(ModbusRegisterArray raw);
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config-description:config-descriptions
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
-        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:sunspec:modbusconfig">
 
@@ -36,6 +35,5 @@
 		</parameter>
 
 	</config-description>
-
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
@@ -6,9 +6,9 @@
 
 	<config-description uri="thing-type:sunspec:modbusconfig">
 
-		<parameter name="refresh" type="integer" min="0">
-			<label>Interval</label>
-			<description>Poll interval in seconds. Use zero to disable automatic polling.</description>
+		<parameter name="refresh" type="integer" min="0" unit="s">
+			<label>Refresh Interval</label>
+			<description>Poll interval. Use zero to disable automatic polling.</description>
 			<default>5</default>
 		</parameter>
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
@@ -7,28 +7,28 @@
 	<config-description uri="thing-type:sunspec:modbusconfig">
 
 		<parameter name="refresh" type="integer" min="0">
-			<label>interval (s)</label>
+			<label>Interval (s)</label>
 			<description>Poll interval in seconds. Use zero to disable automatic polling.</description>
 			<default>5</default>
 			<unitLabel>s</unitLabel>
 		</parameter>
 
 		<parameter name="address" type="integer" min="0" max="65535">
-			<label>Start address</label>
+			<label>Start Address</label>
 			<description>Start address of the model block</description>
 			<default>40000</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="length" type="integer" min="1" max="65535">
-			<label>Block length</label>
+			<label>Block Length</label>
 			<description>Length of the model block in 2 byte words</description>
 			<default>61</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="maxTries" type="integer" min="1">
-			<label>Maximum tries when reading</label>
+			<label>Maximum Tries When Reading</label>
 			<default>3</default>
 			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
 			<advanced>true</advanced>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:sunspec:modbusconfig">
+
+		<parameter name="refresh" type="integer" min="0">
+			<label>interval (s)</label>
+			<description>Poll interval in seconds. Use zero to disable automatic polling.</description>
+			<default>5</default>
+			<unitLabel>s</unitLabel>
+		</parameter>
+
+		<parameter name="address" type="integer" min="0" max="65535">
+			<label>Start address</label>
+			<description>Start address of the model block</description>
+			<default>40000</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="length" type="integer" min="1" max="65535">
+			<label>Block length</label>
+			<description>Length of the model block in 2 byte words</description>
+			<default>61</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="maxTries" type="integer" min="1">
+			<label>Maximum tries when reading</label>
+			<default>3</default>
+			<description>Number of tries when reading data, if some of the reading fail. For single try, enter 1.</description>
+			<advanced>true</advanced>
+		</parameter>
+
+	</config-description>
+
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/config/config-descriptions.xml
@@ -7,10 +7,9 @@
 	<config-description uri="thing-type:sunspec:modbusconfig">
 
 		<parameter name="refresh" type="integer" min="0">
-			<label>Interval (s)</label>
+			<label>Interval</label>
 			<description>Poll interval in seconds. Use zero to disable automatic polling.</description>
 			<default>5</default>
-			<unitLabel>s</unitLabel>
 		</parameter>
 
 		<parameter name="address" type="integer" min="0" max="65535">

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-group-type id="device-information">
-		<label>Device information</label>
+		<label>Device Information</label>
 		<channels>
 			<channel id="cabinet-temperature" typeId="cabinet-temperature-type"/>
 			<channel id="heatsink-temperature" typeId="heatsink-temperature-type"/>
@@ -15,7 +15,7 @@
 	</channel-group-type>
 	
 	<channel-group-type id="ac-general">
-		<label>AC summary</label>
+		<label>AC Summary</label>
 		<channels>
 			<channel id="ac-total-current" typeId="ac-total-current-type"/>
 			<channel id="ac-power" typeId="ac-power-type"/>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="device-information">
+		<label>Device information</label>
+		<channels>
+			<channel id="cabinet-temperature" typeId="cabinet-temperature-type"/>
+			<channel id="heatsink-temperature" typeId="heatsink-temperature-type"/>
+			<channel id="transformer-temperature" typeId="transformer-temperature-type"/>
+			<channel id="other-temperature" typeId="other-temperature-type"/>
+			<channel id="status" typeId="status-type"/>
+		</channels>
+	</channel-group-type>
+	
+	<channel-group-type id="ac-general">
+		<label>AC summary</label>
+		<channels>
+			<channel id="ac-total-current" typeId="ac-total-current-type"/>
+			<channel id="ac-power" typeId="ac-power-type"/>
+			<channel id="ac-frequency" typeId="ac-frequency-type"/>
+			<channel id="ac-apparent-power" typeId="ac-apparent-power-type"/>
+			<channel id="ac-reactive-power" typeId="ac-reactive-power-type"/>
+			<channel id="ac-power-factor" typeId="ac-power-factor-type"/>
+			<channel id="ac-lifetime-energy" typeId="ac-lifetime-energy-type"/>
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="modbus" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-group-type id="device-information">
 		<label>Device information</label>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -71,14 +71,14 @@
 
 
 	<channel-type id="status-type">
-		<item-type>Number</item-type>
+		<item-type>String</item-type>
 		<label>Status</label>
 		<description>Device status</description>
 		<state readOnly="true">
 			<options>
-				<option value="1">Off</option>
-				<option value="2">Sleeping / Night mode</option>
-				<option value="4">On - producing power</option>
+				<option value="OFF">Off</option>
+				<option value="SLEEP">Sleeping / Night mode</option>
+				<option value="ON">On - producing power</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="ac-total-current-type">
+		<item-type>Number</item-type>
+		<label>AC Total Current value (A)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-power-type">
+		<item-type>Number</item-type>
+		<label>AC Power value (W)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-frequency-type">
+		<item-type>Number</item-type>
+		<label>AC Frequency value (Hz)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-apparent-power-type" advanced="true">
+		<item-type>Number</item-type>
+		<label>AC Apparent Power value</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-reactive-power-type" advanced="true">
+		<item-type>Number</item-type>
+		<label>AC Reactive Power value</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-power-factor-type">
+		<item-type>Number</item-type>
+		<label>AC Power Factor (%)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="ac-lifetime-energy-type">
+		<item-type>Number</item-type>
+		<label>AC Lifetime Energy production (Wh)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="cabinet-temperature-type">
+		<item-type>Number</item-type>
+		<label>Cabinet temperature (C)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="heatsink-temperature-type">
+		<item-type>Number</item-type>
+		<label>Heat Sink temperature (C)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="transformer-temperature-type">
+		<item-type>Number</item-type>
+		<label>Transformer temperature (C)</label>
+		<state readOnly="true" />
+	</channel-type>
+	
+	<channel-type id="other-temperature-type">
+		<item-type>Number</item-type>
+		<label>Other temperature (C)</label>
+		<state readOnly="true" />
+	</channel-type>
+
+
+	<channel-type id="status-type">
+		<item-type>Number</item-type>
+		<label>Status</label>
+		<description>Device status</description>
+		<state readOnly="true">
+			<options>
+				<option value="1">Off</option>
+				<option value="2">Sleeping / Night mode</option>
+				<option value="4">On - producing power</option>
+			</options>
+		</state>
+	</channel-type>
+
+</thing:thing-descriptions>
+	

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="modbus" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-type id="ac-total-current-type">
 		<item-type>Number</item-type>
@@ -82,6 +82,4 @@
 			</options>
 		</state>
 	</channel-type>
-
 </thing:thing-descriptions>
-	

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -5,31 +5,31 @@
 
 	<channel-type id="ac-total-current-type">
 		<item-type>Number</item-type>
-		<label>AC Total Current value (A)</label>
+		<label>AC Total Current Value (A)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="ac-power-type">
 		<item-type>Number</item-type>
-		<label>AC Power value (W)</label>
+		<label>AC Power Value (W)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="ac-frequency-type">
 		<item-type>Number</item-type>
-		<label>AC Frequency value (Hz)</label>
+		<label>AC Frequency Value (Hz)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="ac-apparent-power-type" advanced="true">
 		<item-type>Number</item-type>
-		<label>AC Apparent Power value</label>
+		<label>AC Apparent Power Value</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="ac-reactive-power-type" advanced="true">
 		<item-type>Number</item-type>
-		<label>AC Reactive Power value</label>
+		<label>AC Reactive Power Value</label>
 		<state readOnly="true" />
 	</channel-type>
 	
@@ -41,31 +41,31 @@
 	
 	<channel-type id="ac-lifetime-energy-type">
 		<item-type>Number</item-type>
-		<label>AC Lifetime Energy production (Wh)</label>
+		<label>AC Lifetime Energy Production (Wh)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="cabinet-temperature-type">
 		<item-type>Number</item-type>
-		<label>Cabinet temperature (C)</label>
+		<label>Cabinet Temperature (C)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="heatsink-temperature-type">
 		<item-type>Number</item-type>
-		<label>Heat Sink temperature (C)</label>
+		<label>Heat Sink Temperature (C)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="transformer-temperature-type">
 		<item-type>Number</item-type>
-		<label>Transformer temperature (C)</label>
+		<label>Transformer Temperature (C)</label>
 		<state readOnly="true" />
 	</channel-type>
 	
 	<channel-type id="other-temperature-type">
 		<item-type>Number</item-type>
-		<label>Other temperature (C)</label>
+		<label>Other Temperature (C)</label>
 		<state readOnly="true" />
 	</channel-type>
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -4,21 +4,21 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-type id="ac-total-current-type">
-		<item-type>Number</item-type>
-		<label>AC Total Current Value (A)</label>
-		<state readOnly="true" />
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>AC Total Current Value</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-power-type">
-		<item-type>Number</item-type>
-		<label>AC Power Value (W)</label>
-		<state readOnly="true" />
+		<item-type>Number:Power</item-type>
+		<label>AC Power Value</label>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-frequency-type">
-		<item-type>Number</item-type>
-		<label>AC Frequency Value (Hz)</label>
-		<state readOnly="true" />
+		<item-type>Number:Frequency</item-type>
+		<label>AC Frequency Value</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-apparent-power-type" advanced="true">
@@ -34,39 +34,39 @@
 	</channel-type>
 	
 	<channel-type id="ac-power-factor-type">
-		<item-type>Number</item-type>
-		<label>AC Power Factor (%)</label>
-		<state readOnly="true" />
+		<item-type>Number:Dimensionless</item-type>
+		<label>AC Power Factor</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-lifetime-energy-type">
-		<item-type>Number</item-type>
-		<label>AC Lifetime Energy Production (Wh)</label>
-		<state readOnly="true" />
+		<item-type>Number:Energy</item-type>
+		<label>AC Lifetime Energy Production</label>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	
 	<channel-type id="cabinet-temperature-type">
-		<item-type>Number</item-type>
-		<label>Cabinet Temperature (C)</label>
-		<state readOnly="true" />
+		<item-type>Number:Temperature</item-type>
+		<label>Cabinet Temperature</label>
+		<state readOnly="true"  pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="heatsink-temperature-type">
-		<item-type>Number</item-type>
-		<label>Heat Sink Temperature (C)</label>
-		<state readOnly="true" />
+		<item-type>Number:Temperature</item-type>
+		<label>Heat Sink Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="transformer-temperature-type">
-		<item-type>Number</item-type>
-		<label>Transformer Temperature (C)</label>
-		<state readOnly="true" />
+		<item-type>Number:Temperature</item-type>
+		<label>Transformer Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	
 	<channel-type id="other-temperature-type">
-		<item-type>Number</item-type>
-		<label>Other Temperature (C)</label>
-		<state readOnly="true" />
+		<item-type>Number:Temperature</item-type>
+		<label>Other Temperature</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -22,15 +22,15 @@
 	</channel-type>
 	
 	<channel-type id="ac-apparent-power-type" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:Power</item-type>
 		<label>AC Apparent Power Value</label>
-		<state readOnly="true" />
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-reactive-power-type" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:Power</item-type>
 		<label>AC Reactive Power Value</label>
-		<state readOnly="true" />
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	
 	<channel-type id="ac-power-factor-type">

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="modbus"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="inverter-single-phase">
 		<supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -10,7 +10,7 @@
 			<bridge-type-ref id="serial" />
 		</supported-bridge-type-refs>
 
-		<label>Single phase inverter</label>
+		<label>Single Phase Inverter</label>
 		<description>Single phase inverter supporting SunSpec mapping over tcp modbus connection</description>
 		<category>Inverter</category>
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="modbus"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="inverter-single-phase">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp" />
+			<bridge-type-ref id="serial" />
+		</supported-bridge-type-refs>
+
+		<label>Single phase inverter</label>
+		<description>Single phase inverter supporting SunSpec mapping over tcp modbus connection</description>
+		<category>Inverter</category>
+
+		<channel-groups>
+			<channel-group id="deviceInformation" typeId="device-information" />
+			<channel-group id="acGeneral" typeId="ac-general" />
+		</channel-groups>
+
+		<properties>
+			<property name="vendor" />
+			<property name="model" />
+			<property name="version" />
+			<property name="serialNumber" />
+			<property name="uniqueAddress" />
+		</properties>
+
+		<representation-property>uniqueAddress</representation-property>
+
+		<config-description-ref uri="thing-type:sunspec:modbusconfig" />
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -11,7 +11,7 @@
 		</supported-bridge-type-refs>
 
 		<label>Single Phase Inverter</label>
-		<description>Single phase inverter supporting SunSpec mapping over tcp modbus connection</description>
+		<description>Single phase inverter supporting SunSpec mapping over tcp modbus connection.</description>
 		<category>Inverter</category>
 
 		<channel-groups>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -140,6 +140,7 @@
     <module>org.openhab.binding.milight</module>
     <module>org.openhab.binding.minecraft</module>
     <module>org.openhab.binding.modbus</module>
+    <module>org.openhab.binding.modbus.sunspec</module>
     <module>org.openhab.binding.mqtt</module>
     <module>org.openhab.binding.mqtt.generic</module>
     <module>org.openhab.binding.mqtt.homeassistant</module>
@@ -208,7 +209,6 @@
     <module>org.openhab.binding.sonyprojector</module>
     <module>org.openhab.binding.spotify</module>
     <module>org.openhab.binding.squeezebox</module>
-    <module>org.openhab.binding.modbus.sunspec</module>
     <module>org.openhab.binding.synopanalyzer</module>
     <module>org.openhab.binding.systeminfo</module>
     <module>org.openhab.binding.tado</module>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -208,6 +208,7 @@
     <module>org.openhab.binding.sonyprojector</module>
     <module>org.openhab.binding.spotify</module>
     <module>org.openhab.binding.squeezebox</module>
+    <module>org.openhab.binding.modbus.sunspec</module>
     <module>org.openhab.binding.synopanalyzer</module>
     <module>org.openhab.binding.systeminfo</module>
     <module>org.openhab.binding.tado</module>


### PR DESCRIPTION
SunSpec is an open standard for solar inverters and other related devices to share data about their internal state. The standard is implemented by several vendors like ABB, Fronius, SMA, Schneider Electric, Solaredge, etc.

The goal of this work is to add user friendly support of these devices to openHAB.

The standard is built on the Modbus protocol, so this work is heavily based on the Modbus binding. Also the Bluetooth binding and several of it's solutions were taken as an example how to extend an already existing binding with a new bundle.

Related issue: #3216

This is a stripped down version of a SunSpec bundle aimed to ease reviewing as requested by @davidgraeff 

Original PR with all the features can be found here: #4220 

This version contains only a limited support for single phase inverters, but no auto discovery or any other fancy features are included.

Other changes from my original PR:
 - migrated to the new build system
 - using NonNull values wherever possible
 - modell classes were moved to a dto package and highly simplified
 - reflected code changes in the modbus package
 - other minor code changes

