### PR TITLE
[mqtt.generic] Allow availabilty topic for generic components

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.mqtt.generic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+<features name="org.openhab.binding.mqtt.generic-${project.version}"
+	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-    <feature name="openhab-binding-mqtt-generic" description="MQTT Binding Generic" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <feature>openhab-transport-mqtt</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
-        <bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.generic/${project.version}</bundle>
-    </feature>
+	<feature name="openhab-binding-mqtt-generic" description="MQTT Binding Generic" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-mqtt</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
+		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.generic/${project.version}</bundle>
+	</feature>
 
 </features>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/feature/feature.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.mqtt.generic-${project.version}"
-	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="org.openhab.binding.mqtt.generic-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-mqtt-generic" description="MQTT Binding Generic" version="${project.version}">

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -12,14 +12,24 @@
  */
 package org.openhab.binding.mqtt.generic;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelGroupUID;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -30,7 +40,11 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.core.util.UIDUtils;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.binding.mqtt.generic.utils.FutureCollector;
+import org.openhab.binding.mqtt.generic.values.OnOffValue;
+import org.openhab.binding.mqtt.generic.values.Value;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,12 +75,16 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-public abstract class AbstractMQTTThingHandler extends BaseThingHandler implements ChannelStateUpdateListener {
+public abstract class AbstractMQTTThingHandler extends BaseThingHandler
+        implements ChannelStateUpdateListener, AvailabilityTracker {
     private final Logger logger = LoggerFactory.getLogger(AbstractMQTTThingHandler.class);
     // Timeout for the entire tree parsing and subscription
     private final int subscribeTimeout;
 
     protected @Nullable MqttBrokerConnection connection;
+
+    private AtomicBoolean messageReceived = new AtomicBoolean(false);
+    private Map<String, @Nullable ChannelState> availabilityStates = new ConcurrentHashMap<>();
 
     public AbstractMQTTThingHandler(Thing thing, int subscribeTimeout) {
         super(thing);
@@ -95,6 +113,13 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
      * You should clean up all resources that depend on a working connection.
      */
     protected void stop() {
+        availabilityStates.values().stream().map(s -> {
+            if (s != null) {
+                return s.stop();
+            }
+            return CompletableFuture.allOf();
+        }).collect(FutureCollector.allOf()).join();
+        resetMessageReceived();
     }
 
     @Override
@@ -154,6 +179,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
         AbstractBrokerHandler h = getBridgeHandler();
         if (h == null) {
+            resetMessageReceived();
             logger.warn("Bridge handler not found!");
             return;
         }
@@ -162,6 +188,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         try {
             connection = h.getConnectionAsync().get(500, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException ignored) {
+            resetMessageReceived();
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
                     "Bridge handler has no valid broker connection!");
             return;
@@ -172,7 +199,16 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         // We do not set the thing to ONLINE here in the AbstractBase, that is the responsibility of a derived
         // class.
         try {
-            start(connection).thenApply(e -> true).exceptionally(e -> {
+            Collection<CompletableFuture<@Nullable Void>> futures = availabilityStates.values().stream().map(s -> {
+                if (s != null) {
+                    return s.start(connection, scheduler, 0);
+                }
+                return CompletableFuture.allOf();
+            }).collect(Collectors.toList());
+
+            futures.add(start(connection));
+
+            futures.stream().collect(FutureCollector.allOf()).exceptionally(e -> {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
                 return null;
             }).get(subscribeTimeout, TimeUnit.MILLISECONDS);
@@ -237,11 +273,17 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
 
     @Override
     public void updateChannelState(ChannelUID channelUID, State value) {
+        if (messageReceived.compareAndSet(false, true)) {
+            calculateThingStatus();
+        }
         super.updateState(channelUID, value);
     }
 
     @Override
     public void triggerChannel(ChannelUID channelUID, String event) {
+        if (messageReceived.compareAndSet(false, true)) {
+            calculateThingStatus();
+        }
         super.triggerChannel(channelUID, event);
     }
 
@@ -262,4 +304,72 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
     public void setConnection(MqttBrokerConnection connection) {
         this.connection = connection;
     }
+
+    @Override
+    public void addAvailabilityTopic(String availability_topic, String payload_available,
+            String payload_not_available) {
+        availabilityStates.computeIfAbsent(availability_topic, topic -> {
+            Value value = new OnOffValue(payload_available, payload_not_available);
+            ChannelGroupUID groupUID = new ChannelGroupUID(getThing().getUID(), "availablility");
+            ChannelUID channelUID = new ChannelUID(groupUID, UIDUtils.encode(topic));
+            ChannelState state = new ChannelState(ChannelConfigBuilder.create().withStateTopic(topic).build(),
+                    channelUID, value, new ChannelStateUpdateListener() {
+                        @Override
+                        public void updateChannelState(ChannelUID channelUID, State value) {
+                            calculateThingStatus();
+                        }
+
+                        @Override
+                        public void triggerChannel(ChannelUID channelUID, String eventPayload) {
+                        }
+
+                        @Override
+                        public void postChannelCommand(ChannelUID channelUID, Command value) {
+                        }
+                    });
+            MqttBrokerConnection connection = getConnection();
+            if (connection != null) {
+                state.start(connection, scheduler, 0);
+            }
+
+            return state;
+        });
+    }
+
+    @Override
+    public void removeAvailabilityTopic(@NonNull String availability_topic) {
+        availabilityStates.computeIfPresent(availability_topic, (topic, state) -> {
+            if (connection != null && state != null) {
+                state.stop();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void clearAllAvailabilityTopics() {
+        Set<String> topics = new HashSet<>(availabilityStates.keySet());
+        topics.forEach(t -> removeAvailabilityTopic(t));
+    }
+
+    @Override
+    public void resetMessageReceived() {
+        if (messageReceived.compareAndSet(true, false)) {
+            calculateThingStatus();
+        }
+    }
+
+    protected void calculateThingStatus() {
+        final boolean availabilityTopicsSeen;
+
+        if (availabilityStates.isEmpty()) {
+            availabilityTopicsSeen = true;
+        } else {
+            availabilityTopicsSeen = availabilityStates.values().stream().allMatch(
+                    c -> c != null && OnOffType.ON.equals(c.getCache().getChannelState().as(OnOffType.class)));
+        }
+        updateThingStatus(messageReceived.get(), availabilityTopicsSeen);
+    }
+
+    protected abstract void updateThingStatus(boolean messageReceived, boolean availabilityTopicsSeen);
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -349,7 +349,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler
     @Override
     public void clearAllAvailabilityTopics() {
         Set<String> topics = new HashSet<>(availabilityStates.keySet());
-        topics.forEach(t -> removeAvailabilityTopic(t));
+        topics.forEach(this::removeAvailabilityTopic);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AvailabilityTracker.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AvailabilityTracker.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.generic;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Interface to keep track of the availability of device using an availability topic or messages received
+ *
+ * @author Jochen Klein - Initial contribution
+ */
+@NonNullByDefault
+public interface AvailabilityTracker {
+
+    /**
+     * Adds an availability topic to determine the availability of a device.
+     * <p>
+     * Availability topics are usually set by the device as LWT.
+     *
+     * @param availability_topic
+     * @param payload_available
+     * @param payload_not_available
+     */
+    public void addAvailabilityTopic(String availability_topic, String payload_available, String payload_not_available);
+
+    public void removeAvailabilityTopic(String availability_topic);
+
+    public void clearAllAvailabilityTopics();
+
+    /**
+     * resets the indicator, if messages have been received.
+     * <p>
+     * This is used to time out the availability of the device after some time without receiving a message.
+     */
+    public void resetMessageReceived();
+
+}

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -158,8 +158,7 @@ public class ChannelState implements MqttMessageSubscriber {
             if (transformedValue != null) {
                 strValue = transformedValue;
             } else {
-                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue,
-                        t.serviceName);
+                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue, t.serviceName);
                 receivedOrTimeout();
                 return;
             }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingConfiguration.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.generic.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+
+/**
+ * The {@link GenericMQTTThingHandler} manages Things that are responsible for MQTT components.
+ * This class contains the necessary configuration for such a Thing handler.
+ *
+ * @author Jochen Klein - Initial contribution
+ */
+@NonNullByDefault
+public class GenericThingConfiguration {
+    /**
+     * topic for the availability channel
+     */
+    public @Nullable String availabilityTopic;
+
+    /**
+     * payload for the availability topic when the device is available.
+     */
+    public String payloadAvailable = OnOffType.ON.toString();
+
+    /**
+     * payload for the availability topic when the device is *not* available.
+     */
+    public String payloadNotAvailable = OnOffType.OFF.toString();
+}

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/MQTTvalueTransform.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/MQTTvalueTransform.java
@@ -47,6 +47,8 @@ import java.lang.annotation.Target;
 @Target(FIELD)
 public @interface MQTTvalueTransform {
     String suffix() default "";
+
     String prefix() default "";
+
     String splitCharacter() default "";
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopic.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopic.java
@@ -127,7 +127,7 @@ public class SubscribeFieldToMQTTtopic implements MqttMessageSubscriber {
      */
     @SuppressWarnings({ "null", "unused" })
     @Override
-    public void processMessage(String topic, byte [] payload) {
+    public void processMessage(String topic, byte[] payload) {
         final ScheduledFuture<?> scheduledFuture = this.scheduledFuture;
         if (scheduledFuture != null) { // Cancel timeout
             scheduledFuture.cancel(false);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/ChildMap.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/ChildMap.java
@@ -85,7 +85,7 @@ public class ChildMap<T> {
 
         // Add all entries to the map, that are not in there yet.
         final Map<String, T> newSubnodes = arrayValues.stream().filter(entry -> !this.map.containsKey(entry))
-                .collect(Collectors.toMap(k -> k, k -> supplyNewChild.apply(k)));
+                .collect(Collectors.toMap(k -> k, supplyNewChild));
         this.map.putAll(newSubnodes);
 
         // Remove any entries that are not listed in the 'childIDs'.
@@ -99,7 +99,7 @@ public class ChildMap<T> {
 
         // Apply the 'addedAction' function for all new entries.
         return CompletableFuture
-                .allOf(newSubnodes.values().stream().map(v -> addedAction.apply(v)).toArray(CompletableFuture[]::new));
+                .allOf(newSubnodes.values().stream().map(addedAction).toArray(CompletableFuture[]::new));
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/utils/FutureCollector.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/utils/FutureCollector.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.mqtt.homeassistant.internal.util;
+package org.openhab.binding.mqtt.generic.utils;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
@@ -13,6 +13,20 @@
 		<label>Generic MQTT Thing</label>
 		<description>You need a configured Broker first. Dynamically add channels of various types to this Thing. Link
 			different MQTT topics to each channel.</description>
-	</thing-type>
 
+		<config-description>
+			<parameter name="availabilityTopic" type="text">
+				<label>Availability Topic</label>
+				<description>Topic of the LWT of the device</description>
+			</parameter>
+			<parameter name="payloadAvailable" type="text">
+				<label>Payload available</label>
+				<description>Payload of the 'Availability Topic', when the device is available. Default: 'ON'</description>
+			</parameter>
+			<parameter name="payloadNotAvailable" type="text">
+				<label>Payload not availabe</label>
+				<description>Payload of the 'Availability Topic', when the device is *not* available. Default: 'OFF'</description>
+			</parameter>
+		</config-description>
+	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
@@ -18,14 +18,17 @@
 			<parameter name="availabilityTopic" type="text">
 				<label>Availability Topic</label>
 				<description>Topic of the LWT of the device</description>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="payloadAvailable" type="text">
 				<label>Payload available</label>
 				<description>Payload of the 'Availability Topic', when the device is available. Default: 'ON'</description>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="payloadNotAvailable" type="text">
 				<label>Payload not availabe</label>
 				<description>Payload of the 'Availability Topic', when the device is *not* available. Default: 'OFF'</description>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTransformationTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTransformationTests.java
@@ -36,10 +36,6 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.openhab.binding.mqtt.generic.ChannelState;
-import org.openhab.binding.mqtt.generic.ChannelStateTransformation;
-import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
-import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.generic.internal.handler.GenericMQTTThingHandler;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -41,7 +41,6 @@ import org.openhab.binding.mqtt.generic.ChannelState;
 import org.openhab.binding.mqtt.generic.MqttChannelStateDescriptionProvider;
 import org.openhab.binding.mqtt.generic.ThingHandlerHelper;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
-import org.openhab.binding.mqtt.generic.internal.handler.GenericMQTTThingHandler;
 import org.openhab.binding.mqtt.generic.values.OnOffValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.ValueFactory;
@@ -188,7 +187,8 @@ public class GenericThingHandlerTests {
         // Test process message
         channelConfig.processMessage("test/state", payload);
 
-        verify(callback).statusUpdated(eq(thing), argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
+        verify(callback, atLeastOnce()).statusUpdated(eq(thing),
+                argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
 
         verify(callback).stateUpdated(eq(textChannelUID), argThat(arg -> "UPDATE".equals(arg.toString())));
         assertThat(textValue.getChannelState().toString(), is("UPDATE"));

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
@@ -36,19 +36,17 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
-import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
-import org.openhab.binding.mqtt.generic.mapping.MQTTvalueTransform;
-import org.openhab.binding.mqtt.generic.mapping.SubscribeFieldToMQTTtopic;
-import org.openhab.binding.mqtt.generic.mapping.TopicPrefix;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass.AttributeChanged;
 
 /**
- * Tests cases for {@link AbstractMqttAttributeClass}.
+ * Tests cases for {@link org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass}.
+ *
  * <p>
  * How it works:
+ *
  * <ol>
- * <li>A DTO (data transfer object) is defined, here it is {@link Attributes},
- * which extends {@link AbstractMqttAttributeClass}.
+ * <li>A DTO (data transfer object) is defined, here it is {@link Attributes}, which extends
+ * {@link org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass}.
  * <li>The createSubscriber method is mocked so that no real MQTTConnection interaction happens.
  * <li>The subscribeAndReceive method is called.
  * </ol>

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopicTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/SubscribeFieldToMQTTtopicTests.java
@@ -37,14 +37,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
-import org.openhab.binding.mqtt.generic.mapping.MQTTvalueTransform;
-import org.openhab.binding.mqtt.generic.mapping.SubscribeFieldToMQTTtopic;
-import org.openhab.binding.mqtt.generic.mapping.TopicPrefix;
 import org.openhab.binding.mqtt.generic.mapping.SubscribeFieldToMQTTtopic.FieldChanged;
 
 /**
- * Tests cases for {@link SubscribeFieldToMQTTtopic}.
+ * Tests cases for {@link org.openhab.binding.mqtt.generic.mapping.SubscribeFieldToMQTTtopic}.
  *
  * @author David Graeff - Initial contribution
  */

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
@@ -122,7 +122,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      *         exceptionally on errors.
      */
     public CompletableFuture<@Nullable Void> stop() {
-        return channels.values().parallelStream().map(v -> v.stop()).collect(FutureCollector.allOf());
+        return channels.values().parallelStream().map(CChannel::stop).collect(FutureCollector.allOf());
     }
 
     /**
@@ -197,7 +197,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      * Return the channel group type.
      */
     public ChannelGroupType type() {
-        final List<ChannelDefinition> channelDefinitions = channels.values().stream().map(c -> c.type())
+        final List<ChannelDefinition> channelDefinitions = channels.values().stream().map(CChannel::type)
                 .collect(Collectors.toList());
         return ChannelGroupTypeBuilder.instance(channelGroupTypeUID, name()).withChannelDefinitions(channelDefinitions)
                 .build();
@@ -208,7 +208,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
      * to the MQTT broker got lost.
      */
     public void resetState() {
-        channels.values().forEach(c -> c.resetState());
+        channels.values().forEach(CChannel::resetState);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CFactory.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mqtt.homeassistant.internal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.mqtt.generic.AvailabilityTracker;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.slf4j.Logger;
@@ -44,10 +45,11 @@ public class CFactory {
      * @return A HA MQTT Component
      */
     public static @Nullable AbstractComponent<?> createComponent(ThingUID thingUID, HaID haID,
-            String channelConfigurationJSON, ChannelStateUpdateListener updateListener, Gson gson,
-            TransformationServiceProvider transformationServiceProvider) {
+            String channelConfigurationJSON, ChannelStateUpdateListener updateListener, AvailabilityTracker tracker,
+            Gson gson, TransformationServiceProvider transformationServiceProvider) {
         ComponentConfiguration componentConfiguration = new ComponentConfiguration(thingUID, haID,
-                channelConfigurationJSON, gson, updateListener).transformationProvider(transformationServiceProvider);
+                channelConfigurationJSON, gson, updateListener, tracker)
+                        .transformationProvider(transformationServiceProvider);
         try {
             switch (haID.component) {
                 case "alarm_control_panel":
@@ -78,20 +80,22 @@ public class CFactory {
     }
 
     protected static class ComponentConfiguration {
-        private ThingUID thingUID;
-        private HaID haID;
-        private String configJSON;
+        private final ThingUID thingUID;
+        private final HaID haID;
+        private final String configJSON;
+        private final ChannelStateUpdateListener updateListener;
+        private final AvailabilityTracker tracker;
+        private final Gson gson;
         private @Nullable TransformationServiceProvider transformationServiceProvider;
-        private ChannelStateUpdateListener updateListener;
-        private Gson gson;
 
         protected ComponentConfiguration(ThingUID thingUID, HaID haID, String configJSON, Gson gson,
-                ChannelStateUpdateListener updateListener) {
+                ChannelStateUpdateListener updateListener, AvailabilityTracker tracker) {
             this.thingUID = thingUID;
             this.haID = haID;
             this.configJSON = configJSON;
             this.gson = gson;
             this.updateListener = updateListener;
+            this.tracker = tracker;
         }
 
         public ComponentConfiguration transformationProvider(
@@ -123,6 +127,10 @@ public class CFactory {
 
         public Gson getGson() {
             return gson;
+        }
+
+        public AvailabilityTracker getTracker() {
+            return tracker;
         }
 
         public <C extends BaseChannelConfiguration> C getConfig(Class<C> clazz) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/DiscoverComponents.java
@@ -26,9 +26,10 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
+import org.openhab.binding.mqtt.generic.AvailabilityTracker;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
-import org.openhab.binding.mqtt.homeassistant.internal.util.FutureCollector;
+import org.openhab.binding.mqtt.generic.utils.FutureCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
     private final ThingUID thingUID;
     private final ScheduledExecutorService scheduler;
     private final ChannelStateUpdateListener updateListener;
+    private final AvailabilityTracker tracker;
     private final TransformationServiceProvider transformationServiceProvider;
 
     protected final CompletableFuture<@Nullable Void> discoverFinishedFuture = new CompletableFuture<>();
@@ -72,12 +74,13 @@ public class DiscoverComponents implements MqttMessageSubscriber {
      * @param channelStateUpdateListener Channel update listener. Usually the handler.
      */
     public DiscoverComponents(ThingUID thingUID, ScheduledExecutorService scheduler,
-            ChannelStateUpdateListener channelStateUpdateListener, Gson gson,
+            ChannelStateUpdateListener channelStateUpdateListener, AvailabilityTracker tracker, Gson gson,
             TransformationServiceProvider transformationServiceProvider) {
         this.thingUID = thingUID;
         this.scheduler = scheduler;
         this.updateListener = channelStateUpdateListener;
         this.gson = gson;
+        this.tracker = tracker;
         this.transformationServiceProvider = transformationServiceProvider;
     }
 
@@ -93,7 +96,7 @@ public class DiscoverComponents implements MqttMessageSubscriber {
         AbstractComponent<?> component = null;
 
         if (config.length() > 0) {
-            component = CFactory.createComponent(thingUID, haID, config, updateListener, gson,
+            component = CFactory.createComponent(thingUID, haID, config, updateListener, tracker, gson,
                     transformationServiceProvider);
         }
         if (component != null) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -171,7 +171,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         final String componentNames = components.stream().map(id -> id.component)
                 .map(c -> HA_COMP_TO_NAME.getOrDefault(c, c)).collect(Collectors.joining(", "));
 
-        final List<String> topics = components.stream().map(id -> id.toShortTopic()).collect(Collectors.toList());
+        final List<String> topics = components.stream().map(HaID::toShortTopic).collect(Collectors.toList());
 
         Map<String, Object> properties = new HashMap<>();
         HandlerConfiguration handlerConfig = new HandlerConfiguration(haID.baseTopic, topics);

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -240,4 +240,9 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
             return String.format("%s/%s", config.basetopic, d);
         }).collect(Collectors.toList()).forEach(t -> connection.publish(t, new byte[0], 1, true));
     }
+
+    @Override
+    protected void updateThingStatus(boolean messageReceived, boolean availabilityTopicsSeen) {
+        // not used here
+    }
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -215,8 +215,8 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         if (!device.isInitialized()) {
             return;
         }
-        List<Channel> channels = device.nodes().stream().flatMap(n -> n.properties.stream())
-                .map(prop -> prop.getChannel()).collect(Collectors.toList());
+        List<Channel> channels = device.nodes().stream().flatMap(n -> n.properties.stream()).map(Property::getChannel)
+                .collect(Collectors.toList());
         updateThing(editThing().withChannels(channels).build());
         updateProperty(MqttBindingConstants.HOMIE_PROPERTY_VERSION, device.attributes.homie);
         final MqttBrokerConnection connection = this.connection;

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
@@ -175,7 +175,7 @@ public class Device implements AbstractMqttAttributeClass.AttributeChanged {
      */
     public CompletableFuture<@Nullable Void> stop() {
         return attributes.unsubscribe().thenCompose(
-                b -> CompletableFuture.allOf(nodes.stream().map(n -> n.stop()).toArray(CompletableFuture[]::new)));
+                b -> CompletableFuture.allOf(nodes.stream().map(Node::stop).toArray(CompletableFuture[]::new)));
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
@@ -110,8 +110,8 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
      * @return Returns a future that completes as soon as all unsubscriptions have been performed.
      */
     public CompletableFuture<@Nullable Void> stop() {
-        return attributes.unsubscribe().thenCompose(
-                b -> CompletableFuture.allOf(properties.stream().map(p -> p.stop()).toArray(CompletableFuture[]::new)));
+        return attributes.unsubscribe().thenCompose(b -> CompletableFuture
+                .allOf(properties.stream().map(Property::stop).toArray(CompletableFuture[]::new)));
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -138,9 +138,9 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
     public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
         if (state == MqttConnectionState.CONNECTED) {
             updateStatus(ThingStatus.ONLINE);
-            channelStateByChannelUID.values().forEach(c -> c.start());
+            channelStateByChannelUID.values().forEach(PublishTriggerChannel::start);
         } else {
-            channelStateByChannelUID.values().forEach(c -> c.stop());
+            channelStateByChannelUID.values().forEach(PublishTriggerChannel::stop);
             if (error == null) {
                 updateStatus(ThingStatus.OFFLINE);
             } else {
@@ -159,7 +159,7 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
      */
     @Override
     public void dispose() {
-        channelStateByChannelUID.values().forEach(c -> c.stop());
+        channelStateByChannelUID.values().forEach(PublishTriggerChannel::stop);
         channelStateByChannelUID.clear();
 
         // keep topics, but stop subscriptions

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
@@ -26,15 +26,12 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.openhab.binding.mqtt.generic.AvailabilityTracker;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
 import org.openhab.binding.mqtt.generic.TransformationServiceProvider;
 import org.openhab.binding.mqtt.homeassistant.internal.ChannelConfigurationTypeAdapterFactory;
@@ -61,6 +58,12 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
     @Mock
     TransformationServiceProvider transformationServiceProvider;
 
+    @Mock
+    ChannelStateUpdateListener channelStateUpdateListener;
+
+    @Mock
+    AvailabilityTracker availabilityTracker;
+
     @Before
     public void setUp() {
         initMocks(this);
@@ -83,19 +86,7 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
         Gson gson = new GsonBuilder().registerTypeAdapterFactory(new ChannelConfigurationTypeAdapterFactory()).create();
 
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing,
-                scheduler, new ChannelStateUpdateListener() {
-                    @Override
-                    public void updateChannelState(@NonNull ChannelUID channelUID, @NonNull State value) {
-                    }
-
-                    @Override
-                    public void triggerChannel(@NonNull ChannelUID channelUID, @NonNull String eventPayload) {
-                    }
-
-                    @Override
-                    public void postChannelCommand(@NonNull ChannelUID channelUID, @NonNull Command value) {
-                    }
-                }, gson, transformationServiceProvider));
+                scheduler, channelStateUpdateListener, availabilityTracker, gson, transformationServiceProvider));
 
         HandlerConfiguration config = new HandlerConfiguration("homeassistant",
                 Collections.singletonList("switch/object"));


### PR DESCRIPTION
This PR introduces availabiltyTopic to generic MQTT Things.
The handling is done in `AbstractMQTTThingHandler`. This way I was able to reuse the implementation in homassisant components.

Generic MQTT Things without an availabilityTopic will go online as before.
If an availabilityTopic is defined, the thing will only go ONLINE, if the `payloadAvailable` is seen on the topic.
And the thing will go OFFLINE, as soon as the `payloadNotAvailable` is seen on the topic.

This would adress #6723