### PR TITLE
[daikin] Fix airside fan mode for airbase. Split handler class.

### DIFF
--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -42,8 +42,8 @@ For the BRP15B61:
 | indoortemp      | The indoor temperature as measured by the unit.                                             |
 | outdoortemp     | The outdoor temperature as measured by the external part of the air conditioning system. May not be available when unit is off. |
 | mode            | The mode set for the unit (AUTO, DEHUMIDIFIER, COLD, HEAT, FAN)                             |
-| airbasefanspeed | The fan speed set for the unit (AUTO, LEVEL_1, LEVEL_2, LEVEL_3)                            |
-| zone1           | Turns zone 1 on/off for the air conditioning unit (if a zoned controller is installed.      |
+| airbasefanspeed | The fan speed set for the unit (AIRSIDE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO_LEVEL_1, AUTO_LEVEL_2, AUTO_LEVEL_3, AUTO_LEVEL_4, AUTO_LEVEL_5)  |
+| zone1           | Turns zone 1 on/off for the air conditioning unit (if a zone controller is installed.)      |
 | zone2           | Turns zone 2 on/off for the air conditioning unit.                                          |
 | zone3           | Turns zone 3 on/off for the air conditioning unit.                                          |
 | zone4           | Turns zone 4 on/off for the air conditioning unit.                                          |
@@ -65,7 +65,7 @@ daikin.items:
 
 ```
 Switch DaikinACUnit_Power { channel="daikin:ac_unit:living_room_ac:power" }
-Number:Temperature DaikinACUnit_SetPoint { channel="daikin:ac_unit:living_room_ac:setpoint" }
+Number:Temperature DaikinACUnit_SetPoint { channel="daikin:ac_unit:living_room_ac:settemp" }
 String DaikinACUnit_Mode { channel="daikin:ac_unit:living_room_ac:mode" }
 String DaikinACUnit_Fan { channel="daikin:ac_unit:living_room_ac:fanspeed" }
 Number:Temperature DaikinACUnit_IndoorTemperature { channel="daikin:ac_unit:living_room_ac:indoortemp" }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinDynamicStateDescriptionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinDynamicStateDescriptionProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.daikin.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Dynamic provider of state options while leaving other state description fields as original.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, DaikinDynamicStateDescriptionProvider.class })
+@NonNullByDefault
+public class DaikinDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+
+    @Reference
+    protected void setChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+
+    protected void unsetChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = null;
+    }
+}

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.daikin.internal.handler.DaikinAcUnitHandler;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link DaikinHandlerFactory} is responsible for creating things and thing
@@ -34,6 +35,8 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 public class DaikinHandlerFactory extends BaseThingHandlerFactory {
 
+    private @Nullable DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return DaikinBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -44,9 +47,18 @@ public class DaikinHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AC_UNIT) || thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AIRBASE_AC_UNIT)) {
-            return new DaikinAcUnitHandler(thing);
+            return new DaikinAcUnitHandler(thing, stateDescriptionProvider);
         }
 
         return null;
+    }
+
+    @Reference
+    protected void setDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    protected  void unsetDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.daikin.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
@@ -21,6 +23,7 @@ import org.openhab.binding.daikin.internal.handler.DaikinAcUnitHandler;
 import org.openhab.binding.daikin.internal.handler.DaikinAirbaseUnitHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.Activate;
 
 /**
  * The {@link DaikinHandlerFactory} is responsible for creating things and thing
@@ -31,9 +34,15 @@ import org.osgi.service.component.annotations.Reference;
 
  */
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.daikin")
+@NonNullByDefault
 public class DaikinHandlerFactory extends BaseThingHandlerFactory {
 
-    private DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+    final private DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+
+    @Activate
+    public DaikinHandlerFactory(@Reference DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -41,7 +50,7 @@ public class DaikinHandlerFactory extends BaseThingHandlerFactory {
     }
 
     @Override
-    protected ThingHandler createHandler(Thing thing) {
+    protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AC_UNIT)) {
@@ -50,14 +59,5 @@ public class DaikinHandlerFactory extends BaseThingHandlerFactory {
             return new DaikinAirbaseUnitHandler(thing, stateDescriptionProvider);
         }
         return null;
-    }
-
-    @Reference
-    protected void setDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
-        this.stateDescriptionProvider = stateDescriptionProvider;
-    }
-
-    protected void unsetDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
-        this.stateDescriptionProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
@@ -12,14 +12,13 @@
  */
 package org.openhab.binding.daikin.internal;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.daikin.internal.handler.DaikinAcUnitHandler;
+import org.openhab.binding.daikin.internal.handler.DaikinAirbaseUnitHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -32,10 +31,9 @@ import org.osgi.service.component.annotations.Reference;
 
  */
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.daikin")
-@NonNullByDefault
 public class DaikinHandlerFactory extends BaseThingHandlerFactory {
 
-    private @Nullable DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+    private DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -43,13 +41,14 @@ public class DaikinHandlerFactory extends BaseThingHandlerFactory {
     }
 
     @Override
-    protected @Nullable ThingHandler createHandler(Thing thing) {
+    protected ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AC_UNIT) || thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AIRBASE_AC_UNIT)) {
+        if (thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AC_UNIT)) {
             return new DaikinAcUnitHandler(thing, stateDescriptionProvider);
+        } else if (thingTypeUID.equals(DaikinBindingConstants.THING_TYPE_AIRBASE_AC_UNIT)) {
+            return new DaikinAirbaseUnitHandler(thing, stateDescriptionProvider);
         }
-
         return null;
     }
 
@@ -58,7 +57,7 @@ public class DaikinHandlerFactory extends BaseThingHandlerFactory {
         this.stateDescriptionProvider = stateDescriptionProvider;
     }
 
-    protected  void unsetDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+    protected void unsetDynamicStateDescriptionProvider(DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
         this.stateDescriptionProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/DaikinHandlerFactory.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Activate;
 @NonNullByDefault
 public class DaikinHandlerFactory extends BaseThingHandlerFactory {
 
-    final private DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+    private final DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
 
     @Activate
     public DaikinHandlerFactory(@Reference DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -47,11 +47,7 @@ public class Enums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected Mode value of \"{}\"", value);
-
-            // Default to auto
-            return AUTO;
+            throw new IllegalArgumentException(String.format("Unexpected Mode value of \"%d\"", value));
         }
     }
 
@@ -81,11 +77,7 @@ public class Enums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected FanSpeed value of \"{}\"", value);
-
-            // Default to auto
-            return AUTO;
+            throw new IllegalArgumentException(String.format("Unexpected FanSpeed value of \"%s\"", value));
         }
     }
 
@@ -113,11 +105,7 @@ public class Enums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected FanMovement value of \"{}\"", value);
-
-            // Default to stopped
-            return STOPPED;
+            throw new IllegalArgumentException(String.format("Unexpected FanMovement value of \"%d\"", value));
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/Enums.java
@@ -47,7 +47,10 @@ public class Enums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected Mode value of \"%d\"", value));
+            LOGGER.debug("Unexpected Mode value of \"{}\"", value);
+
+            // Default to auto
+            return AUTO;
         }
     }
 
@@ -77,7 +80,10 @@ public class Enums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected FanSpeed value of \"%s\"", value));
+            LOGGER.debug("Unexpected FanSpeed value of \"{}\"", value);
+
+            // Default to auto
+            return AUTO;
         }
     }
 
@@ -105,7 +111,10 @@ public class Enums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected FanMovement value of \"%d\"", value));
+            LOGGER.debug("Unexpected FanMovement value of \"{}\"", value);
+
+            // Default to stopped
+            return STOPPED;
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanMovement;
-import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanSpeed;
+// import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanSpeed;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,9 @@ public class AirbaseControlInfo {
     public AirbaseMode mode = AirbaseMode.AUTO;
     /** Degrees in Celsius. */
     public Optional<Double> temp = Optional.empty();
-    public AirbaseFanSpeed fanSpeed = AirbaseFanSpeed.AUTO;
+    public Integer f_rate = 1;
+    public boolean f_auto = false;
+    public boolean f_airside = false;
     public AirbaseFanMovement fanMovement = AirbaseFanMovement.STOPPED;
     /* Not supported by all units. Sets the target humidity for dehumidifying. */
     public Optional<Integer> targetHumidity = Optional.empty();
@@ -64,8 +66,9 @@ public class AirbaseControlInfo {
         info.mode = Optional.ofNullable(responseMap.get("mode")).flatMap(value -> parseInt(value))
                 .map(value -> AirbaseMode.fromValue(value)).orElse(AirbaseMode.AUTO);
         info.temp = Optional.ofNullable(responseMap.get("stemp")).flatMap(value -> parseDouble(value));
-        info.fanSpeed = Optional.ofNullable(responseMap.get("f_rate")).map(value -> AirbaseFanSpeed.fromValue(value))
-                .orElse(AirbaseFanSpeed.AUTO);
+        info.f_rate = Optional.ofNullable(responseMap.get("f_rate")).flatMap(value -> parseInt(value)).orElse(1);
+        info.f_auto = "1".equals(responseMap.get("f_auto"));
+        info.f_airside = "1".equals(responseMap.get("f_airside"));
         info.fanMovement = Optional.ofNullable(responseMap.get("f_dir")).flatMap(value -> parseInt(value))
                 .map(value -> AirbaseFanMovement.fromValue(value)).orElse(AirbaseFanMovement.STOPPED);
         info.targetHumidity = Optional.ofNullable(responseMap.get("shum")).flatMap(value -> parseInt(value));
@@ -76,7 +79,9 @@ public class AirbaseControlInfo {
         Map<String, String> params = new HashMap<>();
         params.put("pow", power ? "1" : "0");
         params.put("mode", Integer.toString(mode.getValue()));
-        params.put("f_rate", fanSpeed.getValue());
+        params.put("f_rate", f_rate.toString());
+        params.put("f_auto", f_auto ? "1" : "0");
+        params.put("f_airside", f_airside ? "1" : "0");
         params.put("f_dir", Integer.toString(fanMovement.getValue()));
         params.put("stemp", temp.orElse(20.0).toString());
         params.put("shum", targetHumidity.map(value -> value.toString()).orElse(""));

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseControlInfo.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanMovement;
-// import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanSpeed;
 import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +38,7 @@ public class AirbaseControlInfo {
     public AirbaseMode mode = AirbaseMode.AUTO;
     /** Degrees in Celsius. */
     public Optional<Double> temp = Optional.empty();
-    public Integer f_rate = 1;
+    public int f_rate = 1;
     public boolean f_auto = false;
     public boolean f_airside = false;
     public AirbaseFanMovement fanMovement = AirbaseFanMovement.STOPPED;
@@ -79,7 +78,7 @@ public class AirbaseControlInfo {
         Map<String, String> params = new HashMap<>();
         params.put("pow", power ? "1" : "0");
         params.put("mode", Integer.toString(mode.getValue()));
-        params.put("f_rate", f_rate.toString());
+        params.put("f_rate", Integer.toString(f_rate));
         params.put("f_auto", f_auto ? "1" : "0");
         params.put("f_airside", f_airside ? "1" : "0");
         params.put("f_dir", Integer.toString(fanMovement.getValue()));

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
@@ -24,22 +24,27 @@ import org.slf4j.LoggerFactory;
  */
 public class AirbaseEnums {
     public enum AirbaseMode {
-        UNKNOWN(-1),
-        FAN(0),
-        HEAT(1),
-        COLD(2),
-        DRY(7),
-        AUTO(3);
+        COLD    (2, "Cooling"),
+        HEAT    (1, "Heating"),
+        FAN     (0, "Fan"),
+        DRY     (7, "Dehumidifier"),
+        AUTO    (3, "Auto");
 
         private static final Logger LOGGER = LoggerFactory.getLogger(AirbaseMode.class);
         private final int value;
+        private final String label;
 
-        AirbaseMode(int value) {
+        AirbaseMode(int value, String label) {
             this.value = value;
+            this.label = label;
         }
 
         public int getValue() {
             return value;
+        }
+        
+        public String getLabel() {
+            return label;
         }
 
         public static AirbaseMode fromValue(int value) {
@@ -51,39 +56,73 @@ public class AirbaseEnums {
 
             LOGGER.debug("Unexpected Mode value of \"{}\"", value);
 
-            // Default to auto
-            return AUTO;
+            // Default to cold
+            return COLD;
         }
     }
 
     public enum AirbaseFanSpeed {
-        AUTO("A"),
-        LEVEL_1("1"),
-        LEVEL_2("3"),
-        LEVEL_3("5");
+        // level,f_auto,f_airside
+        LEVEL_1      (1, false, false),
+        LEVEL_2      (2, false, false),
+        LEVEL_3      (3, false, false),
+        LEVEL_4      (4, false, false),
+        LEVEL_5      (5, false, false),
+        AUTO_LEVEL_1 (1, true, false),
+        AUTO_LEVEL_2 (2, true, false),
+        AUTO_LEVEL_3 (3, true, false),
+        AUTO_LEVEL_4 (4, true, false),
+        AUTO_LEVEL_5 (5, true, false),
+        AIRSIDE      (1, false, true);
 
         private static final Logger LOGGER = LoggerFactory.getLogger(AirbaseFanSpeed.class);
-        private final String value;
+        private final int level;
+        private final boolean auto;
+        private final boolean airside;
 
-        AirbaseFanSpeed(String value) {
-            this.value = value;
+        AirbaseFanSpeed(int level, boolean auto, boolean airside) {
+            this.level = level;
+            this.auto = auto;
+            this.airside = airside;
         }
 
-        public String getValue() {
-            return value;
+        public int getLevel() { 
+            return level;
         }
 
-        public static AirbaseFanSpeed fromValue(String value) {
+        public boolean getAuto() {
+            return auto;
+        }
+
+        public boolean getAirside() {
+            return airside;
+        }
+
+        public String getLabel() {
+            if (airside) {
+                return "Airside";
+            }
+            String label = "";
+            if (auto) {
+                label = "Auto ";
+            }
+            return label + "Level " + Integer.toString(level);
+        }
+
+        public static AirbaseFanSpeed fromValue(int rate, boolean auto, boolean airside) { // convert from f_rate, f_auto, f_airside
+            if (airside) {
+                return AIRSIDE;
+            }
             for (AirbaseFanSpeed m : AirbaseFanSpeed.values()) {
-                if (m.getValue().equals(value)) {
+                if (m.getLevel() == rate && m.getAuto() == auto && m.getAirside() == airside) {
                     return m;
                 }
             }
 
-            LOGGER.debug("Unexpected FanSpeed value of \"{}\"", value);
+            LOGGER.debug("Unexpected FanSpeed value from rate={}, auto={}, airside={}", rate, auto, airside);
 
-            // Default to auto
-            return AUTO;
+            // Default to Level 1
+            return LEVEL_1;
         }
     }
 
@@ -116,6 +155,45 @@ public class AirbaseEnums {
 
             // Default to stopped
             return STOPPED;
+        }
+    }
+
+    public enum AirbaseFeature {
+        ZONE            ("en_zone"),
+        FILTER_SIGN     ("en_filter_sign"),
+        TEMP_SETTING    ("en_temp_setting"),
+        FRATE           ("en_frate"),
+        DIR             ("en_dir"),
+        RTEMP_A         ("en_rtemp_a"),
+        SPMODE          ("en_spmode"),
+        MOMPOW          ("en_mompow"),
+        PATROL          ("en_patrol"),
+        AIRSIDE         ("en_airside"),
+        QUICK_TIMER     ("en_quick_timer"),
+        AUTO            ("en_auto"),
+        DRY             ("en_dry"),
+        FRATE_AUTO      ("en_frate_auto");
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(AirbaseFeature.class);
+        private final String value;
+
+        AirbaseFeature(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static AirbaseFeature fromValue(String value) {
+            for (AirbaseFeature m : AirbaseFeature.values()) {
+                if (m.getValue() == value) {
+                    return m;
+                }
+            }
+
+            LOGGER.debug("Unexpected Feature value of \"{}\"", value);
+            return null;
         }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
@@ -184,16 +184,5 @@ public class AirbaseEnums {
         public String getValue() {
             return value;
         }
-
-        public static AirbaseFeature fromValue(String value) {
-            for (AirbaseFeature m : AirbaseFeature.values()) {
-                if (m.getValue() == value) {
-                    return m;
-                }
-            }
-
-            LOGGER.debug("Unexpected Feature value of \"{}\"", value);
-            return null;
-        }
     }
 }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
@@ -53,11 +53,7 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected Mode value of \"{}\"", value);
-
-            // Default to cold
-            return COLD;
+            throw new IllegalArgumentException(String.format("Unexpected Mode value of \"%d\"", value));
         }
     }
 
@@ -118,11 +114,7 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected FanSpeed value from rate={}, auto={}, airside={}", rate, auto, airside);
-
-            // Default to Level 1
-            return LEVEL_1;
+            throw new IllegalArgumentException(String.format("Unexpected FanSpeed value from rate=%d, auto=%d, airside=%d", rate, auto?1:0, airside?1:0));
         }
     }
 
@@ -150,11 +142,7 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-
-            LOGGER.debug("Unexpected FanMovement value of \"{}\"", value);
-
-            // Default to stopped
-            return STOPPED;
+            throw new IllegalArgumentException(String.format("Unexpected FanMovement value of \"%d\"", value));
         }
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
@@ -53,7 +53,8 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected Mode value of \"%d\"", value));
+            LOGGER.debug("Unexpected Mode value of \"{}\"", value);
+            return AUTO;
         }
     }
 
@@ -114,7 +115,8 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected FanSpeed value from rate=%d, auto=%d, airside=%d", rate, auto?1:0, airside?1:0));
+            LOGGER.debug("Unexpected FanSpeed value from rate={}, auto={}, airside={}", rate, auto?1:0, airside?1:0);
+            return LEVEL_1;
         }
     }
 
@@ -142,7 +144,8 @@ public class AirbaseEnums {
                     return m;
                 }
             }
-            throw new IllegalArgumentException(String.format("Unexpected FanMovement value of \"%d\"", value));
+            LOGGER.debug("Unexpected FanMovement value of \"{}\"", value);
+            return STOPPED;
         }
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseModelInfo.java
@@ -15,9 +15,12 @@ package org.openhab.binding.daikin.internal.api.airbase;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.EnumSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFeature;
 
 /**
  * Class for holding the set of parameters used by get model info.
@@ -31,8 +34,11 @@ public class AirbaseModelInfo {
     public String ret;
     public Integer zonespresent;
     public Integer commonzone;
+    public Integer frate_steps; // fan rate steps
+    public EnumSet<AirbaseFeature> features;
 
     private AirbaseModelInfo() {
+        features = EnumSet.noneOf(AirbaseFeature.class);
     }
 
     public static AirbaseModelInfo parse(String response) {
@@ -49,7 +55,13 @@ public class AirbaseModelInfo {
         AirbaseModelInfo info = new AirbaseModelInfo();
         info.ret = responseMap.get("ret");
         info.zonespresent = Integer.parseInt(responseMap.get("en_zone"));
-        info.commonzone = Integer.parseInt(responseMap.get("en_common_zone"));
+        info.commonzone = Integer.parseInt(responseMap.get("en_common_zone"));  
+        info.frate_steps = Integer.parseInt(responseMap.get("frate_steps"));      
+        for (AirbaseFeature f: AirbaseFeature.values()) {
+            if ("1".equals(responseMap.get(f.getValue()))) {
+                info.features.add(f);
+            }
+        }
         return info;
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 
 import javax.measure.quantity.Temperature;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
@@ -59,6 +60,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Smedley <paul@smedley.id.au> - Modifications to support Airbase Controllers
  *
  */
+@NonNullByDefault
 public class DaikinAcUnitHandler extends DaikinBaseHandler {
     public DaikinAcUnitHandler(Thing thing, DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
         super(thing, stateDescriptionProvider);

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.daikin.internal.handler;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.ArrayList;
+
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.daikin.internal.DaikinBindingConstants;
+import org.openhab.binding.daikin.internal.DaikinCommunicationException;
+import org.openhab.binding.daikin.internal.DaikinWebTargets;
+import org.openhab.binding.daikin.internal.DaikinDynamicStateDescriptionProvider;
+import org.openhab.binding.daikin.internal.api.SensorInfo;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFanSpeed;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseMode;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseEnums.AirbaseFeature;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseControlInfo;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseModelInfo;
+import org.openhab.binding.daikin.internal.api.airbase.AirbaseZoneInfo;
+
+import org.openhab.binding.daikin.internal.config.DaikinConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles communicating with a Daikin Airbase wifi adapter.
+ *
+ * @author Tim Waterhouse - Initial Contribution
+ * @author Paul Smedley <paul@smedley.id.au> - Modifications to support Airbase Controllers
+ * @author Jimmy Tanagra - Support Airside and auto fan levels, DynamicStateDescription
+ *
+ */
+public class DaikinAirbaseUnitHandler extends DaikinBaseHandler {
+    private AirbaseModelInfo airbaseModelInfo;
+
+    public DaikinAirbaseUnitHandler(Thing thing, DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+        super(thing, stateDescriptionProvider);
+    }
+
+    @Override
+    protected boolean handleCommandInternal(ChannelUID channelUID, Command command) throws DaikinCommunicationException {
+        if (channelUID.getId().startsWith(DaikinBindingConstants.CHANNEL_AIRBASE_AC_ZONE)) {
+            int zoneNumber = Integer.parseInt(channelUID.getId().substring(4));
+            if (command instanceof OnOffType) {
+                 changeZone(zoneNumber, command == OnOffType.ON);
+                 return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void pollStatus() throws IOException {
+        AirbaseControlInfo controlInfo = webTargets.getAirbaseControlInfo();
+        updateStatus(ThingStatus.ONLINE);
+
+        if (airbaseModelInfo == null || !"OK".equals(airbaseModelInfo.ret)) {
+            airbaseModelInfo = webTargets.getAirbaseModelInfo();
+            updateChannelStateDescriptions();
+        }
+
+        if (controlInfo != null) {
+            updateState(DaikinBindingConstants.CHANNEL_AC_POWER, controlInfo.power ? OnOffType.ON : OnOffType.OFF);
+            updateTemperatureChannel(DaikinBindingConstants.CHANNEL_AC_TEMP, controlInfo.temp);
+            updateState(DaikinBindingConstants.CHANNEL_AC_MODE, new StringType(controlInfo.mode.name()));
+            updateState(DaikinBindingConstants.CHANNEL_AIRBASE_AC_FAN_SPEED, new StringType(AirbaseFanSpeed.fromValue(controlInfo.f_rate, controlInfo.f_auto, controlInfo.f_airside).name()));
+        }
+
+        SensorInfo sensorInfo = webTargets.getAirbaseSensorInfo();
+        if (sensorInfo != null) {
+            updateTemperatureChannel(DaikinBindingConstants.CHANNEL_INDOOR_TEMP, sensorInfo.indoortemp);
+
+            updateTemperatureChannel(DaikinBindingConstants.CHANNEL_OUTDOOR_TEMP, sensorInfo.outdoortemp);
+        }
+
+        AirbaseZoneInfo zoneInfo = webTargets.getAirbaseZoneInfo();
+        if (zoneInfo != null) {
+            IntStream.range(0, zoneInfo.zone.length).forEach(
+            idx -> updateState(DaikinBindingConstants.CHANNEL_AIRBASE_AC_ZONE + idx, OnOffType.from(zoneInfo.zone[idx])));
+        }
+    }
+
+    @Override
+    protected void changePower(boolean power) throws DaikinCommunicationException {
+        AirbaseControlInfo info = webTargets.getAirbaseControlInfo();
+        info.power = power;
+        webTargets.setAirbaseControlInfo(info);
+    }
+
+    @Override
+    protected void changeSetPoint(double newTemperature) throws DaikinCommunicationException {
+        AirbaseControlInfo info = webTargets.getAirbaseControlInfo();
+        info.temp = Optional.of(newTemperature);
+        webTargets.setAirbaseControlInfo(info);
+    }
+
+    @Override
+    protected void changeMode(String mode) throws DaikinCommunicationException {
+        AirbaseControlInfo info = webTargets.getAirbaseControlInfo();
+        info.mode = AirbaseMode.valueOf(mode);
+        webTargets.setAirbaseControlInfo(info);
+    }
+
+    @Override
+    protected void changeFanSpeed(String speed) throws DaikinCommunicationException {
+        AirbaseFanSpeed fanSpeed = AirbaseFanSpeed.valueOf(speed);
+        AirbaseControlInfo info = webTargets.getAirbaseControlInfo();
+        info.f_rate = fanSpeed.getLevel();
+        info.f_auto = fanSpeed.getAuto();
+        info.f_airside = fanSpeed.getAirside();
+        webTargets.setAirbaseControlInfo(info);
+    }
+
+    protected void changeZone(int zone, boolean command) throws DaikinCommunicationException {
+        AirbaseZoneInfo info = webTargets.getAirbaseZoneInfo();
+        info.zone[zone] = command;
+        if (airbaseModelInfo.zonespresent >=zone) {
+            webTargets.setAirbaseZoneInfo(info, airbaseModelInfo);
+        }
+    }
+
+    protected void updateChannelStateDescriptions() {
+        updateAirbaseFanSpeedChannelStateDescription();
+        updateAirbaseModeChannelStateDescription();
+    }
+
+    protected void updateAirbaseFanSpeedChannelStateDescription() {
+        List<StateOption> options = new ArrayList<>();
+        if (airbaseModelInfo.features.contains(AirbaseFeature.AIRSIDE)) {
+            options.add(new StateOption(AirbaseFanSpeed.AIRSIDE.name(), AirbaseFanSpeed.AIRSIDE.getLabel()));
+        }
+        for (AirbaseFanSpeed f : EnumSet.range(AirbaseFanSpeed.LEVEL_1, AirbaseFanSpeed.LEVEL_5)) {
+            options.add(new StateOption(f.name(), f.getLabel()));
+        }
+        if (airbaseModelInfo.features.contains(AirbaseFeature.FRATE_AUTO)) {
+            for (AirbaseFanSpeed f : EnumSet.range(AirbaseFanSpeed.AUTO_LEVEL_1, AirbaseFanSpeed.AUTO_LEVEL_5)) {
+                options.add(new StateOption(f.name(), f.getLabel()));
+            }
+        }
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thing.getUID(), DaikinBindingConstants.CHANNEL_AIRBASE_AC_FAN_SPEED),
+                options);
+    }
+
+    protected void updateAirbaseModeChannelStateDescription() {
+        List<StateOption> options = new ArrayList<>();
+        if (airbaseModelInfo.features.contains(AirbaseFeature.AUTO)) {
+            options.add(new StateOption(AirbaseMode.AUTO.name(), AirbaseMode.AUTO.getLabel()));
+        }
+        for (AirbaseMode f : EnumSet.complementOf(EnumSet.of(AirbaseMode.AUTO, AirbaseMode.DRY))) {
+            options.add(new StateOption(f.name(), f.getLabel()));
+        }
+        if (airbaseModelInfo.features.contains(AirbaseFeature.DRY)) {
+            options.add(new StateOption(AirbaseMode.DRY.name(), AirbaseMode.DRY.getLabel()));
+        }
+        stateDescriptionProvider.setStateOptions(new ChannelUID(thing.getUID(), DaikinBindingConstants.CHANNEL_AC_MODE),
+                options);
+    }
+}

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.daikin.internal.handler;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.ArrayList;
+
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.daikin.internal.DaikinBindingConstants;
+import org.openhab.binding.daikin.internal.DaikinCommunicationException;
+import org.openhab.binding.daikin.internal.DaikinWebTargets;
+import org.openhab.binding.daikin.internal.DaikinDynamicStateDescriptionProvider;
+
+import org.openhab.binding.daikin.internal.config.DaikinConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class that handles common tasks with a Daikin air conditioning unit.
+ *
+ * @author Tim Waterhouse - Initial Contribution
+ * @author Paul Smedley <paul@smedley.id.au> - Modifications to support Airbase Controllers
+ * @author Jimmy Tanagra - Split handler classes, support Airside and DynamicStateDescription
+ *
+ */
+public abstract class DaikinBaseHandler extends BaseThingHandler {
+
+    protected final Logger logger;
+
+    private long refreshInterval;
+
+    protected DaikinWebTargets webTargets;
+    private ScheduledFuture<?> pollFuture;
+    protected final DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
+
+    // Abstract methods to be overridden by specific Daikin implementation class
+    protected abstract void pollStatus() throws IOException;
+
+    protected abstract void changePower(boolean power) throws DaikinCommunicationException;
+    protected abstract void changeSetPoint(double newTemperature) throws DaikinCommunicationException;
+    protected abstract void changeMode(String mode) throws DaikinCommunicationException;
+    protected abstract void changeFanSpeed(String fanSpeed) throws DaikinCommunicationException;
+
+    // Power, Temp, Fan and Mode are handled in this base class. Override this to handle additional channels. 
+    protected abstract boolean handleCommandInternal(ChannelUID channelUID, Command command) throws DaikinCommunicationException;
+
+
+    public DaikinBaseHandler(Thing thing, DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
+        super(thing);
+        logger = LoggerFactory.getLogger(getClass());
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        boolean handled = false;
+        try {
+            switch (channelUID.getId()) {
+                case DaikinBindingConstants.CHANNEL_AC_POWER:
+                    if (command instanceof OnOffType) {
+                        changePower(((OnOffType) command).equals(OnOffType.ON));
+                        handled = true;
+                    }
+                    break;
+                case DaikinBindingConstants.CHANNEL_AC_TEMP:
+                    if (changeSetPoint(command)) {
+                        handled = true;
+                    }
+                    break;
+                case DaikinBindingConstants.CHANNEL_AIRBASE_AC_FAN_SPEED:
+                case DaikinBindingConstants.CHANNEL_AC_FAN_SPEED:
+                    if (command instanceof StringType) {
+                        changeFanSpeed(((StringType) command).toString());
+                        handled = true;
+                    }
+                    break;
+                case DaikinBindingConstants.CHANNEL_AC_MODE:
+                    if (command instanceof StringType) {
+                        changeMode(((StringType) command).toString());
+                        handled = true;
+                    }
+                    break;
+            }
+            if (!handled && !handleCommandInternal(channelUID, command)) {
+                logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command, thing.getUID().getAsString(), channelUID.getId());
+            }
+        } catch (DaikinCommunicationException ex) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
+        }
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Initializing Daikin AC Unit");
+        DaikinConfiguration config = getConfigAs(DaikinConfiguration.class);
+        if (config.host == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Host address must be set");
+        } else {
+            webTargets = new DaikinWebTargets(config.host);
+            refreshInterval = config.refresh;
+
+            schedulePoll();
+        }
+    }
+
+    @Override
+    public void handleRemoval() {
+        super.handleRemoval();
+        stopPoll();
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        stopPoll();
+    }
+
+    protected void schedulePoll() {
+        if (pollFuture != null) {
+            pollFuture.cancel(false);
+        }
+        logger.debug("Scheduling poll for 1s out, then every {} s", refreshInterval);
+        pollFuture = scheduler.scheduleWithFixedDelay(this::poll, 1, refreshInterval, TimeUnit.SECONDS);
+    }
+
+    protected synchronized void stopPoll() {
+        if (pollFuture != null && !pollFuture.isCancelled()) {
+            pollFuture.cancel(true);
+            pollFuture = null;
+        }
+    }
+
+    private synchronized void poll() {
+        try {
+            logger.debug("Polling for state");
+            pollStatus();
+        } catch (IOException e) {
+            logger.debug("Could not connect to Daikin controller", e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        } catch (RuntimeException e) {
+            logger.warn("Unexpected error connecting to Daikin controller", e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    protected void updateTemperatureChannel(String channel, Optional<Double> maybeTemperature) {
+        updateState(channel,
+                maybeTemperature.<State> map(t -> new QuantityType<Temperature>(new DecimalType(t), SIUnits.CELSIUS))
+                        .orElse(UnDefType.UNDEF));
+    }
+
+    /**
+     * @return true if the command was of an expected type, false otherwise
+     */
+    private boolean changeSetPoint(Command command) throws DaikinCommunicationException {
+        double newTemperature;
+        if (command instanceof DecimalType) {
+            newTemperature = ((DecimalType) command).doubleValue();
+        } else if (command instanceof QuantityType) {
+            newTemperature = ((QuantityType<Temperature>) command).toUnit(SIUnits.CELSIUS).doubleValue();
+        } else {
+            return false;
+        }
+
+        // Only half degree increments are allowed, all others are silently rejected by the A/C units
+        newTemperature = Math.round(newTemperature * 2) / 2.0;
+        changeSetPoint(newTemperature);
+        return true;
+    }
+}

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 
 import javax.measure.quantity.Temperature;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
@@ -55,14 +57,14 @@ import org.slf4j.LoggerFactory;
  * @author Jimmy Tanagra - Split handler classes, support Airside and DynamicStateDescription
  *
  */
+@NonNullByDefault
 public abstract class DaikinBaseHandler extends BaseThingHandler {
-
-    protected final Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(DaikinBaseHandler.class);
 
     private long refreshInterval;
 
-    protected DaikinWebTargets webTargets;
-    private ScheduledFuture<?> pollFuture;
+    protected @Nullable DaikinWebTargets webTargets;
+    private @Nullable ScheduledFuture<?> pollFuture;
     protected final DaikinDynamicStateDescriptionProvider stateDescriptionProvider;
 
     // Abstract methods to be overridden by specific Daikin implementation class
@@ -79,7 +81,6 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
 
     public DaikinBaseHandler(Thing thing, DaikinDynamicStateDescriptionProvider stateDescriptionProvider) {
         super(thing);
-        logger = LoggerFactory.getLogger(getClass());
         this.stateDescriptionProvider = stateDescriptionProvider;
     }
 
@@ -137,14 +138,14 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
 
     @Override
     public void handleRemoval() {
-        super.handleRemoval();
         stopPoll();
+        super.handleRemoval();
     }
 
     @Override
     public void dispose() {
-        super.dispose();
         stopPoll();
+        super.dispose();
     }
 
     protected void schedulePoll() {
@@ -167,10 +168,8 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
             logger.debug("Polling for state");
             pollStatus();
         } catch (IOException e) {
-            logger.debug("Could not connect to Daikin controller", e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } catch (RuntimeException e) {
-            logger.warn("Unexpected error connecting to Daikin controller", e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
     }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -86,37 +86,37 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        boolean handled = false;
         try {
+            if (handleCommandInternal(channelUID, command)) {
+                return;
+            }
             switch (channelUID.getId()) {
                 case DaikinBindingConstants.CHANNEL_AC_POWER:
                     if (command instanceof OnOffType) {
                         changePower(((OnOffType) command).equals(OnOffType.ON));
-                        handled = true;
+                        return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AC_TEMP:
                     if (changeSetPoint(command)) {
-                        handled = true;
+                        return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AIRBASE_AC_FAN_SPEED:
                 case DaikinBindingConstants.CHANNEL_AC_FAN_SPEED:
                     if (command instanceof StringType) {
                         changeFanSpeed(((StringType) command).toString());
-                        handled = true;
+                        return;
                     }
                     break;
                 case DaikinBindingConstants.CHANNEL_AC_MODE:
                     if (command instanceof StringType) {
                         changeMode(((StringType) command).toString());
-                        handled = true;
+                        return;
                     }
                     break;
             }
-            if (!handled && !handleCommandInternal(channelUID, command)) {
-                logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command, thing.getUID().getAsString(), channelUID.getId());
-            }
+            logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command, thing.getUID().getAsString(), channelUID.getId());
         } catch (DaikinCommunicationException ex) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
         }

--- a/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -133,14 +133,6 @@
 		<item-type>String</item-type>
 		<label>Fan</label>
 		<description>Current fan speed setting of the AC unit</description>
-		<state>
-			<options>
-				<option value="AUTO">Auto</option>
-				<option value="LEVEL_1">Low</option>
-				<option value="LEVEL_2">Medium</option>
-				<option value="LEVEL_3">High</option>
-			</options>
-		</state>
 	</channel-type>
 
 	<channel-type id="airbase-acunit-zone1">


### PR DESCRIPTION
Split the thing handler class for Daikin "AC Unit" and "Airbase"
Fix the for airbase airside and auto fan modes
Add DynamicStateDescriptionProvider for airbase fan mode to hide airside/auto fan levels when not available
Add DynamicStateDescriptionProvider for airbase ac mode to hide auto/dry when not available
Fix documentation for ac mode state from "DEHUMIDIFIER" ->"DRY"

NOTE that the Airbase fan levels are expanded from 3 levels to 5 levels. Previously, LEVEL_3 means maximum fan speed, it now means "medium" fan speed. This applies to Airbase (airbase_ac_unit) only and does not affect non airbase (ac_unit) implementation.

Fixes #6524