### PR TITLE
Added ohc.version variable

### DIFF
--- a/bom/openhab-core-index/pom.xml
+++ b/bom/openhab-core-index/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.openhab-core</artifactId>
-      <version>${project.version}</version>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>

--- a/bom/runtime-index/pom.xml
+++ b/bom/runtime-index/pom.xml
@@ -16,6 +16,7 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.runtime</artifactId>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>

--- a/bom/test-index/pom.xml
+++ b/bom/test-index/pom.xml
@@ -21,6 +21,7 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.test</artifactId>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>

--- a/bundles/org.openhab.binding.airquality/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.airquality/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.airquality-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-airquality" description="Air Quality Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.airvisualnode/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.airvisualnode-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-airvisualnode" description="AirVisual Node Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.allplay/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.allplay/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.allplay-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-allplay" description="AllPlay Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.amazondashbutton/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.amazondashbutton-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-amazondashbutton" description="Amazon Dash Button Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.amazonechocontrol-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-amazonechocontrol" description="Amazon Echo Control Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.ambientweather/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ambientweather/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ambientweather-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-ambientweather" description="Ambient Weather Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.astro/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.astro/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.astro-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-astro" description="Astro Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.atlona/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.atlona/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.atlona-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-atlona" description="Atlona PRO3 Switch Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.autelis/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.autelis/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.autelis-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-autelis" description="Autelis Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.avmfritz-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-avmfritz" description="AVM FRITZ!Box Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bigassfan/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bigassfan/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bigassfan-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bigassfan" description="Big Ass Fan Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bluetooth.bluegiga-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bluetooth-bluegiga" description="Bluetooth Binding Bluegiga" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bluetooth.bluez-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bluetooth-bluez" description="Bluetooth Binding Bluez" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bluetooth.blukii/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.blukii/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bluetooth.blukii-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bluetooth-bluuki" description="Bluetooth Binding Blukii" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bluetooth.ruuvitag/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth.ruuvitag/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bluetooth.ruuvitag-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bluetooth-ruuvitag" description="Bluetooth Binding Ruuvitag" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bluetooth/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bluetooth/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bluetooth-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.boschindego/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.boschindego/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.boschindego-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-boschindego" description="Bosch Indego Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.bosesoundtouch/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.bosesoundtouch-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-bosesoundtouch" description="Bose SoundTouch Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.buienradar/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.buienradar/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.buienradar-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-buienradar" description="Buienradar Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.chromecast/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.chromecast-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-chromecast" description="Chromecast Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.cm11a/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.cm11a/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.cm11a-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-cm11a" description="cm11a Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.coolmasternet/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.coolmasternet/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.coolmasternet-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-coolmasternet" description="CoolMasterNet Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.daikin/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.daikin/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.daikin-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-daikin" description="Daikin Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.darksky/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.darksky/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.darksky-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-darksky" description="Dark Sky Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.deconz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.deconz-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-deconz" description="Dresden Elektronik deCONZ Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.denonmarantz-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-denonmarantz" description="Denon / Marantz Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.digiplex/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.digiplex-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-digiplex" description="Digiplex/EVO Alarm System Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.digitalstrom/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.digitalstrom-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-digitalstrom" description="digitalSTROM Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dlinksmarthome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.dlinksmarthome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-dlinksmarthome" description="D-Link Smart Home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.dmx/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dmx/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.dmx-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-dmx" description="DMX Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.doorbird/src/main/feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.doorbird-${project.version}"
 	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-doorbird" description="Doorbird Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.dscalarm/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dscalarm/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.dscalarm-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-dscalarm" description="DSCAlarm Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.dsmr/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dsmr/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.dsmr-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-dsmr" description="DSMR Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.dwdunwetter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-dwdunwetter" description="DwdUnwetter Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.elerotransmitterstick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.elerotransmitterstick/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.elerotransmitterstick-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-elerotransmitterstick" description="Elero TransmitterStick Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.enocean/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.enocean-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-enocean" description="EnOcean Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.enturno/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.enturno/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.enturno-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-enturno" description="Enturno Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.evohome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.evohome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.evohome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-evohome" description="Evohome Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.exec/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.exec/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.exec-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-exec" description="Exec Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.feed/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.feed/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.feed-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-feed" description="Feed Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.feican/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.feican/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.feican-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-feican" description="Feican Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.folding/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.folding/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.folding-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-folding" description="Folding Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.foobot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.foobot/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.foobot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-foobot" description="Foobot Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.freebox/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.freebox/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.freebox-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-freebox" description="Freebox Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.fronius/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.fronius/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.fronius-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-fronius" description="Fronius Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.fsinternetradio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.fsinternetradio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.fsinternetradio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-fsinternetradio" description="Frontier Silicon Internet Radio Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.ftpupload/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ftpupload/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ftpupload-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-ftpupload" description="FTP Upload Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.gardena/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.gardena/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.gardena-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-gardena" description="Gardena Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.gpstracker/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.gpstracker/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.gpstracker-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-gpstracker" description="GPSTracker Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.groheondus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-groheondus" description="GROHE ONDUS Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.harmonyhub/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.harmonyhub/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.harmonyhub-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-harmonyhub" description="Harmony Hub Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.hdanywhere/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hdanywhere/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hdanywhere-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hdanywhere" description="HDAnywhere Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hdpowerview-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hdpowerview" description="HD PowerView Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.helios/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.helios/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.helios-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-helios" description="Helios Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.heos/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.heos/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.heos-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-heos" description="Heos Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.homematic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.homematic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-homematic" description="Homematic Binding" version="${project.version}">
         <feature>openhab-transport-upnp</feature>

