### PR TITLE
[mqtt] Enable unit of measurements for number values

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -93,6 +93,7 @@ You can connect this channel to a String item.
 * __min__: An optional minimum value.
 * __max__: An optional maximum value.
 * __step__: For decrease, increase commands the step needs to be known
+* __unit__: Unit of measurement (optional). For supported units see [OpenHAB: List of Units](https://www.openhab.org/docs/concepts/units-of-measurement.html#list-of-units). Examples: "°C", "°F"
 
 A decimal value (like 0.2) is send to the MQTT topic if the number has a fractional part.
 If you always require an integer, please use the formatter.
@@ -245,23 +246,6 @@ Here are a few examples:
   - For an output of *May 23, 1995* use "%1$**tb** %1$**te**,%1$**tY**".
   - For an output of *23.05.1995* use "%1$**td**.%1$**tm**.%1$**tY**".
   - For an output of *23:15* use "%1$**tH**:%1$**tM**".
-  
-Default pattern applied for each type:
-| Type             | Parameter                         | Pattern             | Comment |
-| ---------------- | --------------------------------- | ------------------- | ------- |
-| __string__       | String                            | "%s"                | 
-| __number__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
-| __dimmer__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
-| __contact__      | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
-| __switch__       | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
-| __colorRGB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **red**, **green** and **blue** components.
-| __colorHSB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **hue**, **saturation** and **brightness** components.
-| __location__     | BigDecimal, BigDecimal            | "%2$f,%3$f,%1$f"    | Parameters are **altitude**, **latitude** and **longitude**, altitude is only in default pattern, if value is not '0'.
-| __image__        | --                                | --                  | No publishing supported. 
-| __datetime__     | ZonedDateTime                     | "%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS.%1$tN" | Trailing zeros of the nanoseconds are removed.
-| __rollershutter__| String                            | "%s"                | No pattern supported. Always **up**, **down**, **stop** string or integer percent value.
-
-Any outgoing value transformation will **always** result in a __string__ value.
 
 ## Troubleshooting
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt.generic;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Formatter;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -24,13 +25,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
-import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,7 +158,8 @@ public class ChannelState implements MqttMessageSubscriber {
             if (transformedValue != null) {
                 strValue = transformedValue;
             } else {
-                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue, t.serviceName);
+                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue,
+                        t.serviceName);
                 receivedOrTimeout();
                 return;
             }
