### PR TITLE
[Telegram] Support data URI scheme for base64 encoded images

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -188,8 +188,13 @@ when
     Item Light_GF_Living_Table changed
 then
     val telegramAction = getActions("telegram","telegram:telegramBot:2b155b22")
+    // image as base64 string
     var String base64Image = "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAS1BMVEUAAABAQEA9QUc7P0Y0OD88QEY+QUhmaW7c3N3w8PBlaG0+QUjb29w5PUU3O0G+vsigoas6P0WfoKo4O0I9QUdkZ2w9Qkg+QkkkSUnT3FKbAAAAGXRSTlMACJbx//CV9v//9pT/7Ur//+z/SfD2kpMHrnfDaAAAAGhJREFUeAHt1bUBAzAMRFGZmcL7LxpOalN5r/evLIlgGwBgXMhxSjP64sa6cdYH+hLWzYiKvqSbI4kQeEt5PlBealsMFIkAAgi8HNriOLcjduLTafWwBB9n3p8v/+Ma1Mxxvd4IAGCzB4xDPuBRkEZiAAAAAElFTkSuQmCC"
     telegramAction.sendTelegramPhoto(base64Image, "battery of motion sensor is empty")
+    
+    // image as base64 string in data URI scheme
+    var String base64ImageDataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAS1BMVEUAAABAQEA9QUc7P0Y0OD88QEY+QUhmaW7c3N3w8PBlaG0+QUjb29w5PUU3O0G+vsigoas6P0WfoKo4O0I9QUdkZ2w9Qkg+QkkkSUnT3FKbAAAAGXRSTlMACJbx//CV9v//9pT/7Ur//+z/SfD2kpMHrnfDaAAAAGhJREFUeAHt1bUBAzAMRFGZmcL7LxpOalN5r/evLIlgGwBgXMhxSjP64sa6cdYH+hLWzYiKvqSbI4kQeEt5PlBealsMFIkAAgi8HNriOLcjduLTafWwBB9n3p8v/+Ma1Mxxvd4IAGCzB4xDPuBRkEZiAAAAAElFTkSuQmCC"
+    telegramAction.sendTelegramPhoto(base64ImageDataURI, "battery of motion sensor is empty")    
 end
 ```
 

--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -95,7 +95,7 @@ These actions will send a message to all chat ids configured for this bot.
 | sendTelegram(String format, Object... args)          | Sends a formatted message (See https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html for more information).
 | sendTelegramQuery(String message, String replyId, String... buttons) | Sends a question to the user that can be answered via the defined buttons. The replyId can be freely choosen and is sent back with the answer. Then, the id is required to identify what question has been answered (e.g. in case of multiple open questions). The final result looks like this: ![Telegram Inline Keyboard](doc/queryExample.png). |
 | sendTelegramAnswer(String replyId, String message) | Sends a message after the user has answered a question. You should *always* call this method after you received an answer. It will remove buttons from the specific question and will also stop the progress bar displayed at the client side. If no message is necessary, just pass `null` here. |
-| sendTelegramPhoto(String photoURL, String caption) | Sends a picture. The URL can be specified using the http, https, and file protocols or a base64 encoded image. |
+| sendTelegramPhoto(String photoURL, String caption) | Sends a picture. The URL can be specified using the http, https, and file protocols or a base64 encoded image (simple base64 data or data URI scheme). |
 | sendTelegramPhoto(String photoURL, String caption, String username, String password) | Sends a picture which is downloaded from a username/password protected http/https address. |
 
 ### Actions to send messages to a particular chat

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -342,8 +342,7 @@ public class TelegramActions implements ThingActions {
                 logger.debug("Photo base64 provided; converting to binary.");
                 try {
                     final String photoB64Data;
-                    if (photoURL.startsWith("data:")) // support data URI scheme
-                    {
+                    if (photoURL.startsWith("data:")) { // support data URI scheme
                         String[] photoURLParts = photoURL.split(",");
                         if (photoURLParts.length > 1) {
                             photoB64Data = photoURLParts[1];
@@ -351,12 +350,11 @@ public class TelegramActions implements ThingActions {
                             logger.warn("The provided base64 string is not a valid data URI scheme");
                             return false;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         photoB64Data = photoURL;
                     }
-                    InputStream is = Base64.getDecoder().wrap(new ByteArrayInputStream(photoB64Data.getBytes("UTF-8")));
+                    InputStream is = Base64.getDecoder()
+                            .wrap(new ByteArrayInputStream(photoB64Data.getBytes(StandardCharsets.UTF_8)));
                     try {
                         byte[] photoBytes = IOUtils.toByteArray(is);
                         sendPhoto = new SendPhoto(chatId, photoBytes);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -341,16 +341,22 @@ public class TelegramActions implements ThingActions {
                 // Load image from provided base64 image
                 logger.debug("Photo base64 provided; converting to binary.");
                 try {
+                    final String photoB64Data;
                     if (photoURL.startsWith("data:")) // support data URI scheme
                     {
                         String[] photoURLParts = photoURL.split(",");
                         if (photoURLParts.length > 1) {
-                            photoURL = photoURLParts[1];
+                            photoB64Data = photoURLParts[1];
                         } else {
-                            logger.warn("The provided base64 string doesn't seem to a be valid data URI schema");
+                            logger.warn("The provided base64 string is not a valid data URI scheme");
+                            return false;
                         }
                     }
-                    InputStream is = Base64.getDecoder().wrap(new ByteArrayInputStream(photoURL.getBytes("UTF-8")));
+                    else
+                    {
+                        photoB64Data = photoURL;
+                    }
+                    InputStream is = Base64.getDecoder().wrap(new ByteArrayInputStream(photoB64Data.getBytes("UTF-8")));
                     try {
                         byte[] photoBytes = IOUtils.toByteArray(is);
                         sendPhoto = new SendPhoto(chatId, photoBytes);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -340,30 +340,25 @@ public class TelegramActions implements ThingActions {
             } else {
                 // Load image from provided base64 image
                 logger.debug("Photo base64 provided; converting to binary.");
-                try {
-                    final String photoB64Data;
-                    if (photoURL.startsWith("data:")) { // support data URI scheme
-                        String[] photoURLParts = photoURL.split(",");
-                        if (photoURLParts.length > 1) {
-                            photoB64Data = photoURLParts[1];
-                        } else {
-                            logger.warn("The provided base64 string is not a valid data URI scheme");
-                            return false;
-                        }
+                final String photoB64Data;
+                if (photoURL.startsWith("data:")) { // support data URI scheme
+                    String[] photoURLParts = photoURL.split(",");
+                    if (photoURLParts.length > 1) {
+                        photoB64Data = photoURLParts[1];
                     } else {
-                        photoB64Data = photoURL;
-                    }
-                    InputStream is = Base64.getDecoder()
-                            .wrap(new ByteArrayInputStream(photoB64Data.getBytes(StandardCharsets.UTF_8)));
-                    try {
-                        byte[] photoBytes = IOUtils.toByteArray(is);
-                        sendPhoto = new SendPhoto(chatId, photoBytes);
-                    } catch (IOException e) {
-                        logger.warn("Malformed base64 string: {}", e.getMessage());
+                        logger.warn("The provided base64 string is not a valid data URI scheme");
                         return false;
                     }
-                } catch (UnsupportedEncodingException e) {
-                    logger.warn("Cannot parse data fetched from photo URL as an image. Error: {}", e.getMessage());
+                } else {
+                    photoB64Data = photoURL;
+                }
+                InputStream is = Base64.getDecoder()
+                        .wrap(new ByteArrayInputStream(photoB64Data.getBytes(StandardCharsets.UTF_8)));
+                try {
+                    byte[] photoBytes = IOUtils.toByteArray(is);
+                    sendPhoto = new SendPhoto(chatId, photoBytes);
+                } catch (IOException e) {
+                    logger.warn("Malformed base64 string: {}", e.getMessage());
                     return false;
                 }
             }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -341,6 +341,15 @@ public class TelegramActions implements ThingActions {
                 // Load image from provided base64 image
                 logger.debug("Photo base64 provided; converting to binary.");
                 try {
+                    if (photoURL.startsWith("data:")) // support data URI scheme
+                    {
+                        String[] photoURLParts = photoURL.split(",");
+                        if (photoURLParts.length > 1) {
+                            photoURL = photoURLParts[1];
+                        } else {
+                            logger.warn("The provided base64 string doesn't seem to a be valid data URI schema");
+                        }
+                    }
                     InputStream is = Base64.getDecoder().wrap(new ByteArrayInputStream(photoURL.getBytes("UTF-8")));
                     try {
                         byte[] photoBytes = IOUtils.toByteArray(is);


### PR DESCRIPTION
Base64 encoded images are already supported when the simple data is passed. This PR adds support for  base64 encoded images with [data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) (base64 data starting with "data:").
This was already supported by the old OH1 Telegram action.

Fixes https://github.com/openhab/openhab-addons/issues/6687