### PR TITLE
[telegram] Clarify migration from OH1 Telegram Action

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -2,6 +2,10 @@
 
 The Telegram binding allows sending and receiving messages to and from Telegram clients (https://telegram.org), by using the Telegram Bot API.
 
+# Migrating from the old Telegram Action
+
+This binding replaces the old Telegram Action. In case you want to migrate to this binding, it is recommended to uninstall the old action first. A new configuration as well as changes to your existing rules are necessary. For further details see the following sections.
+
 # Prerequisites
 
 As described in the Telegram Bot API, this is the manual procedure needed in order to get the necessary information.


### PR DESCRIPTION
Many people asked in the forum if they should still install the old Telegram Action in addition to the new Telegram binding. They also want to know if they can just re-use their old .cfg and existing rules.

I hope I can clarify this a bit in the doc. As far as I understood it, there will be most probably a OH 2.5.x release. I assume that this will still contain the old Telegram action, right? Otherwise it wouldn't make sense to update the docs.