@@ -332,7 +332,7 @@ public class ChannelState implements MqttMessageSubscriber {
     public CompletableFuture<Boolean> publishValue(Command command) {
         cachedValue.update(command);
 
-        Value mqttCommandValue = cachedValue;
+        String mqttCommandValue = cachedValue.getMQTTpublishValue();
 
         final MqttBrokerConnection connection = this.connection;
 
@@ -352,12 +352,9 @@ public class ChannelState implements MqttMessageSubscriber {
 
         // Outgoing transformations
         for (ChannelStateTransformation t : transformationsOut) {
-            String commandString = mqttCommandValue.getMQTTpublishValue(null);
-            String transformedValue = t.processValue(commandString);
+            String transformedValue = t.processValue(mqttCommandValue);
             if (transformedValue != null) {
-                Value textValue = new TextValue();
-                textValue.update(new StringType(transformedValue));
-                mqttCommandValue = textValue;
+                mqttCommandValue = transformedValue;
             } else {
                 logger.debug("Transformation '{}' returned null on '{}', discarding message", mqttCommandValue,
                         t.serviceName);
@@ -365,23 +362,19 @@ public class ChannelState implements MqttMessageSubscriber {
             }
         }
 
-        String commandString;
-
         // Formatter: Applied before the channel state value is published to the MQTT broker.
         if (config.formatBeforePublish.length() > 0) {
-            try {
-                commandString = mqttCommandValue.getMQTTpublishValue(config.formatBeforePublish);
+            try (Formatter formatter = new Formatter()) {
+                Formatter format = formatter.format(config.formatBeforePublish, mqttCommandValue);
+                mqttCommandValue = format.toString();
             } catch (IllegalFormatException e) {
                 logger.debug("Format pattern incorrect for {}", channelUID, e);
-                commandString = mqttCommandValue.getMQTTpublishValue(null);
             }
-        } else {
-            commandString = mqttCommandValue.getMQTTpublishValue(null);
         }
 
         int qos = (config.qos != null) ? config.qos : connection.getQos();
 
-        return connection.publish(config.commandTopic, commandString.getBytes(), qos, config.retained);
+        return connection.publish(config.commandTopic, mqttCommandValue.getBytes(), qos, config.retained);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -100,14 +100,15 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
         // Remove all state descriptions of this handler
         channelStateByChannelUID.forEach((uid, state) -> stateDescProvider.remove(uid));
         super.dispose();
-        // there is a design flaw, we can't clean up our stuff because it is needed by the super-class on disposal for unsubscribing
+        // there is a design flaw, we can't clean up our stuff because it is needed by the super-class on disposal for
+        // unsubscribing
         channelStateByChannelUID.clear();
     }
 
     @Override
     public CompletableFuture<Void> unsubscribeAll() {
-        return CompletableFuture.allOf(channelStateByChannelUID.values().stream().map(ChannelState::stop)
-                .toArray(CompletableFuture[]::new));
+        return CompletableFuture.allOf(
+                channelStateByChannelUID.values().stream().map(ChannelState::stop).toArray(CompletableFuture[]::new));
     }
 
     /**
@@ -153,9 +154,12 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
                 Value value = ValueFactory.createValueState(channelConfig, channelTypeUID.getId());
                 ChannelState channelState = createChannelState(channelConfig, channel.getUID(), value);
                 channelStateByChannelUID.put(channel.getUID(), channelState);
-                StateDescription description = value.createStateDescription(channelConfig.unit,
-                        StringUtils.isBlank(channelConfig.commandTopic));
-                stateDescProvider.setDescription(channel.getUID(), description);
+                StateDescription description = value
+                        .createStateDescription(StringUtils.isBlank(channelConfig.commandTopic)).build()
+                        .toStateDescription();
+                if (description != null) {
+                    stateDescProvider.setDescription(channel.getUID(), description);
+                }
             } catch (IllegalArgumentException e) {
                 logger.warn("Channel configuration error", e);
                 configErrors.add(channel.getUID());

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
@@ -109,24 +109,22 @@ public class ColorValue extends Value {
     private static BigDecimal factor = new BigDecimal(2.5);
 
     @Override
-    public String getMQTTpublishValue(@Nullable String pattern) {
+    public String getMQTTpublishValue() {
         if (state == UnDefType.UNDEF) {
             return "";
         }
 
-        String formatPattern = pattern;
-        if (formatPattern == null || "%s".equals(formatPattern)) {
-            formatPattern = "%1$d,%2$d,%3$d";
-        }
-        // ignore the pattern. Don't know
         if (isRGB) {
             PercentType[] rgb = ((HSBType) state).toRGB();
-            return String.format(formatPattern, rgb[0].toBigDecimal().multiply(factor).intValue(),
-                    rgb[1].toBigDecimal().multiply(factor).intValue(),
-                    rgb[2].toBigDecimal().multiply(factor).intValue());
+            StringBuilder b = new StringBuilder();
+            b.append(rgb[0].toBigDecimal().multiply(factor).intValue());
+            b.append(',');
+            b.append(rgb[1].toBigDecimal().multiply(factor).intValue());
+            b.append(',');
+            b.append(rgb[2].toBigDecimal().multiply(factor).intValue());
+            return b.toString();
+        } else {
+            return state.toString();
         }
-        HSBType type = (HSBType) state;
-        return String.format(formatPattern, type.getHue().intValue(), type.getSaturation().intValue(),
-                type.getBrightness().intValue());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -45,14 +44,11 @@ public class DateTimeValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue(@Nullable String pattern) {
+    public String getMQTTpublishValue() {
         if (state == UnDefType.UNDEF) {
             return "";
         }
-        String formatPattern = pattern;
-        if (formatPattern == null || "%s".contentEquals(formatPattern)) {
-            return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(((DateTimeType) state).getZonedDateTime());
-        }
-        return String.format(formatPattern, ((DateTimeType) state).getZonedDateTime());
+
+        return ((DateTimeType) state).getZonedDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
@@ -12,14 +12,10 @@
  */
 package org.openhab.binding.mqtt.generic.values;
 
-import java.math.BigDecimal;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.PointType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -34,22 +30,6 @@ import org.eclipse.smarthome.core.types.Command;
 public class LocationValue extends Value {
     public LocationValue() {
         super(CoreItemFactory.LOCATION, Stream.of(PointType.class, StringType.class).collect(Collectors.toList()));
-    }
-
-    @Override
-    public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
-        String formatPattern = pattern;
-        PointType point = ((PointType) state);
-
-        if (formatPattern == null || "%s".equals(formatPattern)) {
-            if (point.getAltitude().toBigDecimal().equals(BigDecimal.ZERO)) {
-                formatPattern = "%2$f,%3$f";
-            } else {
-                formatPattern = "%2$f,%3$f,%1$f";
-            }
-        }
-        return String.format(Locale.ROOT, formatPattern, point.getAltitude().toBigDecimal(),
-                point.getLatitude().toBigDecimal(), point.getLongitude().toBigDecimal());
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -13,22 +13,23 @@
 package org.openhab.binding.mqtt.generic.values;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import tec.uom.se.AbstractUnit;
 
 /**
  * Implements a number value.
@@ -47,13 +48,16 @@ public class NumberValue extends Value {
     private final @Nullable BigDecimal min;
     private final @Nullable BigDecimal max;
     private final BigDecimal step;
+    private final String unit;
 
-    public NumberValue(@Nullable BigDecimal min, @Nullable BigDecimal max, @Nullable BigDecimal step) {
-        super(CoreItemFactory.NUMBER, Stream.of(DecimalType.class, IncreaseDecreaseType.class, UpDownType.class)
+    public NumberValue(@Nullable BigDecimal min, @Nullable BigDecimal max, @Nullable BigDecimal step,
+            @Nullable String unit) {
+        super(CoreItemFactory.NUMBER, Stream.of(QuantityType.class, IncreaseDecreaseType.class, UpDownType.class)
                 .collect(Collectors.toList()));
         this.min = min;
         this.max = max;
-        this.step = step == null ? new BigDecimal(1.0) : step;
+        this.step = step == null ? BigDecimal.ONE : step;
+        this.unit = unit == null ? "" : unit;
     }
 
     protected boolean checkConditions(BigDecimal newValue, DecimalType oldvalue) {
@@ -70,23 +74,9 @@ public class NumberValue extends Value {
     }
 
     @Override
-    public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
-        if (state == UnDefType.UNDEF) {
-            return "";
-        }
-
-        String formatPattern = pattern;
-        if (formatPattern == null || "%s".equals(formatPattern)) {
-            formatPattern = "%f";
-        }
-
-        return state.format(formatPattern);
-    }
-
-    @Override
     public void update(Command command) throws IllegalArgumentException {
         DecimalType oldvalue = (state == UnDefType.UNDEF) ? new DecimalType() : (DecimalType) state;
-        BigDecimal newValue;
+        BigDecimal newValue = null;
         if (command instanceof DecimalType) {
             if (!checkConditions(((DecimalType) command).toBigDecimal(), oldvalue)) {
                 return;
@@ -102,6 +92,23 @@ public class NumberValue extends Value {
                 return;
             }
             state = new DecimalType(newValue);
+        } else if (command instanceof QuantityType<?>) {
+            QuantityType<?> qType = (QuantityType<?>) command;
+
+            if (qType.getUnit().isCompatible(AbstractUnit.ONE)) {
+                newValue = qType.toBigDecimal();
+            } else {
+                qType = qType.toUnit(unit);
+                if (qType != null) {
+                    newValue = qType.toBigDecimal();
+                }
+            }
+            if (newValue != null) {
+                if (!checkConditions(newValue, oldvalue)) {
+                    return;
+                }
+                state = new DecimalType(newValue);
+            }
         } else {
             newValue = new BigDecimal(command.toString());
             if (!checkConditions(newValue, oldvalue)) {
@@ -112,7 +119,20 @@ public class NumberValue extends Value {
     }
 
     @Override
-    public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(min, max, step, "%s " + unit.replace("%", "%%"), readOnly, Collections.emptyList());
+    public StateDescriptionFragmentBuilder createStateDescription(boolean readOnly) {
+        StateDescriptionFragmentBuilder builder = super.createStateDescription(readOnly);
+        BigDecimal max = this.max;
+        if (max != null) {
+            builder = builder.withMaximum(max);
+        }
+        BigDecimal min = this.min;
+        if (min != null) {
+            builder = builder.withMinimum(min);
+        }
+        builder = builder.withStep(step);
+        if (this.unit.length() > 0) {
+            builder = builder.withPattern("%s " + this.unit.replace("%", "%%"));
+        }
+        return builder;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
@@ -87,7 +87,7 @@ public class OnOffValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue(@Nullable String pattern) {
+    public String getMQTTpublishValue() {
         return (state == OnOffType.ON) ? onCommand : offCommand;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
@@ -70,7 +70,7 @@ public class OpenCloseValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue(@Nullable String pattern) {
+    public String getMQTTpublishValue() {
         return (state == OpenClosedType.OPEN) ? openString : closeString;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -113,7 +113,7 @@ public class RollershutterValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue(@Nullable String pattern) {
+    public String getMQTTpublishValue() {
         final String upString = this.upString;
         final String downString = this.downString;
         if (this.nextIsStop) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.binding.mqtt.generic.values;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,7 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.StateOption;
 
 /**
@@ -76,14 +74,14 @@ public class TextValue extends Value {
     }
 
     @Override
-    public StateDescription createStateDescription(String unit, boolean readOnly) {
-        List<StateOption> stateOptions = new ArrayList<>();
+    public StateDescriptionFragmentBuilder createStateDescription(boolean readOnly) {
+        StateDescriptionFragmentBuilder builder = super.createStateDescription(readOnly);
         final Set<String> states = this.states;
         if (states != null) {
             for (String state : states) {
-                stateOptions.add(new StateOption(state, state));
+                builder = builder.withOption(new StateOption(state, state));
             }
         }
-        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly, stateOptions);
+        return builder;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
@@ -15,7 +15,6 @@ package org.openhab.binding.mqtt.generic.values;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URLConnection;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -26,7 +25,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.RawType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
@@ -94,11 +93,8 @@ public abstract class Value {
         return state;
     }
 
-    public String getMQTTpublishValue(@Nullable String pattern) {
-        if (pattern == null) {
-            return state.format("%s");
-        }
-        return state.format(pattern);
+    public String getMQTTpublishValue() {
+        return state.toString();
     }
 
     /**
@@ -162,14 +158,12 @@ public abstract class Value {
     }
 
     /**
-     * Return the state description for this value state.
+     * Return the state description fragment builder for this value state.
      *
-     * @param unit An optional unit string. Might be an empty string.
      * @param readOnly True if this is a read-only value.
-     * @return A state description
+     * @return A state description fragment builder
      */
-    public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly,
-                Collections.emptyList());
+    public StateDescriptionFragmentBuilder createStateDescription(boolean readOnly) {
+        return StateDescriptionFragmentBuilder.create().withReadOnly(readOnly).withPattern("%s");
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ValueFactory.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ValueFactory.java
@@ -47,7 +47,7 @@ public class ValueFactory {
                 value = new LocationValue();
                 break;
             case MqttBindingConstants.NUMBER:
-                value = new NumberValue(config.min, config.max, config.step);
+                value = new NumberValue(config.min, config.max, config.step, config.unit);
                 break;
             case MqttBindingConstants.DIMMER:
                 value = new PercentageValue(config.min, config.max, config.step, config.on, config.off);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/number-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/number-channel-config.xml
@@ -89,5 +89,10 @@
 			<default>1.0</default>
 			<advanced>true</advanced>
 		</parameter>
+        <parameter name="unit" type="text">
+            <label>Unit Of Measurement</label>
+            <description>Unit of measurement (optional). The unit is used for representing the value in the GUI as well as for converting incoming values (like from '°F' to '°C'). Examples: "°C", "°F"</description>
+            <advanced>true</advanced>
+        </parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -157,7 +157,7 @@ public class ChannelStateTests {
 
     @Test
     public void receiveDecimalTest() {
-        NumberValue value = new NumberValue(null, null, new BigDecimal(10));
+        NumberValue value = new NumberValue(null, null, new BigDecimal(10), null);
         ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
         c.start(connection, mock(ScheduledExecutorService.class), 100);
 
@@ -175,7 +175,7 @@ public class ChannelStateTests {
 
     @Test
     public void receiveDecimalFractionalTest() {
-        NumberValue value = new NumberValue(null, null, new BigDecimal(10.5));
+        NumberValue value = new NumberValue(null, null, new BigDecimal(10.5), null);
         ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
         c.start(connection, mock(ScheduledExecutorService.class), 100);
 
@@ -204,8 +204,6 @@ public class ChannelStateTests {
 
         c.processMessage("state", "INCREASE".getBytes());
         assertThat(value.getChannelState().toString(), is("60"));
-        assertThat(value.getMQTTpublishValue(null), is("20"));
-        assertThat(value.getMQTTpublishValue("%03.0f"), is("020"));
     }
 
     @Test
@@ -216,23 +214,22 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
         // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue(null), is("13,20,225"));
-        assertThat(value.getMQTTpublishValue("%3$d,%2$d,%1$d"), is("225,20,13"));
+        assertThat(value.getMQTTpublishValue(), is("13,20,225"));
     }
 
     @Test
@@ -243,19 +240,19 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
 
         c.processMessage("state", "12,18,100".getBytes());
         assertThat(value.getChannelState().toString(), is("12,18,100"));
-        assertThat(value.getMQTTpublishValue(null), is("12,18,100"));
+        assertThat(value.getMQTTpublishValue(), is("12,18,100"));
     }
 
     @Test
@@ -266,7 +263,7 @@ public class ChannelStateTests {
 
         c.processMessage("state", "46.833974, 7.108433".getBytes());
         assertThat(value.getChannelState().toString(), is("46.833974,7.108433"));
-        assertThat(value.getMQTTpublishValue(null), is("46.833974,7.108433"));
+        assertThat(value.getMQTTpublishValue(), is("46.833974,7.108433"));
     }
 
     @Test
@@ -283,7 +280,7 @@ public class ChannelStateTests {
         String channelState = value.getChannelState().toString();
         assertTrue("Expected '" + channelState + "' to start with '" + datetime + "'",
                 channelState.startsWith(datetime));
-        assertThat(value.getMQTTpublishValue(null), is(datetime));
+        assertThat(value.getMQTTpublishValue(), is(datetime));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -77,7 +77,7 @@ public class ValueTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void illegalNumberCommand() {
-        NumberValue v = new NumberValue(null, null, null);
+        NumberValue v = new NumberValue(null, null, null, null);
         v.update(OnOffType.OFF);
     }
 
@@ -104,26 +104,26 @@ public class ValueTests {
         OnOffValue v = new OnOffValue("fancyON", "fancyOff");
         // Test with command
         v.update(OnOffType.OFF);
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(OnOffType.ON);
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with string, representing the command
         v.update(new StringType("OFF"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("ON"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
     }
 
@@ -132,26 +132,26 @@ public class ValueTests {
         OpenCloseValue v = new OpenCloseValue("fancyON", "fancyOff");
         // Test with command
         v.update(OpenClosedType.CLOSED);
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(OpenClosedType.OPEN);
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with string, representing the command
         v.update(new StringType("CLOSED"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("OPEN"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
     }
 
@@ -160,21 +160,21 @@ public class ValueTests {
         RollershutterValue v = new RollershutterValue("fancyON", "fancyOff", "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(null), is("27"));
+        assertThat(v.getMQTTpublishValue(), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
@@ -183,21 +183,21 @@ public class ValueTests {
         RollershutterValue v = new RollershutterValue(null, null, "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(null), is("0"));
+        assertThat(v.getMQTTpublishValue(), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(null), is("100"));
+        assertThat(v.getMQTTpublishValue(), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(PercentType.ZERO);
-        assertThat(v.getMQTTpublishValue(null), is("0"));
+        assertThat(v.getMQTTpublishValue(), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(PercentType.HUNDRED);
-        assertThat(v.getMQTTpublishValue(null), is("100"));
+        assertThat(v.getMQTTpublishValue(), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(null), is("27"));
+        assertThat(v.getMQTTpublishValue(), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
@@ -205,12 +205,12 @@ public class ValueTests {
     public void percentCalc() {
         PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), null,
                 null);
-        v.update(new DecimalType("110.0"));
+        v.update(new DecimalType(110.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
-        assertThat(v.getMQTTpublishValue(null), is("110"));
+        assertThat(v.getMQTTpublishValue(), is("110.0"));
         v.update(new DecimalType(10.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
-        assertThat(v.getMQTTpublishValue(null), is("10"));
+        assertThat(v.getMQTTpublishValue(), is("10.0"));
 
         v.update(OnOffType.ON);
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
@@ -220,8 +220,8 @@ public class ValueTests {
 
     @Test
     public void percentCustomOnOff() {
-        PercentageValue v = new PercentageValue(new BigDecimal("0.0"), new BigDecimal("100.0"), new BigDecimal("1.0"),
-                "on", "off");
+        PercentageValue v = new PercentageValue(new BigDecimal(0.0), new BigDecimal(100.0), new BigDecimal(1.0), "on",
+                "off");
         v.update(new StringType("on"));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new StringType("off"));
@@ -230,8 +230,8 @@ public class ValueTests {
 
     @Test
     public void decimalCalc() {
-        PercentageValue v = new PercentageValue(new BigDecimal("0.1"), new BigDecimal("1.0"), new BigDecimal("0.1"),
-                null, null);
+        PercentageValue v = new PercentageValue(new BigDecimal(0.1), new BigDecimal(1.0), new BigDecimal(0.1), null,
+                null);
         v.update(new DecimalType(1.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new DecimalType(0.1));

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.generic.ChannelConfigBuilder;
 import org.openhab.binding.mqtt.generic.ChannelState;
@@ -126,7 +127,6 @@ public class CChannel {
         private @Nullable String command_topic;
         private boolean retain;
         private @Nullable Integer qos;
-        private String unit = "";
         private ChannelStateUpdateListener channelStateUpdateListener;
 
         private @Nullable String templateIn;
@@ -156,11 +156,6 @@ public class CChannel {
                     }
                 }
             }
-            return this;
-        }
-
-        public Builder unit(String unit) {
-            this.unit = unit;
             return this;
         }
 
@@ -207,9 +202,11 @@ public class CChannel {
                 type = ChannelTypeBuilder.trigger(channelTypeUID, label)
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL)).build();
             } else {
+                StateDescription description = valueState.createStateDescription(command_topic == null).build()
+                        .toStateDescription();
                 type = ChannelTypeBuilder.state(channelTypeUID, label, channelState.getItemType())
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL))
-                        .withStateDescription(valueState.createStateDescription(unit, command_topic == null)).build();
+                        .withStateDescription(description).build();
             }
 
             Configuration configuration = new Configuration();

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentBinarySensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentBinarySensor.java
@@ -33,7 +33,6 @@ public class ComponentBinarySensor extends AbstractComponent<ComponentBinarySens
             super("MQTT Binary Sensor");
         }
 
-        protected String unit_of_measurement = "";
         protected @Nullable String device_class;
         protected boolean force_update = false;
         protected int expire_after = 0;
@@ -53,7 +52,6 @@ public class ComponentBinarySensor extends AbstractComponent<ComponentBinarySens
         buildChannel(sensorChannelID, new OnOffValue(channelConfiguration.payload_on, channelConfiguration.payload_off),
                 channelConfiguration.name, componentConfiguration.getUpdateListener())//
                         .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                        .unit(channelConfiguration.unit_of_measurement)//
                         .build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
@@ -12,9 +12,12 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.generic.values.NumberValue;
 import org.openhab.binding.mqtt.generic.values.TextValue;
+import org.openhab.binding.mqtt.generic.values.Value;
 
 /**
  * A MQTT sensor, following the https://www.home-assistant.io/components/sensor.mqtt/ specification.
@@ -33,7 +36,7 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
             super("MQTT Sensor");
         }
 
-        protected String unit_of_measurement = "";
+        protected @Nullable String unit_of_measurement;
         protected @Nullable String device_class;
         protected boolean force_update = false;
         protected int expire_after = 0;
@@ -48,11 +51,19 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
             throw new UnsupportedOperationException("Component:Sensor does not support forced updates");
         }
 
-        buildChannel(sensorChannelID, new TextValue(), channelConfiguration.name,
-                componentConfiguration.getUpdateListener())//
-                        .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                        .unit(channelConfiguration.unit_of_measurement)//
-                        .build();
+        Value value;
+
+        String uom = channelConfiguration.unit_of_measurement;
+
+        if (uom != null && StringUtils.isNotBlank(uom)) {
+            value = new NumberValue(null, null, null, uom);
+        } else {
+            value = new TextValue();
+        }
+
+        buildChannel(sensorChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
+                .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
+                .build();
     }
 
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
@@ -138,8 +138,8 @@ public class Property implements AttributeChanged {
         if (attributes.retained) {
             return ChannelTypeBuilder.state(channelTypeUID, attributes.name, channelState.getItemType())
                     .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HOMIE_CHANNEL))
-                    .withStateDescription(
-                            channelState.getCache().createStateDescription(attributes.unit, !attributes.settable))
+                    .withStateDescription(channelState.getCache().createStateDescription(!attributes.settable).build()
+                            .toStateDescription())
                     .build();
         } else {
             if (attributes.datatype.equals(DataTypeEnum.enum_)) {
@@ -193,7 +193,7 @@ public class Property implements AttributeChanged {
                     step = new BigDecimal(1);
                 }
 
-                value = new NumberValue(min, max, step);
+                value = new NumberValue(min, max, step, attributes.unit);
                 break;
             case string_:
             case unknown:


### PR DESCRIPTION
This PR enables UOMs for number channels.
There is a new optional config parameter `unit`.
The `NumberValue` accepts `QuantityType` updates, which are even converted to the selected uom (like `°F` to `°C`).
The creation of `StateDescription` has been changed to `StateDescriptionFragmentBuilder` to remove deprecated warnings.
For homeassistant, sensors with units are changed to NumberValues (compability issue?)

Addesses / inspired by #6751, #6663