--- a/bundles/org.openhab.binding.hpprinter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hpprinter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hpprinter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hpprinter" description="HP Printer Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.hue/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hue/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hue-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hue" description="Hue Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.hydrawise/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hydrawise/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hydrawise-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hydrawise" description="Hydrawise Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hyperion/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.hyperion-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-hyperion" description="Hyperion Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.iaqualink/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.iaqualink/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.iaqualink-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-iaqualink" description="iAqualink Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.icloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.icloud/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.icloud-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-icloud" description="icloud Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.ihc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ihc/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ihc-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-ihc" description="IHC / ELKO Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.innogysmarthome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-innogysmarthome" description="innogy Smarthome Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.ipp/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ipp/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ipp-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-ipp" description="IPP Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.irtrans/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.irtrans/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.irtrans-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-irtrans" description="IRTrans Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.jeelink/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.jeelink-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-jeelink" description="Jeelink Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.keba/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.keba/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.keba-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-keba" description="Keba Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.km200/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.km200/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.km200-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-km200" description="KM200 Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.knx/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.knx/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.knx-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-knx" description="KNX Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.kodi/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.kodi/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.kodi-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-kodi" description="Kodi Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.konnected/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.konnected-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-konnected" description="Konnected Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.kostalinverter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-kostalinverter" description="Kostal Inverter Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lametrictime/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lametrictime/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lametrictime-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lametrictime" description="LaMetric Time Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.leapmotion/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.leapmotion/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.leapmotion-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-leapmotion" description="LeapMotion Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lghombot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lghombot/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lghombot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-lghombot" description="LG HomBot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lgtvserial/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lgtvserial-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lgtvserial" description="LG TV Serial Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lgwebos/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lgwebos/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lgwebos-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lgwebos" description="LG webOS Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lifx/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lifx-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lifx" description="LIFX Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.linuxinput/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.linuxinput/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.linuxinput-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-linuxinput" description="Linux Input Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lirc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lirc/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lirc-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lirc" description="LIRC Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.logreader/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.logreader/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.logreader-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-logreader" description="Log Reader Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.loxone/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.loxone/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.loxone-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-loxone" description="Loxone Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.lutron/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lutron-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-lutron" description="Lutron Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mail/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mail/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mail-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mail" description="Mail Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.max/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.max/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.max-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-max" description="MAX! Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mcp23017/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mcp23017/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mcp23017-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mcp23017" description="MCP23017 Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.melcloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.melcloud/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ihc-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-melcloud" description="MELCloud Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.meteoblue/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.meteoblue/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.meteoblue-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-meteoblue" description="meteoblue Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.meteostick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.meteostick/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.meteostick-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-meteostick" description="Meteostick Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.miele/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.miele/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.miele-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-miele" description="Miele@home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mihome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mihome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mihome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mihome" description="Xiaomi Mi Smart Home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.miio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.miio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.miio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-miio" description="Xiaomi Mi IO Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.milight/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.milight/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.milight-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-milight" description="Milight Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.minecraft/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.minecraft/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.minecraft-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-minecraft" description="Minecraft Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mqtt.generic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mqtt-generic" description="MQTT Binding Generic" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mqtt.homeassistant-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mqtt-homeassistant" description="MQTT Binding Homeassistant" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mqtt.homie-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mqtt-homie" description="MQTT Binding Homie" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.mqtt/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.mqtt-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-mqtt" description="MQTT Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nanoleaf-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nanoleaf" description="Nanoleaf Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.neato/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.neato/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.neato-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-neato" description="Neato Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.neeo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.neeo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.neeo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-neeo" description="NEEO Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.neohub/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.neohub/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.neohub-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-neohub" description="NeoHub Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nest/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nest/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nest-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nest" description="Nest Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.netatmo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.netatmo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-netatmo" description="Netatmo Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.network/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.network/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.network-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-network" description="Network Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.networkupstools/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.networkupstools/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.networkupstools-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-networkupstools" description="Network UPS Tools Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nibeheatpump/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nibeheatpump/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nibeheatpump-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nibeheatpump" description="Nibe Heat Pump Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nibeuplink/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nibeuplink/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nibeuplink-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nibeuplink" description="NibeUplink Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nikobus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nikobus/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nikobus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nikobus" description="Nikobus Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nikohomecontrol-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nikohomecontrol" description="Niko Home Control Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.ntp/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.ntp/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.ntp-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-ntp" description="NTP Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.nuki/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.nuki-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-nuki" description="Nuki Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.oceanic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.oceanic/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.oceanic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-oceanic" description="Oceanic Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.omnikinverter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.omnikinverter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.omnikinverter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-omnikinverter" description="Omnik Inverter Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.onebusaway/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.onebusaway/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.onebusaway-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-onebusaway" description="OneBusAway Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.onewire/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.onewire/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.onewire-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-onewire" description="OneWire Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.onewiregpio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.onewiregpio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-onewiregpio" description="OneWireGPIO Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.onkyo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.onkyo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.onkyo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-onkyo" description="Onkyo Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.opengarage/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.opengarage/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.opengarage-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-opengarage" description="OpenGarage Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.opensprinkler-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-opensprinkler" description="OpenSprinkler Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.openuv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.openuv/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.openuv-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-openuv" description="OpenUV Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.openweathermap/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.openweathermap/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.openweathermap-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-openweathermap" description="OpenWeatherMap Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.orvibo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.orvibo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.orvibo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-orvibo" description="Orvibo Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.paradoxalarm-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-paradoxalarm" description="Paradox Alarm System Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pentair/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pentair/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pentair-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pentair" description="Pentair Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.phc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.phc/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.phc-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-phc" description="PHC Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pioneeravr/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pioneeravr-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pioneeravr" description="PioneerAVR Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pixometer/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pixometer/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pixometer-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pixometer" description="pixometer Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pjlinkdevice-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pjlinkdevice" description="PJLinkDevice Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.plclogo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.plclogo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.plclogo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-plclogo" description="PLCLogo Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.plugwise/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.plugwise-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-plugwise" description="Plugwise Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.powermax/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.powermax/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.powermax-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-powermax" description="Powermax Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pulseaudio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pulseaudio" description="Pulseaudio Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.pushbullet/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pushbullet/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.pushbullet-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-pushbullet" description="Pushbullet Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.regoheatpump/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.regoheatpump-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-regoheatpump" description="RegoHeatPump Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.rfxcom/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.rfxcom-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-rfxcom" description="RFXCOM Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.rme/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.rme/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.rme-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-rme" description="RME Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.robonect/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.robonect/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.robonect-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-robonect" description="Robonect Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.rotel/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.rotel/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.freebox-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-rotel" description="Rotel Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.rotelra1x/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.rotelra1x/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.rotelra1x-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-rotelra1x" description="RotelRa1x Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.russound/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.russound/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.russound-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-russound" description="Russound Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.samsungtv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.samsungtv/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.samsungtv-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-samsungtv" description="Samsung TV Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.satel/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.satel/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.satel-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-satel" description="Satel Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.seneye/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.seneye/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.seneye-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-seneye" description="Seneye Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.sensebox/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sensebox/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.sensebox-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sensebox" description="Sensebox Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.serialbutton/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.serialbutton/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.serialbutton-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-serialbutton" description="Serial Button Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.shelly/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.shelly-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-shelly" description="Shelly Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>        

