### PR TITLE
[jeelink] add revolt support

### DIFF
--- a/bundles/org.openhab.binding.jeelink/README.md
+++ b/bundles/org.openhab.binding.jeelink/README.md
@@ -16,6 +16,7 @@ This binding supports:
 *   LaCrosseGateway (connected over TCP)
 *   LaCrosse temperature sensors
 *   EC3000 power monitors
+*   Revolt power monitors
 *   PCA301 power monitoring wireless sockets
 *   TX22 temperature & humidity Sensors (including connected TX23 wind and TX26 rain sensors)
 
@@ -85,6 +86,13 @@ The available init commands depend on the sketch that is running on the USB stic
 | Sensor Timeout    | Number       | The amount of time in seconds that should result in OFFLINE status when no readings have been received from the sensor |
 | Retry Count       | Number       | The number of times a switch command will be resent to the socket until giving up                                      |
 
+#### Revolt power monitors
+
+| Parameter         | Item Type    | Description                                                                                                            |
+|-------------------|--------------|------------------------------------------------------------------------------------------------------------------------|
+| Sensor ID         | Number       | The ID of the connected sensor                                                                                         |
+| Sensor Timeout    | Number       | The amount of time in seconds that should result in OFFLINE status when no readings have been received from the sensor |
+
 ## Channels
 
 #### LaCrosse temperature sensors
@@ -127,13 +135,23 @@ The available init commands depend on the sketch that is running on the USB stic
 | currentPower            | Number:Power  | Current power draw                                   |
 | consumptionTotal        | Number:Energy | Total energy consumption                             |
 
+#### Revolt power monitors
+| Channel Type ID   | Item Type                | Description                               |
+|-------------------|--------------------------|-------------------------------------------|
+| currentPower      | Number:Power             | Current power draw                        |
+| consumptionTotal  | Number:Energy            | Total energy consumption                  |
+| powerFactor       | Number                   | Ratio of real power to apparent power     |
+| electricCurrent   | Number:ElectricCurrent   | The measured Electric Current             |
+| electricPotential | Number:ElectricPotential | The measured Electric Potential           |
+| powerFrequency    | Number:Frequency         | The measured AC power frequency           |
+
 ## Commands
 
 #### PCA301 power monitoring wireless sockets
 
-| Channel Type ID         | Item Type    | Description                                        |
-|-------------------------|--------------|----------------------------------------------------|
-| switchingState          | Switch       | Supports ON and OFF commands to switch the socket. |
+| Channel Type ID         | Item Type    | Description                                       |
+|-------------------------|--------------|---------------------------------------------------|
+| switchingState          | Switch       | Supports ON and OFF commands to switch the socket |
 
 ## Full Example
 
@@ -158,6 +176,13 @@ A typical Thing configuration for lacrosse looks like this:
 Thing jeelink:jeelinkUsb:lacrosse "Jeelink lacrosse" @ "home" [ serialPort="COM6" ]
 Thing jeelink:lacrosse:sensor1 "Jeelink lacrosse 1" (jeelink:jeelinkUsb:lacrosse)  @ "home" [ sensorId="16", minTemp=10, maxTemp=32]
 Thing jeelink:lacrosse:sensor2 "Jeelink lacrosse 2" (jeelink:jeelinkUsb:lacrosse)  @ "home" [ sensorId="18", minTemp=10, maxTemp=32]
+```
+
+A typical thing configuration for Revolt looks like this:
+
+```
+Thing jeelink:jeelinkUsb:revolt "Jeelink revolt" @ "home" [ serialPort="COM4" ]
+Thing jeelink:revolt:4F1B "revolt 1" (jeelink:jeelinkUsb:revolt)  @ "home" [ sensorId="4F1B"]
 ```
 
 A typical item configuration for a LaCrosse temperature sensor looks like this:
@@ -189,3 +214,15 @@ Number:Speed WindStrength "Wind [%.1f %unit%]" {channel="jeelink:tx22:42:windStr
 Number:Angle WindDir "Wind dir [%.1f %unit%]" {channel="jeelink:tx22:42:windAngle"}
 Number:Speed GustStrength "Gust [%.1f %unit%]" {channel="jeelink:tx22:42:gustStrength"}
 ```
+
+A typical item configuration for a Revolt power monitor looks like this:
+
+```
+Number:Power SocketWattage {channel="jeelink:revolt:4F1B:currentPower"}
+Number:Energy SocketConsumption {channel="jeelink:revolt:4F1B:consumptionTotal"}
+Number:Dimensionless POwerFactor {channel="jeelink:revolt:4F1B:powerFactor"}
+Number:ElectricCurrent Current {channel="jeelink:revolt:4F1B:electricCurrent"}
+Number:ElectricPotential Voltage {channel="jeelink:revolt:4F1B:electricPotential"}
+Number:Frequency PowerFrequency {channel="jeelink:revolt:4F1B:powerFrequency"}
+```
+

--- a/bundles/org.openhab.binding.jeelink/README.md
+++ b/bundles/org.openhab.binding.jeelink/README.md
@@ -136,6 +136,7 @@ The available init commands depend on the sketch that is running on the USB stic
 | consumptionTotal        | Number:Energy | Total energy consumption                             |
 
 #### Revolt power monitors
