### PR TITLE
[network] Documentation workaround to use DHCP with Docker

### DIFF
--- a/bundles/org.openhab.binding.network/README.md
+++ b/bundles/org.openhab.binding.network/README.md
@@ -156,6 +156,18 @@ iptables -A PREROUTING -t mangle -p udp ! -s 127.0.0.1 --dport 67 -j TEE --gatew
 iptables -A OUTPUT -t nat -p udp -s 127.0.0.1/32 --dport 67 -j DNAT --to 127.0.0.1:6767
 ```
 
+Above iptables solutions to check *dhcp_state* are not working when OpenHAB is started in Docker. Use another workaround
+
+```shell
+iptables -I PREROUTING -t nat -p udp --src 0.0.0.0 --dport 67 -j DNAT --to 0.0.0.0:6767
+```
+
+To verify PREROUTING list use below command
+
+```shell
+iptables -L -n -t nat
+```
+
 ## Channels
 
 Things support the following channels:


### PR DESCRIPTION
I got presence instantly when my smartphone connects to the wifi on my OpenHAB running in Docker 18.03.1 in Ubuntu 18.04.3 LTS.
Hope this trick will be helpful for others since another two options where not working for me.

Same approach was working for other specific cases based on discussion https://community.openhab.org/t/dhcp-listen-port-forwarding-issue/36846/6