--- a/bundles/org.openhab.binding.siemensrds/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.siemensrds/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.neohub-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-siemensrds" description="Siemens RDS Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.silvercrestwifisocket/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.silvercrestwifisocket/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.silvercrestwifisocket-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-silvercrestwifisocket" description="Silvercrest Wifi Plug Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.sinope/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sinope/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.sinope-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sinope" description="Sinope Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.sleepiq/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sleepiq/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.sleepiq-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sleepiq" description="SleepIQ Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.smaenergymeter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.smaenergymeter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.smaenergymeter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-smaenergymeter" description="SMA Energy Monitor Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.smartmeter/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.smartmeter/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.smartmeter-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-smartmeter" description="Smartmeter Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.snmp/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.snmp/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.snmp-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-snmp" description="SNMP Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.solaredge/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.solaredge/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.solaredge-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-solaredge" description="SolarEdge Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.solarlog/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.solarlog/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.solarlog-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-solarlog" description="SolarLog Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.somfytahoma/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.somfytahoma-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-somfytahoma" description="Somfy Tahoma Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.sonos/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sonos/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.sonos-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sonos" description="Sonos Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.sonyaudio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sonyaudio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.sonyaudio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sonyaudio" description="Sony Audio Binding" version="${project.version}">
         <feature>openhab-transport-upnp</feature>