+
 | Channel Type ID   | Item Type                | Description                               |
 |-------------------|--------------------------|-------------------------------------------|
 | currentPower      | Number:Power             | Current power draw                        |

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkBindingConstants.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkBindingConstants.java
@@ -43,6 +43,7 @@ public class JeeLinkBindingConstants {
     public static final ThingTypeUID EC3000_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "ec3k");
     public static final ThingTypeUID PCA301_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "pca301");
     public static final ThingTypeUID TX22_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "tx22");
+    public static final ThingTypeUID REVOLT_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "revolt");
 
     // List of all channel ids for lacrosse sensor things
     public static final String TEMPERATURE_CHANNEL = "temperature";
@@ -63,6 +64,12 @@ public class JeeLinkBindingConstants {
     // List of all additional channel ids for pca301 sensor things
     public static final String SWITCHING_STATE_CHANNEL = "switchingState";
 
+    // List of all additional channel ids for revolt sensor things
+    public static final String POWER_FACTOR_CHANNEL = "powerFactor";
+    public static final String ELECTRIC_CURRENT_CHANNEL = "electricCurrent";
+    public static final String ELECTRIC_POTENTIAL_CHANNEL = "electricPotential";
+    public static final String FREQUENCY_CHANNEL = "powerFrequency";
+    
     // List of all additional channel ids for tx22 sensor things
     public static final String PRESSURE_CHANNEL = "pressure";
     public static final String RAIN_CHANNEL = "rain";

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkHandler.java
@@ -19,9 +19,6 @@ import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -43,15 +40,12 @@ import org.slf4j.LoggerFactory;
  * @author Volker Bier - Initial contribution
  */
 public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, ConnectionListener {
-    private static final Pattern READING_P = Pattern.compile("^OK\\s+(WS|[0-9]+)(?:\\s+([0-9]+))+$");
-
     private final Logger logger = LoggerFactory.getLogger(JeeLinkHandler.class);
 
     private JeeLinkConnection connection;
+    private List<JeeLinkReadingConverter<?>> converters = new ArrayList<>();
     private Map<String, JeeLinkReadingConverter<?>> sensorTypeConvertersMap = new HashMap<>();
     private Map<Class<?>, List<ReadingHandler<? extends Reading>>> readingClassHandlerMap = new HashMap<>();
-
-    private final AtomicReference<ReadingHandler<Reading>> discoveryHandler = new AtomicReference<>();
 
     private AtomicBoolean connectionInitialized = new AtomicBoolean(false);
     private ScheduledFuture<?> connectJob;
@@ -155,7 +149,17 @@ public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, 
             List<ReadingHandler<? extends Reading>> handlers = readingClassHandlerMap.get(h.getReadingClass());
             if (handlers == null) {
                 handlers = new ArrayList<>();
+                
+                // this is the first handler for this reading class => also setup converter
                 readingClassHandlerMap.put(h.getReadingClass(), handlers);
+                
+                JeeLinkReadingConverter<?> c = SensorDefinition.getConverter(h.getSensorType());
+                if (c != null) {
+                    converters.add(c);
+                    sensorTypeConvertersMap.put(h.getSensorType(), c);
+                } else if ("ALL".equals(h.getSensorType())) {
+                    converters.addAll(SensorDefinition.getDiscoveryConverters());
+                }
             }
 
             if (!handlers.contains(h)) {
@@ -174,7 +178,15 @@ public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, 
                 handlers.remove(h);
 
                 if (handlers.isEmpty()) {
+                    // this was the last handler for this reading class => also remove converter
                     readingClassHandlerMap.remove(h.getReadingClass());
+                    
+                    JeeLinkReadingConverter<?> c = sensorTypeConvertersMap.get(h.getSensorType());
+                    if (c != null) {
+                        converters.remove(c);
+                    } else if ("ALL".equals(h.getSensorType())) {
+                        converters.removeAll(SensorDefinition.getDiscoveryConverters());
+                    }
                 }
             }
         }
@@ -187,50 +199,44 @@ public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, 
     @Override
     public void handleInput(String input) {
         lastReadingTime = System.currentTimeMillis();
-
-        Matcher matcher = READING_P.matcher(input);
-        if (matcher.matches()) {
-            intializeConnection();
-
-            String sensorType = matcher.group(1);
-            JeeLinkReadingConverter<?> converter;
-
-            synchronized (sensorTypeConvertersMap) {
-                converter = sensorTypeConvertersMap.get(sensorType);
-                if (converter == null) {
-                    converter = SensorDefinition.getConverter(sensorType);
-
-                    if (converter == null) {
-                        logger.debug("Missing converter for sensor type {}. Ignoring readings.", sensorType);
-                        converter = new IgnoringConverter();
-                    } else {
-                        logger.debug("Registering converter for sensor type {}: {}", sensorType, converter);
-                    }
-
-                    sensorTypeConvertersMap.put(sensorType, converter);
-                }
-            }
-
-            Reading r = converter.createReading(input);
+        
+        // try all associated converters to find the correct one
+        for (JeeLinkReadingConverter<?> c : converters) {
+            Reading r = c.createReading(input);
+            
             if (r != null) {
-                ReadingHandler<Reading> d = discoveryHandler.get();
-                if (d != null) {
-                    d.handleReading(r);
-                }
+                // this converter is responsible
+                intializeConnection();
 
                 // propagate to the appropriate sensor handler
                 synchronized (readingClassHandlerMap) {
-                    List<ReadingHandler<? extends Reading>> handlers = readingClassHandlerMap.get(r.getClass());
-                    if (handlers != null) {
-                        for (ReadingHandler h : handlers) {
-                            h.handleReading(r);
-                        }
+                    List<ReadingHandler<? extends Reading>> handlers = getAllHandlers(r.getClass());
+                    
+                    for (ReadingHandler h : handlers) {
+                        h.handleReading(r);
                     }
                 }
+                
+                break;
             }
         }
     }
 
+    private List<ReadingHandler<? extends Reading>> getAllHandlers(Class<? extends Reading> readingClass) {
+        List<ReadingHandler<? extends Reading>> handlers = new ArrayList<>();
+        
+        List<ReadingHandler<? extends Reading>> typeHandlers = readingClassHandlerMap.get(readingClass);
+        if (typeHandlers != null) {
+            handlers.addAll(typeHandlers);
+        }
+        List<ReadingHandler<? extends Reading>> discoveryHandlers = readingClassHandlerMap.get(Reading.class);
+        if (discoveryHandlers != null) {
+            handlers.addAll(discoveryHandlers);
+        }
+        
+        return handlers;
+    }
+    
     private void intializeConnection() {
         if (!connectionInitialized.getAndSet(true)) {
             JeeLinkConfig cfg = getConfig().as(JeeLinkConfig.class);
@@ -254,22 +260,10 @@ public class JeeLinkHandler extends BaseBridgeHandler implements BridgeHandler, 
             connection.closeConnection();
         }
 
-        synchronized (sensorTypeConvertersMap) {
-            sensorTypeConvertersMap.clear();
-        }
-
         super.dispose();
     }
 
     public JeeLinkConnection getConnection() {
         return connection;
-    }
-
-    public void startDiscovery(ReadingHandler<Reading> handler) {
-        discoveryHandler.set(handler);
-    }
-
-    public void stopDiscovery() {
-        discoveryHandler.set(null);
     }
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkSensorHandler.java
@@ -30,16 +30,23 @@ import org.openhab.binding.jeelink.internal.config.JeeLinkSensorConfig;
  */
 public abstract class JeeLinkSensorHandler<R extends Reading> extends BaseThingHandler implements ReadingHandler<R> {
     protected String id;
+    protected final String sensorType;
 
     private ReadingPublisher<R> publisher;
     private long secsSinceLastReading;
     private ScheduledFuture<?> statusUpdateJob;
 
-    public JeeLinkSensorHandler(Thing thing) {
+    public JeeLinkSensorHandler(Thing thing, String sensorType) {
         super(thing);
+        this.sensorType = sensorType;
     }
 
     public abstract ReadingPublisher<R> createPublisher();
+
+    @Override
+    public String getSensorType() {
+        return sensorType;
+    }
 
     @Override
     public void handleReading(R r) {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ReadingHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ReadingHandler.java
@@ -21,4 +21,6 @@ public interface ReadingHandler<R extends Reading> {
     public void handleReading(R r);
 
     public Class<R> getReadingClass();
+
+    public String getSensorType();
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.jeelink.internal;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -21,6 +23,7 @@ import org.openhab.binding.jeelink.internal.ec3k.Ec3kSensorDefinition;
 import org.openhab.binding.jeelink.internal.lacrosse.LaCrosseSensorDefinition;
 import org.openhab.binding.jeelink.internal.lacrosse.Tx22SensorDefinition;
 import org.openhab.binding.jeelink.internal.pca301.Pca301SensorDefinition;
+import org.openhab.binding.jeelink.internal.revolt.RevoltSensorDefinition;
 
 /**
  * Base class for sensor definitions.
@@ -31,16 +34,19 @@ import org.openhab.binding.jeelink.internal.pca301.Pca301SensorDefinition;
  */
 public abstract class SensorDefinition<R extends Reading> {
     private static final HashSet<SensorDefinition<?>> SENSOR_DEFS = new HashSet<>();
+    private static final List<JeeLinkReadingConverter<?>> CONVERTERS = new ArrayList<>();
+
+    protected final String type;
 
     final ThingTypeUID thingTypeUid;
     final String name;
-    final String type;
 
     static {
         SENSOR_DEFS.add(new LaCrosseSensorDefinition());
         SENSOR_DEFS.add(new Ec3kSensorDefinition());
         SENSOR_DEFS.add(new Pca301SensorDefinition());
         SENSOR_DEFS.add(new Tx22SensorDefinition());
+        SENSOR_DEFS.add(new RevoltSensorDefinition());
     }
 
     public SensorDefinition(ThingTypeUID thingTypeUid, String name, String type) {
@@ -94,6 +100,18 @@ public abstract class SensorDefinition<R extends Reading> {
             }
         }
         return null;
+    }
+
+    public static List<JeeLinkReadingConverter<?>> getDiscoveryConverters() {
+        synchronized (CONVERTERS) {
+            if (CONVERTERS.isEmpty()) {
+                for (SensorDefinition<?> sensor : SENSOR_DEFS) {
+                    CONVERTERS.add(sensor.createConverter());
+                }    
+            }
+        }
+        
+        return CONVERTERS;
     }
 
     private String getSensorType() {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -12,9 +12,8 @@
  */
 package org.openhab.binding.jeelink.internal;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
 
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -33,8 +32,9 @@ import org.openhab.binding.jeelink.internal.revolt.RevoltSensorDefinition;
  * @param <R> the Reading type this sensor provides.
  */
 public abstract class SensorDefinition<R extends Reading> {
-    private static final HashSet<SensorDefinition<?>> SENSOR_DEFS = new HashSet<>();
-    private static final List<JeeLinkReadingConverter<?>> CONVERTERS = new ArrayList<>();
+	public static final String ALL_TYPE = "All";
+    private static final Set<SensorDefinition<?>> SENSOR_DEFS = new HashSet<>();
+    private static final Set<JeeLinkReadingConverter<?>> CONVERTERS = new HashSet<>();
 
     protected final String type;
 
@@ -79,7 +79,7 @@ public abstract class SensorDefinition<R extends Reading> {
         return null;
     }
 
-    public static HashSet<SensorDefinition<?>> getDefinitions() {
+    public static Set<SensorDefinition<?>> getDefinitions() {
         return SENSOR_DEFS;
     }
 
@@ -102,7 +102,7 @@ public abstract class SensorDefinition<R extends Reading> {
         return null;
     }
 
-    public static List<JeeLinkReadingConverter<?>> getDiscoveryConverters() {
+    public static Set<JeeLinkReadingConverter<?>> getDiscoveryConverters() {
         synchronized (CONVERTERS) {
             if (CONVERTERS.isEmpty()) {
                 for (SensorDefinition<?> sensor : SENSOR_DEFS) {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -100,7 +100,7 @@ public abstract class SensorDefinition<R extends Reading> {
     }
 
     public static Set<JeeLinkReadingConverter<?>> getDiscoveryConverters() {
-    	return CONVERTERS;
+        return CONVERTERS;
     }
 
     private String getSensorType() {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.jeelink.internal;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -33,21 +34,17 @@ import org.openhab.binding.jeelink.internal.revolt.RevoltSensorDefinition;
  */
 public abstract class SensorDefinition<R extends Reading> {
     public static final String ALL_TYPE = "All";
-    private static final Set<SensorDefinition<?>> SENSOR_DEFS = new HashSet<>();
-    private static final Set<JeeLinkReadingConverter<?>> CONVERTERS = new HashSet<>();
+    
+    private static final Set<SensorDefinition<?>> SENSOR_DEFS = Stream
+            .of(new LaCrosseSensorDefinition(), new Ec3kSensorDefinition(), new Pca301SensorDefinition(),
+                    new Tx22SensorDefinition(), new RevoltSensorDefinition()).collect(Collectors.toSet());
+    private static final Set<JeeLinkReadingConverter<?>> CONVERTERS = SENSOR_DEFS.stream()
+            .map(SensorDefinition::createConverter).collect(Collectors.toSet());
 
     protected final String type;
 
     final ThingTypeUID thingTypeUid;
     final String name;
-
-    static {
-        SENSOR_DEFS.add(new LaCrosseSensorDefinition());
-        SENSOR_DEFS.add(new Ec3kSensorDefinition());
-        SENSOR_DEFS.add(new Pca301SensorDefinition());
-        SENSOR_DEFS.add(new Tx22SensorDefinition());
-        SENSOR_DEFS.add(new RevoltSensorDefinition());
-    }
 
     public SensorDefinition(ThingTypeUID thingTypeUid, String name, String type) {
         this.thingTypeUid = thingTypeUid;
@@ -103,15 +100,7 @@ public abstract class SensorDefinition<R extends Reading> {
     }
 
     public static Set<JeeLinkReadingConverter<?>> getDiscoveryConverters() {
-        synchronized (CONVERTERS) {
-            if (CONVERTERS.isEmpty()) {
-                for (SensorDefinition<?> sensor : SENSOR_DEFS) {
-                    CONVERTERS.add(sensor.createConverter());
-                }    
-            }
-        }
-        
-        return CONVERTERS;
+    	return CONVERTERS;
     }
 
     private String getSensorType() {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -32,7 +32,7 @@ import org.openhab.binding.jeelink.internal.revolt.RevoltSensorDefinition;
  * @param <R> the Reading type this sensor provides.
  */
 public abstract class SensorDefinition<R extends Reading> {
-	public static final String ALL_TYPE = "All";
+    public static final String ALL_TYPE = "All";
     private static final Set<SensorDefinition<?>> SENSOR_DEFS = new HashSet<>();
     private static final Set<JeeLinkReadingConverter<?>> CONVERTERS = new HashSet<>();
 

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/BufferedSensorConfig.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/BufferedSensorConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/BufferedSensorConfig.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/BufferedSensorConfig.java
@@ -13,11 +13,11 @@
 package org.openhab.binding.jeelink.internal.config;
 
 /**
- * Configuration for a JeeLinkSensorHandler.
+ * Configuration for a Handler that is able to buffer values.
  *
  * @author Volker Bier - Initial contribution
  */
-public class JeeLinkSensorConfig {
-    public String sensorId;
-    public int sensorTimeout;
+public class BufferedSensorConfig extends JeeLinkSensorConfig {
+    public int updateInterval;
+    public int bufferSize;
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/LaCrosseTemperatureSensorConfig.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/LaCrosseTemperatureSensorConfig.java
@@ -17,7 +17,7 @@ package org.openhab.binding.jeelink.internal.config;
  *
  * @author Volker Bier - Initial contribution
  */
-public class LaCrosseTemperatureSensorConfig extends JeeLinkSensorConfig {
+public class LaCrosseTemperatureSensorConfig extends BufferedSensorConfig {
     public float minTemp;
     public float maxTemp;
     public float maxDiff;

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/Pca301SensorConfig.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/config/Pca301SensorConfig.java
@@ -17,8 +17,6 @@ package org.openhab.binding.jeelink.internal.config;
  *
  * @author Volker Bier - Initial contribution
  */
-public class Pca301SensorConfig {
-    public String sensorId;
-    public int updateInterval;
+public class Pca301SensorConfig extends JeeLinkSensorConfig {
     public int sendCount;
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.ConnectException;
-import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
@@ -80,10 +80,6 @@ public abstract class AbstractJeeLinkConnection implements JeeLinkConnection {
         if (commands != null && !commands.trim().isEmpty()) {
             initCommands = commands.split(";");
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Writing to device on port {}: {} ", port, Arrays.toString(initCommands));
-            }
-
             try (OutputStream initStream = getInitStream()) {
                 if (initStream == null) {
                     throw new IOException(
@@ -94,7 +90,11 @@ public abstract class AbstractJeeLinkConnection implements JeeLinkConnection {
                 // in case of tcp connections, the underlying socket
                 OutputStreamWriter w = new OutputStreamWriter(initStream);
                 for (String cmd : initCommands) {
-                    w.write(cmd);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Writing to device on port {}: {} ", port, cmd);
+                    }
+
+                    w.write(cmd + "\n");
                 }
                 w.flush();
             } catch (IOException ex) {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/connection/AbstractJeeLinkConnection.java
@@ -89,9 +89,7 @@ public abstract class AbstractJeeLinkConnection implements JeeLinkConnection {
                 // in case of tcp connections, the underlying socket
                 OutputStreamWriter w = new OutputStreamWriter(initStream);
                 for (String cmd : initCommands) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Writing to device on port {}: {} ", port, cmd);
-                    }
+                    logger.debug("Writing to device on port {}: {} ", port, cmd);
 
                     w.write(cmd + "\n");
                 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
@@ -58,7 +58,7 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
             logger.debug("discovery started for bridge {}", bridge.getThing().getUID());
 
             // start listening for new sensor values
-            bridge.startDiscovery(this);
+            bridge.addReadingHandler(this);
             capture.set(true);
         }
     }
@@ -71,7 +71,7 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
     @Override
     protected synchronized void stopScan() {
         if (capture.getAndSet(false)) {
-            bridge.stopDiscovery();
+            bridge.removeReadingHandler(this);
             logger.debug("discovery stopped for bridge {}", bridge.getThing().getUID());
         }
     }
@@ -133,9 +133,16 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
             logger.debug("discovery for bridge {} found already known sensor id {}", bridge.getThing().getUID(), id);
         }
     }
+    
+    
 
     @Override
     public Class<Reading> getReadingClass() {
         return Reading.class;
+    }
+
+    @Override
+    public String getSensorType() {
+        return "ALL";
     }
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
@@ -133,8 +133,6 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
             logger.debug("discovery for bridge {} found already known sensor id {}", bridge.getThing().getUID(), id);
         }
     }
-    
-    
 
     @Override
     public Class<Reading> getReadingClass() {
@@ -143,6 +141,6 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
 
     @Override
     public String getSensorType() {
-        return "ALL";
+        return SensorDefinition.ALL_TYPE;
     }
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorDefinition.java
@@ -41,7 +41,7 @@ public class Ec3kSensorDefinition extends SensorDefinition<Ec3kReading> {
 
     @Override
     public JeeLinkSensorHandler<Ec3kReading> createHandler(Thing thing) {
-        return new Ec3kSensorHandler(thing);
+        return new Ec3kSensorHandler(thing, type);
     }
 
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/ec3k/Ec3kSensorHandler.java
@@ -26,7 +26,7 @@ import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.ReadingPublisher;
 import org.openhab.binding.jeelink.internal.RollingAveragePublisher;
 import org.openhab.binding.jeelink.internal.RollingReadingAverage;
-import org.openhab.binding.jeelink.internal.config.JeeLinkSensorConfig;
+import org.openhab.binding.jeelink.internal.config.BufferedSensorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +38,8 @@ import org.slf4j.LoggerFactory;
 public class Ec3kSensorHandler extends JeeLinkSensorHandler<Ec3kReading> {
     private final Logger logger = LoggerFactory.getLogger(Ec3kSensorHandler.class);
 
-    public Ec3kSensorHandler(Thing thing) {
-        super(thing);
+    public Ec3kSensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class Ec3kSensorHandler extends JeeLinkSensorHandler<Ec3kReading> {
             }
         };
 
-        JeeLinkSensorConfig cfg = getConfigAs(JeeLinkSensorConfig.class);
+        BufferedSensorConfig cfg = getConfigAs(BufferedSensorConfig.class);
         if (cfg.bufferSize > 1 && cfg.updateInterval > 0) {
             publisher = new RollingAveragePublisher<Ec3kReading>(cfg.bufferSize, cfg.updateInterval, publisher,
                     scheduler) {

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LaCrosseTemperatureSensorHandler.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 public class LaCrosseTemperatureSensorHandler extends JeeLinkSensorHandler<LaCrosseTemperatureReading> {
     private final Logger logger = LoggerFactory.getLogger(LaCrosseTemperatureSensorHandler.class);
 
-    public LaCrosseTemperatureSensorHandler(Thing thing) {
-        super(thing);
+    public LaCrosseTemperatureSensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
     }
 
     @Override

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorDefinition.java
@@ -41,6 +41,6 @@ public class Tx22SensorDefinition extends SensorDefinition<Tx22Reading> {
 
     @Override
     public JeeLinkSensorHandler<Tx22Reading> createHandler(Thing thing) {
-        return new Tx22SensorHandler(thing);
+        return new Tx22SensorHandler(thing, type);
     }
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/Tx22SensorHandler.java
@@ -37,8 +37,8 @@ import org.slf4j.LoggerFactory;
 public class Tx22SensorHandler extends JeeLinkSensorHandler<Tx22Reading> {
     private final Logger logger = LoggerFactory.getLogger(Tx22SensorHandler.class);
 
-    public Tx22SensorHandler(Thing thing) {
-        super(thing);
+    public Tx22SensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
     }
 
     @Override

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorDefinition.java
@@ -41,7 +41,7 @@ public class Pca301SensorDefinition extends SensorDefinition<Pca301Reading> {
 
     @Override
     public JeeLinkSensorHandler<Pca301Reading> createHandler(Thing thing) {
-        return new Pca301SensorHandler(thing);
+        return new Pca301SensorHandler(thing, type);
     }
 
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/pca301/Pca301SensorHandler.java
@@ -49,8 +49,8 @@ public class Pca301SensorHandler extends JeeLinkSensorHandler<Pca301Reading> {
     private ScheduledFuture<?> retry;
     private int sendCount;
 
-    public Pca301SensorHandler(Thing thing) {
-        super(thing);
+    public Pca301SensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
     }
 
     @Override

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReading.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReading.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReading.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReading.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.revolt;
+
+import org.openhab.binding.jeelink.internal.Reading;
+
+/**
+ * Reading of a Revolt Energy Meter sensor.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class RevoltReading implements Reading {
+    private int voltage;
+    private float current;
+    private int frequency;
+    private float power;
+    private float powerFact;
+    private float consumption;
+    private String sensorId;
+
+    public RevoltReading(String sensorId, int voltage, float current, int frequency, float power, float powerFactor,
+            float consumption) {
+        this.sensorId = sensorId;
+        this.voltage = voltage;
+        this.current = current;
+        this.frequency = frequency;
+        this.power = power;
+        this.powerFact = powerFactor;
+        this.consumption = consumption;
+    }
+
+    @Override
+    public String toString() {
+        return "sensorId=" + sensorId + ": voltage=" + voltage + ", current=" + current + ", frequency=" + frequency + 
+                ", power=" + power + ", powerFact=" + powerFact + ", consumption=" + consumption;
+    }
+
+    @Override
+    public String getSensorId() {
+        return sensorId;
+    }
+
+    public int getVoltage() {
+        return voltage;
+    }
+
+    public float getCurrent() {
+        return current;
+    }
+
+    public int getFrequency() {
+        return frequency;
+    }
+
+    public float getPower() {
+        return power;
+    }
+
+    public float getPowerFactor() {
+        return powerFact;
+    }
+
+    public float getConsumption() {
+        return consumption;
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReadingConverter.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReadingConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReadingConverter.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltReadingConverter.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.revolt;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+
+/**
+ * Converter for converting a line read from a SlowRF CUL to a RevoltReading.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class RevoltReadingConverter implements JeeLinkReadingConverter<RevoltReading> {
+    private static final Pattern LINE_P = Pattern
+            .compile("r([0-9A-Za-z]{4})([0-9A-Za-z]{2})([0-9A-Za-z]{4})([0-9A-Za-z]{2})([0-9A-Za-z]{4})"
+                    + "([0-9A-Za-z]{2})([0-9A-Za-z]{4})[0-9A-Za-z][0-9A-Za-z]");
+
+    @Override
+    public RevoltReading createReading(String inputLine) {
+        if (inputLine != null) {
+            Matcher matcher = LINE_P.matcher(inputLine);
+            if (matcher.matches()) {
+                /*
+                 * r4F1BE400513206875B312F25
+                 */
+                String id = matcher.group(1);                         // 4F1B
+                
+                int voltage = toInt(matcher.group(2));                // 0xE4 = 228     => 228 V
+                float current = toInt(matcher.group(3)) / 100f;       // 0x0051 = 81    => 0,81 A
+                int frequency = toInt(matcher.group(4));              // 0x32 = 50      => 50 Hz
+                float power = toInt(matcher.group(5)) / 10f;          // 0x0687 = 1671  => 167,1 W
+                float powerFact = toInt(matcher.group(6)) / 100f;     // 0x5B = 91      => 0,91 VA
+                float consumption = toInt(matcher.group(7)) / 100f;   // 0x312F = 12591 => 125,91 Wh
+
+                return new RevoltReading(id, voltage, current, frequency, power, powerFact, consumption);
+            }
+        }
+
+        return null;
+    }
+    
+    private int toInt(String hex) {
+        Integer i = Integer.parseInt(hex, 16);
+        return i.intValue();
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorDefinition.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.jeelink.internal.lacrosse;
+package org.openhab.binding.jeelink.internal.revolt;
 
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.jeelink.internal.JeeLinkBindingConstants;
@@ -19,28 +19,27 @@ import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
 import org.openhab.binding.jeelink.internal.SensorDefinition;
 
 /**
- * Sensor Defintion of a LaCrosse Temperature Sensor
+ * Sensor Definition of a Revolt Energy Meter.
  *
  * @author Volker Bier - Initial contribution
  */
-public class LaCrosseSensorDefinition extends SensorDefinition<LaCrosseTemperatureReading> {
-
-    public LaCrosseSensorDefinition() {
-        super(JeeLinkBindingConstants.LACROSSE_SENSOR_THING_TYPE, "LaCrosse Temperature Sensor", "9");
+public class RevoltSensorDefinition extends SensorDefinition<RevoltReading> {
+    public RevoltSensorDefinition() {
+        super(JeeLinkBindingConstants.REVOLT_SENSOR_THING_TYPE, "Revolt Power Monitor", "r");
     }
 
     @Override
-    public JeeLinkReadingConverter<LaCrosseTemperatureReading> createConverter() {
-        return new LaCrosseTemperatureReadingConverter();
+    public JeeLinkReadingConverter<RevoltReading> createConverter() {
+        return new RevoltReadingConverter();
     }
 
     @Override
-    public Class<LaCrosseTemperatureReading> getReadingClass() {
-        return LaCrosseTemperatureReading.class;
+    public Class<RevoltReading> getReadingClass() {
+        return RevoltReading.class;
     }
 
     @Override
-    public JeeLinkSensorHandler<LaCrosseTemperatureReading> createHandler(Thing thing) {
-        return new LaCrosseTemperatureSensorHandler(thing, type);
+    public JeeLinkSensorHandler<RevoltReading> createHandler(Thing thing) {
+        return new RevoltSensorHandler(thing, type);
     }
 }

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/revolt/RevoltSensorHandler.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.revolt;
+
+import static org.openhab.binding.jeelink.internal.JeeLinkBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
+import org.openhab.binding.jeelink.internal.ReadingPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for a Revolt Energy Meter sensor thing.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class RevoltSensorHandler extends JeeLinkSensorHandler<RevoltReading> {
+    private final Logger logger = LoggerFactory.getLogger(RevoltSensorHandler.class);
+
+    public RevoltSensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
+    }
+
+    @Override
+    public Class<RevoltReading> getReadingClass() {
+        return RevoltReading.class;
+    }
+
+    @Override
+    public ReadingPublisher<RevoltReading> createPublisher() {
+        ReadingPublisher<RevoltReading> publisher = new ReadingPublisher<RevoltReading>() {
+            @Override
+            public void publish(RevoltReading reading) {
+                if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
+                    BigDecimal power = new BigDecimal(reading.getPower()).setScale(1, RoundingMode.HALF_UP);
+                    BigDecimal powerFactor = new BigDecimal(reading.getPowerFactor()).setScale(2, RoundingMode.HALF_UP);
+                    BigDecimal consumption = new BigDecimal(reading.getConsumption()).setScale(2, RoundingMode.HALF_UP);
+                    BigDecimal current = new BigDecimal(reading.getCurrent()).setScale(2, RoundingMode.HALF_UP);
+
+                    logger.debug(
+                            "updating states for thing {}: power={}, powerFactor={}, consumption={}, current={}, voltage={}, frequency={} ",
+                            getThing().getUID().getId(), power, powerFactor, consumption, current, reading.getVoltage(), reading.getFrequency());
+
+                    updateState(CURRENT_POWER_CHANNEL, new QuantityType<>(power, SmartHomeUnits.WATT));
+                    updateState(POWER_FACTOR_CHANNEL, new DecimalType(powerFactor));
+                    updateState(CONSUMPTION_CHANNEL, new QuantityType<>(consumption, SmartHomeUnits.WATT_HOUR));
+                    updateState(ELECTRIC_CURRENT_CHANNEL, new QuantityType<>(current, SmartHomeUnits.AMPERE));
+                    updateState(ELECTRIC_POTENTIAL_CHANNEL, new QuantityType<>(reading.getVoltage(), SmartHomeUnits.VOLT));
+                    updateState(FREQUENCY_CHANNEL, new QuantityType<>(reading.getFrequency(), SmartHomeUnits.HERTZ));
+                }
+            }
+
+            @Override
+            public void dispose() {
+            }
+        };
+
+        return publisher;
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink.properties
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink.properties
@@ -21,6 +21,8 @@ thing-type.pca301.label = PCA301
 thing-type.pca301.description = Thing for a PCA301 power monitoring wireless socket connected to a JeeLink USB Receiver.
 thing-type.tx22.label = TX22 Sensor
 thing-type.tx22.description = Thing for a TX22 Sensor connected to a JeeLink USB Receiver.
+thing-type.revolt.label = Revolt Power Monitor
+thing-type.revolt.description = Thing for a Revolt Power Monitor connected to a JeeLink USB Receiver.
 
 # parameters
 parameter.serialport.label = Serial Port
@@ -88,3 +90,11 @@ channel-type.pressure.label = Pressure
 channel-type.pressure.description = Current pressure
 gust-strength.label = Gust Strength
 gust-strength.description = Current gust speed
+channel-type.electric-current.label = Electric Current
+channel-type.electric-current.description = The measured electric current.
+channel-type.power-factor.label = Power Factor
+channel-type.power-factor.description = The ratio of the real power absorbed by the load to the apparent power flowing in the circuit.
+channel-type.electric-potential.label = Voltage
+channel-type.electric-potential.description = The measured electric potential.
+channel-type.power-frequency.label = Power Frequency
+channel-type.power-frequency.description = The measured AC power frequency.

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink_de.properties
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink_de.properties
@@ -21,6 +21,8 @@ thing-type.pca301.label = PCA301
 thing-type.pca301.description = Eine mit dem JeeLink USB Empfänger verbundene PCA301 Steckdose.
 thing-type.tx22.label = TX22 Sensor
 thing-type.tx22.description = Eine mit dem JeeLink USB Empfänger verbundener TX22 Sensor.
+thing-type.revolt.label = Revolt Energie-Messgerät
+thing-type.revolt.description = Ein mit dem JeeLink USB Empfänger verbundenes Revolt Energie-Messgerät.
 
 # parameters
 parameter.serialport.label = Serielle Schnittstelle
@@ -88,3 +90,11 @@ channel-type.pressure.label = Luftdruck
 channel-type.pressure.description = Momentaner Luftdruck
 gust-strength.label = Böenstärke
 gust-strength.description = Momentane Böenstärke
+channel-type.electric-current.label = Stromstärke
+channel-type.electric-current.description = Die gemessene elektrische Stromstärke .
+channel-type.power-factor.label = Leistungsfaktor
+channel-type.power-factor.description = Verhältnis des Betrages der Wirkleistung zur Scheinleistung.
+channel-type.electric-potential.label = Spannung
+channel-type.electric-potential.description = Die gemessene elektrische Spannung.
+channel-type.power-frequency.label = Stromnetzfrequenz
+channel-type.power-frequency.description = Die gemessene Netzfrequenz des Stromnetzes. 

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -289,6 +289,40 @@
 		</config-description>
 	</thing-type>
 
+	<!-- Revolt Energy Meter Thing Type -->
+	<thing-type id="revolt">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="jeelinkTcp" />
+			<bridge-type-ref id="jeelinkUsb" />
+			<bridge-type-ref id="lgwTcp" />
+			<bridge-type-ref id="lgwUsb" />
+		</supported-bridge-type-refs>
+
+		<label>@text/thing-type.revolt.label</label>
+		<description>@text/thing-type.revolt.description</description>
+
+		<channels>
+			<channel id="currentPower" typeId="current-power" />
+			<channel id="consumptionTotal" typeId="consumption-total" />
+			<channel id="powerFactor" typeId="power-factor" />
+			<channel id="electricCurrent" typeId="electric-current" />
+			<channel id="electricPotential" typeId="electric-potential" />
+			<channel id="powerFrequency" typeId="power-frequency" />
+		</channels>
+
+		<config-description>
+			<parameter name="sensorId" type="text" required="true">
+				<label>@text/parameter.sensorid.label</label>
+				<description>@text/parameter.sensorid.description</description>
+			</parameter>
+			<parameter name="sensorTimeout" type="integer" required="false" min="5" max="3600" unit="s" step="5">
+				<label>@text/parameter.sensortimeout.label</label>
+				<description>@text/parameter.sensortimeout.description</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<!-- TX22 Temperature/Humidity SensorThing Type -->
 	<thing-type id="tx22">
 		<supported-bridge-type-refs>
@@ -440,5 +474,33 @@
 		<item-type>Switch</item-type>
 		<label>@text/channel-type.switching-state.label</label>
 		<description>@text/channel-type.switching-state.description</description>
+	</channel-type>
+	
+	<!-- Revolt Current Type -->
+	<channel-type id="electric-current">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>@text/channel-type.electric-current.label</label>
+		<description>@text/channel-type.electric-current.description</description>
+	</channel-type>
+
+	<!-- Revolt Apparent Power Type -->
+	<channel-type id="power-factor">
+		<item-type>Number:Dimensionless</item-type>
+		<label>@text/channel-type.power-factor.label</label>
+		<description>@text/channel-type.power-factor.description</description>
+	</channel-type>
+	
+	<!-- Revolt Electric Potential Type -->
+	<channel-type id="electric-potential">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>@text/channel-type.electric-potential.label</label>
+		<description>@text/channel-type.electric-potential.description</description>
+	</channel-type>
+	
+	<!-- Revolt Frequency Type -->
+	<channel-type id="power-frequency">
+		<item-type>Number:Frequency</item-type>
+		<label>@text/channel-type.power-frequency.label</label>
+		<description>@text/channel-type.power-frequency.description</description>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Adds support for the revolt protocol to the jeelink binding. Fixes #6077.

Signed-off-by: Volker Bier <volker.bier@web.de>