### PR TITLE
[miio] Enable local database files

### DIFF
--- a/bundles/org.openhab.binding.miio/README.base.md
+++ b/bundles/org.openhab.binding.miio/README.base.md
@@ -20,6 +20,19 @@ The following things types are available:
 
 !!!devices
 
+# Advanced: Unsupported devices
+
+Newer devices may not yet be supported. However, many devices share large similarties with existing devices.
+The binding allows to try/test if your new device is working with database files of older devices as well.
+For this, first remove your unsupported thing. Manually add a miio:basic thing. Besides the regular configuration (like ip address, token) the modelId needs to be provided.
+Normally the modelId is populated with the model of your device, however in this case, use the modelId of a similar device.
+Look at the openhab forum, or the openhab github repository for the modelId of similar devices.
+
+# Advanced: adding local database files to support new devices
+
+Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
+The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in Openhab github.
+
 # Discovery
 
 The binding has 2 methods for discovering devices. Depending on your network setup and the device model, your device may be discovered by one or both methods. If both methods discover your device, 2 discovery results may be in your inbox for the same device.

--- a/bundles/org.openhab.binding.miio/README.base.md
+++ b/bundles/org.openhab.binding.miio/README.base.md
@@ -31,7 +31,10 @@ Look at the openhab forum, or the openhab github repository for the modelId of s
 # Advanced: adding local database files to support new devices
 
 Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
-The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in Openhab github.
+The config/misc/miio (e.g. in Linux `/opt/openhab2/config/misc/miio/`) is scanned for database files and will be used for your devices. 
+Note that local database files take preference over build-in ones. 
+Hence if a json file is local and in the database the local file will be used. 
+For format, please check the current database files in Openhab github.
 
 # Discovery
 
@@ -45,12 +48,12 @@ Accept only one of the 2 discovery results, the alternate one can further be ign
 
 The binding needs a token from the Xiaomi Mi Device in order to be able to control it.
 Some devices provide the token upon discovery. This may depends on the firmware version.
-
 If the device does not discover your token, it needs to be retrieved from the Mi Home app.
