### PR TITLE
[mqtt][homeassistant] fix state/command values for switches

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
@@ -37,11 +37,11 @@ public class ComponentSwitch extends AbstractComponent<ComponentSwitch.ChannelCo
         protected boolean optimistic = false;
 
         protected String state_topic = "";
-        protected String state_on = "true";
-        protected String state_off = "false";
+        protected String state_on = "ON";
+        protected String state_off = "OFF";
         protected @Nullable String command_topic;
-        protected String payload_on = "true";
-        protected String payload_off = "false";
+        protected String payload_on = "ON";
+        protected String payload_off = "OFF";
     }
 
     public ComponentSwitch(CFactory.ComponentConfiguration componentConfiguration) {


### PR DESCRIPTION
Fixes #6364 

According to https://www.home-assistant.io/integrations/switch.mqtt/ the default values are ON and OFF. As long as we do not provide the ability to configure state and command values for auto-discovered devices we should go with the default values.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
