### PR TITLE
[Wemo] ping default port first #6694

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -17,12 +17,9 @@ import static org.openhab.binding.wemo.internal.WemoBindingConstants.*;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.net.ConnectException;
 import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -467,16 +464,27 @@ public class WemoHandler extends AbstractWemoHandler implements UpnpIOParticipan
         String host = null;
         String port = null;
         if (descriptorURL != null) {
-            host = StringUtils.substringBetween(descriptorURL.toString(), "://", ":");
-            for (int i = portCheckStart; i < portCheckStop; i++) {
-                try {
-                    boolean portFound = servicePing(host, i);
-                    if (portFound) {
-                        logger.trace("WeMo device {} responded at Port {}", getUDN(), i);
-                        port = String.valueOf(i);
-                        break;
-                    }
-                } catch (Exception e) {
+            
+            int defaultPort = descriptorURL.getPort();
+            if(defaultPort == -1) {
+                defaultPort = descriptorURL.getDefaultPort();
+            }
+            
+            host = descriptorURL.getHost();
+            boolean portFound = false;
+            if (defaultPort != -1) {
+                portFound = servicePing(host, defaultPort);
+            }
+            if (portFound) {
+                port = String.valueOf(defaultPort);
+            } else {
+                for (int i = portCheckStart; i < portCheckStop; i++) {
+                        portFound = servicePing(host, i);
+                        if (portFound) {
+                            logger.trace("WeMo device {} responded at Port {}", getUDN(), i);
+                            port = String.valueOf(i);
+                            break;
+                        }
                 }
             }
             wemoURL = "http://" + host + ":" + port + "/upnp/control/" + actionService + "1";
@@ -485,13 +493,13 @@ public class WemoHandler extends AbstractWemoHandler implements UpnpIOParticipan
         return wemoURL;
     }
 
-    public boolean servicePing(String host, int port) throws IOException {
+    public boolean servicePing(String host, int port) {
         SocketAddress socketAddress = new InetSocketAddress(host, port);
         try (Socket socket = new Socket()) {
             logger.trace("Ping WeMo device at '{}'", socketAddress);
             socket.connect(socketAddress, 250);
             return true;
-        } catch (ConnectException | SocketTimeoutException | NoRouteToHostException ignored) {
+        } catch (IOException ignored) {
             return false;
         }
     }


### PR DESCRIPTION
PR for the issue #6694 
Wemo emulation in Tasmota firmware may use non-standard Wemo ports(49151-49157). Mine uses port 80 in descriptorURL.
After fix #6253 my devices stop responding to the commands.

Suggested solution - ping first default port from descriptorUrl and only if it doesn't respond iterate over default wemo port range