-Note: latest Android MiHome no longer has the tokens in the database. Use 5.0.19 version or lower 
-The token needs to be retrieved from the application database. The easiest way on Android to do is by using [MiToolkit](https://github.com/ultrara1n/MiToolkit/releases).
 
-Alternatively, on Android open a backup file, or browse a rooted device, find the mio2db file with and read it sqlite.
+The easiest way to obtain tokens is to browse through log files of the Mi Home app version 5.4.49 for Android. 
+It seems that version was released with debug messages turned on by mistake. 
+An APK file with the old version can be easily found using one of the popular web search engines. 
+After downgrading use a file browser to navigate to directory SmartHome/logs/plug_DeviceManager, then open the most recent file and search for the token. When finished, use Google Play to get the most recent version back.
 
 For iPhone, use an un-encrypted iTunes-Backup and unpack it and use a sqlite tool to view the files in it: 
 Then search in "RAW, com.xiaomi.home," for "USERID_mihome.sqlite" and look for the 32-digit-token or 96 digit encrypted token.

--- a/bundles/org.openhab.binding.miio/README.base.md
+++ b/bundles/org.openhab.binding.miio/README.base.md
@@ -32,8 +32,7 @@ Look at the openhab forum, or the openhab github repository for the modelId of s
 
 Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
 The config/misc/miio (e.g. in Linux `/opt/openhab2/config/misc/miio/`) is scanned for database files and will be used for your devices. 
-Note that local database files take preference over build-in ones. 
-Hence if a json file is local and in the database the local file will be used. 
+Note that local database files take preference over build-in ones, hence if a json file is local and in the database the local file will be used. 
 For format, please check the current database files in Openhab github.
 
 # Discovery

--- a/bundles/org.openhab.binding.miio/README.base.md
+++ b/bundles/org.openhab.binding.miio/README.base.md
@@ -22,15 +22,18 @@ The following things types are available:
 
 # Advanced: Unsupported devices
 
-Newer devices may not yet be supported. However, many devices share large similarties with existing devices.
+Newer devices may not yet be supported.
+However, many devices share large similarties with existing devices.
 The binding allows to try/test if your new device is working with database files of older devices as well.
-For this, first remove your unsupported thing. Manually add a miio:basic thing. Besides the regular configuration (like ip address, token) the modelId needs to be provided.
+For this, first remove your unsupported thing. Manually add a miio:basic thing. 
+Besides the regular configuration (like ip address, token) the modelId needs to be provided.
 Normally the modelId is populated with the model of your device, however in this case, use the modelId of a similar device.
 Look at the openhab forum, or the openhab github repository for the modelId of similar devices.
 
 # Advanced: adding local database files to support new devices
 
-Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
+Things using the basic handler (miio:basic things) are driven by json 'database' files.
+This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
 The config/misc/miio (e.g. in Linux `/opt/openhab2/config/misc/miio/`) is scanned for database files and will be used for your devices. 
 Note that local database files take preference over build-in ones, hence if a json file is local and in the database the local file will be used. 
 For format, please check the current database files in Openhab github.

--- a/bundles/org.openhab.binding.miio/README.md
+++ b/bundles/org.openhab.binding.miio/README.md
@@ -145,18 +145,20 @@ The following things types are available:
 
 # Advanced: Unsupported devices
 
-Newer devices may not yet be supported. However, many devices share large similarties with existing devices.
+Newer devices may not yet be supported.
+However, many devices share large similarties with existing devices.
 The binding allows to try/test if your new device is working with database files of older devices as well.
-For this, first remove your unsupported thing. Manually add a miio:basic thing. Besides the regular configuration (like ip address, token) the modelId needs to be provided.
+For this, first remove your unsupported thing. Manually add a miio:basic thing. 
+Besides the regular configuration (like ip address, token) the modelId needs to be provided.
 Normally the modelId is populated with the model of your device, however in this case, use the modelId of a similar device.
 Look at the openhab forum, or the openhab github repository for the modelId of similar devices.
 
 # Advanced: adding local database files to support new devices
 
-Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
+Things using the basic handler (miio:basic things) are driven by json 'database' files.
+This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
 The config/misc/miio (e.g. in Linux `/opt/openhab2/config/misc/miio/`) is scanned for database files and will be used for your devices. 
-Note that local database files take preference over build-in ones. 
-Hence if a json file is local and in the database the local file will be used. 
+Note that local database files take preference over build-in ones, hence if a json file is local and in the database the local file will be used. 
 For format, please check the current database files in Openhab github.
 
 # Discovery

--- a/bundles/org.openhab.binding.miio/README.md
+++ b/bundles/org.openhab.binding.miio/README.md
@@ -27,6 +27,7 @@ The following things types are available:
 | Midea Air Conditioner xa1    | miio:unsupported | midea.aircondition.xa1 | No        |            |
 | Mi Air Monitor v1            | miio:basic       | [zhimi.airmonitor.v1](#zhimi-airmonitor-v1) | Yes       |            |
 | Mi Air Quality Monitor 2gen  | miio:basic       | [cgllc.airmonitor.b1](#cgllc-airmonitor-b1) | Yes       |            |
+| Mi Air Quality Monitor S1    | miio:basic       | [cgllc.airmonitor.s1](#cgllc-airmonitor-s1) | Yes       |            |
 | Mi Air Humidifier            | miio:basic       | [zhimi.humidifier.v1](#zhimi-humidifier-v1) | Yes       |            |
 | Mi Air Humidifier            | miio:basic       | [zhimi.humidifier.ca1](#zhimi-humidifier-ca1) | Yes       |            |
 | Mija Smart humidifier        | miio:basic       | [deerma.humidifier.mjjsq](#deerma-humidifier-mjjsq) | Yes       |            |
@@ -43,7 +44,8 @@ The following things types are available:
 | Mi Air Purifier 3            | miio:basic       | [zhimi.airpurifier.ma4](#zhimi-airpurifier-ma4) | Yes       |            |
 | Mi Air Purifier Super        | miio:basic       | [zhimi.airpurifier.sa1](#zhimi-airpurifier-sa1) | Yes       |            |
 | Mi Air Purifier Super 2      | miio:basic       | [zhimi.airpurifier.sa2](#zhimi-airpurifier-sa2) | Yes       |            |
-| Mi Fresh Air Ventilator      | miio:unsupported | dmaker.airfresh.t2017  | No        |            |
+| Mi Fresh Air Ventilator      | miio:basic       | [dmaker.airfresh.t2017](#dmaker-airfresh-t2017) | Yes       |            |
+| Mi Fresh Air Ventilator A1   | miio:basic       | [dmaker.airfresh.a1](#dmaker-airfresh-a1) | Yes       |            |
 | Xiao AI Smart Alarm Clock    | miio:unsupported | zimi.clock.myk01       | No        |            |
 | Yeelight Smart Bath Heater   | miio:unsupported | yeelight.bhf_light.v2  | No        |            |
 | XIAOMI MIJIA WIDETECH WDH318EFW1 Dehumidifier | miio:unsupported | nwt.derh.wdh318efw1    | No        |            |
@@ -140,6 +142,7 @@ The following things types are available:
 | Yeelight Color Bulb YLDP06YL 10W | miio:basic       | [yeelink.light.color2](#yeelink-light-color2) | Yes       |            |
 | Yeelight Color Bulb          | miio:basic       | [yeelink.light.color3](#yeelink-light-color3) | Yes       |            |
 
+
 # Advanced: Unsupported devices
 
 Newer devices may not yet be supported. However, many devices share large similarties with existing devices.
@@ -151,7 +154,10 @@ Look at the openhab forum, or the openhab github repository for the modelId of s
 # Advanced: adding local database files to support new devices
 
 Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
-The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in Openhab github.
+The config/misc/miio (e.g. in Linux `/opt/openhab2/config/misc/miio/`) is scanned for database files and will be used for your devices. 
+Note that local database files take preference over build-in ones. 
+Hence if a json file is local and in the database the local file will be used. 
+For format, please check the current database files in Openhab github.
 
 # Discovery
 
@@ -165,12 +171,12 @@ Accept only one of the 2 discovery results, the alternate one can further be ign
 
 The binding needs a token from the Xiaomi Mi Device in order to be able to control it.
 Some devices provide the token upon discovery. This may depends on the firmware version.
-
 If the device does not discover your token, it needs to be retrieved from the Mi Home app.
-Note: latest Android MiHome no longer has the tokens in the database. Use 5.0.19 version or lower 
-The token needs to be retrieved from the application database. The easiest way on Android to do is by using [MiToolkit](https://github.com/ultrara1n/MiToolkit/releases).
 
-Alternatively, on Android open a backup file, or browse a rooted device, find the mio2db file with and read it sqlite.
+The easiest way to obtain tokens is to browse through log files of the Mi Home app version 5.4.49 for Android. 
+It seems that version was released with debug messages turned on by mistake. 
+An APK file with the old version can be easily found using one of the popular web search engines. 
+After downgrading use a file browser to navigate to directory SmartHome/logs/plug_DeviceManager, then open the most recent file and search for the token. When finished, use Google Play to get the most recent version back.
 
 For iPhone, use an un-encrypted iTunes-Backup and unpack it and use a sqlite tool to view the files in it: 
 Then search in "RAW, com.xiaomi.home," for "USERID_mihome.sqlite" and look for the 32-digit-token or 96 digit encrypted token.
@@ -237,14 +243,23 @@ e.g. `smarthome:send actionCommand 'upd_timer["1498595904821", "on"]'` would ena
 
 | Channel          | Type    | Description                         |
 |------------------|---------|-------------------------------------|
-| power            | Switch  | Power                               |
-| aqi              | Number  | Air Quality Index                   |
 | battery          | Number  | Battery                             |
-| usb_state        | Switch  | USB State                           |
-| time_state       | Switch  | Time State                          |
-| night_state      | Switch  | Night State                         |
-| night_begin      | Number  | Night Begin Time                    |
-| night_end        | Number  | Night End Time                      |
+| pm25             | Number  | PM2.5                               |
+| co2              | Number  | CO2e                                |
+| tvoc             | Number  | tVOC                                |
+| humidity         | Number  | Humidity                            |
+| temperature      | Number  | Temperature                         |
+
+### Mi Air Quality Monitor S1 (<a name="cgllc-airmonitor-s1">cgllc.airmonitor.s1</a>) Channels
+
+| Channel          | Type    | Description                         |
+|------------------|---------|-------------------------------------|
+| battery          | Number  | Battery                             |
+| pm25             | Number  | PM2.5                               |
+| co2              | Number  | CO2                                 |
+| tvoc             | Number  | tVOC                                |
+| humidity         | Number  | Humidity                            |
+| temperature      | Number  | Temperature                         |
 
 ### Mi Air Humidifier (<a name="zhimi-humidifier-v1">zhimi.humidifier.v1</a>) Channels
 
@@ -556,6 +571,50 @@ e.g. `smarthome:send actionCommand 'upd_timer["1498595904821", "on"]'` would ena
 | temperature      | Number  | Temperature                         |
 | purifyvolume     | Number  | Purivied Volume                     |
 | childlock        | Switch  | Child Lock                          |
+
+### Mi Fresh Air Ventilator (<a name="dmaker-airfresh-t2017">dmaker.airfresh.t2017</a>) Channels
+
+| Channel          | Type    | Description                         |
+|------------------|---------|-------------------------------------|
+| power            | Switch  | Power                               |
+| airFreshMode     | String  | Mode                                |
+| airFreshPTCPower | Switch  | PTC                                 |
+| airFreshPtcLevel | String  | PTC Level                           |
+| airFreshPTCStatus | Switch  | PTC Status                          |
+| airFreshDisplayDirection | String  | Screen direction                    |
+| airFreshDisplay  | Switch  | Display                             |
+| airFreshChildLock | Switch  | Child Lock                          |
+| airFreshSound    | Switch  | Sound                               |
+| airFreshPM25     | Number  | PM2.5                               |
+| airFreshCO2      | Number  | CO2                                 |
+| airFreshCurrentSpeed | Number  | Current Speed                       |
+| airFreshFavoriteSpeed | Number  | Favorite Speed                      |
+| airFreshTemperature | Number  | Temperature Outside                 |
+| airFreshFilterPercents | Number  | Filter Percents Remaining           |
+| airFreshFilterDays | Number  | Filter Days Remaining               |
+| airFreshFilterProPercents | Number  | Filter Pro Percents Remaining       |
+| airFreshFilterProDays | Number  | Filter Pro Days Remaining           |
+| airFreshResetFilter | String  | Reset Filter                        |
+
+### Mi Fresh Air Ventilator A1 (<a name="dmaker-airfresh-a1">dmaker.airfresh.a1</a>) Channels
+
+| Channel          | Type    | Description                         |
+|------------------|---------|-------------------------------------|
+| power            | Switch  | Power                               |
+| airFreshMode     | String  | Mode                                |
+| airFreshPTCPower | Switch  | PTC                                 |
+| airFreshPTCStatus | Switch  | PTC Status                          |
+| airFreshDisplay  | Switch  | Display                             |
+| airFreshChildLock | Switch  | Child Lock                          |
+| airFreshSound    | Switch  | Sound                               |
+| airFreshPM25     | Number  | PM2.5                               |
+| airFreshCO2      | Number  | CO2                                 |
+| airFreshCurrentSpeed | Number  | Current Speed                       |
+| airFreshFavoriteSpeed | Number  | Favorite Speed                      |
+| airFreshTemperature | Number  | Temperature Outside                 |
+| airFreshFilterPercents | Number  | Filter Percents Remaining           |
+| airFreshFilterDays | Number  | Filter Days Remaining               |
+| airFreshResetFilterA1 | String  | Reset Filter                        |
 
 ### Mi Air Purifier mb1 (<a name="zhimi-airpurifier-mb1">zhimi.airpurifier.mb1</a>) Channels
 
@@ -872,6 +931,7 @@ e.g. `smarthome:send actionCommand 'upd_timer["1498595904821", "on"]'` would ena
 |------------------|---------|-------------------------------------|
 | power            | Switch  | Power                               |
 | temperature      | Number  | Temperature                         |
+| led              | Switch  | Indicator light                     |
 
 ### Mi Power-plug v1 (<a name="chuangmi-plug-v1">chuangmi.plug.v1</a>) Channels
 
@@ -902,6 +962,7 @@ e.g. `smarthome:send actionCommand 'upd_timer["1498595904821", "on"]'` would ena
 |------------------|---------|-------------------------------------|
 | power            | Switch  | Power                               |
 | temperature      | Number  | Temperature                         |
+| led              | Switch  | Indicator light                     |
 
 ### Mi Smart Plug (<a name="chuangmi-plug-hmi205">chuangmi.plug.hmi205</a>) Channels
 
@@ -909,6 +970,7 @@ e.g. `smarthome:send actionCommand 'upd_timer["1498595904821", "on"]'` would ena
 |------------------|---------|-------------------------------------|
 | power            | Switch  | Power                               |
 | temperature      | Number  | Temperature                         |
+| led              | Switch  | Indicator light                     |
 
 ### Qing Mi Smart Power Strip v1 (<a name="qmi-powerstrip-v1">qmi.powerstrip.v1</a>) Channels
 
@@ -1348,14 +1410,26 @@ note: Autogenerated example. Replace the id (airmonitor) in the channel with you
 
 ```java
 Group G_airmonitor "Mi Air Quality Monitor 2gen" <status>
-Switch power "Power" (G_airmonitor) {channel="miio:basic:airmonitor:power"}
-Number aqi "Air Quality Index" (G_airmonitor) {channel="miio:basic:airmonitor:aqi"}
 Number battery "Battery" (G_airmonitor) {channel="miio:basic:airmonitor:battery"}
-Switch usb_state "USB State" (G_airmonitor) {channel="miio:basic:airmonitor:usb_state"}
-Switch time_state "Time State" (G_airmonitor) {channel="miio:basic:airmonitor:time_state"}
-Switch night_state "Night State" (G_airmonitor) {channel="miio:basic:airmonitor:night_state"}
-Number night_begin "Night Begin Time" (G_airmonitor) {channel="miio:basic:airmonitor:night_begin"}
-Number night_end "Night End Time" (G_airmonitor) {channel="miio:basic:airmonitor:night_end"}
+Number pm25 "PM2.5" (G_airmonitor) {channel="miio:basic:airmonitor:pm25"}
+Number co2 "CO2e" (G_airmonitor) {channel="miio:basic:airmonitor:co2"}
+Number tvoc "tVOC" (G_airmonitor) {channel="miio:basic:airmonitor:tvoc"}
+Number humidity "Humidity" (G_airmonitor) {channel="miio:basic:airmonitor:humidity"}
+Number temperature "Temperature" (G_airmonitor) {channel="miio:basic:airmonitor:temperature"}
+```
+
+### Mi Air Quality Monitor S1 (cgllc.airmonitor.s1) item file lines
+
+note: Autogenerated example. Replace the id (airmonitor) in the channel with your own. Replace `basic` with `generic` in the thing UID depending on how your thing was discovered.
+
+```java
+Group G_airmonitor "Mi Air Quality Monitor S1" <status>
+Number battery "Battery" (G_airmonitor) {channel="miio:basic:airmonitor:battery"}
+Number pm25 "PM2.5" (G_airmonitor) {channel="miio:basic:airmonitor:pm25"}
+Number co2 "CO2" (G_airmonitor) {channel="miio:basic:airmonitor:co2"}
+Number tvoc "tVOC" (G_airmonitor) {channel="miio:basic:airmonitor:tvoc"}
+Number humidity "Humidity" (G_airmonitor) {channel="miio:basic:airmonitor:humidity"}
+Number temperature "Temperature" (G_airmonitor) {channel="miio:basic:airmonitor:temperature"}
 ```
 
 ### Mi Air Humidifier (zhimi.humidifier.v1) item file lines
@@ -1712,6 +1786,56 @@ Number favoritelevel "Favorite Level" (G_airpurifier) {channel="miio:basic:airpu
 Number temperature "Temperature" (G_airpurifier) {channel="miio:basic:airpurifier:temperature"}
 Number purifyvolume "Purivied Volume" (G_airpurifier) {channel="miio:basic:airpurifier:purifyvolume"}
 Switch childlock "Child Lock" (G_airpurifier) {channel="miio:basic:airpurifier:childlock"}
+```
+
+### Mi Fresh Air Ventilator (dmaker.airfresh.t2017) item file lines
+
+note: Autogenerated example. Replace the id (airfresh) in the channel with your own. Replace `basic` with `generic` in the thing UID depending on how your thing was discovered.
+
+```java
+Group G_airfresh "Mi Fresh Air Ventilator" <status>
+Switch power "Power" (G_airfresh) {channel="miio:basic:airfresh:power"}
+String airFreshMode "Mode" (G_airfresh) {channel="miio:basic:airfresh:airFreshMode"}
+Switch airFreshPTCPower "PTC" (G_airfresh) {channel="miio:basic:airfresh:airFreshPTCPower"}
+String airFreshPtcLevel "PTC Level" (G_airfresh) {channel="miio:basic:airfresh:airFreshPtcLevel"}
+Switch airFreshPTCStatus "PTC Status" (G_airfresh) {channel="miio:basic:airfresh:airFreshPTCStatus"}
+String airFreshDisplayDirection "Screen direction" (G_airfresh) {channel="miio:basic:airfresh:airFreshDisplayDirection"}
+Switch airFreshDisplay "Display" (G_airfresh) {channel="miio:basic:airfresh:airFreshDisplay"}
+Switch airFreshChildLock "Child Lock" (G_airfresh) {channel="miio:basic:airfresh:airFreshChildLock"}
+Switch airFreshSound "Sound" (G_airfresh) {channel="miio:basic:airfresh:airFreshSound"}
+Number airFreshPM25 "PM2.5" (G_airfresh) {channel="miio:basic:airfresh:airFreshPM25"}
+Number airFreshCO2 "CO2" (G_airfresh) {channel="miio:basic:airfresh:airFreshCO2"}
+Number airFreshCurrentSpeed "Current Speed" (G_airfresh) {channel="miio:basic:airfresh:airFreshCurrentSpeed"}
+Number airFreshFavoriteSpeed "Favorite Speed" (G_airfresh) {channel="miio:basic:airfresh:airFreshFavoriteSpeed"}
+Number airFreshTemperature "Temperature Outside" (G_airfresh) {channel="miio:basic:airfresh:airFreshTemperature"}
+Number airFreshFilterPercents "Filter Percents Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterPercents"}
+Number airFreshFilterDays "Filter Days Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterDays"}
+Number airFreshFilterProPercents "Filter Pro Percents Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterProPercents"}
+Number airFreshFilterProDays "Filter Pro Days Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterProDays"}
+String airFreshResetFilter "Reset Filter" (G_airfresh) {channel="miio:basic:airfresh:airFreshResetFilter"}
+```
+
+### Mi Fresh Air Ventilator A1 (dmaker.airfresh.a1) item file lines
+
+note: Autogenerated example. Replace the id (airfresh) in the channel with your own. Replace `basic` with `generic` in the thing UID depending on how your thing was discovered.
+
+```java
+Group G_airfresh "Mi Fresh Air Ventilator A1" <status>
+Switch power "Power" (G_airfresh) {channel="miio:basic:airfresh:power"}
+String airFreshMode "Mode" (G_airfresh) {channel="miio:basic:airfresh:airFreshMode"}
+Switch airFreshPTCPower "PTC" (G_airfresh) {channel="miio:basic:airfresh:airFreshPTCPower"}
+Switch airFreshPTCStatus "PTC Status" (G_airfresh) {channel="miio:basic:airfresh:airFreshPTCStatus"}
+Switch airFreshDisplay "Display" (G_airfresh) {channel="miio:basic:airfresh:airFreshDisplay"}
+Switch airFreshChildLock "Child Lock" (G_airfresh) {channel="miio:basic:airfresh:airFreshChildLock"}
+Switch airFreshSound "Sound" (G_airfresh) {channel="miio:basic:airfresh:airFreshSound"}
+Number airFreshPM25 "PM2.5" (G_airfresh) {channel="miio:basic:airfresh:airFreshPM25"}
+Number airFreshCO2 "CO2" (G_airfresh) {channel="miio:basic:airfresh:airFreshCO2"}
+Number airFreshCurrentSpeed "Current Speed" (G_airfresh) {channel="miio:basic:airfresh:airFreshCurrentSpeed"}
+Number airFreshFavoriteSpeed "Favorite Speed" (G_airfresh) {channel="miio:basic:airfresh:airFreshFavoriteSpeed"}
+Number airFreshTemperature "Temperature Outside" (G_airfresh) {channel="miio:basic:airfresh:airFreshTemperature"}
+Number airFreshFilterPercents "Filter Percents Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterPercents"}
+Number airFreshFilterDays "Filter Days Remaining" (G_airfresh) {channel="miio:basic:airfresh:airFreshFilterDays"}
+String airFreshResetFilterA1 "Reset Filter" (G_airfresh) {channel="miio:basic:airfresh:airFreshResetFilterA1"}
 ```
 
 ### Mi Air Purifier mb1 (zhimi.airpurifier.mb1) item file lines
@@ -2091,6 +2215,7 @@ note: Autogenerated example. Replace the id (plug) in the channel with your own.
 Group G_plug "Mi Power-plug" <status>
 Switch power "Power" (G_plug) {channel="miio:basic:plug:power"}
 Number temperature "Temperature" (G_plug) {channel="miio:basic:plug:temperature"}
+Switch led "Indicator light" (G_plug) {channel="miio:basic:plug:led"}
 ```
 
 ### Mi Power-plug v1 (chuangmi.plug.v1) item file lines
@@ -2133,6 +2258,7 @@ note: Autogenerated example. Replace the id (plug) in the channel with your own.
 Group G_plug "Mi Power-plug" <status>
 Switch power "Power" (G_plug) {channel="miio:basic:plug:power"}
 Number temperature "Temperature" (G_plug) {channel="miio:basic:plug:temperature"}
+Switch led "Indicator light" (G_plug) {channel="miio:basic:plug:led"}
 ```
 
 ### Mi Smart Plug (chuangmi.plug.hmi205) item file lines
@@ -2143,6 +2269,7 @@ note: Autogenerated example. Replace the id (plug) in the channel with your own.
 Group G_plug "Mi Smart Plug" <status>
 Switch power "Power" (G_plug) {channel="miio:basic:plug:power"}
 Number temperature "Temperature" (G_plug) {channel="miio:basic:plug:temperature"}
+Switch led "Indicator light" (G_plug) {channel="miio:basic:plug:led"}
 ```
 
 ### Qing Mi Smart Power Strip v1 (qmi.powerstrip.v1) item file lines

--- a/bundles/org.openhab.binding.miio/README.md
+++ b/bundles/org.openhab.binding.miio/README.md
@@ -140,10 +140,18 @@ The following things types are available:
 | Yeelight Color Bulb YLDP06YL 10W | miio:basic       | [yeelink.light.color2](#yeelink-light-color2) | Yes       |            |
 | Yeelight Color Bulb          | miio:basic       | [yeelink.light.color3](#yeelink-light-color3) | Yes       |            |
 
+# Advanced: Unsupported devices
+
+Newer devices may not yet be supported. However, many devices share large similarties with existing devices.
+The binding allows to try/test if your new device is working with database files of older devices as well.
+For this, first remove your unsupported thing. Manually add a miio:basic thing. Besides the regular configuration (like ip address, token) the modelId needs to be provided.
+Normally the modelId is populated with the model of your device, however in this case, use the modelId of a similar device.
+Look at the openhab forum, or the openhab github repository for the modelId of similar devices.
+
 # Advanced: adding local database files to support new devices
 
-Things using the basic handler are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
-The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in github.
+Things using the basic handler (miio:basic things) are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
+The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in Openhab github.
 
 # Discovery
 

--- a/bundles/org.openhab.binding.miio/README.md
+++ b/bundles/org.openhab.binding.miio/README.md
@@ -140,6 +140,10 @@ The following things types are available:
 | Yeelight Color Bulb YLDP06YL 10W | miio:basic       | [yeelink.light.color2](#yeelink-light-color2) | Yes       |            |
 | Yeelight Color Bulb          | miio:basic       | [yeelink.light.color3](#yeelink-light-color3) | Yes       |            |
 
+# Advanced: adding local database files to support new devices
+
+Things using the basic handler are driven by json 'database' files. This instructs the binding which channels to create, which properties and actions are associated with the channels etc.
+The User Data Folder/miio (e.g. in Linux `/opt/openhab2/userdata/miio/`) is scanned for database files and will be used for your devices. Note that local database files take preference over build-in ones. Hence if a json file is local and in the database the local file will be used. For format, please check the current database files in github.
 
 # Discovery
 

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoHandlerFactory.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoHandlerFactory.java
@@ -42,7 +42,6 @@ public class MiIoHandlerFactory extends BaseThingHandlerFactory {
     @Activate
     public MiIoHandlerFactory(@Reference MiIoDatabaseWatchService miIoDatabaseWatchService) {
         this.miIoDatabaseWatchService = miIoDatabaseWatchService;
-        miIoDatabaseWatchService.getSourcePath();
     }
 
     @Override

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoHandlerFactory.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoHandlerFactory.java
@@ -19,11 +19,14 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.miio.internal.basic.MiIoDatabaseWatchService;
 import org.openhab.binding.miio.internal.handler.MiIoBasicHandler;
 import org.openhab.binding.miio.internal.handler.MiIoGenericHandler;
 import org.openhab.binding.miio.internal.handler.MiIoUnsupportedHandler;
 import org.openhab.binding.miio.internal.handler.MiIoVacuumHandler;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link MiIoHandlerFactory} is responsible for creating things and thing
@@ -34,6 +37,14 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.miio")
 public class MiIoHandlerFactory extends BaseThingHandlerFactory {
 
+    private MiIoDatabaseWatchService miIoDatabaseWatchService;
+
+    @Activate
+    public MiIoHandlerFactory(@Reference MiIoDatabaseWatchService miIoDatabaseWatchService) {
+        this.miIoDatabaseWatchService = miIoDatabaseWatchService;
+        miIoDatabaseWatchService.getSourcePath();
+    }
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -43,14 +54,14 @@ public class MiIoHandlerFactory extends BaseThingHandlerFactory {
     protected ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
         if (thingTypeUID.equals(THING_TYPE_MIIO)) {
-            return new MiIoGenericHandler(thing);
+            return new MiIoGenericHandler(thing, miIoDatabaseWatchService);
         }
         if (thingTypeUID.equals(THING_TYPE_BASIC)) {
-            return new MiIoBasicHandler(thing);
+            return new MiIoBasicHandler(thing, miIoDatabaseWatchService);
         }
         if (thingTypeUID.equals(THING_TYPE_VACUUM)) {
-            return new MiIoVacuumHandler(thing);
+            return new MiIoVacuumHandler(thing, miIoDatabaseWatchService);
         }
-        return new MiIoUnsupportedHandler(thing);
+        return new MiIoUnsupportedHandler(thing, miIoDatabaseWatchService);
     }
 }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
@@ -106,7 +106,7 @@ public final class Utils {
     @NonNullByDefault
     public List<URL> findDatabaseFiles(Logger logger) {
         List<URL> urlEntries = new ArrayList<>();
-        String userDbFolder = ConfigConstants.getUserDataFolder() + File.separator + BINDING_ID;
+        String userDbFolder = ConfigConstants.getConfigFolder() + File.separator + "misc" + File.separator + BINDING_ID;
         try {
             new File(userDbFolder).mkdirs();
         } catch (SecurityException e) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
@@ -91,5 +91,4 @@ public final class Utils {
         jsonObject = jsonElement.getAsJsonObject();
         return jsonObject;
     }
-
 }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
@@ -12,21 +12,10 @@
  */
 package org.openhab.binding.miio.internal;
 
-import static org.openhab.binding.miio.internal.MiIoBindingConstants.BINDING_ID;
-
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.config.core.ConfigConstants;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
-import org.slf4j.Logger;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
@@ -103,29 +92,4 @@ public final class Utils {
         return jsonObject;
     }
 
-    @NonNullByDefault
-    public List<URL> findDatabaseFiles(Logger logger) {
-        List<URL> urlEntries = new ArrayList<>();
-        String userDbFolder = ConfigConstants.getConfigFolder() + File.separator + "misc" + File.separator + BINDING_ID;
-        try {
-            new File(userDbFolder).mkdirs();
-        } catch (SecurityException e) {
-            logger.debug("Error while creating folder '{}' for local database files: {}", userDbFolder, e.getMessage());
-        }
-        try {
-            File[] userDbFiles = new File(userDbFolder).listFiles((dir, name) -> name.endsWith(".json"));
-            if (userDbFiles != null) {
-                for (File f : userDbFiles) {
-                    urlEntries.add(f.toURI().toURL());
-                    logger.debug("Adding local json db file: {}, {}", f.getName(), f.toURI().toURL());
-                }
-            }
-            Bundle bundle = FrameworkUtil.getBundle(getClass());
-            urlEntries
-                    .addAll(Collections.list(bundle.findEntries(MiIoBindingConstants.DATABASE_PATH, "*.json", false)));
-        } catch (Exception e) {
-            logger.debug("Error while searching for database files: {}", e.getMessage());
-        }
-        return urlEntries;
-    }
 }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/Utils.java
@@ -106,9 +106,14 @@ public final class Utils {
     @NonNullByDefault
     public List<URL> findDatabaseFiles(Logger logger) {
         List<URL> urlEntries = new ArrayList<>();
+        String userDbFolder = ConfigConstants.getUserDataFolder() + File.separator + BINDING_ID;
         try {
-            File[] userDbFiles = new File(ConfigConstants.getUserDataFolder() + File.separator + BINDING_ID)
-                    .listFiles((dir, name) -> name.endsWith(".json"));
+            new File(userDbFolder).mkdirs();
+        } catch (SecurityException e) {
+            logger.debug("Error while creating folder '{}' for local database files: {}", userDbFolder, e.getMessage());
+        }
+        try {
+            File[] userDbFiles = new File(userDbFolder).listFiles((dir, name) -> name.endsWith(".json"));
             if (userDbFiles != null) {
                 for (File f : userDbFiles) {
                     urlEntries.add(f.toURI().toURL());

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -112,11 +112,11 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
         for (URL db : urlEntries) {
             logger.trace("Adding devices for db file: {}", db);
             try {
-                JsonObject deviceMapping = Utils.convertFileToJSON(db);
-                Gson gson = new GsonBuilder().serializeNulls().create();
                 @Nullable
-                MiIoBasicDevice devdb = gson.fromJson(deviceMapping, MiIoBasicDevice.class);
-                if (devdb != null) {
+                JsonObject deviceMapping = Utils.convertFileToJSON(db);
+                if (deviceMapping != null) {
+                    Gson gson = new GsonBuilder().serializeNulls().create();
+                    MiIoBasicDevice devdb = gson.fromJson(deviceMapping, MiIoBasicDevice.class);
                     for (String id : devdb.getDevice().getId()) {
                         workingDatabaseList.put(id, db);
                     }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.miio.internal.basic;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+import static org.openhab.binding.miio.internal.MiIoBindingConstants.BINDING_ID;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigConstants;
+import org.eclipse.smarthome.core.service.AbstractWatchService;
+import org.openhab.binding.miio.internal.MiIoBindingConstants;
+import org.openhab.binding.miio.internal.Utils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * The {@link MiIoDatabaseWatchService} creates a registry of database file per ModelId
+ *
+ * @author Marcel Verpaalen - Initial contribution
+ */
+@Component(service = MiIoDatabaseWatchService.class)
+@NonNullByDefault
+public class MiIoDatabaseWatchService extends AbstractWatchService {
+    private static final String LOCAL_DATABASE_PATH = ConfigConstants.getConfigFolder() + File.separator + "misc"
+            + File.separator + BINDING_ID;
+    private static final String DATABASE_FILES = ".json";
+
+    private final Logger logger = LoggerFactory.getLogger(MiIoDatabaseWatchService.class);
+    private Map<String, URL> databaseList = new HashMap<>();
+
+    @Activate
+    public MiIoDatabaseWatchService() {
+        super(LOCAL_DATABASE_PATH);
+        logger.warn("Miio is watching: {}", LOCAL_DATABASE_PATH);
+        processWatchEvent(null, null, Paths.get(LOCAL_DATABASE_PATH));
+        populateDatabase();
+        if (logger.isTraceEnabled()) {
+            for (String device : databaseList.keySet()) {
+                logger.trace("Device: {} using URL: {}", device, databaseList.get(device));
+            }
+        }
+    }
+
+    @Override
+    protected boolean watchSubDirectories() {
+        return true;
+    }
+
+    @Override
+    protected WatchEvent.Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
+        return new WatchEvent.Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+    }
+
+    @Override
+    protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
+            @Nullable Path path) {
+        if (path != null && path.getFileName().toString().endsWith(DATABASE_FILES)) {
+            logger.debug("Local Databases file {} changed. Refreshing device database", path.getFileName());
+            populateDatabase();
+        }
+    }
+
+    /**
+     * Return the database file URL for a given modelId
+     *
+     * @param modelId the model
+     * @return URL with the definition for the model
+     */
+    public @Nullable URL getDatabaseUrl(String modelId) {
+        if (databaseList.containsKey(modelId)) {
+            return databaseList.get(modelId);
+        }
+        return null;
+    }
+
+    private void populateDatabase() {
+        Map<String, URL> workingDatabaseList = new HashMap<>();
+        List<URL> urlEntries = findDatabaseFiles();
+        for (URL db : urlEntries) {
+            logger.trace("Adding devices for db file: {}", db);
+            try {
+                JsonObject deviceMapping = Utils.convertFileToJSON(db);
+                Gson gson = new GsonBuilder().serializeNulls().create();
+                @Nullable
+                MiIoBasicDevice devdb = gson.fromJson(deviceMapping, MiIoBasicDevice.class);
+                if (devdb != null) {
+                    for (String id : devdb.getDevice().getId()) {
+                        workingDatabaseList.put(id, db);
+                    }
+                }
+            } catch (JsonIOException | JsonSyntaxException | IOException e) {
+                logger.debug("Error while searching for {} in database '{}': {}", db, e.getMessage());
+            }
+            databaseList = workingDatabaseList;
+        }
+    }
+
+    private List<URL> findDatabaseFiles() {
+        List<URL> urlEntries = new ArrayList<>();
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        urlEntries.addAll(Collections.list(bundle.findEntries(MiIoBindingConstants.DATABASE_PATH, "*.json", false)));
+        String userDbFolder = ConfigConstants.getConfigFolder() + File.separator + "misc" + File.separator + BINDING_ID;
+        try {
+            File[] userDbFiles = new File(userDbFolder).listFiles((dir, name) -> name.endsWith(".json"));
+            if (userDbFiles != null) {
+                for (File f : userDbFiles) {
+                    urlEntries.add(f.toURI().toURL());
+                    logger.debug("Adding local json db file: {}, {}", f.getName(), f.toURI().toURL());
+                }
+            }
+        } catch (IOException e) {
+            logger.debug("Error while searching for database files: {}", e.getMessage());
+        }
+        return urlEntries;
+    }
+}

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -100,10 +100,7 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
      * @return URL with the definition for the model
      */
     public @Nullable URL getDatabaseUrl(String modelId) {
-        if (databaseList.containsKey(modelId)) {
-            return databaseList.get(modelId);
-        }
-        return null;
+        return databaseList.get(modelId);
     }
 
     private void populateDatabase() {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -122,7 +122,7 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
                     }
                 }
             } catch (JsonIOException | JsonSyntaxException | IOException e) {
-                logger.debug("Error while searching for {} in database '{}': {}", db, e.getMessage());
+                logger.debug("Error while processing database '{}': {}", db, e.getMessage());
             }
             databaseList = workingDatabaseList;
         }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -65,7 +65,6 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
     @Activate
     public MiIoDatabaseWatchService() {
         super(LOCAL_DATABASE_PATH);
-        logger.warn("Miio is watching: {}", LOCAL_DATABASE_PATH);
         processWatchEvent(null, null, Paths.get(LOCAL_DATABASE_PATH));
         populateDatabase();
         if (logger.isTraceEnabled()) {
@@ -89,7 +88,7 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
     protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
             @Nullable Path path) {
         if (path != null && path.getFileName().toString().endsWith(DATABASE_FILES)) {
-            logger.debug("Local Databases file {} changed. Refreshing device database", path.getFileName());
+            logger.debug("Local Databases file {} changed. Refreshing device database.", path.getFileName());
             populateDatabase();
         }
     }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoAbstractHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoAbstractHandler.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -474,6 +475,7 @@ public abstract class MiIoAbstractHandler extends BaseThingHandler implements Mi
         }
     }
 
+    @Nullable
     protected URL findDatabaseEntry(String deviceName) {
         List<URL> urlEntries = new Utils().findDatabaseFiles(logger);
         for (URL db : urlEntries) {
@@ -481,6 +483,7 @@ public abstract class MiIoAbstractHandler extends BaseThingHandler implements Mi
             try {
                 JsonObject deviceMapping = Utils.convertFileToJSON(db);
                 Gson gson = new GsonBuilder().serializeNulls().create();
+                @Nullable
                 MiIoBasicDevice devdb = gson.fromJson(deviceMapping, MiIoBasicDevice.class);
                 for (String id : devdb.getDevice().getId()) {
                     if (deviceName.equals(id)) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
@@ -391,7 +392,8 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         }
     }
 
-    private void updateChannel(MiIoBasicChannel basicChannel, String param, JsonElement val) {
+    private void updateChannel(@Nullable MiIoBasicChannel basicChannel, String param, JsonElement value) {
+        JsonElement val = value;
         if (basicChannel != null) {
             if (basicChannel.getTransfortmation() != null) {
                 JsonElement transformed = Conversions.execute(basicChannel.getTransfortmation(), val);

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -12,21 +12,18 @@
  */
 package org.openhab.binding.miio.internal.handler;
 
-import static org.openhab.binding.miio.internal.MiIoBindingConstants.*;
+import static org.openhab.binding.miio.internal.MiIoBindingConstants.CHANNEL_COMMAND;
 
 import java.awt.Color;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
@@ -40,7 +37,6 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
-import org.openhab.binding.miio.internal.MiIoBindingConstants;
 import org.openhab.binding.miio.internal.MiIoCommand;
 import org.openhab.binding.miio.internal.MiIoCryptoException;
 import org.openhab.binding.miio.internal.MiIoSendCommand;
@@ -51,8 +47,6 @@ import org.openhab.binding.miio.internal.basic.MiIoBasicChannel;
 import org.openhab.binding.miio.internal.basic.MiIoBasicDevice;
 import org.openhab.binding.miio.internal.basic.MiIoDeviceAction;
 import org.openhab.binding.miio.internal.transport.MiIoAsyncCommunication;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,42 +271,6 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
             }
 
         }
-    }
-
-    private URL findDatabaseEntry(String deviceName) {
-        List<URL> urlEntries = new ArrayList<>();
-        try {
-            File[] userDbFiles = new File(ConfigConstants.getUserDataFolder() + File.separator + BINDING_ID)
-                    .listFiles((dir, name) -> name.endsWith(".json"));
-            if (userDbFiles != null) {
-                for (File f : userDbFiles) {
-                    urlEntries.add(f.toURI().toURL());
-                    logger.debug("Adding local json db file: {}, {}", f.getName(), f.toURI().toURL());
-                }
-            }
-            Bundle bundle = FrameworkUtil.getBundle(getClass());
-            urlEntries
-                    .addAll(Collections.list(bundle.findEntries(MiIoBindingConstants.DATABASE_PATH, "*.json", false)));
-            for (URL db : urlEntries) {
-                logger.trace("Testing for {} in db file: {}", deviceName, db);
-                try {
-                    JsonObject deviceMapping = Utils.convertFileToJSON(db);
-                    Gson gson = new GsonBuilder().serializeNulls().create();
-                    MiIoBasicDevice devdb = gson.fromJson(deviceMapping, MiIoBasicDevice.class);
-                    for (String id : devdb.getDevice().getId()) {
-                        if (deviceName.equals(id)) {
-                            return db;
-                        }
-                    }
-                } catch (Exception e) {
-                    // not relevant
-                    logger.debug("Error while searching for {} in database '{}': {}", deviceName, db, e.getMessage());
-                }
-            }
-        } catch (Exception e) {
-            logger.debug("Error while searching for {} in database: {}", deviceName, e.getMessage());
-        }
-        return null;
     }
 
     private boolean buildChannelStructure(String deviceName) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -45,6 +45,7 @@ import org.openhab.binding.miio.internal.basic.CommandParameterType;
 import org.openhab.binding.miio.internal.basic.Conversions;
 import org.openhab.binding.miio.internal.basic.MiIoBasicChannel;
 import org.openhab.binding.miio.internal.basic.MiIoBasicDevice;
+import org.openhab.binding.miio.internal.basic.MiIoDatabaseWatchService;
 import org.openhab.binding.miio.internal.basic.MiIoDeviceAction;
 import org.openhab.binding.miio.internal.transport.MiIoAsyncCommunication;
 import org.slf4j.Logger;
@@ -80,8 +81,9 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
     private Map<String, MiIoDeviceAction> actions;
 
     @NonNullByDefault
-    public MiIoBasicHandler(Thing thing) {
+    public MiIoBasicHandler(Thing thing, MiIoDatabaseWatchService miIoDatabaseWatchService) {
         super(thing);
+        this.miIoDatabaseWatchService = miIoDatabaseWatchService;
     }
 
     @Override
@@ -275,7 +277,7 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
 
     private boolean buildChannelStructure(String deviceName) {
         logger.debug("Building Channel Structure for {} - Model: {}", getThing().getUID().toString(), deviceName);
-        URL fn = findDatabaseEntry(deviceName);
+        URL fn = miIoDatabaseWatchService.getDatabaseUrl(deviceName);
         if (fn == null) {
             logger.warn("Database entry for model '{}' cannot be found.", deviceName);
             return false;
@@ -405,10 +407,8 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
                     updateState(basicChannel.getChannel(), new StringType(val.getAsString()));
                 }
                 if (basicChannel.getType().equals("Switch")) {
-                    updateState(basicChannel.getChannel(),
-                            val.getAsString().toLowerCase().equals("on")
-                                    || val.getAsString().toLowerCase().equals("true") ? OnOffType.ON
-                                    : OnOffType.OFF);
+                    updateState(basicChannel.getChannel(), val.getAsString().toLowerCase().equals("on")
+                            || val.getAsString().toLowerCase().equals("true") ? OnOffType.ON : OnOffType.OFF);
                 }
                 if (basicChannel.getType().equals("Color")) {
                     Color rgb = new Color(val.getAsInt());

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoGenericHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoGenericHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.miio.internal.basic.MiIoDatabaseWatchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +33,9 @@ public class MiIoGenericHandler extends MiIoAbstractHandler {
     private final Logger logger = LoggerFactory.getLogger(MiIoGenericHandler.class);
 
     @NonNullByDefault
-    public MiIoGenericHandler(Thing thing) {
+    public MiIoGenericHandler(Thing thing, MiIoDatabaseWatchService miIoDatabaseWatchService) {
         super(thing);
+        this.miIoDatabaseWatchService = miIoDatabaseWatchService;
     }
 
     @Override

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoUnsupportedHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoUnsupportedHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.miio.internal.basic.MiIoDatabaseWatchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +42,9 @@ public class MiIoUnsupportedHandler extends MiIoAbstractHandler {
     });
 
     @NonNullByDefault
-    public MiIoUnsupportedHandler(Thing thing) {
+    public MiIoUnsupportedHandler(Thing thing, MiIoDatabaseWatchService miIoDatabaseWatchService) {
         super(thing);
+        this.miIoDatabaseWatchService = miIoDatabaseWatchService;
     }
 
     @Override

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -34,6 +34,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.miio.internal.MiIoCommand;
 import org.openhab.binding.miio.internal.MiIoSendCommand;
+import org.openhab.binding.miio.internal.basic.MiIoDatabaseWatchService;
 import org.openhab.binding.miio.internal.robot.ConsumablesType;
 import org.openhab.binding.miio.internal.robot.FanModeType;
 import org.openhab.binding.miio.internal.robot.StatusType;
@@ -60,8 +61,9 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
     private String lastHistoryId;
 
     @NonNullByDefault
-    public MiIoVacuumHandler(Thing thing) {
+    public MiIoVacuumHandler(Thing thing, MiIoDatabaseWatchService miIoDatabaseWatchService) {
         super(thing);
+        this.miIoDatabaseWatchService = miIoDatabaseWatchService;
     }
 
     @Override
@@ -128,9 +130,11 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
     private boolean updateVacuumStatus(JsonObject statusData) {
         updateState(CHANNEL_BATTERY, new DecimalType(statusData.get("battery").getAsBigDecimal()));
         updateState(CHANNEL_CLEAN_AREA, new DecimalType(statusData.get("clean_area").getAsDouble() / 1000000.0));
-        updateState(CHANNEL_CLEAN_TIME, new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
+        updateState(CHANNEL_CLEAN_TIME,
+                new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
-        updateState(CHANNEL_ERROR_CODE, new StringType(VacuumErrorType.getType(statusData.get("error_code").getAsInt()).getDescription()));
+        updateState(CHANNEL_ERROR_CODE,
+                new StringType(VacuumErrorType.getType(statusData.get("error_code").getAsInt()).getDescription()));
         updateState(CHANNEL_ERROR_ID, new DecimalType(statusData.get("error_code").getAsInt()));
         int fanLevel = statusData.get("fan_power").getAsInt();
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));


### PR DESCRIPTION
* Allow users to create their own database files to speed up adoption
for new devices
* Local database files get priority over ones defined in the binding
* Local files to be located in the getUserDataFolder\miio folder

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
