### PR TITLE
[bluetooth.bluez] Improve permission setup documentation

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/README.md
+++ b/bundles/org.openhab.binding.bluetooth.bluez/README.md
@@ -2,9 +2,37 @@
 
 This extension supports Bluetooth access via BlueZ on Linux (ARMv6hf).
 
+# Setup
+
 Please note that at least BlueZ 5.43 is required, while 5.48 or above are [not (yet) supported](https://github.com/intel-iot-devkit/tinyb/issues/131) either.
 
-Also note that the OS user needs to be a member of the "bluetooth" group of Linux in order to have the rights to access the BlueZ stack.
+Some settings are required to ensure that openHAB has access to Bluez. To allow openHAB to access Bluez via dbus you need to add the following entry within your dbus configuration in `/etc/dbus-1/system.d/bluetooth.conf`
+
+```xml
+<busconfig>
+  <policy user="root">
+    ...
+  </policy>
+  <policy group="bluetooth">
+    <allow send_destination="org.bluez"/>
+  </policy>
+  ...
+</busconfig>
+```
+
+and add openHAB to the "bluetooth" group.
+
+```shell
+sudo adduser openhab bluetooth
+```
+
+Also, in case you don't want to manually enable your bluetooth adapters with `bluetoothctl`, ensure that it's automatically enabled by setting the option `AutoEnable` in your `/etc/bluetooth/main.conf` to `true`. Restart running services for changes to take effect.
+
+```
+systemctl restart dbus
+systemctl restart bluetooth
+systemctl restart openhab2
+```
 
 ## Supported Things
 

--- a/bundles/org.openhab.binding.bluetooth.bluez/README.md
+++ b/bundles/org.openhab.binding.bluetooth.bluez/README.md
@@ -6,7 +6,8 @@ This extension supports Bluetooth access via BlueZ on Linux (ARMv6hf).
 
 Please note that at least BlueZ 5.43 is required, while 5.48 or above are [not (yet) supported](https://github.com/intel-iot-devkit/tinyb/issues/131) either.
 
-Some settings are required to ensure that openHAB has access to Bluez. To allow openHAB to access Bluez via dbus you need to add the following entry within your dbus configuration in `/etc/dbus-1/system.d/bluetooth.conf`
+Some settings are required to ensure that openHAB has access to Bluez.
+To allow openHAB to access Bluez via dbus you need to add the following entry within your dbus configuration in `/etc/dbus-1/system.d/bluetooth.conf`
 
 ```xml
 <busconfig>
@@ -26,7 +27,8 @@ and add openHAB to the "bluetooth" group.
 sudo adduser openhab bluetooth
 ```
 
-Also, in case you don't want to manually enable your bluetooth adapters with `bluetoothctl`, ensure that it's automatically enabled by setting the option `AutoEnable` in your `/etc/bluetooth/main.conf` to `true`. Restart running services for changes to take effect.
+Also, in case you don't want to manually enable your bluetooth adapters with `bluetoothctl`, ensure that it's automatically enabled by setting the option `AutoEnable` in your `/etc/bluetooth/main.conf` to `true`.
+Restart running services for changes to take effect.
 
 ```
 systemctl restart dbus


### PR DESCRIPTION
The documentation lacks some necessary steps for Bluez setup. I'd suggest to not put this into the installation section of openhab-docs, but directly into the binding, as it only supports Linux anyway.

Signed-off-by: Patrick Fink <mail@pfink.de>