### PR TITLE
[tplinksmarthome] Fix typo thing xml kl110 devices

### DIFF
--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/ESH-INF/thing/KL110.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/ESH-INF/thing/KL110.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="kl10">
+	<thing-type id="kl110">
 		<label>KL110</label>
 		<description>TP-Link KL110 Smart Wi-Fi LED Bulb with Brightness</description>
 		<category>Lightbulb</category>


### PR DESCRIPTION
The kl110 device accidentally got the id kl10 instead of kl110. There it won't work because the code would correctly use the value kl110 and that value is also used to match the device with what is returned by the device itself.
