### PR TITLE
Fix itest.bndrun version numbers

### DIFF
--- a/bom/runtime-index/pom.xml
+++ b/bom/runtime-index/pom.xml
@@ -16,6 +16,7 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.runtime</artifactId>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>

--- a/bom/test-index/pom.xml
+++ b/bom/test-index/pom.xml
@@ -21,6 +21,7 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.test</artifactId>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>

--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -23,8 +23,8 @@ Fragment-Host: org.openhab.binding.astro
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.astro;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.astro.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.astro;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.astro.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -33,8 +33,8 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
-	org.openhab.binding.avmfritz;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.avmfritz.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.avmfritz;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.avmfritz.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core.config.discovery.upnp;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -32,8 +32,8 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
-	org.openhab.binding.feed;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.feed.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.feed;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.feed.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -30,8 +30,8 @@ Fragment-Host: org.openhab.binding.hue
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
-	org.openhab.binding.hue;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.hue.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.hue;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.hue.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -28,8 +28,8 @@ Fragment-Host: org.openhab.binding.max
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.openhab.binding.max;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.max.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.max;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.max.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -40,10 +40,10 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.mqtt;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.generic;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.homeassistant;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.homeassistant.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.mqtt;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.generic;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.homeassistant;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.homeassistant.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -39,10 +39,10 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.mqtt;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.generic;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.homie;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.mqtt.homie.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.mqtt;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.generic;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.homie;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt.homie.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -41,8 +41,8 @@ Fragment-Host: org.openhab.binding.nest
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	org.openhab.binding.nest;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.nest.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.nest;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.nest.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -29,8 +29,8 @@ Fragment-Host: org.openhab.binding.ntp
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.ntp;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.ntp.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.ntp;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.ntp.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -25,8 +25,8 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.openhab.binding.systeminfo;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.systeminfo.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.systeminfo;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.systeminfo.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -36,8 +36,8 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.binding.tradfri;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.tradfri.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.tradfri;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.tradfri.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core.config.discovery.mdns;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mdns;version='[2.5.0,2.5.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -31,8 +31,8 @@ Fragment-Host: org.openhab.binding.wemo
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.wemo;version='[2.5.0,2.5.1)',\
-	org.openhab.binding.wemo.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.wemo;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.wemo.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.io.hueemulation.tests/itest.bndrun
+++ b/itests/org.openhab.io.hueemulation.tests/itest.bndrun
@@ -34,8 +34,8 @@ Fragment-Host: org.openhab.io.hueemulation
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.io.hueemulation;version='[2.5.0,2.5.1)',\
-	org.openhab.io.hueemulation.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.io.hueemulation;version='[2.5.1,2.5.2)',\
+	org.openhab.io.hueemulation.tests;version='[2.5.1,2.5.2)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
@@ -49,8 +49,8 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mqtt;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.io.mqttembeddedbroker;version='[2.5.0,2.5.1)',\
-	org.openhab.io.mqttembeddedbroker.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.io.mqttembeddedbroker;version='[2.5.1,2.5.2)',\
+	org.openhab.io.mqttembeddedbroker.tests;version='[2.5.1,2.5.2)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -23,8 +23,8 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.persistence;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.persistence.mapdb;version='[2.5.0,2.5.1)',\
-	org.openhab.persistence.mapdb.tests;version='[2.5.0,2.5.1)',\
+	org.openhab.persistence.mapdb;version='[2.5.1,2.5.2)',\
+	org.openhab.persistence.mapdb.tests;version='[2.5.1,2.5.2)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\


### PR DESCRIPTION
itest.bndrun files pointed to older version number for the addons it tested.