### PR TITLE
[mqtt] Allow outgoing format

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -245,6 +245,23 @@ Here are a few examples:
   - For an output of *May 23, 1995* use "%1$**tb** %1$**te**,%1$**tY**".
   - For an output of *23.05.1995* use "%1$**td**.%1$**tm**.%1$**tY**".
   - For an output of *23:15* use "%1$**tH**:%1$**tM**".
+  
+Default pattern applied for each type:
+| Type             | Parameter                         | Pattern             | Comment |
+| ---------------- | --------------------------------- | ------------------- | ------- |
+| __string__       | String                            | "%s"                | 
+| __number__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
+| __dimmer__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
+| __contact__      | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
+| __switch__       | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
+| __colorRGB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **red**, **green** and **blue** components.
+| __colorHSB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **hue**, **saturation** and **brightness** components.
+| __location__     | BigDecimal, BigDecimal            | "%2$f,%3$f,%1$f"    | Parameters are **altitude**, **latitude** and **longitude**, altitude is only in default pattern, if value is not '0'.
+| __image__        | --                                | --                  | No publishing supported. 
+| __datetime__     | ZonedDateTime                     | "%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS.%1$tN" | Trailing zeros of the nanoseconds are removed.
+| __rollershutter__| String                            | "%s"                | No pattern supported. Always **up**, **down**, **stop** string or integer percent value.
+
+Any outgoing value transformation will **always** result in a __string__ value.
 
 ## Troubleshooting
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
@@ -109,22 +109,24 @@ public class ColorValue extends Value {
     private static BigDecimal factor = new BigDecimal(2.5);
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
 
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            formatPattern = "%1$d,%2$d,%3$d";
+        }
+        // ignore the pattern. Don't know
         if (isRGB) {
             PercentType[] rgb = ((HSBType) state).toRGB();
-            StringBuilder b = new StringBuilder();
-            b.append(rgb[0].toBigDecimal().multiply(factor).intValue());
-            b.append(',');
-            b.append(rgb[1].toBigDecimal().multiply(factor).intValue());
-            b.append(',');
-            b.append(rgb[2].toBigDecimal().multiply(factor).intValue());
-            return b.toString();
-        } else {
-            return state.toString();
+            return String.format(formatPattern, rgb[0].toBigDecimal().multiply(factor).intValue(),
+                    rgb[1].toBigDecimal().multiply(factor).intValue(),
+                    rgb[2].toBigDecimal().multiply(factor).intValue());
         }