--- a/bundles/org.openhab.binding.sonyprojector/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.powermax-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-sonyprojector" description="Sony Projector Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.spotify/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.spotify/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.spotify-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-spotify" description="Spotify Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.squeezebox/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.squeezebox-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-squeezebox" description="Squeezebox Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.synopanalyzer/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.synopanalyzer/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.synopanalyzer-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-synopanalyzer" description="Synop Analyzer Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.systeminfo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-systeminfo" description="System Info Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tado/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tado/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tado-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tado" description="Tado Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tankerkoenig/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tankerkoenig/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tankerkoenig-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tankerkoenig" description="Tankerkoenig Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.telegram-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-telegram" description="Telegram Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tellstick-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tellstick" description="Tellstick Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tesla/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tesla-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tesla" description="Tesla Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.toon/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.toon/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.toon-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-toon" description="Toon Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tplinksmarthome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tplinksmarthome" description="TP-Link Smart Home Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.tradfri/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.tradfri-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-tradfri" description="TRÅDFRI Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.unifi/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.unifi/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.unifi-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-unifi" description="UniFi Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.urtsi/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.urtsi/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.urtsi-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-urtsi" description="Somfy URTSI II Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.valloxmv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.valloxmv/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.valloxmv-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-valloxmv" description="ValloxMV Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.vektiva/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.vektiva/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.vektiva-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-vektiva" description="Vektiva Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.velbus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.velbus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-velbus" description="Velbus Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.vitotronic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.vitotronic/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.vitotronic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-vitotronic" description="Vitotronic Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.volvooncall/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.volvooncall/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.astro-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-volvooncall" description="Volvo On Call Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.weathercompany/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.weathercompany/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.weathercompany-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features
 	</repository>
 
 	<feature name="openhab-binding-weathercompany" description="Weather Company Binding" version="${project.version}">

--- a/bundles/org.openhab.binding.weatherunderground/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.weatherunderground-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-weatherunderground" description="WeatherUnderground Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.wemo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wemo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.wemo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-wemo" description="Wemo Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.wifiled/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wifiled/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.wifiled-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-wifiled" description="WiFi LED Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.windcentrale/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.windcentrale/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.windcentrale-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-windcentrale" description="Windcentrale Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.xmltv/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmltv/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.xmltv-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-xmltv" description="XMLTV Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.xmppclient/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.xmppclient-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-xmppclient" description="XMPP Client Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.yamahareceiver-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-yamahareceiver" description="Yamaha Receiver Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.yeelight/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.yeelight/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.yeelight-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-yeelight" description="Yeelight Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.zoneminder/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.zoneminder/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.zoneminder-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-zoneminder" description="ZoneMinder Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.binding.zway/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.zway/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.zway-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-binding-zway" description="Z-Way Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.extensionservice.marketplace.automation/src/main/feature/feature.xml
+++ b/bundles/org.openhab.extensionservice.marketplace.automation/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.extensionservice.marketplace.automation-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 
 </features>

--- a/bundles/org.openhab.extensionservice.marketplace/src/main/feature/feature.xml
+++ b/bundles/org.openhab.extensionservice.marketplace/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.extensionservice.marketplace-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-market" description="Eclipse IoT Market" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.azureiothub/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.azureiothub/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.azureiothub-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-azureiothub" description="Azure IoT Hub Connector" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.homekit/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.homekit/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.homekit-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-homekit" description="HomeKit Integration" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.hueemulation/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.hueemulation/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.hueemulation-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-hueemulation" description="Hue Emulation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.imperihome/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.imperihome/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.imperihome-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-imperihome" description="ImperiHome Integration" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.javasound/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.javasound/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.javasound-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-io-javasound" description="JavaSound Audio Support" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.mqttembeddedbroker/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.mqttembeddedbroker/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.mqttembeddedbroker-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-mqttbroker" description="MQTT Broker Moquette" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.neeo/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.neeo/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.neeo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
      <feature name="openhab-misc-neeo" description="NEEO Integration" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.openhabcloud-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-misc-openhabcloud" description="openHAB Cloud Connector" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.transport.modbus/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.transport.modbus/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.transport.modbus-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transport-modbus" description="Modbus Transport" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.io.webaudio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.webaudio/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.io.webaudio-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-io-webaudio" description="Web Audio Support" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.persistence.mapdb/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.mapdb/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.persistence.mapdb-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 
 </features>

