### PR TITLE
[mqtt.homassistant] Review Switch

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelConfigBuilder.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelConfigBuilder.java
@@ -64,6 +64,11 @@ public class ChannelConfigBuilder {
         return this;
     }
 
+    public ChannelConfigBuilder withQos(@Nullable Integer qos) {
+        config.qos = qos;
+        return this;
+    }
+
     public ChannelConfigBuilder makeTrigger(boolean trigger) {
         config.trigger = trigger;
         return this;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
@@ -125,6 +125,7 @@ public class CChannel {
         private @Nullable String state_topic;
         private @Nullable String command_topic;
         private boolean retain;
+        private @Nullable Integer qos;
         private String unit = "";
         private ChannelStateUpdateListener channelStateUpdateListener;
 
@@ -163,9 +164,23 @@ public class CChannel {
             return this;
         }
 
+        /**
+         * @deprecated use commandTopic(String, boolean, int)
+         * @param command_topic
+         * @param retain
+         * @return
+         */
+        @Deprecated
         public Builder commandTopic(@Nullable String command_topic, boolean retain) {
             this.command_topic = command_topic;
             this.retain = retain;
+            return this;
+        }
+
+        public Builder commandTopic(@Nullable String command_topic, boolean retain, int qos) {
+            this.command_topic = command_topic;
+            this.retain = retain;
+            this.qos = qos;
             return this;
         }
 
@@ -184,7 +199,7 @@ public class CChannel {
             channelTypeUID = new ChannelTypeUID(MqttBindingConstants.BINDING_ID,
                     channelUID.getGroupId() + "_" + channelID);
             channelState = new ChannelState(
-                    ChannelConfigBuilder.create().withRetain(retain).withStateTopic(state_topic)
+                    ChannelConfigBuilder.create().withRetain(retain).withQos(qos).withStateTopic(state_topic)
                             .withCommandTopic(command_topic).build(),
                     channelUID, valueState, channelStateUpdateListener);
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSwitch.java
@@ -34,30 +34,41 @@ public class ComponentSwitch extends AbstractComponent<ComponentSwitch.ChannelCo
             super("MQTT Switch");
         }
 
-        protected boolean optimistic = false;
+        protected @Nullable Boolean optimistic;
 
-        protected String state_topic = "";
-        protected String state_on = "ON";
-        protected String state_off = "OFF";
         protected @Nullable String command_topic;
+        protected String state_topic = "";
+
+        protected @Nullable String state_on;
+        protected @Nullable String state_off;
         protected String payload_on = "ON";
         protected String payload_off = "OFF";
+
+        protected @Nullable String json_attributes_topic;
+        protected @Nullable String json_attributes_template;
     }
 
     public ComponentSwitch(CFactory.ComponentConfiguration componentConfiguration) {
         super(componentConfiguration, ChannelConfiguration.class);
 
-        // We do not support all HomeAssistant quirks
-        if (channelConfiguration.optimistic && StringUtils.isNotBlank(channelConfiguration.state_topic)) {
+        boolean optimistic = channelConfiguration.optimistic != null ? channelConfiguration.optimistic
+                : StringUtils.isBlank(channelConfiguration.state_topic);
+
+        if (optimistic && StringUtils.isNotBlank(channelConfiguration.state_topic)) {
             throw new UnsupportedOperationException("Component:Switch does not support forced optimistic mode");
         }
 
-        OnOffValue value = new OnOffValue(channelConfiguration.state_on, channelConfiguration.state_off,
-                channelConfiguration.payload_on, channelConfiguration.payload_off);
+        String state_on = channelConfiguration.state_on != null ? channelConfiguration.state_on
+                : channelConfiguration.payload_on;
+        String state_off = channelConfiguration.state_off != null ? channelConfiguration.state_off
+                : channelConfiguration.payload_off;
 
-        buildChannel(switchChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
+        OnOffValue value = new OnOffValue(state_on, state_off, channelConfiguration.payload_on,
+                channelConfiguration.payload_off);
+
+        buildChannel(switchChannelID, value, "state", componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain)//
+                .commandTopic(channelConfiguration.command_topic, channelConfiguration.retain, channelConfiguration.qos)//
                 .build();
     }
 }


### PR DESCRIPTION
My plan is to go over each HA component and fix things that are missing from the HA spec.
Switch is the first.
Fixed here:
- honor `qos` config
- correct default state_xx values
- correct default `optimistic` flag
- rename channel, as group now has the component name already.