### PR TITLE
[network] Fix misleading latency values

### DIFF
--- a/bundles/org.openhab.binding.network/README.md
+++ b/bundles/org.openhab.binding.network/README.md
@@ -13,6 +13,7 @@ The binding has the following configuration options:
 -   **allowDHCPlisten:**  If devices leave and reenter a network, they usually request their last IPv4 address by using DHCP requests. By listening for those messages, the status update can be more "real-time" without having to wait for the next refresh cycle. Default is true.
 -   **arpPingToolPath:** If the arp ping tool is not called `arping` and cannot be found in the PATH environment variable, the absolute path can be configured here. Default is `arping`.
 -   **cacheDeviceStateTimeInMS:** The result of a device presence detection is cached for a small amount of time. Set this time here in milliseconds. Be aware that no new pings will be issued within this time frame, even if explicitly requested. Default is 2000.
+-   **preferResponseTimeAsLatency:** If enabled, an attempt will be made to extract the latency from the output of the ping command. If no such latency value is found in the ping command output, the time to execute the ping command is used as fallback latency. If disabled, the time to execute the ping command is always used as latency value. This is disabled by default to be backwards-compatible and to not break statistics and monitoring which existed before this feature.
 
 Create a `<openHAB-conf>/services/network.cfg` file and use the above options like this:
 

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfiguration.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.network.internal;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.network.internal.utils.NetworkUtils;
@@ -26,19 +28,47 @@ import org.openhab.binding.network.internal.utils.NetworkUtils.ArpPingUtilEnum;
  */
 @NonNullByDefault
 public class NetworkBindingConfiguration {
+
     public Boolean allowSystemPings = true;
     public Boolean allowDHCPlisten = true;
     public BigDecimal cacheDeviceStateTimeInMS = BigDecimal.valueOf(2000);
     public String arpPingToolPath = "arping";
     public @NonNullByDefault({}) ArpPingUtilEnum arpPingUtilMethod;
+    // For backwards compatibility reasons, the default is to use the ping method execution time as latency value
+    public boolean preferResponseTimeAsLatency = false;
+
+    private List<NetworkBindingConfigurationListener> listeners = new ArrayList<>();
 
     public void update(NetworkBindingConfiguration newConfiguration) {
         this.allowSystemPings = newConfiguration.allowSystemPings;
         this.allowDHCPlisten = newConfiguration.allowDHCPlisten;
         this.cacheDeviceStateTimeInMS = newConfiguration.cacheDeviceStateTimeInMS;
         this.arpPingToolPath = newConfiguration.arpPingToolPath;
+        this.preferResponseTimeAsLatency = newConfiguration.preferResponseTimeAsLatency;
 
         NetworkUtils networkUtils = new NetworkUtils();
         this.arpPingUtilMethod = networkUtils.determineNativeARPpingMethod(arpPingToolPath);
+
+        notifyListeners();
+    }
+
+    public void addNetworkBindingConfigurationListener(NetworkBindingConfigurationListener listener) {
+        listeners.add(listener);
+    }
+
+    private void notifyListeners() {
+        listeners.forEach(NetworkBindingConfigurationListener::bindingConfigurationChanged);
+    }
+
+    @Override
+    public String toString() {
+        return "NetworkBindingConfiguration{" +
+                "allowSystemPings=" + allowSystemPings +
+                ", allowDHCPlisten=" + allowDHCPlisten +
+                ", cacheDeviceStateTimeInMS=" + cacheDeviceStateTimeInMS +
+                ", arpPingToolPath='" + arpPingToolPath + '\'' +
+                ", arpPingUtilMethod=" + arpPingUtilMethod +
+                ", preferResponseTimeAsLatency=" + preferResponseTimeAsLatency +
+                '}';
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfigurationListener.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfigurationListener.java
@@ -1,0 +1,6 @@
+package org.openhab.binding.network.internal;
+
+public interface NetworkBindingConfigurationListener {
+
+    void bindingConfigurationChanged();
+}

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfigurationListener.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkBindingConfigurationListener.java
@@ -1,5 +1,22 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.network.internal;
 
+/**
+ * Listener for binding configuration changes.
+ *
+ * @author Andreas Hirsch - Initial contribution
+ */
 public interface NetworkBindingConfigurationListener {
 
     void bindingConfigurationChanged();

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 public class NetworkHandlerFactory extends BaseThingHandlerFactory {
     final NetworkBindingConfiguration configuration = new NetworkBindingConfiguration();
 
+    private final Logger logger = LoggerFactory.getLogger(NetworkHandlerFactory.class);
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return NetworkBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -67,6 +69,7 @@ public class NetworkHandlerFactory extends BaseThingHandlerFactory {
         // configuration, the values are automatically available in all handlers. Because they all
         // share the same instance.
         configuration.update(new Configuration(config).as(NetworkBindingConfiguration.class));
+        logger.debug("Updated binding configuration to {}", configuration);
     }
 
     @Override

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The handler factory retrieves the binding configuration and is responsible for creating

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/PresenceDetection.java
@@ -509,8 +509,10 @@ public class PresenceDetection implements IPRequestReceivedCallback {
 
             networkUtils.nativeARPPing(arpPingMethod, arpPingUtilPath, interfaceName,
                     destinationAddress.getHostAddress(), timeoutInMS).ifPresent(o -> {
-                PresenceDetectionValue v = updateReachableValue(PresenceDetectionType.ARP_PING, getLatency(o, preferResponseTimeAsLatency));
-                updateListener.partialDetectionResult(v);
+                        if (o.isSuccess()) {
+                            PresenceDetectionValue v = updateReachableValue(PresenceDetectionType.ARP_PING, getLatency(o, preferResponseTimeAsLatency));
+                            updateListener.partialDetectionResult(v);
+                        }
             });
         } catch (IOException e) {
             logger.trace("Failed to execute an arp ping for ip {}", hostname, e);
@@ -534,8 +536,10 @@ public class PresenceDetection implements IPRequestReceivedCallback {
         }
 
         networkUtils.javaPing(timeoutInMS, destinationAddress).ifPresent(o -> {
-            PresenceDetectionValue v = updateReachableValue(PresenceDetectionType.ICMP_PING, getLatency(o, preferResponseTimeAsLatency));
-            updateListener.partialDetectionResult(v);
+            if (o.isSuccess()) {
+                PresenceDetectionValue v = updateReachableValue(PresenceDetectionType.ICMP_PING, getLatency(o, preferResponseTimeAsLatency));
+                updateListener.partialDetectionResult(v);
+            }
         });
     }
 

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/handler/NetworkHandler.java
@@ -35,12 +35,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.UnDefType;
-import org.openhab.binding.network.internal.NetworkBindingConfiguration;
-import org.openhab.binding.network.internal.NetworkBindingConstants;
-import org.openhab.binding.network.internal.NetworkHandlerConfiguration;
-import org.openhab.binding.network.internal.PresenceDetection;
-import org.openhab.binding.network.internal.PresenceDetectionListener;
-import org.openhab.binding.network.internal.PresenceDetectionValue;
+import org.openhab.binding.network.internal.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Rewritten
  */
 @NonNullByDefault
-public class NetworkHandler extends BaseThingHandler implements PresenceDetectionListener {
+public class NetworkHandler extends BaseThingHandler implements PresenceDetectionListener, NetworkBindingConfigurationListener {
     private final Logger logger = LoggerFactory.getLogger(NetworkHandler.class);
     private @NonNullByDefault({}) PresenceDetection presenceDetection;
 
@@ -72,6 +67,7 @@ public class NetworkHandler extends BaseThingHandler implements PresenceDetectio
         super(thing);
         this.isTCPServiceDevice = isTCPServiceDevice;
         this.configuration = configuration;
+        this.configuration.addNetworkBindingConfigurationListener(this);
     }
 
     private void refreshValue(ChannelUID channelUID) {
@@ -165,6 +161,7 @@ public class NetworkHandler extends BaseThingHandler implements PresenceDetectio
 
         this.presenceDetection = presenceDetection;
         presenceDetection.setHostname(handlerConfiguration.hostname);
+        presenceDetection.setPreferResponseTimeAsLatency(configuration.preferResponseTimeAsLatency);
 
         if (isTCPServiceDevice) {
             Integer port = handlerConfiguration.port;
@@ -217,5 +214,11 @@ public class NetworkHandler extends BaseThingHandler implements PresenceDetectio
      */
     public boolean isTCPServiceDevice() {
         return isTCPServiceDevice;
+    }
+
+    @Override
+    public void bindingConfigurationChanged() {
+        // Make sure that changed binding configuration is reflected
+        presenceDetection.setPreferResponseTimeAsLatency(configuration.preferResponseTimeAsLatency);
     }
 }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
@@ -1,0 +1,45 @@
+package org.openhab.binding.network.internal.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Examines output lines of the ping command and tries to extract the contained latency value.
+ */
+public class LatencyParser {
+
+    private final Logger logger = LoggerFactory.getLogger(LatencyParser.class);
+
+    // This is how the input looks like on Mac and Linux:
+    // ping -c 1 192.168.1.1
+    // PING 192.168.1.1 (192.168.1.1): 56 data bytes
+    // 64 bytes from 192.168.1.1: icmp_seq=0 ttl=64 time=1.225 ms
+    //
+    // --- 192.168.1.1 ping statistics ---
+    // 1 packets transmitted, 1 packets received, 0.0% packet loss
+    // round-trip min/avg/max/stddev = 1.225/1.225/1.225/0.000 ms
+
+    /**
+     * Examine a single ping command output line and try to extract the latency value if it is contained.
+     *
+     * @param inputLine Single output line of the ping command.
+     * @return Latency value provided by the ping command. Optional is empty if the provided line did not contain a
+     * latency value which matches the known patterns.
+     */
+    public Optional<Double> parseLatency(String inputLine) {
+        logger.debug("Parsing latency from input {}", inputLine);
+
+        String pattern = ".*time=(.*) ms";
+        Matcher m = Pattern.compile(pattern).matcher(inputLine);
+        if(m.find() && m.groupCount() == 1) {
+            return Optional.of(Double.parseDouble(m.group(1)));
+        }
+
+        logger.debug("Did not find a latency value");
+        return Optional.empty();
+    }
+}

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/LatencyParser.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.network.internal.utils;
 
 import org.slf4j.Logger;
@@ -9,6 +21,8 @@ import java.util.regex.Pattern;
 
 /**
  * Examines output lines of the ping command and tries to extract the contained latency value.
+ *
+ * @author Andreas Hirsch - Initial contribution
  */
 public class LatencyParser {
 

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -12,28 +12,6 @@
  */
 package org.openhab.binding.network.internal.utils;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.ConnectException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.NoRouteToHostException;
-import java.net.PortUnreachableException;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.net.util.SubnetUtils;
@@ -44,6 +22,13 @@ import org.eclipse.smarthome.core.net.NetUtil;
 import org.eclipse.smarthome.io.net.exec.ExecUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.*;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Network utility functions for pinging and for determining all interfaces and assigned IP addresses.
@@ -75,7 +60,7 @@ public class NetworkUtils {
 
         try {
             // For each interface ...
-            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
+            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements(); ) {
                 NetworkInterface networkInterface = en.nextElement();
                 if (!networkInterface.isLoopback()) {
                     result.add(networkInterface.getName());
@@ -101,7 +86,7 @@ public class NetworkUtils {
     /**
      * Takes the interfaceIPs and fetches every IP which can be assigned on their network
      *
-     * @param networkIPs The IPs which are assigned to the Network Interfaces
+     * @param interfaceIPs The IPs which are assigned to the Network Interfaces
      * @param maximumPerInterface The maximum of IP addresses per interface or 0 to get all.
      * @return Every single IP which can be assigned on the Networks the computer is connected to
      */
@@ -150,17 +135,18 @@ public class NetworkUtils {
      * @param host The IP or hostname
      * @param port The tcp port. Must be not 0.
      * @param timeout Timeout in ms
-     * @param logger A slf4j logger instance to log IOException
-     * @return
+     * @return Ping result information. Optional is empty if ping command was not executed.
      * @throws IOException
      */
-    public boolean servicePing(String host, int port, int timeout) throws IOException {
+    public Optional<PingResult> servicePing(String host, int port, int timeout) throws IOException {
+        double execStartTimeInMS = System.currentTimeMillis();
+
         SocketAddress socketAddress = new InetSocketAddress(host, port);
         try (Socket socket = new Socket()) {
             socket.connect(socketAddress, timeout);
-            return true;
+            return Optional.of(new PingResult(true, System.currentTimeMillis() - execStartTimeInMS));
         } catch (ConnectException | SocketTimeoutException | NoRouteToHostException ignored) {
-            return false;
+            return Optional.of(new PingResult(false, System.currentTimeMillis() - execStartTimeInMS));
         }
     }
 
@@ -182,7 +168,8 @@ public class NetworkUtils {
         }
 
         try {
-            if (nativePing(method, "127.0.0.1", 1000)) {
+            Optional<PingResult> pingResult = nativePing(method, "127.0.0.1", 1000);
+            if (pingResult.isPresent() && pingResult.get().isSuccess()) {
                 return method;
             }
         } catch (IOException ignored) {
@@ -225,14 +212,16 @@ public class NetworkUtils {
      *
      * @param hostname The DNS name, IPv4 or IPv6 address. Must not be null.
      * @param timeoutInMS Timeout in milliseconds. Be aware that DNS resolution is not part of this timeout.
-     * @return Returns true if the device responded
+     * @return Ping result information. Optional is empty if ping command was not executed.
      * @throws IOException The ping command could probably not be found
      */
-    public boolean nativePing(@Nullable IpPingMethodEnum method, String hostname, int timeoutInMS)
+    public Optional<PingResult> nativePing(@Nullable IpPingMethodEnum method, String hostname, int timeoutInMS)
             throws IOException, InterruptedException {
+        double execStartTimeInMS = System.currentTimeMillis();
+
         Process proc;
         if (method == null) {
-            return false;
+            return Optional.empty();
         }
         // Yes, all supported operating systems have their own ping utility with a different command line
         switch (method) {
@@ -250,7 +239,7 @@ public class NetworkUtils {
             case JAVA_PING:
             default:
                 // We cannot estimate the command line for any other operating system and just return false
-                return false;
+                return Optional.empty();
         }
 
         // The return code is 0 for a successful ping, 1 if device didn't
@@ -259,12 +248,12 @@ public class NetworkUtils {
         // Exception: return code is also 0 in Windows for all requests on the local subnet.
         // see https://superuser.com/questions/403905/ping-from-windows-7-get-no-reply-but-sets-errorlevel-to-0
         if (method != IpPingMethodEnum.WINDOWS_PING) {
-            return proc.waitFor() == 0;
+            return Optional.of(new PingResult(proc.waitFor() == 0, System.currentTimeMillis() - execStartTimeInMS));
         }
 
         int result = proc.waitFor();
         if (result != 0) {
-            return false;
+            return Optional.of(new PingResult(false, System.currentTimeMillis() - execStartTimeInMS));
         }
 
         try (BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
@@ -274,12 +263,12 @@ public class NetworkUtils {
             }
             do {
                 if (line.contains("TTL=")) {
-                    return true;
+                    return Optional.of(new PingResult(true, System.currentTimeMillis() - execStartTimeInMS));
                 }
                 line = r.readLine();
             } while (line != null);
 
-            return false;
+            return Optional.of(new PingResult(false, System.currentTimeMillis() - execStartTimeInMS));
         }
     }
 
@@ -302,13 +291,15 @@ public class NetworkUtils {
      * @param interfaceName An interface name, on linux for example "wlp58s0", shown by ifconfig. Must not be null.
      * @param ipV4address The ipV4 address. Must not be null.
      * @param timeoutInMS A timeout in milliseconds
-     * @return Return true if the device responded
+     * @return Ping result information. Optional is empty if ping command was not executed.
      * @throws IOException The ping command could probably not be found
      */
-    public boolean nativeARPPing(@Nullable ArpPingUtilEnum arpingTool, @Nullable String arpUtilPath,
-            String interfaceName, String ipV4address, int timeoutInMS) throws IOException, InterruptedException {
+    public Optional<PingResult> nativeARPPing(@Nullable ArpPingUtilEnum arpingTool, @Nullable String arpUtilPath,
+                                              String interfaceName, String ipV4address, int timeoutInMS) throws IOException, InterruptedException {
+        double execStartTimeInMS = System.currentTimeMillis();
+
         if (arpUtilPath == null || arpingTool == null || arpingTool == ArpPingUtilEnum.UNKNOWN_TOOL) {
-            return false;
+            return Optional.empty();
         }
         Process proc;
         if (arpingTool == ArpPingUtilEnum.THOMAS_HABERT_ARPING_WITHOUT_TIMEOUT) {
@@ -325,7 +316,25 @@ public class NetworkUtils {
 
         // The return code is 0 for a successful ping. 1 if device didn't respond and 2 if there is another error like
         // network interface not ready.
-        return proc.waitFor() == 0;
+        return Optional.of(new PingResult(proc.waitFor() == 0, System.currentTimeMillis() - execStartTimeInMS));
+    }
+
+    /**
+     * Execute a Java ping.
+     *
+     * @param timeoutInMS A timeout in milliseconds
+     * @param destinationAddress The address to check
+     * @return Ping result information. Optional is empty if ping command was not executed.
+     */
+    public Optional<PingResult> javaPing(int timeoutInMS, InetAddress destinationAddress) {
+        double execStartTimeInMS = System.currentTimeMillis();
+
+        try {
+            destinationAddress.isReachable(timeoutInMS);
+            return Optional.of(new PingResult(true, System.currentTimeMillis() - execStartTimeInMS));
+        } catch (IOException e) {
+            return Optional.of(new PingResult(false, System.currentTimeMillis() - execStartTimeInMS));
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/PingResult.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/PingResult.java
@@ -1,0 +1,62 @@
+package org.openhab.binding.network.internal.utils;
+
+import java.util.Optional;
+
+/**
+ * Information about the ping result.
+ *
+ * @author Andreas Hirsch - Initial contribution
+ */
+public class PingResult {
+
+    private boolean success;
+    private Double responseTimeInMS;
+    private double executionTimeInMS;
+
+    /**
+     * @param success     <code>true</code> if the device was reachable, <code>false</code> if not.
+     * @param executionTimeInMS Execution time of the ping command in ms.
+     */
+    public PingResult(boolean success, double executionTimeInMS) {
+        this.success = success;
+        this.executionTimeInMS = executionTimeInMS;
+    }
+
+    /**
+     * @return <code>true</code> if the device was reachable, <code>false</code> if not.
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /**
+     * @return Response time in ms which was returned by the ping command. Optional is empty if response time provided
+     * by ping command is not available.
+     */
+    public Optional<Double> getResponseTimeInMS() {
+        return responseTimeInMS == null ? Optional.empty() : Optional.of(responseTimeInMS);
+    }
+
+    /**
+     * @param responseTimeInMS Response time in ms which was returned by the ping command.
+     */
+    public void setResponseTimeInMS(double responseTimeInMS) {
+        this.responseTimeInMS = responseTimeInMS;
+    }
+
+    @Override
+    public String toString() {
+        return "PingResult{" +
+                "success=" + success +
+                ", responseTimeInMS=" + responseTimeInMS +
+                ", executionTimeInMS=" + executionTimeInMS +
+                '}';
+    }
+
+    /**
+     * @return Execution time of the ping command in ms.
+     */
+    public double getExecutionTimeInMS() {
+        return executionTimeInMS;
+    }
+}

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/PingResult.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/PingResult.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.network.internal.utils;
 
 import java.util.Optional;

--- a/bundles/org.openhab.binding.network/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.network/src/main/resources/ESH-INF/binding/binding.xml
@@ -29,7 +29,12 @@
 		<parameter name="arpPingToolPath" type="text">
 			<default>arping</default>
 			<label>ARP Ping Tool Path</label>
-			<description>If your arp ping tool is not called arping and cannot be found in the PATH environment, you can configure the absolute path / tool name here</description>
+			<description>If your arp ping tool is not called arping and cannot be found in the PATH environment, you can configure the absolute path / tool name here.</description>
+		</parameter>
+		<parameter name="preferResponseTimeAsLatency" type="boolean">
+			<default>false</default>
+			<label>Use Response Time as Latency</label>
+			<description>If enabled, an attempt will be made to extract the latency from the output of the ping command. If no such latency value is found in the ping command output, the time to execute the ping command is used as fallback latency. If disabled, the time to execute the ping command is always used as latency value.</description>
 		</parameter>
 	</config-description>
 </binding:binding>

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -35,6 +36,7 @@ import org.openhab.binding.network.internal.toberemoved.cache.ExpiringCacheHelpe
 import org.openhab.binding.network.internal.utils.NetworkUtils;
 import org.openhab.binding.network.internal.utils.NetworkUtils.ArpPingUtilEnum;
 import org.openhab.binding.network.internal.utils.NetworkUtils.IpPingMethodEnum;
+import org.openhab.binding.network.internal.utils.PingResult;
 
 /**
  * Tests cases for {@see PresenceDetectionValue}
@@ -113,10 +115,10 @@ public class PresenceDetectionTest {
 
     @Test
     public void partialAndFinalCallbackTests() throws InterruptedException, IOException {
-        doReturn(true).when(networkUtils).nativePing(eq(IpPingMethodEnum.WINDOWS_PING), anyString(), anyInt());
-        doReturn(true).when(networkUtils).nativeARPPing(eq(ArpPingUtilEnum.IPUTILS_ARPING), anyString(), anyString(),
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).nativePing(eq(IpPingMethodEnum.WINDOWS_PING), anyString(), anyInt());
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).nativeARPPing(eq(ArpPingUtilEnum.IPUTILS_ARPING), anyString(), anyString(),
                 any(), anyInt());
-        doReturn(true).when(networkUtils).servicePing(anyString(), anyInt(), anyInt());
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).servicePing(anyString(), anyInt(), anyInt());
 
         assertTrue(subject.performPresenceDetection(false));
         subject.waitForPresenceDetection();
@@ -135,10 +137,10 @@ public class PresenceDetectionTest {
 
     @Test
     public void cacheTest() throws InterruptedException, IOException {
-        doReturn(true).when(networkUtils).nativePing(eq(IpPingMethodEnum.WINDOWS_PING), anyString(), anyInt());
-        doReturn(true).when(networkUtils).nativeARPPing(eq(ArpPingUtilEnum.IPUTILS_ARPING), anyString(), anyString(),
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).nativePing(eq(IpPingMethodEnum.WINDOWS_PING), anyString(), anyInt());
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).nativeARPPing(eq(ArpPingUtilEnum.IPUTILS_ARPING), anyString(), anyString(),
                 any(), anyInt());
-        doReturn(true).when(networkUtils).servicePing(anyString(), anyInt(), anyInt());
+        doReturn(Optional.of(new PingResult(true, 10))).when(networkUtils).servicePing(anyString(), anyInt(), anyInt());
 
         doReturn(executorService).when(subject).getThreadsFor(anyInt());
 

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.network.internal.utils;
 
 import org.junit.Assert;
@@ -5,6 +17,11 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+/**
+ * Tests the parser which extracts latency values from the output of the ping command.
+ *
+ * @author Andreas Hirsch - Initial contribution
+ */
 public class LatencyParserTest {
 
     @Test

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
@@ -1,0 +1,47 @@
+package org.openhab.binding.network.internal.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+public class LatencyParserTest {
+
+    @Test
+    public void parseLinuxAndMacResultFoundTest() {
+        // Arrange
+        LatencyParser latencyParser = new LatencyParser();
+        String input = "64 bytes from 192.168.1.1: icmp_seq=0 ttl=64 time=1.225 ms";
+
+        // Act
+        Optional<Double> resultLatency = latencyParser.parseLatency(input);
+
+        // Assert
+        Assert.assertTrue(resultLatency.isPresent());
+        Assert.assertEquals(1.225, resultLatency.get(), 0);
+    }
+
+    @Test
+    public void parseLinuxAndMacResultNotFoundTest() {
+        // Arrange
+        LatencyParser latencyParser = new LatencyParser();
+        // This is the output of the command. We exclude the line which contains the latency, because here we want
+        // to test that no latency is returned for all other lines.
+        String[] inputLines = {
+                "ping -c 1 192.168.1.1",
+                "PING 192.168.1.1 (192.168.1.1): 56 data bytes",
+                // "64 bytes from 192.168.1.1: icmp_seq=0 ttl=64 time=1.225 ms",
+                "--- 192.168.1.1 ping statistics ---",
+                "1 packets transmitted, 1 packets received, 0.0% packet loss",
+                "round-trip min/avg/max/stddev = 1.225/1.225/1.225/0.000 ms"
+        };
+
+        for (String inputLine : inputLines) {
+            // Act
+            Optional<Double> resultLatency = latencyParser.parseLatency(inputLine);
+
+            // Assert
+            Assert.assertFalse(resultLatency.isPresent());
+        }
+    }
+}


### PR DESCRIPTION
This is a fix for the issue [network] Misleading latency values #6741. I won't copy the issue content to this pull request to avoid redundant information.

- The binding configuration option `preferResponseTimeAsLatency` was added. It is by default false which leads to the same behavior as before the feature provided by this pull request existed.
- If the option is enabled, the binding tries to extract the latency value from the ping command output. If no value is found, the fallback is to use the time it took to execute the ping command (same as before).