### PR TITLE
[satel] Fixes for arming in mode 1

### DIFF
--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ModuleVersionCommand.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ModuleVersionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ModuleVersionCommand.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/ModuleVersionCommand.java
@@ -46,7 +46,7 @@ public class ModuleVersionCommand extends SatelCommandBase {
     /**
      * @return <code>true</code> if the module supports extended (32-bit) payload for zones/outputs
      */
-    public boolean isExtPayloadSupported() {
+    public boolean hasExtPayloadSupport() {
         return (response.getPayload()[11] & 0x01) != 0;
     }
 
@@ -54,7 +54,7 @@ public class ModuleVersionCommand extends SatelCommandBase {
     public boolean handleResponse(EventDispatcher eventDispatcher, SatelMessage response) {
         if (super.handleResponse(eventDispatcher, response)) {
             // dispatch version event
-            eventDispatcher.dispatchEvent(new ModuleVersionEvent(getVersion(), isExtPayloadSupported()));
+            eventDispatcher.dispatchEvent(new ModuleVersionEvent(getVersion(), hasExtPayloadSupport()));
             return true;
         } else {
             return false;

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommandBase.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/SatelCommandBase.java
@@ -40,11 +40,8 @@ public abstract class SatelCommandBase extends SatelMessage implements SatelComm
     /**
      * Creates new command basing on command code and extended command flag.
      *
-     * @param commandCode
-     *            command code
-     * @param extended
-     *            if <code>true</code> command will be sent as extended (256
-     *            zones or outputs)
+     * @param commandCode command code
+     * @param extended    if <code>true</code> command will be sent as extended (256 zones or outputs)
      */
     public SatelCommandBase(byte commandCode, boolean extended) {
         this(commandCode, extended ? EXTENDED_CMD_PAYLOAD : EMPTY_PAYLOAD);
@@ -53,10 +50,8 @@ public abstract class SatelCommandBase extends SatelMessage implements SatelComm
     /**
      * Creates new instance with specified command code and payload.
      *
-     * @param command
-     *            command code
-     * @param payload
-     *            command payload
+     * @param command command code
+     * @param payload command payload
      */
     public SatelCommandBase(byte commandCode, byte[] payload) {
         super(commandCode, payload);
@@ -189,6 +184,22 @@ public abstract class SatelCommandBase extends SatelMessage implements SatelComm
             logger.info("{}. {}", errorMsg, getRequest());
         }
         return false;
+    }
+
+    /**
+     * Decodes firmware version and release date from command payload
+     *
+     * @param offset starting offset in payload
+     * @return decoded firmware version and release date as string
+     */
+    public String getVersion(int offset) {
+        // build version string
+        String verStr = new String(response.getPayload(), offset, 1) + "."
+                + new String(response.getPayload(), offset + 1, 2) + " "
+                + new String(response.getPayload(), offset + 3, 4) + "-"
+                + new String(response.getPayload(), offset + 7, 2) + "-"
+                + new String(response.getPayload(), offset + 9, 2);
+        return verStr;
     }
 
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ModuleVersionEvent.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ModuleVersionEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ModuleVersionEvent.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ModuleVersionEvent.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.satel.internal.event;
+
+/**
+ * Event class describing version of communication module.
+ *
+ * @author Krzysztof Goworek - Initial contribution
+ */
+public class ModuleVersionEvent implements SatelEvent {
+
+    private String version;
+    private boolean extPayloadSupport;
+
+    /**
+     * Constructs new event class.
+     *
+     * @param version           string describing version number and firmware revision
+     * @param extPayloadSupport the module supports extended (32-bit) payload for zones/outputs
+     */
+    public ModuleVersionEvent(String version, boolean extPayloadSupport) {
+        this.version = version;
+        this.extPayloadSupport = extPayloadSupport;
+    }
+
+    /**
+     * @return firmware version and date
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @return <code>true</code> if the module supports extended (32-bit) payload for zones/outputs
+     */
+    public boolean hasExtPayloadSupport() {
+        return this.extPayloadSupport;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ModuleVersionEvent: version = %s, extPayloadSupport = %b", this.version,
+                this.extPayloadSupport);
+    }
+}

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelBridgeHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelBridgeHandler.java
@@ -61,7 +61,7 @@ public abstract class SatelBridgeHandler extends ConfigStatusBridgeHandler imple
             // update bridge status and get new states from the system
             if (statusEvent.isConnected()) {
                 updateStatus(ThingStatus.ONLINE);
-                satelModule.sendCommand(new NewStatesCommand(satelModule.getIntegraType().hasExtPayload()));
+                satelModule.sendCommand(new NewStatesCommand(satelModule.hasExtPayloadSupport()));
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
                         statusEvent.getReason());
@@ -94,7 +94,7 @@ public abstract class SatelBridgeHandler extends ConfigStatusBridgeHandler imple
 
                     // get list of states that have changed
                     logger.trace("Sending 'get new states' command");
-                    satelModule.sendCommand(new NewStatesCommand(satelModule.getIntegraType().hasExtPayload()));
+                    satelModule.sendCommand(new NewStatesCommand(satelModule.hasExtPayloadSupport()));
                 };
                 pollingJob = scheduler.scheduleWithFixedDelay(pollingCommand, 0, config.getRefresh(),
                         TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This PR fixes issue with updating states with code greater than 0x27 (for example partitions armed in mode 1).
This issue is described here: https://community.openhab.org/t/satel-binding-support-announcements-and-feature-requests/56135/117

PR replaces #6614 with 2.5.x as destination branch.

Signed-off-by: Krzysztof Goworek krzysztof.goworek@gmail.com