### PR TITLE
[chromecast] Fixed IAE when downloaded image is 'null'

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/ChromecastStatusUpdater.java
@@ -257,7 +257,8 @@ public class ChromecastStatusUpdater {
         }
 
         if (callback.isLinked(CHANNEL_IMAGE)) {
-            callback.updateState(CHANNEL_IMAGE, imageSrc == null ? UNDEF : HttpUtil.downloadImage(imageSrc));
+            State image = imageSrc == null ? UNDEF : HttpUtil.downloadImage(imageSrc);
+            callback.updateState(CHANNEL_IMAGE, image == null ? UNDEF : image);
         }
     }
 


### PR DESCRIPTION
- Fixed IAE when downloaded image is `null`

e.g.:

```
2019-12-29 21:05:43.963 [ERROR] [nternal.items.ItemStateConverterImpl] - A conversion of null was requested:
java.lang.IllegalArgumentException: State must not be null.
        at org.eclipse.smarthome.core.internal.items.ItemStateConverterImpl.convertToAcceptedState(ItemStateConverterImpl.java:58) ~[?:?]
        at org.eclipse.smarthome.core.thing.internal.profiles.ProfileCallbackImpl.sendUpdate(ProfileCallbackImpl.java:134) ~[?:?]
        at org.eclipse.smarthome.core.thing.internal.profiles.SystemDefaultProfile.onStateUpdateFromHandler(SystemDefaultProfile.java:53) ~[?:?]
        at org.eclipse.smarthome.core.thing.internal.CommunicationManager.lambda$9(CommunicationManager.java:467) ~[?:?]
        at org.eclipse.smarthome.core.thing.internal.CommunicationManager.lambda$11(CommunicationManager.java:487) ~[?:?]
        at java.lang.Iterable.forEach(Iterable.java:75) [?:1.8.0_152]
        at org.eclipse.smarthome.core.thing.internal.CommunicationManager.handleCallFromHandler(CommunicationManager.java:483) [bundleFile:?]
        at org.eclipse.smarthome.core.thing.internal.CommunicationManager.stateUpdated(CommunicationManager.java:465) [bundleFile:?]
        at org.eclipse.smarthome.core.thing.internal.ThingManagerImpl$1.stateUpdated(ThingManagerImpl.java:168) [bundleFile:?]
        at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.updateState(BaseThingHandler.java:245) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.handler.ChromecastHandler.updateState(ChromecastHandler.java:160) [bundleFile:?]
        at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.updateState(BaseThingHandler.java:264) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.handler.ChromecastHandler.updateState(ChromecastHandler.java:155) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateImage(ChromecastStatusUpdater.java:260) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMetadataStatus(ChromecastStatusUpdater.java:197) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMediaInfoStatus(ChromecastStatusUpdater.java:192) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.ChromecastStatusUpdater.updateMediaStatus(ChromecastStatusUpdater.java:174) [bundleFile:?]
        at org.openhab.binding.chromecast.internal.ChromecastEventReceiver.spontaneousEventReceived(ChromecastEventReceiver.java:62) [bundleFile:?]
        at su.litvak.chromecast.api.v2.EventListenerHolder.spontaneousEventReceived(EventListenerHolder.java:108) [bundleFile:?]
        at su.litvak.chromecast.api.v2.EventListenerHolder.deliverEvent(EventListenerHolder.java:88) [bundleFile:?]
        at su.litvak.chromecast.api.v2.Channel.notifyListenersOfSpontaneousEvent(Channel.java:456) [bundleFile:?]
        at su.litvak.chromecast.api.v2.Channel.access$700(Channel.java:51) [bundleFile:?]
        at su.litvak.chromecast.api.v2.Channel$ReadThread.run(Channel.java:199) [bundleFile:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
