### PR TITLE
[digiplex] Fix "Area Ready" channel definition (#6600)

### DIFF
--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
@@ -86,8 +86,8 @@
 		<description>Indicates if area is ready (no open zones)</description>
 		<state readOnly="true">
 			<options>
-				<option value="CLOSED">Ready</option>
-				<option value="OPEN">Not ready</option>
+				<option value="CLOSED">Not ready</option>
+				<option value="OPEN">Ready</option>
 			</options>
 		</state>
 	</channel-type>


### PR DESCRIPTION
Fix for wrong description of channel states