### PR TITLE
NullAnnotationsCheck added to DTO

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -3,7 +3,7 @@
 <suppressions>
     <!-- These suppressions define which files to be suppressed for which checks. -->
     <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
-    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />
+    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
 
     <!-- Homematic and Tellstick bindings are creating and configuring things dynamically, they will log false positives for unused configuration -->


### PR DESCRIPTION
This changes allows parsing of inner classes when the outer one is already @NonNullByDefault

It's requires for the Shelly and MagentaTV bindings to get rid of Travis warnings.

Signed-off-by: Markus Michels <markus7017@gmail.com>