### PR TITLE
Add property bnd.additional in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,8 @@ Import-Package: \\
   ${bnd.exportpackage}
 -sources: false
 -contract: *
--includeresource: ${bnd.includeresource}]]></bnd>
+-includeresource: ${bnd.includeresource}
+${bnd.additional}]]></bnd>
             <!-- -dsannotations-options: norequirements -->
             <!-- Bundle-SymbolicName: ${project.groupId}.${project.artifactId} -->
           </configuration>


### PR DESCRIPTION
Add tiny property bnd.additional so individual bundles can add extra properties to the bnd configuration without overwriting the whole of the plugin configuration

That way a bundle can define the following property with any other specific bnd command(s) that may be required.
```xml
    <bnd.additional>-fixupmessages: "a specific error that can be ignored safely"</bnd.additional>
```

Specifically I need the exact example above in order to get bnd to behave correctly with an addon I am working on. I know the error can be ignored safely for my addon, and in order to not introduce any adverse effects on all other bundles I do not want to add the bnd command to the generel bnd configuration in the top level pom.xml. 

This way and in a separate completely PR maintainers can determine if this is an appropriate way to allow bundles a little more flexibility. 

(should something like this be agains 2.5.x branch and/or master?)