--- a/bundles/org.openhab.transform.bin2json/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.bin2json/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.bin2json-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-bin2json" description="Binary To JSON Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.exec/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.exec/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.exec-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-exec" description="Exec Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.javascript/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.javascript/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.javascript-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-javascript" description="Javascript Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.jinja-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-jinja" description="Jinja Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.jsonpath/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jsonpath/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.jsonpath-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-jsonpath" description="JSONPath Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.map/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.map/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.map-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-map" description="Map Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.regex/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.regex/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.regex-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-regex" description="RegEx Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.scale/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.scale/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.scale-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-scale" description="Scale Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.xpath/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.xpath/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.xpath-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-xpath" description="XPath Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.transform.xslt/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.xslt/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.transform.xslt-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-transformation-xslt" description="XSLT Transformation" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.googletts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.googletts/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.googletts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-googletts" description="Google Cloud Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.mactts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.mactts/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.mactts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-mactts" description="macOS Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.marytts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.marytts/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.marytts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-marytts" description="Mary Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.picotts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.picotts/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.picotts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-picotts" description="Pico Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.pollytts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-pollytts" description="Polly Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/bundles/org.openhab.voice.voicerss/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.voicerss/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.voice.voicerss-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
     <feature name="openhab-voice-voicerss" description="VoiceRSS Text-to-Speech" version="${project.version}">
         <feature>openhab-runtime-base</feature>

--- a/features/openhab-addons/src/main/resources/header.xml
+++ b/features/openhab-addons/src/main/resources/header.xml
@@ -15,5 +15,5 @@
 -->
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -40,13 +40,14 @@
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.openhab-core</artifactId>
-      <version>${project.version}</version>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bom</groupId>
       <artifactId>org.openhab.core.bom.compile</artifactId>
+      <version>${ohc.version}</version>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
@@ -89,6 +90,7 @@
         <dependency>
           <groupId>org.openhab.core.bom</groupId>
           <artifactId>org.openhab.core.bom.test</artifactId>
+          <version>${ohc.version}</version>
           <type>pom</type>
           <scope>provided</scope>
         </dependency>
@@ -96,21 +98,21 @@
         <dependency>
           <groupId>org.openhab.core.bom</groupId>
           <artifactId>org.openhab.core.bom.test-index</artifactId>
-          <version>${project.version}</version>
+          <version>${ohc.version}</version>
           <type>pom</type>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.openhab.core.bom</groupId>
           <artifactId>org.openhab.core.bom.openhab-core-index</artifactId>
-          <version>${project.version}</version>
+          <version>${ohc.version}</version>
           <type>pom</type>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.openhab.core.bom</groupId>
           <artifactId>org.openhab.core.bom.runtime-index</artifactId>
-          <version>${project.version}</version>
+          <version>${ohc.version}</version>
           <type>pom</type>
           <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
+    <ohc.version>${project.version}</ohc.version>
     <bnd.version>4.3.0</bnd.version>
     <karaf.version>4.2.7</karaf.version>
     <sat.version>0.8.0</sat.version>
@@ -85,35 +86,35 @@
       <dependency>
         <groupId>org.openhab.core.bom</groupId>
         <artifactId>org.openhab.core.bom.compile</artifactId>
-        <version>${project.version}</version>
+        <version>${ohc.version}</version>
         <type>pom</type>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.openhab.core.bom</groupId>
         <artifactId>org.openhab.core.bom.compile-model</artifactId>
-        <version>${project.version}</version>
+        <version>${ohc.version}</version>
         <type>pom</type>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.openhab.core.bom</groupId>
         <artifactId>org.openhab.core.bom.openhab-core</artifactId>
-        <version>${project.version}</version>
+        <version>${ohc.version}</version>
         <type>pom</type>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.openhab.core.bom</groupId>
         <artifactId>org.openhab.core.bom.runtime</artifactId>
-        <version>${project.version}</version>
+        <version>${ohc.version}</version>
         <type>pom</type>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.openhab.core.bom</groupId>
         <artifactId>org.openhab.core.bom.test</artifactId>
-        <version>${project.version}</version>
+        <version>${ohc.version}</version>
         <type>pom</type>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
This allows for easier working with a specific core version.
Run maven with -Dohc.version=<core-version> to compile against a specific core version.

This change was also added to the 2.5.x branch, so it also makes changes with that branch smaller.