### PR TITLE
Update POM, documentation, NOTICE files and comments for renamed repository (2.5.x)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ else is working on the same thing.
 ### Create issues...
 
 Any significant improvement should be documented as [a GitHub
-issue](https://github.com/openhab/openhab2-addons/issues?labels=enhancement&page=1&state=open) before anybody
+issue](https://github.com/openhab/openhab-addons/issues?labels=enhancement&page=1&state=open) before anybody
 starts working on it.
 
 ### ...but check for existing issues first!
@@ -142,7 +142,7 @@ On the command line you can use `git commit -s` to sign off the commit.
 
 * Step 1: learn the component inside out
 * Step 2: make yourself useful by contributing code, bugfixes, support etc.
-* Step 3: volunteer on [the discussion group](https://github.com/openhab/openhab2-addons/issues?labels=question&page=1&state=open)
+* Step 3: volunteer on [the discussion group](https://github.com/openhab/openhab-addons/issues?labels=question&page=1&state=open)
 
 Don't forget: being a maintainer is a time investment. Make sure you will have time to make yourself available.
 You don't have to be a maintainer to make a difference on the project!

--- a/bundles/org.openhab.binding.airquality/NOTICE
+++ b/bundles/org.openhab.binding.airquality/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.airvisualnode/NOTICE
+++ b/bundles/org.openhab.binding.airvisualnode/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.allplay/NOTICE
+++ b/bundles/org.openhab.binding.allplay/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java
+++ b/bundles/org.openhab.binding.allplay/src/main/java/org/openhab/binding/allplay/internal/AllPlayHandlerFactory.java
@@ -60,7 +60,7 @@ public class AllPlayHandlerFactory extends BaseThingHandlerFactory {
     private AllPlay allPlay;
     private AllPlayBindingProperties bindingProperties;
 
-    // Bindings should not use the ThingRegistry! See https://github.com/openhab/openhab2-addons/pull/6080 and
+    // Bindings should not use the ThingRegistry! See https://github.com/openhab/openhab-addons/pull/6080 and
     // https://github.com/eclipse/smarthome/issues/5182
     private final ThingRegistry thingRegistry;
     private final AudioHTTPServer audioHTTPServer;

--- a/bundles/org.openhab.binding.amazondashbutton/NOTICE
+++ b/bundles/org.openhab.binding.amazondashbutton/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.amazonechocontrol/NOTICE
+++ b/bundles/org.openhab.binding.amazonechocontrol/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.ambientweather/NOTICE
+++ b/bundles/org.openhab.binding.ambientweather/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.astro/NOTICE
+++ b/bundles/org.openhab.binding.astro/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/SunCalcTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/SunCalcTest.java
@@ -36,9 +36,9 @@ import org.openhab.binding.astro.internal.model.SunPhaseName;
  * <li>checks if the generated {@link Sun#getAllRanges()} are consistent with
  * each other</li>
  * </ul>
- * 
+ *
  * @author Witold Markowski - Initial contribution
- * @see <a href="https://github.com/openhab/openhab2-addons/issues/5006">[astro]
+ * @see <a href="https://github.com/openhab/openhab-addons/issues/5006">[astro]
  *      Sun Phase returns UNDEF</a>
  * @see <a href="https://www.heavens-above.com/sun.aspx">Heavens Above Sun</a>
  */

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/model/SunTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/model/SunTest.java
@@ -27,9 +27,9 @@ import org.openhab.binding.astro.internal.util.PropertyUtils;
 /***
  * A set of standard unit test of {@link Sun} class. In particular it checks if
  * {@link Sun#getAllRanges()} contains a correct {@link SunPhaseName}.
- * 
+ *
  * @author Witold Markowski - Initial contribution
- * @see <a href="https://github.com/openhab/openhab2-addons/issues/5006">[astro]
+ * @see <a href="https://github.com/openhab/openhab-addons/issues/5006">[astro]
  *      Sun Phase returns UNDEF</a>
  */
 public class SunTest {

--- a/bundles/org.openhab.binding.atlona/NOTICE
+++ b/bundles/org.openhab.binding.atlona/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.autelis/NOTICE
+++ b/bundles/org.openhab.binding.autelis/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.avmfritz/NOTICE
+++ b/bundles/org.openhab.binding.avmfritz/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.bigassfan/NOTICE
+++ b/bundles/org.openhab.binding.bigassfan/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.bluetooth.bluez/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth.bluez/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.bluetooth.blukii/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth.blukii/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.bluetooth.ruuvitag/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth.ruuvitag/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.bluetooth/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.boschindego/NOTICE
+++ b/bundles/org.openhab.binding.boschindego/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.bosesoundtouch/NOTICE
+++ b/bundles/org.openhab.binding.bosesoundtouch/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.buienradar/NOTICE
+++ b/bundles/org.openhab.binding.buienradar/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.chromecast/NOTICE
+++ b/bundles/org.openhab.binding.chromecast/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.cm11a/NOTICE
+++ b/bundles/org.openhab.binding.cm11a/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.coolmasternet/NOTICE
+++ b/bundles/org.openhab.binding.coolmasternet/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.daikin/NOTICE
+++ b/bundles/org.openhab.binding.daikin/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.darksky/NOTICE
+++ b/bundles/org.openhab.binding.darksky/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.deconz/NOTICE
+++ b/bundles/org.openhab.binding.deconz/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.denonmarantz/NOTICE
+++ b/bundles/org.openhab.binding.denonmarantz/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.digiplex/NOTICE
+++ b/bundles/org.openhab.binding.digiplex/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.digitalstrom/NOTICE
+++ b/bundles/org.openhab.binding.digitalstrom/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.dlinksmarthome/NOTICE
+++ b/bundles/org.openhab.binding.dlinksmarthome/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.dmx/NOTICE
+++ b/bundles/org.openhab.binding.dmx/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.doorbird/NOTICE
+++ b/bundles/org.openhab.binding.doorbird/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.dscalarm/NOTICE
+++ b/bundles/org.openhab.binding.dscalarm/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.dsmr/NOTICE
+++ b/bundles/org.openhab.binding.dsmr/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.dwdunwetter/NOTICE
+++ b/bundles/org.openhab.binding.dwdunwetter/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.elerotransmitterstick/NOTICE
+++ b/bundles/org.openhab.binding.elerotransmitterstick/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.enocean/NOTICE
+++ b/bundles/org.openhab.binding.enocean/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.enturno/NOTICE
+++ b/bundles/org.openhab.binding.enturno/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.evohome/NOTICE
+++ b/bundles/org.openhab.binding.evohome/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.exec/NOTICE
+++ b/bundles/org.openhab.binding.exec/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.feed/NOTICE
+++ b/bundles/org.openhab.binding.feed/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.feican/NOTICE
+++ b/bundles/org.openhab.binding.feican/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.folding/NOTICE
+++ b/bundles/org.openhab.binding.folding/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.foobot/NOTICE
+++ b/bundles/org.openhab.binding.foobot/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.freebox/NOTICE
+++ b/bundles/org.openhab.binding.freebox/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.fronius/NOTICE
+++ b/bundles/org.openhab.binding.fronius/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.fsinternetradio/NOTICE
+++ b/bundles/org.openhab.binding.fsinternetradio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.fsinternetradio/README.md
+++ b/bundles/org.openhab.binding.fsinternetradio/README.md
@@ -33,7 +33,7 @@ If your radio is not discovered, please try to access its API via: `http://<radi
 If you get a 404 error, maybe a different port than the standard port 80 is used by your radio; try scanning the open ports of your radio.<br/>
 If you get a result like `FS_OK 1902014387`, your radio is supported.
 
-If this is the case, please [add your model to this documentation](https://github.com/openhab/openhab2-addons/edit/master/bundles/org.openhab.binding.fsinternetradio/README.md) and/or provide discovery information in [this thread](https://community.openhab.org/t/internet-radio-i-need-your-help/2131).
+If this is the case, please [add your model to this documentation](https://github.com/openhab/openhab-addons/edit/master/bundles/org.openhab.binding.fsinternetradio/README.md) and/or provide discovery information in [this thread](https://community.openhab.org/t/internet-radio-i-need-your-help/2131).
 
 ## Binding Configuration
 

--- a/bundles/org.openhab.binding.ftpupload/NOTICE
+++ b/bundles/org.openhab.binding.ftpupload/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.gardena/NOTICE
+++ b/bundles/org.openhab.binding.gardena/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.globalcache/NOTICE
+++ b/bundles/org.openhab.binding.globalcache/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.gpstracker/NOTICE
+++ b/bundles/org.openhab.binding.gpstracker/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.groheondus/NOTICE
+++ b/bundles/org.openhab.binding.groheondus/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.harmonyhub/NOTICE
+++ b/bundles/org.openhab.binding.harmonyhub/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.hdanywhere/NOTICE
+++ b/bundles/org.openhab.binding.hdanywhere/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.hdpowerview/NOTICE
+++ b/bundles/org.openhab.binding.hdpowerview/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.helios/NOTICE
+++ b/bundles/org.openhab.binding.helios/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.heos/NOTICE
+++ b/bundles/org.openhab.binding.heos/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.homematic/NOTICE
+++ b/bundles/org.openhab.binding.homematic/NOTICE
@@ -10,5 +10,5 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 

--- a/bundles/org.openhab.binding.hpprinter/NOTICE
+++ b/bundles/org.openhab.binding.hpprinter/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.hue/NOTICE
+++ b/bundles/org.openhab.binding.hue/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.hydrawise/NOTICE
+++ b/bundles/org.openhab.binding.hydrawise/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.hyperion/NOTICE
+++ b/bundles/org.openhab.binding.hyperion/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.iaqualink/NOTICE
+++ b/bundles/org.openhab.binding.iaqualink/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.icloud/NOTICE
+++ b/bundles/org.openhab.binding.icloud/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.ihc/NOTICE
+++ b/bundles/org.openhab.binding.ihc/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.innogysmarthome/NOTICE
+++ b/bundles/org.openhab.binding.innogysmarthome/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.ipp/NOTICE
+++ b/bundles/org.openhab.binding.ipp/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.irtrans/NOTICE
+++ b/bundles/org.openhab.binding.irtrans/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.jeelink/NOTICE
+++ b/bundles/org.openhab.binding.jeelink/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.keba/NOTICE
+++ b/bundles/org.openhab.binding.keba/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.km200/NOTICE
+++ b/bundles/org.openhab.binding.km200/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.knx/NOTICE
+++ b/bundles/org.openhab.binding.knx/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.kodi/NOTICE
+++ b/bundles/org.openhab.binding.kodi/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.konnected/NOTICE
+++ b/bundles/org.openhab.binding.konnected/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.kostalinverter/NOTICE
+++ b/bundles/org.openhab.binding.kostalinverter/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.lametrictime/NOTICE
+++ b/bundles/org.openhab.binding.lametrictime/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.leapmotion/NOTICE
+++ b/bundles/org.openhab.binding.leapmotion/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.lghombot/NOTICE
+++ b/bundles/org.openhab.binding.lghombot/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.lgtvserial/NOTICE
+++ b/bundles/org.openhab.binding.lgtvserial/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.lgwebos/NOTICE
+++ b/bundles/org.openhab.binding.lgwebos/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.lifx/NOTICE
+++ b/bundles/org.openhab.binding.lifx/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.linuxinput/NOTICE
+++ b/bundles/org.openhab.binding.linuxinput/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.lirc/NOTICE
+++ b/bundles/org.openhab.binding.lirc/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.logreader/NOTICE
+++ b/bundles/org.openhab.binding.logreader/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.loxone/NOTICE
+++ b/bundles/org.openhab.binding.loxone/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.lutron/NOTICE
+++ b/bundles/org.openhab.binding.lutron/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.mail/NOTICE
+++ b/bundles/org.openhab.binding.mail/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.max/NOTICE
+++ b/bundles/org.openhab.binding.max/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.mcp23017/NOTICE
+++ b/bundles/org.openhab.binding.mcp23017/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.melcloud/NOTICE
+++ b/bundles/org.openhab.binding.melcloud/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.meteoblue/NOTICE
+++ b/bundles/org.openhab.binding.meteoblue/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.meteostick/NOTICE
+++ b/bundles/org.openhab.binding.meteostick/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.miele/NOTICE
+++ b/bundles/org.openhab.binding.miele/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -55,7 +55,7 @@ Thing coffeemachine coffeemachine [uid="001d63fffe020505#190"]
 
 ## Channels
 
-The definition of the channels in use can best be checked in the [source repository](https://github.com/openhab/openhab2-addons/tree/master/bundles/org.openhab.binding.miele/src/main/resources/ESH-INF/thing).
+The definition of the channels in use can best be checked in the [source repository](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.miele/src/main/resources/ESH-INF/thing).
 
 ## Example
 

--- a/bundles/org.openhab.binding.mihome/NOTICE
+++ b/bundles/org.openhab.binding.mihome/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.miio/NOTICE
+++ b/bundles/org.openhab.binding.miio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.milight/NOTICE
+++ b/bundles/org.openhab.binding.milight/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.millheat/NOTICE
+++ b/bundles/org.openhab.binding.millheat/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.minecraft/NOTICE
+++ b/bundles/org.openhab.binding.minecraft/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.modbus/NOTICE
+++ b/bundles/org.openhab.binding.modbus/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
+++ b/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusDataHandlerTest.java
@@ -122,7 +122,7 @@ import org.osgi.framework.InvalidSyntaxException;
  */
 @RunWith(MockitoJUnitRunner.class)
 @Ignore("Tests fail because the thingRegistry field has been removed from BaseThingHandler, "
-        + "see: https://github.com/openhab/openhab2-addons/issues/6171")
+        + "see: https://github.com/openhab/openhab-addons/issues/6171")
 public class ModbusDataHandlerTest extends JavaTest {
 
     private class ItemChannelLinkRegistryTestImpl extends ItemChannelLinkRegistry {

--- a/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
+++ b/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/ModbusPollerThingHandlerTest.java
@@ -67,7 +67,7 @@ import org.openhab.io.transport.modbus.PollTask;
  */
 @RunWith(MockitoJUnitRunner.class)
 @Ignore("Tests fail because the thingRegistry field has been removed from BaseThingHandler, "
-        + "see: https://github.com/openhab/openhab2-addons/issues/6171")
+        + "see: https://github.com/openhab/openhab-addons/issues/6171")
 public class ModbusPollerThingHandlerTest {
 
     @Mock

--- a/bundles/org.openhab.binding.mqtt/NOTICE
+++ b/bundles/org.openhab.binding.mqtt/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nanoleaf/NOTICE
+++ b/bundles/org.openhab.binding.nanoleaf/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.neato/NOTICE
+++ b/bundles/org.openhab.binding.neato/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.neeo/NOTICE
+++ b/bundles/org.openhab.binding.neeo/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.neohub/NOTICE
+++ b/bundles/org.openhab.binding.neohub/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nest/NOTICE
+++ b/bundles/org.openhab.binding.nest/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.netatmo/NOTICE
+++ b/bundles/org.openhab.binding.netatmo/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.network/NOTICE
+++ b/bundles/org.openhab.binding.network/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.networkupstools/NOTICE
+++ b/bundles/org.openhab.binding.networkupstools/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nibeheatpump/NOTICE
+++ b/bundles/org.openhab.binding.nibeheatpump/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nibeheatpump/README.md
+++ b/bundles/org.openhab.binding.nibeheatpump/README.md
@@ -59,7 +59,7 @@ An Arduino-based solution has been tested with Arduino uno + RS485 and Ethernet 
 The [ProDiNo](https://www.kmpelectronics.eu/en-us/products/prodinoethernet.aspx) NetBoards are also supported.
 A ProDiNo has an Ethernet and RS-485 port on the board.
 
-Arduino code is available [here](https://github.com/openhab/openhab2-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
+Arduino code is available [here](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
 
 Arduino code can be build via Arduino IDE.
 For more details see [www.arduino.cc](https://www.arduino.cc/en/Main/Software). 
@@ -67,7 +67,7 @@ NibeGW configuration (such IP addresses, ports, etc) can be adapted directly by 
 
 ### Raspberry Pi (or other Linux/Unix based boards)
 
-C code is available [here](https://github.com/openhab/openhab2-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/RasPi).
+C code is available [here](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/RasPi).
 
 To build the C code use: 
 

--- a/bundles/org.openhab.binding.nibeuplink/NOTICE
+++ b/bundles/org.openhab.binding.nibeuplink/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nikobus/NOTICE
+++ b/bundles/org.openhab.binding.nikobus/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nikohomecontrol/NOTICE
+++ b/bundles/org.openhab.binding.nikohomecontrol/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.ntp/NOTICE
+++ b/bundles/org.openhab.binding.ntp/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nuki/NOTICE
+++ b/bundles/org.openhab.binding.nuki/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.oceanic/NOTICE
+++ b/bundles/org.openhab.binding.oceanic/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.omnikinverter/NOTICE
+++ b/bundles/org.openhab.binding.omnikinverter/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.onebusaway/NOTICE
+++ b/bundles/org.openhab.binding.onebusaway/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.onewire/NOTICE
+++ b/bundles/org.openhab.binding.onewire/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.onewiregpio/NOTICE
+++ b/bundles/org.openhab.binding.onewiregpio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.onkyo/NOTICE
+++ b/bundles/org.openhab.binding.onkyo/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.opengarage/NOTICE
+++ b/bundles/org.openhab.binding.opengarage/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.opensprinkler/NOTICE
+++ b/bundles/org.openhab.binding.opensprinkler/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.openuv/NOTICE
+++ b/bundles/org.openhab.binding.openuv/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.openweathermap/NOTICE
+++ b/bundles/org.openhab.binding.openweathermap/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.orvibo/NOTICE
+++ b/bundles/org.openhab.binding.orvibo/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.paradoxalarm/NOTICE
+++ b/bundles/org.openhab.binding.paradoxalarm/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pentair/NOTICE
+++ b/bundles/org.openhab.binding.pentair/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.phc/NOTICE
+++ b/bundles/org.openhab.binding.phc/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pioneeravr/NOTICE
+++ b/bundles/org.openhab.binding.pioneeravr/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pixometer/NOTICE
+++ b/bundles/org.openhab.binding.pixometer/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pjlinkdevice/NOTICE
+++ b/bundles/org.openhab.binding.pjlinkdevice/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.plclogo/NOTICE
+++ b/bundles/org.openhab.binding.plclogo/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.plugwise/NOTICE
+++ b/bundles/org.openhab.binding.plugwise/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.powermax/NOTICE
+++ b/bundles/org.openhab.binding.powermax/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pulseaudio/NOTICE
+++ b/bundles/org.openhab.binding.pulseaudio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pushbullet/NOTICE
+++ b/bundles/org.openhab.binding.pushbullet/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.regoheatpump/NOTICE
+++ b/bundles/org.openhab.binding.regoheatpump/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.rfxcom/NOTICE
+++ b/bundles/org.openhab.binding.rfxcom/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -765,10 +765,10 @@ end
 
 | Brand | What          | Action      | Command ID | Supported | Source | 
 |-------|---------------|-------------|------------|-----------|--------|
-| Kerui | Motion Sensor | Motion      | 10         | as ON     | [#3103](https://github.com/openhab/openhab2-addons/issues/3103) |
-| Kerui | Door Contact  | door open   | 14         | as OFF    | [#3103](https://github.com/openhab/openhab2-addons/issues/3103) |
-| Kerui | Door Contact  | door closed | 7          | as ON     | [#3103](https://github.com/openhab/openhab2-addons/issues/3103) |
-| Kerui | Door Contact  | tamper      | 7          | as ON     | [#3103](https://github.com/openhab/openhab2-addons/issues/3103) |
+| Kerui | Motion Sensor | Motion      | 10         | as ON     | [#3103](https://github.com/openhab/openhab-addons/issues/3103) |
+| Kerui | Door Contact  | door open   | 14         | as OFF    | [#3103](https://github.com/openhab/openhab-addons/issues/3103) |
+| Kerui | Door Contact  | door closed | 7          | as ON     | [#3103](https://github.com/openhab/openhab-addons/issues/3103) |
+| Kerui | Door Contact  | tamper      | 7          | as ON     | [#3103](https://github.com/openhab/openhab-addons/issues/3103) |
 
 ### lighting5 - RFXCOM Lighting5 Actuator
 

--- a/bundles/org.openhab.binding.rme/NOTICE
+++ b/bundles/org.openhab.binding.rme/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.robonect/NOTICE
+++ b/bundles/org.openhab.binding.robonect/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.rotel/NOTICE
+++ b/bundles/org.openhab.binding.rotel/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.rotelra1x/NOTICE
+++ b/bundles/org.openhab.binding.rotelra1x/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.russound/NOTICE
+++ b/bundles/org.openhab.binding.russound/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.samsungtv/NOTICE
+++ b/bundles/org.openhab.binding.samsungtv/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.satel/NOTICE
+++ b/bundles/org.openhab.binding.satel/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.seneye/NOTICE
+++ b/bundles/org.openhab.binding.seneye/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sensebox/NOTICE
+++ b/bundles/org.openhab.binding.sensebox/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.serialbutton/NOTICE
+++ b/bundles/org.openhab.binding.serialbutton/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.shelly/NOTICE
+++ b/bundles/org.openhab.binding.shelly/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.siemensrds/NOTICE
+++ b/bundles/org.openhab.binding.siemensrds/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.silvercrestwifisocket/NOTICE
+++ b/bundles/org.openhab.binding.silvercrestwifisocket/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sinope/NOTICE
+++ b/bundles/org.openhab.binding.sinope/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sleepiq/NOTICE
+++ b/bundles/org.openhab.binding.sleepiq/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.smaenergymeter/NOTICE
+++ b/bundles/org.openhab.binding.smaenergymeter/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.smartmeter/NOTICE
+++ b/bundles/org.openhab.binding.smartmeter/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.snmp/NOTICE
+++ b/bundles/org.openhab.binding.snmp/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.solaredge/NOTICE
+++ b/bundles/org.openhab.binding.solaredge/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.solarlog/NOTICE
+++ b/bundles/org.openhab.binding.solarlog/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.somfytahoma/NOTICE
+++ b/bundles/org.openhab.binding.somfytahoma/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sonos/NOTICE
+++ b/bundles/org.openhab.binding.sonos/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosHandlerFactory.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosHandlerFactory.java
@@ -53,7 +53,7 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(SonosHandlerFactory.class);
 
-    // Bindings should not use the ThingRegistry! See https://github.com/openhab/openhab2-addons/pull/6080 and
+    // Bindings should not use the ThingRegistry! See https://github.com/openhab/openhab-addons/pull/6080 and
     // https://github.com/eclipse/smarthome/issues/5182
     private final ThingRegistry thingRegistry;
     private final UpnpIOService upnpIOService;

--- a/bundles/org.openhab.binding.sonyaudio/NOTICE
+++ b/bundles/org.openhab.binding.sonyaudio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.sonyprojector/NOTICE
+++ b/bundles/org.openhab.binding.sonyprojector/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.spotify/NOTICE
+++ b/bundles/org.openhab.binding.spotify/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.squeezebox/NOTICE
+++ b/bundles/org.openhab.binding.squeezebox/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.synopanalyzer/NOTICE
+++ b/bundles/org.openhab.binding.synopanalyzer/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.systeminfo/NOTICE
+++ b/bundles/org.openhab.binding.systeminfo/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.tado/NOTICE
+++ b/bundles/org.openhab.binding.tado/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.tankerkoenig/NOTICE
+++ b/bundles/org.openhab.binding.tankerkoenig/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.telegram/NOTICE
+++ b/bundles/org.openhab.binding.telegram/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.tellstick/NOTICE
+++ b/bundles/org.openhab.binding.tellstick/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.tesla/NOTICE
+++ b/bundles/org.openhab.binding.tesla/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.toon/NOTICE
+++ b/bundles/org.openhab.binding.toon/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.tplinksmarthome/NOTICE
+++ b/bundles/org.openhab.binding.tplinksmarthome/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.tradfri/NOTICE
+++ b/bundles/org.openhab.binding.tradfri/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.unifi/NOTICE
+++ b/bundles/org.openhab.binding.unifi/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.urtsi/NOTICE
+++ b/bundles/org.openhab.binding.urtsi/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.valloxmv/NOTICE
+++ b/bundles/org.openhab.binding.valloxmv/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.vektiva/NOTICE
+++ b/bundles/org.openhab.binding.vektiva/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.velbus/NOTICE
+++ b/bundles/org.openhab.binding.velbus/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.vitotronic/NOTICE
+++ b/bundles/org.openhab.binding.vitotronic/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.volvooncall/NOTICE
+++ b/bundles/org.openhab.binding.volvooncall/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.weathercompany/NOTICE
+++ b/bundles/org.openhab.binding.weathercompany/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.weatherunderground/NOTICE
+++ b/bundles/org.openhab.binding.weatherunderground/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third Party Dependencies
 

--- a/bundles/org.openhab.binding.wemo/NOTICE
+++ b/bundles/org.openhab.binding.wemo/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.wifiled/NOTICE
+++ b/bundles/org.openhab.binding.wifiled/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.windcentrale/NOTICE
+++ b/bundles/org.openhab.binding.windcentrale/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.xmltv/NOTICE
+++ b/bundles/org.openhab.binding.xmltv/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.xmppclient/NOTICE
+++ b/bundles/org.openhab.binding.xmppclient/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.yamahareceiver/NOTICE
+++ b/bundles/org.openhab.binding.yamahareceiver/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.yeelight/NOTICE
+++ b/bundles/org.openhab.binding.yeelight/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.zoneminder/NOTICE
+++ b/bundles/org.openhab.binding.zoneminder/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.zway/NOTICE
+++ b/bundles/org.openhab.binding.zway/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.binding.zway/doc/GETTING_STARTED.md
+++ b/bundles/org.openhab.binding.zway/doc/GETTING_STARTED.md
@@ -13,7 +13,7 @@
 
     ```shell
     cd /opt/openhab2/addons
-    sudo wget https://github.com/openhab/openhab2-addons/files/636686/org.openhab.binding.zway-2.0.0-SNAPSHOT.zip
+    sudo wget https://github.com/openhab/openhab-addons/files/636686/org.openhab.binding.zway-2.0.0-SNAPSHOT.zip
     sudo unzip org.openhab.binding.zway-2.0.0-SNAPSHOT.zip
     sudo rm org.openhab.binding.zway-2.0.0-SNAPSHOT.zip
     ```

--- a/bundles/org.openhab.extensionservice.marketplace.automation/NOTICE
+++ b/bundles/org.openhab.extensionservice.marketplace.automation/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.extensionservice.marketplace/NOTICE
+++ b/bundles/org.openhab.extensionservice.marketplace/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.azureiothub/NOTICE
+++ b/bundles/org.openhab.io.azureiothub/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.io.homekit/NOTICE
+++ b/bundles/org.openhab.io.homekit/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -172,7 +172,7 @@ public class HomekitTaggedItem {
         if (CREATED_ACCESSORY_IDS.containsKey(id)) {
             if (!CREATED_ACCESSORY_IDS.get(id).equals(item.getName())) {
                 logger.warn(
-                        "Could not create homekit accessory {} because its hash conflicts with {}. This is a 1:1,000,000 chance occurrence. Change one of the names and consider playing the lottery. See https://github.com/openhab/openhab2-addons/issues/257#issuecomment-125886562",
+                        "Could not create homekit accessory {} because its hash conflicts with {}. This is a 1:1,000,000 chance occurrence. Change one of the names and consider playing the lottery. See https://github.com/openhab/openhab-addons/issues/257#issuecomment-125886562",
                         item.getName(), CREATED_ACCESSORY_IDS.get(id));
                 return 0;
             }

--- a/bundles/org.openhab.io.hueemulation/NOTICE
+++ b/bundles/org.openhab.io.hueemulation/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
@@ -22,7 +22,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  *
  */
 public class HueStateBulb extends HueStatePlug {
-    // https://github.com/openhab/openhab2-addons/issues/2881
+    // https://github.com/openhab/openhab-addons/issues/2881
     // Apparently the maximum brightness is 254
     public static int MAX_BRI = 254;
     public int bri = 0;

--- a/bundles/org.openhab.io.imperihome/NOTICE
+++ b/bundles/org.openhab.io.imperihome/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.javasound/NOTICE
+++ b/bundles/org.openhab.io.javasound/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.mqttembeddedbroker/NOTICE
+++ b/bundles/org.openhab.io.mqttembeddedbroker/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.neeo/NOTICE
+++ b/bundles/org.openhab.io.neeo/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.io.openhabcloud/NOTICE
+++ b/bundles/org.openhab.io.openhabcloud/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.io.transport.modbus/NOTICE
+++ b/bundles/org.openhab.io.transport.modbus/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.io.webaudio/NOTICE
+++ b/bundles/org.openhab.io.webaudio/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.persistence.mapdb/NOTICE
+++ b/bundles/org.openhab.persistence.mapdb/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.bin2json/NOTICE
+++ b/bundles/org.openhab.transform.bin2json/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.transform.exec/NOTICE
+++ b/bundles/org.openhab.transform.exec/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.javascript/NOTICE
+++ b/bundles/org.openhab.transform.javascript/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.jinja/NOTICE
+++ b/bundles/org.openhab.transform.jinja/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.transform.jsonpath/NOTICE
+++ b/bundles/org.openhab.transform.jsonpath/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.transform.map/NOTICE
+++ b/bundles/org.openhab.transform.map/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.regex/NOTICE
+++ b/bundles/org.openhab.transform.regex/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.scale/NOTICE
+++ b/bundles/org.openhab.transform.scale/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.xpath/NOTICE
+++ b/bundles/org.openhab.transform.xpath/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.transform.xslt/NOTICE
+++ b/bundles/org.openhab.transform.xslt/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.voice.googletts/NOTICE
+++ b/bundles/org.openhab.voice.googletts/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.voice.marytts/NOTICE
+++ b/bundles/org.openhab.voice.marytts/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.voice.picotts/NOTICE
+++ b/bundles/org.openhab.voice.picotts/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.voice.pollytts/NOTICE
+++ b/bundles/org.openhab.voice.pollytts/NOTICE
@@ -10,7 +10,7 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons
 
 == Third-party Content
 

--- a/bundles/org.openhab.voice.voicerss/NOTICE
+++ b/bundles/org.openhab.voice.voicerss/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.astro.tests/NOTICE
+++ b/itests/org.openhab.binding.astro.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.avmfritz.tests/NOTICE
+++ b/itests/org.openhab.binding.avmfritz.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.feed.tests/NOTICE
+++ b/itests/org.openhab.binding.feed.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.hue.tests/NOTICE
+++ b/itests/org.openhab.binding.hue.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.max.tests/NOTICE
+++ b/itests/org.openhab.binding.max.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/NOTICE
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.mqtt.homie.tests/NOTICE
+++ b/itests/org.openhab.binding.mqtt.homie.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.nest.tests/NOTICE
+++ b/itests/org.openhab.binding.nest.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.ntp.tests/NOTICE
+++ b/itests/org.openhab.binding.ntp.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.systeminfo.tests/NOTICE
+++ b/itests/org.openhab.binding.systeminfo.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.tradfri.tests/NOTICE
+++ b/itests/org.openhab.binding.tradfri.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.binding.wemo.tests/NOTICE
+++ b/itests/org.openhab.binding.wemo.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.io.hueemulation.tests/NOTICE
+++ b/itests/org.openhab.io.hueemulation.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/NOTICE
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/itests/org.openhab.persistence.mapdb.tests/NOTICE
+++ b/itests/org.openhab.persistence.mapdb.tests/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,14 @@
   </modules>
 
   <scm>
-    <connection>scm:git:https://github.com/openhab/openhab2-addons.git</connection>
-    <developerConnection>scm:git:https://github.com/openhab/openhab2-addons.git</developerConnection>
-    <url>https://github.com/openhab/openhab2-addons</url>
+    <connection>scm:git:https://github.com/openhab/openhab-addons.git</connection>
+    <developerConnection>scm:git:https://github.com/openhab/openhab-addons.git</developerConnection>
+    <url>https://github.com/openhab/openhab-addons</url>
   </scm>
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/openhab/openhab2-addons/issues</url>
+    <url>https://github.com/openhab/openhab-addons/issues</url>
   </issueManagement>
 
   <distributionManagement>

--- a/src/etc/NOTICE
+++ b/src/etc/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons


### PR DESCRIPTION
There's still a Bintray repo that may need to be renamed some day @kaikreuzer:

https://github.com/openhab/openhab-addons/blob/090279c0dc5df99b91f6212e7bc1a78d69cebcf3/pom.xml#L52