### PR TITLE
[mqtt] Enable discovery timeout reset

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -129,6 +129,8 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     @Override
     public void receivedMessage(ThingUID connectionBridge, MqttBrokerConnection connection, String topic,
             byte[] payload) {
+        resetTimeout();
+
         // For HomeAssistant we need to subscribe to a wildcard topic, because topics can either be:
         // homeassistant/<component>/<node_id>/<object_id>/config OR
         // homeassistant/<component>/<object_id>/config.

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
@@ -80,6 +80,9 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
     @Override
     public void receivedMessage(ThingUID connectionBridge, MqttBrokerConnection connection, String topic,
             byte[] payload) {
+
+        resetTimeout();
+
         if (!checkVersion(payload)) {
             logger.trace("Found homie device. But version {} is out of range.",
                     new String(payload, StandardCharsets.UTF_8));

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
@@ -80,7 +80,6 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
     @Override
     public void receivedMessage(ThingUID connectionBridge, MqttBrokerConnection connection, String topic,
             byte[] payload) {
-
         resetTimeout();
 
         if (!checkVersion(payload)) {

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService implements MQTTTopicDiscoveryParticipant {
-
     private final Logger logger = LoggerFactory.getLogger(AbstractMQTTDiscovery.class);
 
     protected final String subscribeTopic;

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
@@ -12,13 +12,17 @@
  */
 package org.openhab.binding.mqtt.discovery;
 
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-
-import java.util.Date;
-import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base MQTT discovery class. Responsible for connecting to the {@link MQTTTopicDiscoveryService}.
@@ -36,12 +40,20 @@ import java.util.Set;
  */
 @NonNullByDefault
 public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService implements MQTTTopicDiscoveryParticipant {
+
+    private final Logger logger = LoggerFactory.getLogger(AbstractMQTTDiscovery.class);
+
     protected final String subscribeTopic;
+
+    private int timeout;
+
+    private @Nullable ScheduledFuture<?> scheduledStop;
 
     public AbstractMQTTDiscovery(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout,
             boolean backgroundDiscoveryEnabledByDefault, String baseTopic) {
-        super(supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault);
+        super(supportedThingTypes, 0, backgroundDiscoveryEnabledByDefault);
         this.subscribeTopic = baseTopic;
+        this.timeout = timeout;
     }
 
     /**
@@ -49,12 +61,40 @@ public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService imp
      */
     protected abstract MQTTTopicDiscoveryService getDiscoveryService();
 
+    private synchronized void stopTimeout() {
+        if (scheduledStop != null) {
+            scheduledStop.cancel(false);
+            scheduledStop = null;
+        }
+    }
+
+    protected synchronized void resetTimeout() {
+        stopTimeout();
+
+        // schedule an automatic call of stopScan when timeout is reached
+        if (timeout > 0) {
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        stopScan();
+                    } catch (Exception e) {
+                        logger.debug("Exception occurred during execution: {}", e.getMessage(), e);
+                    }
+                }
+            };
+
+            scheduledStop = scheduler.schedule(runnable, timeout, TimeUnit.SECONDS);
+        }
+    }
+
     @Override
     protected void startScan() {
         if (isBackgroundDiscoveryEnabled()) {
             super.stopScan();
             return;
         }
+        resetTimeout();
         getDiscoveryService().subscribe(this, subscribeTopic);
     }
 
@@ -64,8 +104,15 @@ public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService imp
             super.stopScan();
             return;
         }
+        stopTimeout();
         getDiscoveryService().unsubscribe(this);
         super.stopScan();
+    }
+
+    @Override
+    public synchronized void abortScan() {
+        stopTimeout();
+        super.abortScan();
     }
 
     @Override


### PR DESCRIPTION
Enable the MQTT discovery to reset the timeout while there are still messages received.
The timeout of `AbstractDiscoveryService` is disabled in `AbstractMQTTDiscovery` and replaced by an own one, which can be reset by dervied classes.

see #6691

@davidgraeff It would acutally be nicer in `AbstractDiscoveryService`, but is it worth the effort?