+        HSBType type = (HSBType) state;
+        return String.format(formatPattern, type.getHue().intValue(), type.getSaturation().intValue(),
+                type.getBrightness().intValue());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -30,6 +31,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  */
 @NonNullByDefault
 public class DateTimeValue extends Value {
+    private static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
     public DateTimeValue() {
         super(CoreItemFactory.DATETIME, Stream.of(DateTimeType.class, StringType.class).collect(Collectors.toList()));
     }
@@ -44,11 +47,14 @@ public class DateTimeValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
-
-        return ((DateTimeType) state).getZonedDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".contentEquals(formatPattern)) {
+            formatPattern = DATE_PATTERN;
+        }
+        return DateTimeFormatter.ofPattern(formatPattern).format(((DateTimeType) state).getZonedDateTime());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
@@ -31,8 +31,6 @@ import org.eclipse.smarthome.core.types.UnDefType;
  */
 @NonNullByDefault
 public class DateTimeValue extends Value {
-    private static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-
     public DateTimeValue() {
         super(CoreItemFactory.DATETIME, Stream.of(DateTimeType.class, StringType.class).collect(Collectors.toList()));
     }
@@ -53,8 +51,8 @@ public class DateTimeValue extends Value {
         }
         String formatPattern = pattern;
         if (formatPattern == null || "%s".contentEquals(formatPattern)) {
-            formatPattern = DATE_PATTERN;
+            return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(((DateTimeType) state).getZonedDateTime());
         }
-        return DateTimeFormatter.ofPattern(formatPattern).format(((DateTimeType) state).getZonedDateTime());
+        return String.format(formatPattern, ((DateTimeType) state).getZonedDateTime());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.mqtt.generic.values;
 
+import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,13 +39,17 @@ public class LocationValue extends Value {
     @Override
     public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
         String formatPattern = pattern;
+        PointType point = ((PointType) state);
 
         if (formatPattern == null || "%s".equals(formatPattern)) {
-            formatPattern = "%1$f,%2$f";
+            if (point.getAltitude().toBigDecimal().equals(BigDecimal.ZERO)) {
+                formatPattern = "%2$f,%3$f";
+            } else {
+                formatPattern = "%2$f,%3$f,%1$f";
+            }
         }
-        PointType point = ((PointType) state);
-        return String.format(Locale.ROOT, formatPattern, point.getLatitude().toBigDecimal(),
-                point.getLongitude().toBigDecimal(), point.getAltitude().toBigDecimal());
+        return String.format(Locale.ROOT, formatPattern, point.getAltitude().toBigDecimal(),
+                point.getLatitude().toBigDecimal(), point.getLongitude().toBigDecimal());
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
@@ -12,10 +12,13 @@
  */
 package org.openhab.binding.mqtt.generic.values;
 
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.PointType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -30,6 +33,18 @@ import org.eclipse.smarthome.core.types.Command;
 public class LocationValue extends Value {
     public LocationValue() {
         super(CoreItemFactory.LOCATION, Stream.of(PointType.class, StringType.class).collect(Collectors.toList()));
+    }
+
+    @Override
+    public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
+        String formatPattern = pattern;
+
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            formatPattern = "%1$f,%2$f";
+        }
+        PointType point = ((PointType) state);
+        return String.format(Locale.ROOT, formatPattern, point.getLatitude().toBigDecimal(),
+                point.getLongitude().toBigDecimal(), point.getAltitude().toBigDecimal());
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
@@ -66,6 +67,20 @@ public class NumberValue extends Value {
         }
 
         return true;
+    }
+
+    @Override
+    public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
+        if (state == UnDefType.UNDEF) {
+            return "";
+        }
+
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            formatPattern = "%f";
+        }
+
+        return state.format(formatPattern);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
@@ -87,7 +87,7 @@ public class OnOffValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         return (state == OnOffType.ON) ? onCommand : offCommand;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
@@ -70,7 +70,7 @@ public class OpenCloseValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         return (state == OpenClosedType.OPEN) ? openString : closeString;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -132,7 +132,7 @@ public class PercentageValue extends Value {
         // Calculation need to happen with big decimals to either return a straight integer or a decimal depending on
         // the value.
         BigDecimal value = ((PercentType) state).toBigDecimal().multiply(span).divide(DB100, MathContext.DECIMAL128)
-                .add(min);
+                .add(min).stripTrailingZeros();
 
         String formatPattern = pattern;
         if (formatPattern == null || "%s".equals(formatPattern)) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.mqtt.generic.values;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,10 +47,11 @@ import org.eclipse.smarthome.core.types.UnDefType;
  */
 @NonNullByDefault
 public class PercentageValue extends Value {
-    private final double min;
-    private final double max;
-    private final double span;
-    private final double step;
+    private static final BigDecimal DB100 = BigDecimal.valueOf(100);
+    private final BigDecimal min;
+    private final BigDecimal max;
+    private final BigDecimal span;
+    private final BigDecimal step;
     private final @Nullable String onValue;
     private final @Nullable String offValue;
 
@@ -59,13 +62,13 @@ public class PercentageValue extends Value {
                 .collect(Collectors.toList()));
         this.onValue = onValue;
         this.offValue = offValue;
-        this.min = min == null ? 0.0 : min.doubleValue();
-        this.max = max == null ? 100.0 : max.doubleValue();
-        if (this.min >= this.max) {
+        this.min = min == null ? BigDecimal.ZERO : min;
+        this.max = max == null ? DB100 : max;
+        if (this.min.compareTo(this.max) >= 0) {
             throw new IllegalArgumentException("Min need to be smaller than max!");
         }
-        this.span = this.max - this.min;
-        this.step = step == null ? 1.0 : step.doubleValue();
+        this.span = this.max.subtract(this.min);
+        this.step = step == null ? BigDecimal.ONE : step;
     }
 
     @Override
@@ -77,18 +80,18 @@ public class PercentageValue extends Value {
         } else //
                // A decimal type need to be converted according to the current min/max values
         if (command instanceof DecimalType) {
-            double v = ((DecimalType) command).doubleValue();
-            v = (v - min) * 100.0 / (max - min);
-            state = new PercentType(new BigDecimal(v));
+            BigDecimal v = ((DecimalType) command).toBigDecimal();
+            v = v.subtract(min).multiply(DB100).divide(max.subtract(min), MathContext.DECIMAL128).stripTrailingZeros();
+            state = new PercentType(v);
         } else //
                // Increase or decrease by "step"
         if (command instanceof IncreaseDecreaseType) {
             if (((IncreaseDecreaseType) command) == IncreaseDecreaseType.INCREASE) {
-                final double v = oldvalue.doubleValue() + step;
-                state = new PercentType(new BigDecimal(v <= max ? v : max));
+                final BigDecimal v = oldvalue.toBigDecimal().add(step);
+                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
             } else {
-                double v = oldvalue.doubleValue() - step;
-                state = new PercentType(new BigDecimal(v >= min ? v : min));
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
+                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
             }
         } else //
                // On/Off equals 100 or 0 percent
@@ -98,19 +101,19 @@ public class PercentageValue extends Value {
               // Increase or decrease by "step"
         if (command instanceof UpDownType) {
             if (((UpDownType) command) == UpDownType.UP) {
-                final double v = oldvalue.doubleValue() + step;
-                state = new PercentType(new BigDecimal(v <= max ? v : max));
+                final BigDecimal v = oldvalue.toBigDecimal().add(step);
+                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
             } else {
-                final double v = oldvalue.doubleValue() - step;
-                state = new PercentType(new BigDecimal(v >= min ? v : min));
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
+                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
             }
         } else //
                // Check against custom on/off values
         if (command instanceof StringType) {
             if (onValue != null && command.toString().equals(onValue)) {
-                state = new PercentType(new BigDecimal(max));
+                state = new PercentType(max);
             } else if (offValue != null && command.toString().equals(offValue)) {
-                state = new PercentType(new BigDecimal(min));
+                state = new PercentType(min);
             } else {
                 throw new IllegalStateException("Unknown String!");
             }
@@ -121,20 +124,29 @@ public class PercentageValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
-        // Formular: From percentage to custom min/max: value*span/100+min
+        // Formula: From percentage to custom min/max: value*span/100+min
         // Calculation need to happen with big decimals to either return a straight integer or a decimal depending on
         // the value.
-        return ((PercentType) state).toBigDecimal().multiply(BigDecimal.valueOf(span)).divide(BigDecimal.valueOf(100))
-                .add(BigDecimal.valueOf(min)).toString();
+        BigDecimal value = ((PercentType) state).toBigDecimal().multiply(span).divide(DB100, MathContext.DECIMAL128)
+                .add(min);
+
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            if (value.scale() > 0) {
+                formatPattern = "%." + value.scale() + "f";
+            } else {
+                formatPattern = "%.0f";
+            }
+        }
+        return String.format(Locale.ROOT, formatPattern, value);
     }
 
     @Override
     public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(new BigDecimal(min), new BigDecimal(max), new BigDecimal(step),
-                "%s " + unit.replace("%", "%%"), readOnly, Collections.emptyList());
+        return new StateDescription(min, max, step, "%s " + unit.replace("%", "%%"), readOnly, Collections.emptyList());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -23,7 +23,6 @@ import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * Implements an rollershutter value.
@@ -114,7 +113,7 @@ public class RollershutterValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         final String upString = this.upString;
         final String downString = this.downString;
         if (this.nextIsStop) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
@@ -94,8 +94,11 @@ public abstract class Value {
         return state;
     }
 
-    public String getMQTTpublishValue() {
-        return state.toString();
+    public String getMQTTpublishValue(@Nullable String pattern) {
+        if (pattern == null) {
+            return state.format("%s");
+        }
+        return state.format(pattern);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -13,8 +13,7 @@
 package org.openhab.binding.mqtt.generic;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -205,6 +204,8 @@ public class ChannelStateTests {
 
         c.processMessage("state", "INCREASE".getBytes());
         assertThat(value.getChannelState().toString(), is("60"));
+        assertThat(value.getMQTTpublishValue(null), is("20"));
+        assertThat(value.getMQTTpublishValue("%03.0f"), is("020"));
     }
 
     @Test
@@ -215,22 +216,23 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
         // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue(), is("13,20,225"));
+        assertThat(value.getMQTTpublishValue(null), is("13,20,225"));
+        assertThat(value.getMQTTpublishValue("%3$d,%2$d,%1$d"), is("225,20,13"));
     }
 
     @Test
@@ -241,19 +243,19 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
 
         c.processMessage("state", "12,18,100".getBytes());
         assertThat(value.getChannelState().toString(), is("12,18,100"));
-        assertThat(value.getMQTTpublishValue(), is("12,18,100"));
+        assertThat(value.getMQTTpublishValue(null), is("12,18,100"));
     }
 
     @Test
@@ -264,7 +266,7 @@ public class ChannelStateTests {
 
         c.processMessage("state", "46.833974, 7.108433".getBytes());
         assertThat(value.getChannelState().toString(), is("46.833974,7.108433"));
-        assertThat(value.getMQTTpublishValue(), is("46.833974,7.108433"));
+        assertThat(value.getMQTTpublishValue(null), is("46.833974,7.108433"));
     }
 
     @Test
@@ -281,7 +283,7 @@ public class ChannelStateTests {
         String channelState = value.getChannelState().toString();
         assertTrue("Expected '" + channelState + "' to start with '" + datetime + "'",
                 channelState.startsWith(datetime));
-        assertThat(value.getMQTTpublishValue(), is(datetime));
+        assertThat(value.getMQTTpublishValue(null), is(datetime));
     }
 
     @Test
@@ -290,7 +292,7 @@ public class ChannelStateTests {
         ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
         c.start(connection, mock(ScheduledExecutorService.class), 100);
 
-        byte[] payload = new byte[]{(byte) 0xFF, (byte) 0xD8, 0x01, 0x02, (byte) 0xFF, (byte) 0xD9};
+        byte[] payload = new byte[] { (byte) 0xFF, (byte) 0xD8, 0x01, 0x02, (byte) 0xFF, (byte) 0xD9 };
         c.processMessage("state", payload);
         assertThat(value.getChannelState(), is(instanceOf(RawType.class)));
         assertThat(((RawType) value.getChannelState()).getMimeType(), is("image/jpeg"));

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -27,14 +27,6 @@ import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.junit.Test;
-import org.openhab.binding.mqtt.generic.values.ColorValue;
-import org.openhab.binding.mqtt.generic.values.NumberValue;
-import org.openhab.binding.mqtt.generic.values.OnOffValue;
-import org.openhab.binding.mqtt.generic.values.OpenCloseValue;
-import org.openhab.binding.mqtt.generic.values.PercentageValue;
-import org.openhab.binding.mqtt.generic.values.RollershutterValue;
-import org.openhab.binding.mqtt.generic.values.TextValue;
-import org.openhab.binding.mqtt.generic.values.Value;
 
 /**
  * Test cases for the value classes. They should throw exceptions if the wrong command type is used
@@ -112,26 +104,26 @@ public class ValueTests {
         OnOffValue v = new OnOffValue("fancyON", "fancyOff");
         // Test with command
         v.update(OnOffType.OFF);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(OnOffType.ON);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with string, representing the command
         v.update(new StringType("OFF"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("ON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
     }
 
@@ -140,72 +132,72 @@ public class ValueTests {
         OpenCloseValue v = new OpenCloseValue("fancyON", "fancyOff");
         // Test with command
         v.update(OpenClosedType.CLOSED);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(OpenClosedType.OPEN);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with string, representing the command
         v.update(new StringType("CLOSED"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("OPEN"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
     }
 
     @Test
-    public void rollershutterUpdateWithStrings () {
+    public void rollershutterUpdateWithStrings() {
         RollershutterValue v = new RollershutterValue("fancyON", "fancyOff", "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(), is("27"));
+        assertThat(v.getMQTTpublishValue(null), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
     @Test
-    public void rollershutterUpdateWithOutStrings () {
+    public void rollershutterUpdateWithOutStrings() {
         RollershutterValue v = new RollershutterValue(null, null, "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(), is("0"));
+        assertThat(v.getMQTTpublishValue(null), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(), is("100"));
+        assertThat(v.getMQTTpublishValue(null), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(PercentType.ZERO);
-        assertThat(v.getMQTTpublishValue(), is("0"));
+        assertThat(v.getMQTTpublishValue(null), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(PercentType.HUNDRED);
-        assertThat(v.getMQTTpublishValue(), is("100"));
+        assertThat(v.getMQTTpublishValue(null), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(), is("27"));
+        assertThat(v.getMQTTpublishValue(null), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
@@ -213,12 +205,12 @@ public class ValueTests {
     public void percentCalc() {
         PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), null,
                 null);
-        v.update(new DecimalType(110.0));
+        v.update(new DecimalType("110.0"));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
-        assertThat(v.getMQTTpublishValue(), is("110.0"));
+        assertThat(v.getMQTTpublishValue(null), is("110"));
         v.update(new DecimalType(10.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
-        assertThat(v.getMQTTpublishValue(), is("10.0"));
+        assertThat(v.getMQTTpublishValue(null), is("10"));
 
         v.update(OnOffType.ON);
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
@@ -228,8 +220,8 @@ public class ValueTests {
 
     @Test
     public void percentCustomOnOff() {
-        PercentageValue v = new PercentageValue(new BigDecimal(0.0), new BigDecimal(100.0), new BigDecimal(1.0), "on",
-                "off");
+        PercentageValue v = new PercentageValue(new BigDecimal("0.0"), new BigDecimal("100.0"), new BigDecimal("1.0"),
+                "on", "off");
         v.update(new StringType("on"));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new StringType("off"));
@@ -238,8 +230,8 @@ public class ValueTests {
 
     @Test
     public void decimalCalc() {
-        PercentageValue v = new PercentageValue(new BigDecimal(0.1), new BigDecimal(1.0), new BigDecimal(0.1), null,
-                null);
+        PercentageValue v = new PercentageValue(new BigDecimal("0.1"), new BigDecimal("1.0"), new BigDecimal("0.1"),
+                null, null);
         v.update(new DecimalType(1.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new DecimalType(0.1));

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homeassistant.tests</artifactId>

--- a/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homie.tests</artifactId>


### PR DESCRIPTION
This PR handles outgoing formats.

For this the value is kept as a `Value`.
Transformations will retrieve the String value by calling the default format (`Value.getMQTTpublishValue(null)`)
After the transformation, the string result is converted to a TextValue.

After all transformations, the value is converted to a String by calling `Value.getMQTTpublishValue(format)` allowing for special handling of the different values.

Default formats are adjusted to the old behaviour and documented in the README.md

This should adress #6566 (Use "%.0f" as format and not "%d")
