### PR TITLE
[opensprinkler] Show if a station is queued and allow to remove it from the queue

### DIFF
--- a/bundles/org.openhab.binding.opensprinkler/README.md
+++ b/bundles/org.openhab.binding.opensprinkler/README.md
@@ -52,7 +52,10 @@ The following channel is supported by the `station` thing.
 |                    |             |    | used as the time the station will be kept open when      |
 |                    |             |    | switched on. It is advised to add persistence for items  |
 |                    |             |    | linked to this channel, the binding does not persist     |
-|                    |             |    | values of it.
+|                    |             |    | values of it.                                            |
+| queued             | Switch      | RW | Indicates that the station is queued to be turned on.    |
+|                    |             |    | The channel cannot be turned on, only turning it off is  |
+|                    |             |    | supported (which removes the station from the queue).    |
 
 When using the `nextDuration` channel, it is advised to setup persistence (e.g. MapDB) in order to persist the value through restarts.
 

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBindingConstants.java
@@ -48,6 +48,7 @@ public class OpenSprinklerBindingConstants {
     // List of all Channel ids
     public static final String SENSOR_RAIN = "rainsensor";
     public static final String STATION_STATE = "stationState";
+    public static final String STATION_QUEUED = "queued";
     public static final String REMAINING_WATER_TIME = "remainingWaterTime";
     public static final String NEXT_DURATION = "nextDuration";
 }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerStationHandler.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerStationHandler.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
-import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.opensprinkler.internal.api.OpenSprinklerApi;
 import org.openhab.binding.opensprinkler.internal.api.exception.CommunicationApiException;
 import org.openhab.binding.opensprinkler.internal.api.exception.GeneralApiException;
@@ -78,6 +77,9 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
                 case STATION_STATE:
                     handleStationStateCommand(api, command);
                     break;
+                case STATION_QUEUED:
+                    handleQueuedCommand(api, command);
+                    break;
             }
         }
         updateChannels();
@@ -111,6 +113,13 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
         }
     }
 
+    private void handleQueuedCommand(OpenSprinklerApi api, Command command) {
+        if (command == OnOffType.ON) {
+            return;
+        }
+        handleStationStateCommand(api, command);
+    }
+
     private BigDecimal nextStationDuration() {
         BigDecimal nextDurationItemValue = nextDurationValue();
         Channel nextDuration = getThing().getChannel(NEXT_DURATION);
@@ -127,7 +136,7 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
      * @return State representation for the channel.
      */
     @Nullable
-    private State getStationState(int stationId) {
+    private OnOffType getStationState(int stationId) {
         boolean stationOn = false;
         OpenSprinklerApi api = getApi();
         if (api == null) {
@@ -157,7 +166,7 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
      * @param stationId Int of the station to control. Starts at 0.
      * @return State representation for the channel.
      */
-    private @Nullable State getRemainingWaterTime(int stationId) {
+    private @Nullable QuantityType<Time> getRemainingWaterTime(int stationId) {
         long remainingWaterTime = 0;
         OpenSprinklerApi api = getApi();
         if (api == null) {
@@ -179,15 +188,15 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
 
     @Override
     protected void updateChannel(@NonNull ChannelUID channel) {
+        OnOffType currentDeviceState = getStationState(this.getStationIndex());
+        QuantityType<Time> remainingWaterTime = getRemainingWaterTime(config.stationIndex);
         switch (channel.getIdWithoutGroup()) {
             case STATION_STATE:
-                State currentDeviceState = getStationState(this.getStationIndex());
                 if (currentDeviceState != null) {
                     updateState(channel, currentDeviceState);
                 }
                 break;
             case REMAINING_WATER_TIME:
-                State remainingWaterTime = getRemainingWaterTime(config.stationIndex);
                 if (remainingWaterTime != null) {
                     updateState(channel, remainingWaterTime);
                 }
@@ -196,6 +205,14 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
                 BigDecimal duration = nextDurationValue();
                 if (duration != null) {
                     updateState(channel, new DecimalType(duration));
+                }
+                break;
+            case STATION_QUEUED:
+                if (remainingWaterTime != null && currentDeviceState != null && currentDeviceState == OnOffType.OFF
+                        && remainingWaterTime.intValue() != 0) {
+                    updateState(channel, OnOffType.ON);
+                } else {
+                    updateState(channel, OnOffType.OFF);
                 }
                 break;
             default:

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -91,20 +91,20 @@
 		<category>Switch</category>
 	</channel-type>
 
-    <channel-type id="queued">
-        <item-type>Switch</item-type>
-        <label>Queued</label>
-        <description>Indicates if the station is queued to be turned on. Can be removed from the queue by turning off. ON is read-only.</description>
-        <category>Switch</category>
-    </channel-type>
-	
+	<channel-type id="queued">
+		<item-type>Switch</item-type>
+		<label>Queued</label>
+		<description>Indicates if the station is queued to be turned on. Can be removed from the queue by turning off. ON is read-only.</description>
+		<category>Switch</category>
+	</channel-type>
+
 	<channel-type id="remainingWaterTime">
 		<item-type>Number:Time</item-type>
 		<label>Remaining Water Time</label>
 		<description>Read-only property of the remaining water time of the station.</description>
 		<state readOnly="true" pattern="%.0f min"/>
 	</channel-type>
-	
+
 	<channel-type id="nextDuration">
 		<item-type>Number:Time</item-type>
 		<label>Next Open Duration</label>

--- a/bundles/org.openhab.binding.opensprinkler/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -51,6 +51,7 @@
 
 		<channels>
 			<channel id="stationState" typeId="stationState"></channel>
+			<channel id="queued" typeId="queued"></channel>
 			<channel id="remainingWaterTime" typeId="remainingWaterTime"></channel>
 			<channel id="nextDuration" typeId="nextDuration"></channel>
 		</channels>
@@ -89,6 +90,13 @@
 		<description>Controls a station on the OpenSprinkler device.</description>
 		<category>Switch</category>
 	</channel-type>
+
+    <channel-type id="queued">
+        <item-type>Switch</item-type>
+        <label>Queued</label>
+        <description>Indicates if the station is queued to be turned on. Can be removed from the queue by turning off. ON is read-only.</description>
+        <category>Switch</category>
+    </channel-type>
 	
 	<channel-type id="remainingWaterTime">
 		<item-type>Number:Time</item-type>


### PR DESCRIPTION
If a station is already turned on and another station is turned on as
well, opensprinkler will put the station into the queue. The station
then is not open but has a remaining water time. However, there's no way
to remove the station from the queue with openHAB only.

This commit adds a new channel "queued", which indicates, if the station
is queued or not. The state to "ON" is read-only, if done manually,
nothing happens. If the station is queued, the channel can be switched
off, which will remove the station from the queue.

Fixes #6727

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
