### PR TITLE
[bluetooth.bluegiga] [WIP] Fix BlueGiga discovery and manufacturerData handling

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -194,16 +194,22 @@ public class BlueGigaBluetoothDevice extends BluetoothDevice implements BlueGiga
                         case EIR_FLAGS:
                             break;
                         case EIR_MANUFACTURER_SPECIFIC:
-                            Map<Short, int[]> eirRecord = (Map<Short, int[]>) eir.getRecord(EirDataType.EIR_MANUFACTURER_SPECIFIC);
-                            if (eirRecord != null) {
-                                Map.Entry<Short, int[]> eirEntry = eirRecord.entrySet().iterator().next();
-                                int[] manufacturerInt = eirEntry.getValue();
-                                manufacturerData = new byte[manufacturerInt.length];
-                                for (int i = 0; i < manufacturerInt.length; i++) {
-                                    manufacturerData[i] = (byte) manufacturerInt[i];
+                            Object obj = eir.getRecord(EirDataType.EIR_MANUFACTURER_SPECIFIC);
+                            if (obj != null && obj instanceof Map<?, ?>) {
+                                try {
+                                    @SuppressWarnings("unchecked")
+                                    Map<Short, int[]> eirRecord = (Map<Short, int[]>) obj;
+                                    Map.Entry<Short, int[]> eirEntry = eirRecord.entrySet().iterator().next();
+                                    int[] manufacturerInt = eirEntry.getValue();
+                                    manufacturerData = new byte[manufacturerInt.length];
+                                    for (int i = 0; i < manufacturerInt.length; i++) {
+                                        manufacturerData[i] = (byte) manufacturerInt[i];
+                                    }
+                                    manufacturer = (int) eirEntry.getKey();
+                                } catch (ClassCastException e) {
+                                    logger.debug("Unsupported manufacturer specific record received from device {}",
+                                            address);
                                 }
-
-                                manufacturer = (int) eirEntry.getKey();
                             }
                             break;
                         case EIR_NAME_LONG:

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
@@ -341,7 +341,6 @@ public class BlueGigaBridgeHandler extends BaseBridgeHandler
                 device = new BlueGigaBluetoothDevice(this, new BluetoothAddress(scanEvent.getSender()),
                         scanEvent.getAddressType());
                 devices.put(sender, device);
-                deviceDiscovered(device);
             }
 
             return;


### PR DESCRIPTION
There is multiple stuff wrong being able to work with manufacturerData at BlueGiga and Bluez manufacturerData handling. The following has to be done:

- [x] Fix #6465.
- [x] Only ~ 10% of all advertisement events are arriving the `bluegigaEventReceived` method at all. It's definitely a software issue, as with [this binding](https://github.com/sputnikdev/eclipse-smarthome-bluetooth-binding) at least 90% of the events arrive. [EDIT: scan interval have to be increased. Best option would be probably to add them as config parameters to the binding] [EDIT2: is covered by #6921 now]
- [x] Even with this fix, manufacturerData sent by Bluez and BlueGiga are inconsistent. In my opinion, the BlueGiga implementation is correct and the Bluez one is wrong. Bluez includes message ~~length (1 byte), type (1 byte) and~~ manufacturerId (2 byte) within the manufacturerData. From my point of view, these things do not belong to the _data_ and will never be needed in any bluetooth extension (length+byte is just needed to identify the manufacturerData and manufacturerId does not have to be parsed within the extension as it can be retrieved with `device.manufacturerId`) . Anyhow, changing Bluez binding would be API-breaking for extensions that already use it (to my knowledge it's only ruuvitag).

@kaikreuzer @cdjackson: I'm not sure who's maintaining the BlueGiga Binding currently. Would be great if you could review and may provide your opinion / ideas.

Signed-off-by: Patrick Fink <mail@pfink.de>