### PR TITLE
[SNMP] Process enterprise OID in V1TRAP PDUs

### DIFF
--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -209,13 +209,16 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
         final PDU pdu = event.getPDU();
         final String address = ((UdpAddress) event.getPeerAddress()).getInetAddress().getHostAddress();
         final String community = new String(event.getSecurityName());
-        if ((pdu.getType() == PDU.V1TRAP) && config.community.equals(community) && (pdu instanceof PDUv1))
-        {
-                logger.trace("{} received trap is PDUv1.", thing.getUID());
-                PDUv1 pduv1= (PDUv1)pdu;
-                int etrap=pduv1.getGenericTrap();
-                if(etrap==6) etrap=pduv1.getSpecificTrap();
-                updateChannels(pduv1.getEnterprise(),new UnsignedInteger32(etrap),trapChannelSet);     
+        
+        if ((pdu.getType() == PDU.V1TRAP) && config.community.equals(community) && (pdu instanceof PDUv1)){
+            logger.trace("{} received trap is PDUv1.", thing.getUID());
+            PDUv1 pduv1 = (PDUv1)pdu;
+            OID oidEnterprise = pduv1.getEnterprise();
+            int trapValue = pduv1.getGenericTrap();
+            if(trapValue == PDUv1.ENTERPRISE_SPECIFIC){ 
+                trapValue = pduv1.getSpecificTrap();
+            }
+            updateChannels(oidEnterprise, new UnsignedInteger32(trapValue), trapChannelSet);     
         }    
         if ((pdu.getType() == PDU.TRAP || pdu.getType() == PDU.V1TRAP) && config.community.equals(community)
                 && targetAddressString.equals(address)) {

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -209,17 +209,17 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
         final PDU pdu = event.getPDU();
         final String address = ((UdpAddress) event.getPeerAddress()).getInetAddress().getHostAddress();
         final String community = new String(event.getSecurityName());
-        
-        if ((pdu.getType() == PDU.V1TRAP) && config.community.equals(community) && (pdu instanceof PDUv1)){
+
+        if ((pdu.getType() == PDU.V1TRAP) && config.community.equals(community) && (pdu instanceof PDUv1)) {
             logger.trace("{} received trap is PDUv1.", thing.getUID());
-            PDUv1 pduv1 = (PDUv1)pdu;
+            PDUv1 pduv1 = (PDUv1) pdu;
             OID oidEnterprise = pduv1.getEnterprise();
             int trapValue = pduv1.getGenericTrap();
-            if(trapValue == PDUv1.ENTERPRISE_SPECIFIC){ 
+            if (trapValue == PDUv1.ENTERPRISE_SPECIFIC) {
                 trapValue = pduv1.getSpecificTrap();
             }
-            updateChannels(oidEnterprise, new UnsignedInteger32(trapValue), trapChannelSet);     
-        }    
+            updateChannels(oidEnterprise, new UnsignedInteger32(trapValue), trapChannelSet);
+        }
         if ((pdu.getType() == PDU.TRAP || pdu.getType() == PDU.V1TRAP) && config.community.equals(community)
                 && targetAddressString.equals(address)) {
             pdu.getVariableBindings().forEach(variable -> {


### PR DESCRIPTION
This request fixes omission of V1TRAP PDU event.

SNMP4J package sends SNMP V1 Traps in objects of `PDUv1` type. Class `PDUv1` is derived from `PDU` class, specific just for V1 Traps.  If using parent PDU class, there is no access to additional information - `Enterprise OID` / `GenericTrap(GT)` / `SpecificTrap(ST)`.  The code change just calls one more time `updateChannels` with that additional information. 
Regarding GenericTrap/SpecificTrap codes - if GT==6, ST must be used. However RFC1157 allows ST to be populated even if GT !=6. Possible solutions for differentiation between GT/ST are:

- if GT==6 => use ST (possible drawback - misinterpretation of traps that can have either ST or GT values)
- if ST==0 => use GT (possible drawback - SNMP implementations that doesn't set ST=0 when unused)
- use GT*Factor+ST (possible overflow, although very unlikely; has to be documented, as it may be overlooked) 

In this request I choose first option, as it seems most drawback free.
Tested with my UPS (Eaton Network-Card-MS) - traps are caught and processed further (Items updated, rules triggered).

Additional info: [OpenHAB Community discussion](https://community.openhab.org/t/solved-commit-needed-snmp-binding-v2-is-ignoring-enterprise-oid-v1trap-data/86599)
