### PR TITLE
[plugwiseha] Initial contribution

### DIFF
--- a/bundles/org.openhab.binding.plugwiseha/.classpath
+++ b/bundles/org.openhab.binding.plugwiseha/.classpath
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.plugwiseha/.project
+++ b/bundles/org.openhab.binding.plugwiseha/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.plugwiseha</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.plugwiseha/NOTICE
+++ b/bundles/org.openhab.binding.plugwiseha/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/bundles/org.openhab.binding.plugwiseha/README.md
+++ b/bundles/org.openhab.binding.plugwiseha/README.md
@@ -1,0 +1,138 @@
+# PlugwiseHA Binding
+
+The Plugwise Home Automation binding adds support to openHAB for the [Plugwise Home Automation ecosystem](https://www.plugwise.com/en_US/adam_zone_control). This system is built around a gateway from Plugwise called the 'Adam' which incorporates a ZigBee controller to manage thermostatic radiator valves, room thermostats, floor heating pumps, et cetera.
+
+Users can manage and control this system either via a web app or a mobile phone app developed by Plugwise. The (web) app allows users to define heating zone's (e.g. rooms) and add radiator valves to those rooms to manage and control their heating irrespective of other rooms.
+
+Using the Plugwise Home Automation binding you can incorporate the management of these devices and heating zones into openHAB. The binding uses the same RESTfull API that both the mobile phone app and the web app use.
+
+The binding requires users to have a working Plugwise Home Automation setup consisting of at least 1 gateway device (the 'Adam') and preferably 1 radiator valve as a bare minimum. The 'Adam' (from hereon called the gateway) needs to be accessible from the openHAB instance via a TCP/IP connection.
+
+## Supported Things
+
+| Device Type                                              | Description                                                                                                        | Thing Type      |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------- |
+| -                                                        | A Plugwise heating zone configured with at least 1 of the devices below                                            | zone            |
+| [Adam](https://www.plugwise.com/en_US/products/adam-ha)  | The Plugwise Home Automation Bridge is needed to connect to the Adam boiler gateway                                | gateway         |
+| [Tom](https://www.plugwise.com/en_US/products/tom)       | A Plugwise Home Automation radiator valve                                                                          | appliance_valve |
+| [Floor](https://www.plugwise.com/en_US/products/floor)   | A Plugwise Home Automation radiator valve specificaly used for floor heating                                       | appliance_valve |
+| [Circle](https://www.plugwise.com/en_US/products/circle) | A power outlet plug that provides energy measurement and switching control of appliances (e.g. floor heating pump) | appliance_pump  |
+| [Lisa](https://www.plugwise.com/en_US/products/lisa)     | A room thermostat (also supports the 'Anna' room thermostat)                                                       | appliance_thermostat |
+
+
+## Discovery
+
+After setting up the Plugwise Home Automation bridge you can start a manual scan to find all devices registered on the gateway. You can also manually add things by entering the corresponding device id as a configuration parameter. The device id's can be found be enabling TRACE logging in the Karaf console.
+
+## Thing Configuration
+
+You must define a Plugwise Home Automation gateway (Bridge) before defining zones or appliances (Things) for this binding to work.
+
+#### Plugwise Home Automation gateway (Bridge):
+
+| Parameter | Description                                                             | Config   | Default |
+| --------- | ----------------------------------------------------------------------- | -------- | ------- |
+| host      | The IP address or hostname of the Adam HA gateway                       | Required | 'adam'  |
+| username  | The username for the Adam HA gateway                                    | Optional | 'smile' |
+| smileID   | The 8 letter code on the sticker on the back of the Adam boiler gateway | Required | -       |
+| refresh   | The refresh interval in seconds                                         | Optional | 15      |
+
+#### Plugwise Home Automation zone (`zone`):
+
+| Parameter | Description               | Config   | Default |
+| --------- | ------------------------- | -------- | ------- |
+| id        | The unique ID of the zone | Required | -       |
+
+#### Plugwise Home Automation appliance (`appliance_valve`):
+
+| Parameter            | Description                                                                                                        | Config   | Default |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
+| id                   | The unique ID of the radiator valve appliance                                                                      | Required | -       |
+| lowBatteryPercentage | Battery charge remaining at which to trigger battery low warning. (*Only applicable for battery operated devices*) | Optional | 15      |
+
+#### Plugwise Home Automation appliance (`appliance_thermostat`):
+
+| Parameter            | Description                                                                                                        | Config   | Default |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
+| id                   | The unique ID of the room thermostat appliance                                                                     | Required | -       |
+| lowBatteryPercentage | Battery charge remaining at which to trigger battery low warning. (*Only applicable for battery operated devices*) | Optional | 15      |
+
+
+#### Plugwise Home Automation appliance (`appliance_pump`):
+
+| Parameter | Description                         | Config   | Default |
+| --------- | ----------------------------------- | -------- | ------- |
+| id        | The unique ID of the pump appliance | Required | -       |
+
+## Channels
+
+| channel | type   | Read-only?  | description                 |
+| ------- | ------ | ------------ | --------------- |
+| temperature | Number:Temperature | Yes | This channel is used to read the temperature of an appliance that supports the thermostat functionality |
+| setpointTemperature | Number:Temperature | No | This channel is used to read or write the setpoint temperature of an appliance that supports the thermostat functionality |
+| power | Switch | No | This channel is used to toggle an appliance ON/OFF that supports the relay functionality |
+| lock | Switch | No | This channel is used to toggle an appliance lock ON/OFF that supports the relay functionality.(*When the lock is ON the gateway will not automatically control the corresponding relay switch depending on thermostat mode*) |
+| powerUsage | Number | Yes | This channel is used to read the current power usage in Watts of an appliance that supports this |
+| batteryLevel | Number | Yes | This channel is used to read the current battery level of an appliance that is battery operated |
+| batteryLevelLow | Switch | Yes | This channel will switch ON when the battery level of an appliance that is battery operated drops below a certain threshold |
+
+## Full Example
+
+**things/plugwiseha.things**
+
+```
+Bridge plugwiseha:gateway:home "Plugwise Home Automation Gateway" [ smileId="abcdefgh" ] {
+	Thing zone living_room_zone "Living room" [ id="$device_id" ]
+    Thing appliance_valve living_room_radiator "Living room radiator valve" [ id="$device_id" ]
+	Thing appliance_thermostat living_room_thermostat "Living room thermostat" [ id="$device_id" ]
+    Thing appliance_pump living_room_pump "Floor heating pump" [ id="$device_id" ]
+}
+```
+
+Replace `$device_id` accordingly.
+
+**items/plugwiseha.items**
+
+```
+Number living_room_zone_temperature "Zone temperature" {channel="plugwiseha:zone:home:living_room_zone:temperature"}
+Number living_room_zone_temperature_setpoint "Zone temperature setpoint" {channel="plugwiseha:zone:home:living_room_zone:setpointTemperature"}
+
+Number living_room_radiator_temperature "Radiator valve temperature" {channel="plugwiseha:appliance_valve:home:living_room_radiator:temperature"}
+Number living_room_radiator_temperature_setpoint "Radiator valve temperature setpoint" {channel="plugwiseha:appliance_valve:home:living_room_radiator:setpointTemperature"}
+
+Number living_room_thermostat_temperature "Room thermostat temperature" {channel="plugwiseha:appliance_valve:home:living_room_thermostat:temperature"}
+Number living_room_thermostat_temperature_setpoint "Room thermostat temperature setpoint" {channel="plugwiseha:appliance_valve:home:living_room_thermostat:setpointTemperature"}
+
+Switch living_room_pump_power "Floor heating pump power" {channel="plugwiseha:appliance_pump:home:living_room_pump:power"}
+Switch living_room_pump_lock "Floor heating pump lock [MAP:(plugwiseha.map):%s]" {channel="plugwiseha:appliance_pump:home:living_room_pump:lock"}
+Number living_room_pump_power_usage "Floor heating pump power [%0.2fW]" {channel="plugwiseha:appliance_pump:home:living_room_pump:powerUsage"}
+```
+
+**transform/plugwiseha.map**
+
+```
+ON=Locked
+OFF=Unlocked
+```
+
+**sitemaps/plugwiseha.sitemap**
+
+```
+sitemap plugwiseha label="PlugwiseHA Binding"
+{
+	Frame {
+        Text item=living_room_zone_temperature
+        Setpoint item=living_room_zone_temperature_setpoint label="Living room [%.1f °C]" minValue=5.0 maxValue=25 step=0.5
+
+		Text item=living_room_radiator_temperature
+        Setpoint item=living_room_radiator_temperature_setpoint label="Living room [%.1f °C]" minValue=5.0 maxValue=25 step=0.5
+
+		Text item=living_room_thermostat_temperature
+        Setpoint item=living_room_thermostat_temperature_setpoint label="Living room [%.1f °C]" minValue=5.0 maxValue=25 step=0.5
+
+		Number item=living_room_pump_power_usage
+		Switch item=living_room_pump_power
+		Switch item=living_room_pump_lock
+	}
+}
+```

--- a/bundles/org.openhab.binding.plugwiseha/pom.xml
+++ b/bundles/org.openhab.binding.plugwiseha/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.plugwiseha</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: PlugwiseHA Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.plugwiseha-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+
+    <feature name="openhab-binding-plugwiseha" description="PlugwiseHA Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.plugwiseha/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/PlugwiseHABindingConstants.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/PlugwiseHABindingConstants.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+
+/**
+ * The {@link PlugwiseHABindingConstants} class defines common constants, which
+ * are used across the whole binding.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+@NonNullByDefault
+public class PlugwiseHABindingConstants {
+
+        public static final String BINDING_ID = "plugwiseha";
+
+        // List of PlugwiseHA services, related urls, information
+
+        public static final String PLUGWISEHA_API_URL = "http://%s";
+        public static final String PLUGWISEHA_API_APPLIANCES_URL = PLUGWISEHA_API_URL + "/core/appliances";
+        public static final String PLUGWISEHA_API_APPLIANCE_URL = PLUGWISEHA_API_URL + "/core/appliances;id=%s";
+        public static final String PLUGWISEHA_API_LOCATIONS_URL = PLUGWISEHA_API_URL + "/core/locations";
+        public static final String PLUGWISEHA_API_LOCATION_URL = PLUGWISEHA_API_URL + "/core/locations;id=%s";
+
+        // Bridge
+        public static final ThingTypeUID THING_TYPE_GATEWAY = new ThingTypeUID(BINDING_ID, "gateway");
+
+        // List of all Thing Type UIDs
+        public static final ThingTypeUID THING_TYPE_ZONE = new ThingTypeUID(BINDING_ID, "zone");
+        public static final ThingTypeUID THING_TYPE_APPLIANCE_VALVE = new ThingTypeUID(BINDING_ID, "appliance_valve");
+        public static final ThingTypeUID THING_TYPE_APPLIANCE_PUMP = new ThingTypeUID(BINDING_ID, "appliance_pump");
+        public static final ThingTypeUID THING_TYPE_APPLIANCE_THERMOSTAT = new ThingTypeUID(BINDING_ID, "appliance_thermostat");
+
+        // List of channel Type UIDs
+        public static final ChannelTypeUID CHANNEL_TYPE_BATTERYLEVEL = new ChannelTypeUID("system:battery-level");
+        public static final ChannelTypeUID CHANNEL_TYPE_BATTERYLEVELLOW = new ChannelTypeUID("system:low-battery");
+
+        // Empty set
+        public static final Set<ThingTypeUID> SUPPORTED_INTERFACE_TYPES_UIDS_EMPTY = Collections
+                        .unmodifiableSet(Stream.<ThingTypeUID>empty().collect(Collectors.toSet()));
+
+        // List of all Gateway configuration properties
+        public static final String GATEWAY_CONFIG_HOST = "host";
+        public static final String GATEWAY_CONFIG_USERNAME = "username";
+        public static final String GATEWAY_CONFIG_SMILEID = "smileId";
+        public static final String GATEWAY_CONFIG_REFRESH = "refresh";
+
+        // List of all Zone configuration properties
+        public static final String ZONE_CONFIG_ID = "id";
+        public static final String ZONE_CONFIG_NAME = "zoneName";
+
+        // List of all Appliance configuration properties
+        public static final String APPLIANCE_CONFIG_ID = "id";
+        public static final String APPLIANCE_CONFIG_NAME = "applianceName";
+        public static final String APPLIANCE_CONFIG_LOWBATTERY = "lowBatteryPercentage";
+
+        // List of all Channel IDs
+        public static final String ZONE_SETPOINT_CHANNEL = "setpointTemperature";
+        public static final String ZONE_TEMPERATURE_CHANNEL = "temperature";
+
+        public static final String APPLIANCE_SETPOINT_CHANNEL = "setpointTemperature";
+        public static final String APPLIANCE_TEMPERATURE_CHANNEL = "temperature";
+        public static final String APPLIANCE_BATTERYLEVEL_CHANNEL = "batteryLevel";
+        public static final String APPLIANCE_BATTERYLEVELLOW_CHANNEL = "batteryLevelLow";
+        public static final String APPLIANCE_POWER_USAGE_CHANNEL = "powerUsage";
+        public static final String APPLIANCE_POWER_CHANNEL = "power";
+        public static final String APPLIANCE_LOCK_CHANNEL = "lock";
+
+        public static final String APPLIANCE_TYPE_THERMOSTAT = "thermostat";
+        public static final String APPLIANCE_TYPE_GATEWAY = "gateway";
+        public static final String APPLIANCE_TYPE_CENTRALHEATINGPUMP = "central_heating_pump";
+        public static final String APPLIANCE_TYPE_OPENTHERMGATEWAY = "open_therm_gateway";
+        public static final String APPLIANCE_TYPE_ZONETHERMOSTAT = "zone_thermostat";
+        public static final String APPLIANCE_TYPE_HEATERCENTRAL = "heater_central";
+        public static final String APPLIANCE_TYPE_THERMOSTATICRADIATORVALUE = "thermostatic_radiator_valve";
+
+        // Supported things
+        public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+                        Stream.of(THING_TYPE_ZONE, THING_TYPE_APPLIANCE_VALVE, THING_TYPE_APPLIANCE_PUMP)
+                                        .collect(Collectors.toSet()));
+
+        // Appliance types known to binding
+        public static final Set<String> KNOWN_APPLIANCE_TYPES = Stream
+                        .of(APPLIANCE_TYPE_THERMOSTAT, APPLIANCE_TYPE_GATEWAY, APPLIANCE_TYPE_CENTRALHEATINGPUMP,
+                                        APPLIANCE_TYPE_OPENTHERMGATEWAY, APPLIANCE_TYPE_ZONETHERMOSTAT,
+                                        APPLIANCE_TYPE_HEATERCENTRAL, APPLIANCE_TYPE_THERMOSTATICRADIATORVALUE)
+                        .collect(Collectors.toSet());
+
+        public static final Set<String> SUPPORTED_APPLIANCE_TYPES = Stream
+                        .of(APPLIANCE_TYPE_CENTRALHEATINGPUMP, APPLIANCE_TYPE_THERMOSTATICRADIATORVALUE, APPLIANCE_TYPE_ZONETHERMOSTAT)
+                        .collect(Collectors.toSet());
+
+        // Supported things
+        public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = Stream.of(Stream.of(THING_TYPE_GATEWAY))
+                        .reduce(Stream::concat).orElseGet(Stream::empty).collect(Collectors.toSet());
+
+        // Getters & Setters
+
+        public static String getApiUrl(String host) {
+                return String.format(PLUGWISEHA_API_URL, host);
+        }
+
+        public static String getAppliancesUrl(String host) {
+                return String.format(PLUGWISEHA_API_APPLIANCES_URL, host);
+        }
+
+        public static String getApplianceUrl(String host, String applianceId) {
+                return String.format(PLUGWISEHA_API_APPLIANCE_URL, host, applianceId);
+        }
+
+        public static String getLocationsUrl(String host) {
+                return String.format(PLUGWISEHA_API_LOCATIONS_URL, host);
+        }
+
+        public static String getLocationUrl(String host, String locationId) {
+                return String.format(PLUGWISEHA_API_LOCATION_URL, host, locationId);
+        }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/PlugwiseHAHandlerFactory.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/PlugwiseHAHandlerFactory.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.eclipse.jetty.client.HttpClient;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientInitializationException;
+import org.openhab.binding.plugwiseha.internal.discovery.PlugwiseHADiscoveryService;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHAApplianceHandler;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHABridgeHandler;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHAZoneHandler;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link PlugwiseHAHandlerFactory} is responsible for creating things and
+ * thing handlers.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.plugwiseha")
+public class PlugwiseHAHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHAHandlerFactory.class);
+    private HttpClient httpClient;
+
+    // Constructor
+
+    public PlugwiseHAHandlerFactory() {
+        this.httpClient = new HttpClient();
+        try {
+            this.httpClient.start();
+        } catch (Exception e) {
+            throw new HttpClientInitializationException("Could not start HttpClient", e);
+        }
+    }
+
+    // Public methods
+
+    /**
+     * Returns whether the handler is able to create a thing or register a thing
+     * handler for the given type.
+     *
+     * @param thingTypeUID the thing type UID
+     * @return true, if the handler supports the thing type, false otherwise
+     */
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return (PlugwiseHABridgeHandler.supportsThingType(thingTypeUID)
+                || PlugwiseHAZoneHandler.supportsThingType(thingTypeUID))
+                || PlugwiseHAApplianceHandler.supportsThingType(thingTypeUID);
+    }
+
+    /**
+     * Creates a thing for given arguments.
+     *
+     * @param thingTypeUID  thing type uid (not null)
+     * @param configuration configuration
+     * @param thingUID      thing uid, which can be null
+     * @param bridgeUID     bridge uid, which can be null
+     * @return created thing
+     */
+    @Override
+    public @Nullable Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration,
+            @Nullable ThingUID thingUID, @Nullable ThingUID bridgeUID) {
+        if (PlugwiseHABridgeHandler.supportsThingType(thingTypeUID)) {
+            return super.createThing(thingTypeUID, configuration, thingUID, null);
+        } else if (PlugwiseHAZoneHandler.supportsThingType(thingTypeUID)) {
+            return super.createThing(thingTypeUID, configuration, thingUID, bridgeUID);
+        } else if (PlugwiseHAApplianceHandler.supportsThingType(thingTypeUID)) {
+            return super.createThing(thingTypeUID, configuration, thingUID, bridgeUID);
+        }
+
+        throw new IllegalArgumentException(
+                "The thing type " + thingTypeUID + " is not supported by the plugwiseha binding.");
+    }
+
+    // Protected and private methods
+    
+    /**
+     * Creates a {@link ThingHandler} for the given thing.
+     *
+     * @param thing the thing
+     * @return thing the created handler
+     */
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (PlugwiseHABridgeHandler.supportsThingType(thingTypeUID)) {
+            this.logger.debug("Creating new Plugwise Home Automation Bridge");
+            PlugwiseHABridgeHandler bridge = new PlugwiseHABridgeHandler((Bridge) thing, this.httpClient);
+            registerPlugwiseHADiscoveryService(bridge);
+            return bridge;
+        } else if (PlugwiseHAZoneHandler.supportsThingType(thingTypeUID)) {
+            logger.debug("Creating new Plugwise Home Automation Zone");
+            return new PlugwiseHAZoneHandler(thing);
+        } else if (PlugwiseHAApplianceHandler.supportsThingType(thingTypeUID)) {
+            logger.debug("Creating new Plugwise Home Automation Appliance");
+            return new PlugwiseHAApplianceHandler(thing);
+        }
+        return null;
+    }
+
+    private synchronized void registerPlugwiseHADiscoveryService(PlugwiseHABridgeHandler bridgeHandler) {
+        Hashtable<String, Object> properties = new Hashtable<String, Object>();
+        PlugwiseHADiscoveryService discoveryService = new PlugwiseHADiscoveryService(bridgeHandler);
+
+        ServiceRegistration<?> serviceRegistration = bundleContext.registerService(DiscoveryService.class.getName(),
+                discoveryService, properties);
+
+        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), serviceRegistration);
+
+        discoveryService.activate();
+    }
+
+    @Override
+    protected synchronized void removeHandler(ThingHandler thingHandler) {
+        if (thingHandler instanceof PlugwiseHABridgeHandler) {
+            ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.remove(thingHandler.getThing().getUID());
+            if (serviceReg != null) {
+                PlugwiseHADiscoveryService service = (PlugwiseHADiscoveryService) bundleContext
+                        .getService(serviceReg.getReference());
+
+                if (service != null) {
+                    service.deactivate();
+                }
+                serviceReg.unregister();
+                discoveryServiceRegs.remove(thingHandler.getThing().getUID());
+            }
+        }
+    }
+
+    @Reference
+    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = null;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHABadRequestException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHABadRequestException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHABadRequestException} represents a binding specific {@link Exception}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHABadRequestException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHABadRequestException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHABadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHABadRequestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHACommunicationException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHACommunicationException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHACommunicationException} represents a binding specific {@link Exception}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHACommunicationException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHACommunicationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHAException} represents a binding specific {@link Exception}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHAException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHAException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHAException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHAException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAForbiddenException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAForbiddenException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+/**
+ * The {@link PlugwiseHAForbiddenException} signals the controller denied a request due to invalid credentials.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHAForbiddenException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHAForbiddenException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHAForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHAForbiddenException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAInvalidHostException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAInvalidHostException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHAInvalidHostException} signals there was a problem with the hostname of the controller.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHAInvalidHostException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHAInvalidHostException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHAInvalidHostException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHAInvalidHostException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHANotAuthorizedException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHANotAuthorizedException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+/**
+ * The {@link PlugwiseHANotAuthorizedException} signals the controller denied a request due to invalid credentials.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHANotAuthorizedException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHANotAuthorizedException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHANotAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHANotAuthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHATimeoutException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHATimeoutException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHATimeoutException} represents a binding specific {@link Exception}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHATimeoutException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHATimeoutException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHATimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHATimeoutException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAUnauthorizedException.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/exception/PlugwiseHAUnauthorizedException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.api.exception;
+
+/**
+ * The {@link PlugwiseHAUnauthorizedException} represents a binding specific {@link Exception}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHAUnauthorizedException extends PlugwiseHAException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlugwiseHAUnauthorizedException(String message) {
+        super(message);
+    }
+
+    public PlugwiseHAUnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PlugwiseHAUnauthorizedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAController.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAController.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionality;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalityRelay;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalityThermostat;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliance;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliances;
+import org.openhab.binding.plugwiseha.internal.api.model.object.DomainObjects;
+import org.openhab.binding.plugwiseha.internal.api.model.object.GatewayInfo;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Location;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Locations;
+import org.openhab.binding.plugwiseha.internal.api.xml.PlugwiseHAXStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHAController} class provides the interface to the Plugwise
+ * Home Automation API and stores/caches the object model for use by the various
+ * ThingHandlers of this binding.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@NonNullByDefault
+public class PlugwiseHAController {
+
+    // Private member variables/constants
+
+    private final static int MAX_AGE_MINUTES_REFRESH = 10;
+    private final static int MAX_AGE_MINUTES_FULL_REFRESH = 30;
+    private final static DateTimeFormatter FORMAT = DateTimeFormatter.RFC_1123_DATE_TIME; // default Date format that
+                                                                                          // will be used in conversion
+
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHAController.class);
+
+    private final HttpClient httpClient;
+    private final PlugwiseHAXStream xStream;
+    private final Transformer domainObjectsTransformer;
+
+    private final String host;
+    private final int port;
+    private final String username;
+    private final String smileId;
+
+    private @Nullable ZonedDateTime gatewayUpdateDateTime;
+    private @Nullable ZonedDateTime gatewayFullUpdateDateTime;
+    private @Nullable DomainObjects domainObjects;
+
+    public PlugwiseHAController(HttpClient httpClient, String host, int port, String username, String smileId)
+            throws PlugwiseHAException {
+        this.httpClient = httpClient;
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.smileId = smileId;
+
+        this.xStream = new PlugwiseHAXStream();
+        this.domainObjectsTransformer = PlugwiseHAController
+                .setXSLT(new StreamSource(getClass().getClassLoader().getResourceAsStream("domain_objects.xslt")));
+    }
+
+    // Public methods
+
+    public void start(Runnable callback) throws PlugwiseHAException {
+        refresh();
+        callback.run();
+    }
+
+    public void stop() {
+    }
+
+    public void refresh() throws PlugwiseHAException {
+        synchronized (this) {
+            this.getUpdatedDomainObjects();
+        }
+    }
+
+    // Public API methods
+
+    public GatewayInfo getGatewayInfo() throws PlugwiseHAException {
+        return getGatewayInfo(false);
+    }
+
+    public GatewayInfo getGatewayInfo(Boolean forceRefresh) throws PlugwiseHAException {
+        GatewayInfo gatewayInfo = this.domainObjects.getGatewayInfo();
+
+        if (!forceRefresh && gatewayInfo != null) {
+            this.logger.debug("Found Plugwise Home Automation gateway");
+            return gatewayInfo;
+        } else {
+            PlugwiseHAControllerRequest<DomainObjects> request;
+
+            request = newRequest(DomainObjects.class, this.domainObjectsTransformer);
+
+            request.setPath("/core/domain_objects");
+            request.addPathParameter("class", "Gateway");
+
+            DomainObjects domainObjects = executeRequest(request);
+            this.gatewayUpdateDateTime = ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+
+            return mergeDomainObjects(domainObjects).getGatewayInfo();
+        }
+    }
+
+    public Appliances getAppliances() throws PlugwiseHAException {
+        return getAppliances(false);
+    }
+
+    public Appliances getAppliances(Boolean forceRefresh) throws PlugwiseHAException {
+        Appliances appliances = this.domainObjects.getAppliances();
+
+        if (!forceRefresh && appliances != null) {
+            this.logger.debug("Found {} Plugwise Home Automation appliance(s)", appliances.size());
+            return appliances;
+        } else {
+            PlugwiseHAControllerRequest<DomainObjects> request;
+
+            request = newRequest(DomainObjects.class, this.domainObjectsTransformer);
+
+            request.setPath("/core/domain_objects");
+            request.addPathParameter("class", "Appliance");
+
+            DomainObjects domainObjects = executeRequest(request);
+            this.gatewayUpdateDateTime = ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+
+            return mergeDomainObjects(domainObjects).getAppliances();
+        }
+    }
+
+    public Appliance getAppliance(String id) {
+        return this.domainObjects.getAppliances().get(id);
+    }
+
+    public Locations getLocations() throws PlugwiseHAException {
+        return getLocations(false);
+    }
+
+    public Locations getLocations(Boolean forceRefresh) throws PlugwiseHAException {
+        Locations locations = this.domainObjects.getLocations();
+
+        if (!forceRefresh && locations != null) {
+            this.logger.debug("Found {} Plugwise Home Automation location(s)", locations.size());
+            return locations;
+        } else {
+            PlugwiseHAControllerRequest<DomainObjects> request;
+
+            request = newRequest(DomainObjects.class, this.domainObjectsTransformer);
+
+            request.setPath("/core/domain_objects");
+            request.addPathParameter("class", "Location");
+
+            DomainObjects domainObjects = executeRequest(request);
+            this.gatewayUpdateDateTime = ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+
+            return mergeDomainObjects(domainObjects).getLocations();
+        }
+    }
+
+    public Location getLocation(String id) {
+        return this.domainObjects.getLocations().get(id);
+    }
+
+    public @Nullable DomainObjects getDomainObjects() throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<DomainObjects> request;
+
+        request = newRequest(DomainObjects.class, this.domainObjectsTransformer);
+
+        request.setPath("/core/domain_objects");
+        request.addPathParameter("@locale", "en-US");
+
+        DomainObjects domainObjects = executeRequest(request);
+        this.gatewayUpdateDateTime = ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+        this.gatewayFullUpdateDateTime = this.gatewayUpdateDateTime;
+
+        return mergeDomainObjects(domainObjects);
+    }
+
+    public @Nullable DomainObjects getUpdatedDomainObjects() throws PlugwiseHAException {
+        if (this.gatewayUpdateDateTime == null || this.gatewayFullUpdateDateTime == null
+                || this.gatewayUpdateDateTime.isBefore(ZonedDateTime.now().minusMinutes(MAX_AGE_MINUTES_REFRESH))
+                || this.gatewayFullUpdateDateTime
+                        .isBefore(ZonedDateTime.now().minusMinutes(MAX_AGE_MINUTES_FULL_REFRESH))) {
+            return getDomainObjects();
+        } else {
+            return getUpdatedDomainObjects(this.gatewayUpdateDateTime);
+        }
+    }
+
+    public @Nullable DomainObjects getUpdatedDomainObjects(@Nullable ZonedDateTime since) throws PlugwiseHAException {
+        return getUpdatedDomainObjects(since.toEpochSecond());
+    }
+
+    public @Nullable DomainObjects getUpdatedDomainObjects(Long since) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<DomainObjects> request;
+
+        request = newRequest(DomainObjects.class, this.domainObjectsTransformer);
+
+        request.setPath("/core/domain_objects");
+        request.addPathFilter("modified_date", "ge", since);
+        request.addPathFilter("deleted_date", "ge", "0");
+        request.addPathParameter("@memberModifiedDate", since);
+        request.addPathParameter("@locale", "en-US");
+
+        DomainObjects domainObjects = executeRequest(request);
+        this.gatewayUpdateDateTime = ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+
+        return mergeDomainObjects(domainObjects);
+    }
+
+    public void setLocationThermostat(Location location, Double temperature) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+        Optional<ActuatorFunctionality> thermostat = location.getActuatorFunctionalities().getFunctionalityThermostat();
+
+        if (thermostat.isPresent()) {
+            request.setPath("/core/locations");
+
+            request.addPathParameter("id", String.format("%s/thermostat", location.getId()));
+            request.addPathParameter("id", String.format("%s", thermostat.get().getId()));
+            request.setBodyParameter(new ActuatorFunctionalityThermostat(temperature));
+
+            executeRequest(request);
+        }
+    }
+
+    public void setThermostat(Appliance appliance, Double temperature) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+        Optional<ActuatorFunctionality> thermostat = appliance.getActuatorFunctionalities()
+                .getFunctionalityThermostat();
+
+        if (thermostat.isPresent()) {
+            request.setPath("/core/appliances");
+
+            request.addPathParameter("id", String.format("%s/thermostat", appliance.getId()));
+            request.addPathParameter("id", String.format("%s", thermostat.get().getId()));
+            request.setBodyParameter(new ActuatorFunctionalityThermostat(temperature));
+
+            executeRequest(request);
+        }
+    }
+
+    public void switchRelay(Appliance appliance, String state) throws PlugwiseHAException {
+        List<String> allowStates = Arrays.asList("on", "off");
+        if (allowStates.contains(state.toLowerCase())) {
+            if (state.toLowerCase().equals("on")) {
+                switchRelayOn(appliance);
+            } else {
+                switchRelayOff(appliance);
+            }
+        }
+    }
+
+    public void switchRelayOn(Appliance appliance) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+        // Boolean relayLockState = appliance.getRelayLockState().orElse(null);
+
+        request.setPath("/core/appliances");
+        request.addPathParameter("id", String.format("%s/relay", appliance.getId()));
+        request.setBodyParameter(new ActuatorFunctionalityRelay("on"));
+        // request.setBodyParameter(new ActuatorFunctionalityRelay("on", relayLockState));
+
+        executeRequest(request);
+    }
+
+    public void switchRelayOff(Appliance appliance) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+        // Boolean relayLockState = appliance.getRelayLockState().orElse(null);
+
+        request.setPath("/core/appliances");
+        request.addPathParameter("id", String.format("%s/relay", appliance.getId()));
+        request.setBodyParameter(new ActuatorFunctionalityRelay("off"));
+        // request.setBodyParameter(new ActuatorFunctionalityRelay("off", relayLockState));
+
+        executeRequest(request);
+    }
+
+    public void switchRelayLock(Appliance appliance, String state) throws PlugwiseHAException {
+        List<String> allowStates = Arrays.asList("on", "off");
+        if (allowStates.contains(state.toLowerCase())) {
+            if (state.toLowerCase().equals("on")) {
+                switchRelayLockOn(appliance);
+            } else {
+                switchRelayLockOff(appliance);
+            }
+        }
+    }
+
+    public void switchRelayLockOff(Appliance appliance) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+
+        request.setPath("/core/appliances");
+        request.addPathParameter("id", String.format("%s/relay", appliance.getId()));
+        request.setBodyParameter(new ActuatorFunctionalityRelay(null, false));
+
+        executeRequest(request);
+    }
+
+    public void switchRelayLockOn(Appliance appliance) throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request = newRequest(Void.class);
+
+        request.setPath("/core/appliances");
+        request.addPathParameter("id", String.format("%s/relay", appliance.getId()));
+        request.setBodyParameter(new ActuatorFunctionalityRelay(null, true));
+
+        executeRequest(request);
+    }
+
+    public ZonedDateTime ping() throws PlugwiseHAException {
+        PlugwiseHAControllerRequest<Void> request;
+
+        request = newRequest(Void.class, null);
+
+        request.setPath("/cache/gateways");
+        request.addPathParameter("ping");
+
+        executeRequest(request);
+
+        return ZonedDateTime.parse(request.getServerDateTime(), PlugwiseHAController.FORMAT);
+    }
+
+    // Protected and private methods
+
+    private static Transformer setXSLT(StreamSource xsltSource) throws PlugwiseHAException {
+        try {
+            return TransformerFactory.newInstance().newTransformer(xsltSource);
+        } catch (TransformerConfigurationException e) {
+            throw new PlugwiseHAException("Could not create XML transformer", e);
+        }
+    }
+
+    private <T> PlugwiseHAControllerRequest<T> newRequest(Class<T> responseType, @Nullable Transformer transformer) {
+        return new PlugwiseHAControllerRequest<T>(responseType, this.xStream, transformer, this.httpClient, this.host,
+                this.port, this.username, this.smileId);
+    }
+
+    private <T> PlugwiseHAControllerRequest<T> newRequest(Class<T> responseType) {
+        return new PlugwiseHAControllerRequest<T>(responseType, this.xStream, null, this.httpClient, this.host,
+                this.port, this.username, this.smileId);
+    }
+
+    private <T> T executeRequest(PlugwiseHAControllerRequest<T> request) throws PlugwiseHAException {
+        T result;
+        result = request.execute();
+        return result;
+    }
+
+    private @Nullable DomainObjects mergeDomainObjects(@Nullable DomainObjects domainObjects) {
+        if (this.domainObjects != null) {
+            Appliances appliances = domainObjects.getAppliances();
+            Locations locations = domainObjects.getLocations();
+
+            if (appliances != null) {
+                this.domainObjects.mergeAppliances(appliances);
+            }
+
+            if (locations != null) {
+                this.domainObjects.mergeLocations(locations);
+            }
+        } else {
+            this.domainObjects = domainObjects;
+        }
+
+        return this.domainObjects;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAControllerRequest.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAControllerRequest.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import com.thoughtworks.xstream.XStream;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.client.api.ContentProvider;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.util.B64Code;
+import org.eclipse.jetty.util.StringUtil;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHABadRequestException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHACommunicationException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAForbiddenException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAInvalidHostException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHANotAuthorizedException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHATimeoutException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAUnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHAControllerRequest} class is a utility class to create
+ * API requests to the Plugwise Home Automation controller and to deserialize
+ * incoming XML into the appropriate model objects to be used by the {@link
+ * PlugwiseHAController}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@NonNullByDefault
+public class PlugwiseHAControllerRequest<T> {
+
+    private static final String CONTENT_TYPE_TEXT_XML = MimeTypes.Type.TEXT_XML_8859_1.toString();
+    private static final long TIMEOUT_SECONDS = 5;
+
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHAControllerRequest.class);
+    private final XStream xStream;
+    private final HttpClient httpClient;
+    private final String host;
+    private final int port;
+    private final Class<T> resultType;
+    private final @Nullable Transformer transformer;
+
+    private Map<String, String> headers = new HashMap<>();
+    private Map<String, String> queryParameters = new HashMap<>();
+    private @Nullable Object bodyParameter;
+    private @Nullable String serverDateTime;
+    private String path = "/";
+
+    // Constructor
+
+    <X extends XStream> PlugwiseHAControllerRequest(Class<T> resultType, X xStream, @Nullable Transformer transformer,
+            HttpClient httpClient, String host, int port, String username, String password) {
+        this.resultType = resultType;
+        this.xStream = xStream;
+        this.transformer = transformer;
+        this.httpClient = httpClient;
+        this.host = host;
+        this.port = port;
+
+        setHeader(HttpHeader.ACCEPT.toString(), CONTENT_TYPE_TEXT_XML);
+
+        // Create Basic Auth header if username and password are supplied
+        if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+            setHeader(HttpHeader.AUTHORIZATION.toString(),
+                    "Basic " + B64Code.encode(String.format("%s:%s", username, password), StringUtil.__ISO_8859_1));
+        }
+    }
+
+    // Public methods
+
+    public void setPath(String path) {
+        this.setPath(path, (HashMap<String, String>) null);
+    }
+
+    public void setPath(String path,  @Nullable HashMap<String, String> pathParameters) {
+        this.path = path;
+
+        if (pathParameters != null) {
+            this.path += pathParameters.entrySet().stream().map(Object::toString).collect(Collectors.joining(";"));
+        }
+    }
+
+    public void setHeader(String key, Object value) {
+        this.headers.put(key, String.valueOf(value));
+    }
+
+    public void addPathParameter(String key) {
+        this.path += String.format(";%s", key);
+    }
+
+    public void addPathParameter(String key, Object value) {
+        this.path += String.format(";%s=%s", key, value);
+    }
+
+    public void addPathFilter(String key, String operator, Object value) {
+        this.path += String.format(";%s:%s:%s", key, operator, value);
+    }
+
+    public void setQueryParameter(String key, Object value) {
+        this.queryParameters.put(key, String.valueOf(value));
+    }
+
+    public void setBodyParameter(Object body) {
+        this.bodyParameter = body;
+    }
+
+    public @Nullable String getServerDateTime() {
+        return this.serverDateTime;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T execute() throws PlugwiseHAException {
+        T result = null;
+        String xml = getContent();
+
+        if (String.class.equals(resultType)) {
+            if (this.transformer != null) {
+                result = (T) this.transformXML(xml);
+            } else {
+                result = (T) xml;
+            }
+        } else if (!Void.class.equals(resultType)) {
+            if (this.transformer != null) {
+                result = (T) this.xStream.fromXML(this.transformXML(xml));
+            } else {
+                result = (T) this.xStream.fromXML(xml);
+            }
+        }
+        return result;
+    }
+
+    // Protected and private methods
+
+    private String transformXML(String xml) throws PlugwiseHAException {
+        StringReader input = new StringReader(xml);
+        StringWriter output = new StringWriter();
+
+        try {
+            this.transformer.transform(new StreamSource(input), new StreamResult(output));
+        } catch (TransformerException e) {
+            throw new PlugwiseHAException("Could not apply XML stylesheet", e);
+        }
+
+        return output.toString();
+    }
+
+    private String getContent() throws PlugwiseHAException {
+        String content;
+        ContentResponse response;
+
+        try {
+            response = getContentResponse();
+        } catch (PlugwiseHATimeoutException e) {
+            // Retry
+            response = getContentResponse();
+        }
+        
+        int status = response.getStatus();
+        switch (status) {
+        case HttpStatus.OK_200:
+        case HttpStatus.ACCEPTED_202:
+            content = response.getContentAsString();
+            if (logger.isTraceEnabled()) {
+                logger.trace("<< {} {} \n{}", status, HttpStatus.getMessage(status), content);
+            }
+            break;
+        case HttpStatus.BAD_REQUEST_400:
+            throw new PlugwiseHABadRequestException("Bad request");
+        case HttpStatus.UNAUTHORIZED_401:
+            throw new PlugwiseHAUnauthorizedException("Unauthorized");
+        case HttpStatus.FORBIDDEN_403:
+            throw new PlugwiseHAForbiddenException("Forbidden");
+        default:
+            throw new PlugwiseHAException("Unknown HTTP status code " + status + " returned by the controller");
+        }
+
+        this.serverDateTime = response.getHeaders().get("Date");
+
+        return content;
+    }
+
+    private ContentResponse getContentResponse() throws PlugwiseHAException {
+        Request request = newRequest();
+        ContentResponse response;
+
+        if (logger.isTraceEnabled()) {
+            logger.trace(">> {} {}", request.getMethod(), request.getURI());
+        }
+
+        try {
+            response = request.send();
+        } catch (TimeoutException | InterruptedException e) {
+            throw new PlugwiseHATimeoutException(e);
+        } catch (ExecutionException e) {
+            // Unwrap the cause and try to cleanly handle it
+            Throwable cause = e.getCause();
+            if (cause instanceof UnknownHostException) {
+                // Invalid hostname
+                throw new PlugwiseHAException(cause);
+            } else if (cause instanceof ConnectException) {
+                // Cannot connect
+                throw new PlugwiseHAException(cause);
+            } else {
+                // Catch all
+                throw new PlugwiseHAException(cause);
+            }
+        }
+        return response;
+    }
+
+    private Request newRequest() {
+        HttpMethod method = bodyParameter == null ? HttpMethod.GET : HttpMethod.PUT;
+        HttpURI uri = new HttpURI(HttpScheme.HTTP.asString(), this.host, this.port, this.path);
+        Request request = httpClient.newRequest(uri.toString()).timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .method(method);
+
+        for (Entry<String, String> entry : this.headers.entrySet()) {
+            request.header(entry.getKey(), entry.getValue());
+        }
+
+        for (Entry<String, String> entry : this.queryParameters.entrySet()) {
+            request.param(entry.getKey(), entry.getValue());
+        }
+
+        if (this.bodyParameter != null) {
+            String xmlBody = getRequestBodyAsXml();
+            ContentProvider content = new StringContentProvider(CONTENT_TYPE_TEXT_XML, xmlBody, StandardCharsets.UTF_8);
+            request = request.content(content);
+        }
+        return request;
+    }
+
+    private String getRequestBodyAsXml() {
+        return this.xStream.toXML(this.bodyParameter);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAModel.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/PlugwiseHAModel.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model;
+
+/**
+ * The {@link PlugwiseHAModel} interface describes common
+ * methods that need to be implemented by any object model class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public interface PlugwiseHAModel {
+
+    public abstract boolean isBatteryOperated();
+    
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/converter/DateTimeConverter.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/converter/DateTimeConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.converter;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.apache.commons.lang.StringUtils;
+import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
+
+/**
+ * The {@link DateTimeConverter} provides a SingleValueConverter for use by XStream when converting
+ * XML documents with a zoned date/time field.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class DateTimeConverter extends AbstractSingleValueConverter {
+
+    private final static DateTimeFormatter FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME; // default Date format that will be used in conversion
+    
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean canConvert(Class type) {
+        return ZonedDateTime.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public ZonedDateTime fromString(String dateTimeString) {
+        if (StringUtils.isBlank(dateTimeString)) {
+            return null;
+        }
+
+        try {            
+            ZonedDateTime dateTime = ZonedDateTime.parse(dateTimeString, DateTimeConverter.FORMAT);
+            return dateTime;
+        } catch (DateTimeParseException e) {
+            throw new RuntimeException("Invalid datetime format in " + dateTimeString);
+        }
+    }
+
+    public String toString(ZonedDateTime dateTime) {
+        return dateTime.format(DateTimeConverter.FORMAT);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalities.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalities.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The {@link ActuatorFunctionalities} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation controller
+ * for the collection of actuator functionalities. (e.g. 'offset', 'relay', et
+ * cetera). It extends the {@link CustomCollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class ActuatorFunctionalities extends PlugwiseHACollection<ActuatorFunctionality> {
+
+    private final String THERMOSTAT_FUNCTIONALITY = "thermostat";
+    private final String RELAY_FUNCTIONALITY = "relay";
+
+    public Optional<Boolean> getRelayLockState() {
+        return Optional.ofNullable(this.getFunctionalityRelay().map(functionalityEntry -> {
+            String state = functionalityEntry.getRelayLockState().orElse(null);
+            return state != null ? Boolean.parseBoolean(state) : null;
+        }).orElse(null));
+    }
+
+    public Optional<ActuatorFunctionality> getFunctionalityThermostat() {
+        return Optional.ofNullable(this.get(THERMOSTAT_FUNCTIONALITY));
+    }
+
+    public Optional<ActuatorFunctionality> getFunctionalityRelay() {
+        return Optional.ofNullable(this.get(RELAY_FUNCTIONALITY));
+    }
+
+    @Override
+    public void merge(Map<String, ActuatorFunctionality> actuatorFunctionalities) {
+        if (actuatorFunctionalities != null) {
+            for (ActuatorFunctionality actuatorFunctionality : actuatorFunctionalities.values()) {
+                String type = actuatorFunctionality.getType();
+                ActuatorFunctionality originalActuatorFunctionality = this.get(type);
+
+                if (originalActuatorFunctionality == null
+                        || originalActuatorFunctionality.isOlderThan(actuatorFunctionality)) {
+                    this.put(type, actuatorFunctionality);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionality.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionality.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * The {@link ActuatorFunctionality} class is an object model class
+ * that mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for the any actuator functionality. It implements the
+ * {@link PlugwiseComparableDate} interface and extends the abstract class {@link PlugwiseBaseModel}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("actuator_functionality")
+public class ActuatorFunctionality extends PlugwiseBaseModel implements PlugwiseComparableDate<ActuatorFunctionality> {
+
+    private String type;
+    private String setpoint;
+    private String resolution;
+    private String lock;
+
+    @XStreamAlias("lower_bound")
+    private String lowerBound;
+
+    @XStreamAlias("upper_bound")
+    private String upperBound;
+
+    @XStreamAlias("updated_date")
+    private ZonedDateTime updatedDate;
+
+    public String getType() {
+        return type;
+    }
+
+    public String getSetpoint() {
+        return setpoint;
+    }
+
+    public String getResolution() {
+        return resolution;
+    }
+
+    public String getLowerBound() {
+        return lowerBound;
+    }
+
+    public String getUpperBound() {
+        return upperBound;
+    }
+
+    public ZonedDateTime getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public Optional<String> getRelayLockState() {
+        return Optional.ofNullable(lock);
+    }
+
+    @Override
+    public int compareDateWith(ActuatorFunctionality hasUpdatedDate) {
+        return this.getUpdatedDate().compareTo(hasUpdatedDate.getUpdatedDate());
+    }
+
+    @Override
+    public boolean isOlderThan(ActuatorFunctionality hasUpdatedDate) {
+        return this.compareDateWith(hasUpdatedDate) < 0;
+    }
+
+    public boolean isNewerThan(ActuatorFunctionality hasUpdatedDate) {
+        return this.compareDateWith(hasUpdatedDate) > 0;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalityRelay.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalityRelay.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("relay_functionality")
+public class ActuatorFunctionalityRelay extends ActuatorFunctionality {
+
+    private String state;
+    private Boolean lock;
+
+    public ActuatorFunctionalityRelay(String state) {
+        this.state = state;
+    }
+
+    public ActuatorFunctionalityRelay(String state, Boolean lock) {
+        this.state = state;
+        this.lock = lock;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalityThermostat.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ActuatorFunctionalityThermostat.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("thermostat_functionality")
+public class ActuatorFunctionalityThermostat extends ActuatorFunctionality {
+
+    private Double setpoint;
+
+    public ActuatorFunctionalityThermostat(Double temperature) {
+        this.setpoint = temperature;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Appliance.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Appliance.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Optional;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * The {@link Appliance} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for a Plugwise appliance.
+ * It implements the {@link PlugwiseComparableDate} interface and 
+ * extends the abstract class {@link PlugwiseBaseModel}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("appliance")
+public class Appliance extends PlugwiseBaseModel implements PlugwiseComparableDate<Appliance> {
+
+    private String name;
+    private String description;
+    private String type;
+    private String location;
+
+    @XStreamAlias("zig_bee_node")
+    private ZigBeeNode zigbeeNode;
+
+    @XStreamImplicit(itemFieldName = "point_log", keyFieldName = "type")
+    private Logs pointLogs;
+
+    @XStreamImplicit(itemFieldName = "actuator_functionality", keyFieldName = "type")
+    private ActuatorFunctionalities actuatorFunctionalities;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public ZigBeeNode getZigbeeNode() {
+        if (zigbeeNode == null) {
+            zigbeeNode = new ZigBeeNode();
+        }
+        return zigbeeNode;
+    }
+
+    public Logs getPointLogs() {
+        if (pointLogs == null) {
+            pointLogs = new Logs();
+        }
+        return pointLogs;
+    }
+
+    public ActuatorFunctionalities getActuatorFunctionalities() {
+        if (actuatorFunctionalities == null) {
+            actuatorFunctionalities = new ActuatorFunctionalities();
+        }
+        return actuatorFunctionalities;
+    }
+
+    public Optional<Double> getTemperature() {
+        return this.pointLogs.getTemperature();
+    }
+
+    public Optional<Double> getSetpointTemperature() {
+        return this.pointLogs.getThermostatTemperature();
+    }
+
+    public Optional<String> getRelayState() {
+        return this.pointLogs.getRelayState();
+    }
+
+    public Optional<Boolean> getRelayLockState() {
+        return this.actuatorFunctionalities.getRelayLockState();
+    }
+
+    public Optional<Double> getBatteryLevel() {
+        return this.pointLogs.getBatteryLevel();
+    }
+
+    public Optional<Double> getPowerUsage() {
+        return this.pointLogs.getPowerUsage();
+    }
+
+    public boolean isBatteryOperated() {
+        if (this.zigbeeNode instanceof ZigBeeNode) {
+            return this.zigbeeNode.getPowerSource().equals("battery") && this.getBatteryLevel().isPresent();
+        } else {
+            return false;
+        }        
+    }
+
+    @Override
+    public int compareDateWith(Appliance hasModifiedDate) {
+        return this.getModifiedDate().compareTo(hasModifiedDate.getModifiedDate());
+    }
+
+    @Override
+    public boolean isNewerThan(Appliance hasModifiedDate) {
+        return compareDateWith(hasModifiedDate) > 0;
+    }
+
+    @Override
+    public boolean isOlderThan(Appliance hasModifiedDate) {
+        return compareDateWith(hasModifiedDate) < 0;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Appliances.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Appliances.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+
+/**
+ * The {@link Appliances} class is an object model class that mirrors the XML
+ * structure provided by the Plugwise Home Automation controller for the
+ * collection of appliances. It extends the {@link PlugwiseHACollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class Appliances extends PlugwiseHACollection<Appliance> {
+
+    @Override
+    public void merge(Map<String, Appliance> appliances) {
+        if (appliances != null) {
+            for (Appliance updatedAppliance : appliances.values()) {
+                String id = updatedAppliance.getId();
+                Appliance originalAppliance = this.get(id);
+
+                if (originalAppliance != null && originalAppliance.isOlderThan(updatedAppliance)) {
+                    Logs updatedPointLogs = updatedAppliance.getPointLogs();
+                    ActuatorFunctionalities updatedActuatorFunctionalities = updatedAppliance
+                            .getActuatorFunctionalities();
+                    
+                    updatedPointLogs.merge(originalAppliance.getPointLogs());
+                    updatedActuatorFunctionalities.merge(originalAppliance.getActuatorFunctionalities());
+
+                    this.put(id, updatedAppliance);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/DomainObjects.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/DomainObjects.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("domain_objects")
+public class DomainObjects {
+
+    @XStreamAlias("gateway")
+    private GatewayInfo gatewayInfo;
+
+    @XStreamImplicit(itemFieldName = "appliance", keyFieldName = "id")
+    private Appliances appliances = new Appliances();
+
+    @XStreamImplicit(itemFieldName = "location", keyFieldName = "id")
+    private Locations locations = new Locations();
+
+    @XStreamImplicit(itemFieldName = "module", keyFieldName = "id")
+    private Modules modules = new Modules();
+
+    public GatewayInfo getGatewayInfo() {
+        return gatewayInfo;
+    }
+
+    public Appliances getAppliances() {
+        return appliances;
+    }
+
+    public Locations getLocations() {
+        return locations;
+    }
+
+    public Appliances mergeAppliances(Appliances appliances) {
+        if (appliances != null) {
+            this.appliances.merge(appliances);
+        }
+
+        return this.appliances;
+    }
+
+    public Locations mergeLocations(Locations locations) {
+        if (locations != null) {
+            this.locations.merge(locations);
+        }
+
+        return this.locations;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/GatewayEnvironment.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/GatewayEnvironment.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("gateway_environment")
+public class GatewayEnvironment extends PlugwiseBaseModel {
+    private String city;
+    private String country;
+    private String currency;
+    private String latitude;
+    private String longitude;
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/GatewayInfo.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/GatewayInfo.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.time.ZonedDateTime;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("gateway")
+public class GatewayInfo extends PlugwiseBaseModel {
+
+    private String name;
+    private String description;
+    private String hostname;
+    private String timezone;
+    private ZonedDateTime time;
+
+    @XStreamAlias("gateway_environment")
+    private GatewayEnvironment gatewayEnvironment;
+
+    @XStreamAlias("vendor_name")
+    private String vendorName;
+
+    @XStreamAlias("vendor_model")
+    private String vendorModel;
+
+    @XStreamAlias("hardware_version")
+    private String hardwareVersion;
+
+    @XStreamAlias("firmware_version")
+    private String firmwareVersion;
+
+    @XStreamAlias("mac_address")
+    private String macAddress;
+
+    @XStreamAlias("lan_ip")
+    private String lanIp;
+
+    @XStreamAlias("wifi_ip")
+    private String wifiIp;
+
+    @XStreamAlias("last_reset_date")
+    private ZonedDateTime lastResetDate;
+
+    @XStreamAlias("last_boot_date")
+    private ZonedDateTime lastBootDate;
+
+    public ZonedDateTime getTime() {
+        return time;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public GatewayEnvironment getGatewayEnvironment() {
+        return gatewayEnvironment;
+    }
+
+    public String getVendorName() {
+        return vendorName;
+    }
+
+    public String getVendorModel() {
+        return vendorModel;
+    }
+
+    public String getHardwareVersion() {
+        return hardwareVersion;
+    }
+
+    public String getFirmwareVersion() {
+        return firmwareVersion;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public String getLanIp() {
+        return lanIp;
+    }
+
+    public String getWifiIp() {
+        return wifiIp;
+    }
+
+    public ZonedDateTime getLastResetDate() {
+        return lastResetDate;
+    }
+
+    public ZonedDateTime getLastBootDate() {
+        return lastBootDate;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Location.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Location.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * The {@link Location} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for a Plugwise zone/location.
+ * It implements the {@link PlugwiseComparableDate} interface and 
+ * extends the abstract class {@link PlugwiseBaseModel}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("location")
+public class Location extends PlugwiseBaseModel implements PlugwiseComparableDate<Location> {
+
+    private String name;
+    private String description;
+    private String type;
+    private String preset;
+
+    @XStreamImplicit(itemFieldName = "appliance")
+    private List<String> locationAppliances = new ArrayList<String>();
+
+    @XStreamImplicit(itemFieldName = "point_log", keyFieldName = "type")
+    private Logs pointLogs;
+
+    @XStreamImplicit(itemFieldName = "actuator_functionality", keyFieldName = "type")
+    private ActuatorFunctionalities actuatorFunctionalities;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getPreset() {
+        return preset;
+    }
+
+    public List<String> getLocationAppliances() {
+        return locationAppliances;
+    }
+
+    public Logs getPointLogs() {
+        if (pointLogs == null) {
+            pointLogs = new Logs();
+        }
+        return pointLogs;
+    }
+
+    public ActuatorFunctionalities getActuatorFunctionalities() {
+        if (actuatorFunctionalities == null) {
+            actuatorFunctionalities = new ActuatorFunctionalities();
+        }
+        return actuatorFunctionalities;
+    }
+
+    public Optional<Double> getTemperature() {
+        return this.pointLogs.getTemperature();
+    }
+
+    public Optional<Double> getSetpointTemperature() {
+        return this.pointLogs.getThermostatTemperature();
+    }
+
+    public int applianceCount() {
+        if (this.locationAppliances == null) {
+            return 0;
+        } else {
+            return this.locationAppliances.size();
+        }
+    }
+
+    public int compareDateWith(Location hasModifiedDate) {
+        return this.getModifiedDate().compareTo(hasModifiedDate.getModifiedDate());
+    }
+
+    public boolean isOlderThan(Location hasModifiedDate) {
+        return compareDateWith(hasModifiedDate) < 0;
+    }
+
+    public boolean isNewerThan(Location hasModifiedDate) {
+        return this.compareDateWith(hasModifiedDate) > 0;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Locations.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Locations.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+
+/**
+ * The {@link Locations} class is an object model class that mirrors the XML
+ * structure provided by the Plugwise Home Automation controller for the
+ * collection of Plugwise locations/zones. It extends the
+ * {@link PlugwiseHACollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class Locations extends PlugwiseHACollection<Location> {
+
+    @Override
+    public void merge(Map<String, Location> locations) {
+        if (locations != null) {
+            for (Location updatedLocation : locations.values()) {
+                String id = updatedLocation.getId();
+                Location originalLocation = this.get(id);
+
+                try {
+                    if (originalLocation != null && originalLocation.isOlderThan(updatedLocation)) {
+                        Logs updatedPointLogs = updatedLocation.getPointLogs();
+                        ActuatorFunctionalities updatedActuatorFunctionalities = updatedLocation
+                                .getActuatorFunctionalities();
+
+                        updatedPointLogs.merge(originalLocation.getPointLogs());
+                        updatedActuatorFunctionalities.merge(originalLocation.getActuatorFunctionalities());
+
+                        this.put(id, updatedLocation);
+                    }
+                } catch (NullPointerException e) {
+                    e.toString();
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Log.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Log.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("point_log")
+public class Log extends PlugwiseBaseModel implements PlugwiseComparableDate<Log> {
+
+    private String type;
+
+    private String unit;
+
+    private String measurement;
+
+    @XStreamAlias("measurement_date")
+    private ZonedDateTime measurementDate;
+
+    @XStreamAlias("updated_date")
+    private ZonedDateTime updatedDate;
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public Optional<String> getMeasurement() {
+        return Optional.ofNullable(measurement);
+    }
+
+    public Optional<Double> getMeasurementAsDouble() {
+        try {
+            if (measurement != null) {
+                return Optional.of(Double.parseDouble(measurement));
+            } else {
+                return Optional.empty();
+            }
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    public ZonedDateTime getMeasurementDate() {
+        return measurementDate;
+    }
+
+    public ZonedDateTime getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public int compareDateWith(Log hasMeasurementDate) {
+        return this.measurementDate.compareTo(hasMeasurementDate.getMeasurementDate());
+    }
+
+    public boolean isOlderThan(Log hasMeasurementDate) {
+        return this.compareDateWith(hasMeasurementDate) < 0;
+    }
+
+    public boolean isNewerThan(Log hasMeasurementDate) {
+        return this.compareDateWith(hasMeasurementDate) > 0;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Logs.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Logs.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The {@link Logs} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for the collection of logs.
+ * It extends the {@link PlugwiseHACollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class Logs extends PlugwiseHACollection<Log> {
+
+    private final String THERMOSTAT = "thermostat";
+    private final String TEMPERATURE = "temperature";
+    private final String BATTERY = "battery";
+    private final String POWER_USAGE = "electricity_consumed";
+    private final String RELAY = "relay";
+
+    public Optional<Double> getTemperature() {
+        return this.getLogTemperature().map(logEntry -> logEntry.getMeasurementAsDouble()).orElse(Optional.empty());
+    }
+
+    public Optional<Double> getThermostatTemperature() {
+        return this.getLogThermostat().map(logEntry -> logEntry.getMeasurementAsDouble()).orElse(Optional.empty());
+    }
+
+    public Optional<String> getRelayState() {
+        return this.getLogRelay().map(logEntry -> logEntry.getMeasurement()).orElse(Optional.empty());
+    }
+
+    public Optional<Double> getBatteryLevel() {
+        return this.getLogBattery().map(logEntry -> logEntry.getMeasurementAsDouble()).orElse(Optional.empty());
+    }
+
+    public Optional<Double> getPowerUsage() {
+        return this.getLogPowerUsage().map(logEntry -> logEntry.getMeasurementAsDouble()).orElse(Optional.empty());
+    }
+
+    public Optional<Log> getLogThermostat() {
+        return Optional.ofNullable(this.get(THERMOSTAT));
+    }
+
+    public Optional<Log> getLogTemperature() {
+        return Optional.ofNullable(this.get(TEMPERATURE));
+    }
+
+    public Optional<Log> getLogRelay() {
+        return Optional.ofNullable(this.get(RELAY));
+    }
+
+    public Optional<Log> getLogBattery() {
+        return Optional.ofNullable(this.get(BATTERY));
+    }
+
+    public Optional<Log> getLogPowerUsage() {
+        return Optional.ofNullable(this.get(POWER_USAGE));
+    }
+
+    @Override
+    public void merge(Map<String, Log> logs) {
+        if (logs != null) {
+            for (Log log : logs.values()) {
+                String type = log.getType();
+                Log updatedLog = this.get(type);
+
+                try {
+                    if (updatedLog == null || updatedLog.isOlderThan(log)) {
+                        this.put(type, log);
+                    }   
+                } catch (NullPointerException e) {
+                    e.toString();
+                }          
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Module.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Module.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * The {@link Module} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for a Plugwise module.
+ * It implements the {@link PlugwiseComparableDate} interface and 
+ * extends the abstract class {@link PlugwiseBaseModel}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("module")
+public class Module extends PlugwiseBaseModel implements PlugwiseComparableDate<Module> {
+
+    @XStreamImplicit(itemFieldName = "service", keyFieldName = "id")
+    private Services services;
+
+    @XStreamAlias("vendor_name")
+    private String vendorName;
+
+    @XStreamAlias("vendor_model")
+    private String vendorModel;
+
+    @XStreamAlias("hardware_version")
+    private String hardwareVersion;
+
+    @XStreamAlias("firmware_version")
+    private String firmwareVersion;
+
+    public String getVendorName() {
+        return vendorName;
+    }
+
+    public String getVendorModel() {
+        return vendorModel;
+    }
+
+    public String getHardwareVersion() {
+        return hardwareVersion;
+    }
+
+    public String getFirmwareVersion() {
+        return firmwareVersion;
+    }
+
+    @Override
+    public int compareDateWith(Module hasModifiedDate) {
+        return this.getModifiedDate().compareTo(hasModifiedDate.getModifiedDate());
+    }
+
+    @Override
+    public boolean isNewerThan(Module hasModifiedDate) {
+        return compareDateWith(hasModifiedDate) > 0;
+    }
+
+    @Override
+    public boolean isOlderThan(Module hasModifiedDate) {
+        return compareDateWith(hasModifiedDate) < 0;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Modules.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Modules.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+
+/**
+ * The {@link Modules} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for the collection of modules.
+ * It extends the {@link PlugwiseHACollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class Modules extends PlugwiseHACollection<Module> {
+    
+    @Override
+    public void merge(Map<String, Module> modules) {
+
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseBaseModel.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseBaseModel.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.time.ZonedDateTime;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * The {@link PlugwiseBaseModel} abstract class contains
+ * methods and properties that similar for all object model classes.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public abstract class PlugwiseBaseModel {
+
+    private String id;
+    
+    @XStreamAlias("created_date")
+    private ZonedDateTime createdDate;
+
+    @XStreamAlias("modified_date")
+    private ZonedDateTime modifiedDate;
+
+    @XStreamAlias("updated_date")
+    private ZonedDateTime updateDate;
+
+    @XStreamAlias("deleted_date")
+    private ZonedDateTime deletedDate;
+
+    public String getId() {
+        return id;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public ZonedDateTime getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public ZonedDateTime getUpdatedDate() {
+        return updateDate;
+    }
+
+    public ZonedDateTime getDeletedDate() {
+        return deletedDate;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseComparableDate.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseComparableDate.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+public interface PlugwiseComparableDate<T extends PlugwiseBaseModel> {
+    public int compareDateWith(T hasModifiedDate);
+
+    public boolean isOlderThan(T hasModifiedDate);
+
+    public boolean isNewerThan(T hasModifiedDate);
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseHACollection.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/PlugwiseHACollection.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+public abstract class PlugwiseHACollection<T> implements Map<String, T> {
+
+    private Map<String, T> map = new HashMap<String,  T>();
+
+    @Override
+    public int size() {
+        return this.map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return this.map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return this.map.containsValue(value);
+    }
+
+    @Override
+    public T get(Object key) {
+        return this.map.get(key);
+    }
+
+    @Override
+    public T put(String key, T value) {
+        return this.map.put(key, value);
+    }
+
+    @Override
+    public T remove(Object key) {
+        return this.map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends T> m) {
+        this.map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        this.map.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return this.map.keySet();
+    }
+
+    @Override
+    public Collection<T> values() {
+        return this.map.values();
+    }
+
+    @Override
+    public Set<Entry<String, T>> entrySet() {
+        return this.map.entrySet();
+    }
+
+    public abstract void merge(Map<String, T> map);
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Service.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Service.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("service")
+public class Service extends PlugwiseBaseModel {
+   
+    @XStreamAlias("log_type")
+    private String logType;
+
+    @XStreamAlias("point_log")
+    private String pointLogId;
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Services.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/Services.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Map;
+
+/**
+ * The {@link Services} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for the collection of module services.
+ * It extends the {@link PlugwiseHACollection} class.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class Services extends PlugwiseHACollection<Service> {
+
+    @Override
+    public void merge(Map<String, Service> services) {
+
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ZigBeeNode.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/model/object/ZigBeeNode.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.model.object;
+
+import java.util.Optional;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * The {@link ZigBeeNode} class is an object model class that
+ * mirrors the XML structure provided by the Plugwise Home Automation
+ * controller for a Plugwise ZigBeeNode.
+ * It extends the abstract class {@link PlugwiseBaseModel}.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+@XStreamAlias("ZigBeeNode")
+public class ZigBeeNode extends PlugwiseBaseModel {
+
+    private String type;
+    private String reachable;
+    
+    @XStreamAlias("power_source")
+    private String powerSource;
+
+    @XStreamAlias("mac_address")
+    private String macAddress;
+
+    public String getType() {
+        return type;
+    }
+
+    public String getReachable() {
+        return reachable;
+    }
+
+    public String getPowerSource() {
+        return powerSource;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/xml/PlugwiseHAXStream.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/api/xml/PlugwiseHAXStream.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.api.xml;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStreamWriter;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.NullPermission;
+
+import org.openhab.binding.plugwiseha.internal.api.model.converter.DateTimeConverter;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalities;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionality;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalityRelay;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalityThermostat;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliance;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliances;
+import org.openhab.binding.plugwiseha.internal.api.model.object.DomainObjects;
+import org.openhab.binding.plugwiseha.internal.api.model.object.GatewayEnvironment;
+import org.openhab.binding.plugwiseha.internal.api.model.object.GatewayInfo;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Location;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Locations;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Log;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Logs;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Modules;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Module;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Services;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Service;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ZigBeeNode;
+
+/**
+ * The {@link PlugwiseHAXStream} class is a utility class that wraps an XStream
+ * object and provide additional functionality specific to the PlugwiseHA
+ * binding. It automatically load the correct converter classes and processes
+ * the XStream annotions used by the object classes.
+ * 
+ * @author B. van Wetten - Initial contribution
+ */
+public class PlugwiseHAXStream extends XStream {
+
+    private static XmlFriendlyNameCoder customCoder = new XmlFriendlyNameCoder("_-", "_");
+
+    public PlugwiseHAXStream() {
+        super(new StaxDriver(PlugwiseHAXStream.customCoder));
+
+        initialize();
+    }
+
+    // Protected methods
+
+    @SuppressWarnings("rawtypes")
+    protected void allowClass(Class clz) {
+        this.processAnnotations(clz);
+        this.allowTypeHierarchy(clz);
+    }
+
+    protected void initialize() {
+        // Configure XStream
+        this.ignoreUnknownElements();
+        this.setClassLoader(getClass().getClassLoader());
+
+        // Clear out existing
+        this.addPermission(NoTypePermission.NONE);
+        this.addPermission(NullPermission.NULL);
+
+        // Whitelist classes
+        this.allowClass(GatewayInfo.class);
+        this.allowClass(GatewayEnvironment.class);        
+        this.allowClass(Appliances.class);
+        this.allowClass(Appliance.class);
+        this.allowClass(Modules.class);
+        this.allowClass(Module.class);
+        this.allowClass(Locations.class);
+        this.allowClass(Location.class);
+        this.allowClass(Logs.class);
+        this.allowClass(Log.class);
+        this.allowClass(Services.class);
+        this.allowClass(Service.class);
+        this.allowClass(ZigBeeNode.class);
+        this.allowClass(ActuatorFunctionalities.class);
+        this.allowClass(ActuatorFunctionality.class);
+        this.allowClass(ActuatorFunctionalityThermostat.class);
+        this.allowClass(ActuatorFunctionalityRelay.class);
+        this.allowClass(DomainObjects.class);
+
+        // Register custom converters
+        this.registerConverter(new DateTimeConverter());
+    }
+
+    // Public methods
+
+    public void prettyPrint(Object object) {
+        BufferedOutputStream stdout = new BufferedOutputStream(System.out);
+        prettyPrint(object, new OutputStreamWriter(stdout));
+    }
+
+    public void prettyPrint(Object object, OutputStreamWriter outputStreamWriter) {
+        this.marshal(object, new PrettyPrintWriter(outputStreamWriter, PlugwiseHAXStream.customCoder));
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/config/PlugwiseHABridgeThingConfig.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/config/PlugwiseHABridgeThingConfig.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.config;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PlugwiseHABridgeThingConfig} encapsulates all the configuration options for an instance of the
+ * {@link PlugwiseHABridgeHandler}.
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+@NonNullByDefault
+public class PlugwiseHABridgeThingConfig {
+
+    private String host = "adam";
+
+    private int port = 80;
+
+    private String username = "smile";
+
+    private String smileId = "";
+
+    private int refresh = 15;
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getsmileId() {
+        return smileId;
+    }
+
+    public int getRefresh() {
+        return refresh;
+    }
+
+    public boolean isValid() {
+        return StringUtils.isNotBlank(host) && StringUtils.isNotBlank(username) && StringUtils.isNotBlank(smileId);
+    }
+
+    @Override
+    public String toString() {
+        return "PlugwiseHABridgeThingConfig{host = " + host + ", port = " + port + ", username = " + username
+                + ", smileId = *****, refresh = " + refresh + "}";
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/config/PlugwiseHAThingConfig.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/config/PlugwiseHAThingConfig.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.config;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * The {@link PlugwiseHAThingConfig} encapsulates the configuration options for
+ * an instance of the {@link PlugwiseHAApplianceHandler} and the
+ * {@link PlugwiseHAZoneHandler}
+ *
+ * @author Bas van Wetten - Initial contribution
+ */
+public class PlugwiseHAThingConfig {
+
+    private String id;
+
+    private int lowBatteryPercentage = 15;
+
+    // Getters
+
+    public String getId() {
+        return id;
+    }
+
+    public int getLowBatteryPercentage() {
+        return this.lowBatteryPercentage;
+    }
+
+    // Member methods
+
+    public boolean isValid() {
+        return StringUtils.isNotBlank(id) && lowBatteryPercentage > 0 && lowBatteryPercentage < 100;
+    }
+
+    @Override
+    public String toString() {
+        return "PlugwiseHAThingConfig{id = " + id + ", lowBatteryPercentage = " + lowBatteryPercentage + "}";
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/discovery/PlugwiseHADiscoveryService.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/discovery/PlugwiseHADiscoveryService.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.plugwiseha.internal.discovery;
+
+import static org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAController;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliance;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliances;
+import org.openhab.binding.plugwiseha.internal.api.model.object.DomainObjects;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Location;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Locations;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHABridgeHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHADiscoveryService} class is capable of discovering the
+ * available data from the Plugwise Home Automation gateway
+ *
+ * @author Bas van Wetten - Initial contribution
+ *
+ */
+public class PlugwiseHADiscoveryService extends AbstractDiscoveryService {
+
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHADiscoveryService.class);
+    private final PlugwiseHABridgeHandler handler;
+    private static final int TIMEOUT = 5;
+    private static final int REFRESH = 600;
+
+    private ScheduledFuture<?> discoveryFuture;
+
+    public PlugwiseHADiscoveryService(PlugwiseHABridgeHandler bridgeHandler) {
+        super(SUPPORTED_THING_TYPES_UIDS, TIMEOUT, true);
+        this.handler = bridgeHandler;
+    }
+
+    @Override
+    protected synchronized void startScan() {
+        try {
+            discoverDomainObjects();
+        } catch (PlugwiseHAException e) {
+            // Ignore silently
+        }
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        logger.debug("Start Plugwise Home Automation background discovery");
+        if (this.discoveryFuture == null || this.discoveryFuture.isCancelled()) {
+            if (this.handler.getThing().getStatus() == ThingStatus.ONLINE) {
+                logger.debug("Start Scan");
+                this.discoveryFuture = scheduler.scheduleWithFixedDelay(this::startScan, 30, REFRESH, TimeUnit.SECONDS);
+            } else {
+                stopBackgroundDiscovery();
+            }
+        }
+    }
+
+    @Override
+    protected void stopBackgroundDiscovery() {
+        if (this.discoveryFuture != null && !this.discoveryFuture.isCancelled()) {
+            logger.debug("Stop Plugwise Home Automation background discovery");
+            this.discoveryFuture.cancel(true);
+            this.discoveryFuture = null;
+        }
+    }
+
+    @Override
+    protected synchronized void stopScan() {
+        super.stopScan();
+        removeOlderResults(getTimestampOfLastScan());
+    }
+
+    public void activate() {
+        super.activate(null);
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+
+    // @Override
+    // public void accountStatusChanged(ThingStatus status) {
+    // if (status == ThingStatus.ONLINE) {
+    // discoverLocations();
+    // discoverAppliances();
+    // }
+    // }
+
+    private void discoverDomainObjects() throws PlugwiseHAException {
+        PlugwiseHAController controller = this.handler.getController();
+
+        if (controller != null) {
+            DomainObjects domainObjects = controller.getDomainObjects();            
+
+            for (Location location : domainObjects.getLocations().values()) {
+                // Only add locations with at least 1 appliance (this ignores the 'root' (home)
+                // location which is the parent of all other locations.)
+                if (location.applianceCount() > 0) {
+                    locationDiscovery(location);
+                }
+            }
+
+            for (Appliance appliance : domainObjects.getAppliances().values()) {
+                // Only add appliances that are required/supported for this binding
+                if (PlugwiseHABindingConstants.SUPPORTED_APPLIANCE_TYPES.contains(appliance.getType())) {
+                    applianceDiscovery(appliance);
+                }
+            }
+
+        }
+    }
+
+    private void applianceDiscovery(Appliance appliance) {
+        String applianceId = appliance.getId();
+        String applianceName = appliance.getName();
+        String applianceType = appliance.getType();
+        ThingUID bridgeUID = this.handler.getThing().getUID();
+        ThingUID uid;
+
+        Map<String, Object> configProperties = new HashMap<>();
+
+        configProperties.put(APPLIANCE_CONFIG_ID, applianceId);
+
+        switch (applianceType) {
+        case "thermostatic_radiator_valve":
+            uid = new ThingUID(PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_VALVE, bridgeUID, applianceId);
+            configProperties.put(APPLIANCE_CONFIG_LOWBATTERY, 15);
+            break;
+        case "central_heating_pump":
+            uid = new ThingUID(PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_PUMP, bridgeUID, applianceId);
+            break;
+        case "zone_thermostat":
+            uid = new ThingUID(PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_THERMOSTAT, bridgeUID, applianceId);
+            configProperties.put(APPLIANCE_CONFIG_LOWBATTERY, 15);
+            break;
+        default:
+            return;
+        }
+
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(uid).withBridge(bridgeUID)
+                .withLabel(applianceName).withProperties(configProperties).build();
+
+        thingDiscovered(discoveryResult);
+
+        logger.debug("Discovered plugwise appliance type '{}' with name '{}' with id {} ({})", applianceType,
+                applianceName, applianceId, uid);
+    }
+
+    private void locationDiscovery(Location location) {
+        String locationId = location.getId();
+        String locationName = location.getName();
+        ThingUID bridgeUID = this.handler.getThing().getUID();
+        ThingUID uid = new ThingUID(PlugwiseHABindingConstants.THING_TYPE_ZONE, bridgeUID, locationId);
+
+        Map<String, Object> configProperties = new HashMap<>();
+
+        configProperties.put(ZONE_CONFIG_ID, locationId);
+
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(uid).withBridge(bridgeUID)
+                .withLabel(locationName).withProperties(configProperties).build();
+
+        thingDiscovered(discoveryResult);
+
+        logger.debug("Discovered plugwise zone '{}' with id {} ({})", locationName, locationId, uid);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAApplianceHandler.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAApplianceHandler.java
@@ -1,0 +1,359 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.handler;
+
+import static org.eclipse.smarthome.core.thing.ThingStatus.*;
+import static org.eclipse.smarthome.core.thing.ThingStatusDetail.CONFIGURATION_ERROR;
+import static org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.measure.quantity.Temperature;
+
+import org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAController;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliance;
+import org.openhab.binding.plugwiseha.internal.config.PlugwiseHAThingConfig;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.eclipse.smarthome.core.thing.type.ChannelKind;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHABaseHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHAApplianceHandler} class is responsible for handling
+ * commands and status updates for the Plugwise Home Automation appliances.
+ * Extends @{link PlugwiseHABaseHandler}
+ *
+ * @author Bas van Wetten - Initial contribution
+ *
+ */
+public class PlugwiseHAApplianceHandler extends PlugwiseHABaseHandler<Appliance, PlugwiseHAThingConfig> {
+
+    // private PlugwiseHAThingConfig config = new PlugwiseHAThingConfig();
+    private @Nullable Appliance appliance;
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHAApplianceHandler.class);
+
+    // Constructor
+
+    public PlugwiseHAApplianceHandler(Thing thing) {
+        super(thing);
+    }
+
+    public static boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_VALVE.equals(thingTypeUID)
+                || PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_PUMP.equals(thingTypeUID)
+                || PlugwiseHABindingConstants.THING_TYPE_APPLIANCE_THERMOSTAT.equals(thingTypeUID);
+    }
+
+    // Overrides
+
+    @Override
+    protected synchronized void initialize(PlugwiseHAThingConfig config) {
+        if (thing.getStatus() == INITIALIZING) {
+            logger.debug("Initializing Plugwise Home Automation appliance handler with config = {}", config);
+            if (!config.isValid()) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR,
+                        "Invalid configuration for Plugwise Home Automation appliance handler.");
+                return;
+            }
+            // this.config = config;
+            this.appliance = getEntity(this.getPlugwiseHABridge().getController());
+
+            if (this.appliance.isBatteryOperated()) {
+                addBatteryChannels();
+            }
+
+            setApplianceProperties();
+            updateStatus(ONLINE);
+        }
+    }
+
+    @Override
+    public void thingUpdated(Thing thing) {
+        super.thingUpdated(thing);
+
+        if (this.appliance.isBatteryOperated()) {
+            addBatteryChannels();
+        }
+
+        ThingHandler thingHandler = thing.getHandler();
+
+        if (thingHandler != null) {
+            for (Channel channel : thing.getChannels()) {
+                if (this.isLinked(channel.getUID())) {
+                    this.refreshChannel(this.appliance, channel.getUID());
+                }
+            }
+        }
+    }
+
+    @Override
+    protected @Nullable Appliance getEntity(PlugwiseHAController controller) {
+        PlugwiseHAThingConfig config = getPlugwiseThingConfig();
+        Appliance appliance = controller.getAppliance(config.getId());
+
+        return appliance;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void handleCommand(Appliance entity, ChannelUID channelUID, Command command) throws PlugwiseHAException {
+        String channelID = channelUID.getIdWithoutGroup();
+        switch (channelID) {
+        case APPLIANCE_SETPOINT_CHANNEL:
+            if (command instanceof QuantityType) {
+                QuantityType<Temperature> state = (QuantityType<Temperature>) command;
+
+                Optional.ofNullable(this.getPlugwiseHABridge()).ifPresent(bridge -> {
+                    Optional.ofNullable(bridge.getController()).ifPresent(controller -> {
+                        try {
+                            controller.setThermostat(entity, state.doubleValue());
+                            updateState(APPLIANCE_SETPOINT_CHANNEL, (State) command);
+                        } catch (PlugwiseHAException e) {
+                            logger.warn("Unable to update setpoint for appliance '{}': {} -> {}", entity.getName(),
+                                    entity.getSetpointTemperature().orElse(null), state.doubleValue());
+                        }
+                    });
+                });
+            }
+            break;
+        case APPLIANCE_POWER_CHANNEL:
+            if (command instanceof OnOffType) {
+                OnOffType state = (OnOffType) command;
+
+                Optional.ofNullable(this.getPlugwiseHABridge()).ifPresent(bridge -> {
+                    Optional.ofNullable(bridge.getController()).ifPresent(controller -> {
+                        try {
+                            if (state == OnOffType.ON) {
+                                controller.switchRelayOn(entity);
+                            } else {
+                                controller.switchRelayOff(entity);
+                            }
+                            updateState(APPLIANCE_SETPOINT_CHANNEL, (State) command);
+                        } catch (PlugwiseHAException e) {
+                            logger.warn("Unable to switch relay {} for appliance '{}'", state, entity.getName());
+                        }
+                    });
+                });
+            }
+            break;
+        case APPLIANCE_LOCK_CHANNEL:
+            if (command instanceof OnOffType) {
+                OnOffType state = (OnOffType) command;
+
+                Optional.ofNullable(this.getPlugwiseHABridge()).ifPresent(bridge -> {
+                    Optional.ofNullable(bridge.getController()).ifPresent(controller -> {
+                        try {
+                            if (state == OnOffType.ON) {
+                                controller.switchRelayLockOn(entity);
+                            } else {
+                                controller.switchRelayLockOff(entity);
+                            }
+                            updateState(APPLIANCE_LOCK_CHANNEL, (State) command);
+                        } catch (PlugwiseHAException e) {
+                            logger.warn("Unable to switch relay lock {} for appliance '{}'", state, entity.getName());
+                        }
+                    });
+                });
+            }
+            break;
+        default:
+            logger.warn("Ignoring unsupported command = {} for channel = {}", command, channelUID);
+        }
+    }
+
+    private State getDefaultState(String channelID) {
+        State state = UnDefType.NULL;
+        switch (channelID) {
+        case APPLIANCE_SETPOINT_CHANNEL:
+        case APPLIANCE_TEMPERATURE_CHANNEL:
+        case APPLIANCE_BATTERYLEVEL_CHANNEL:
+        case APPLIANCE_POWER_USAGE_CHANNEL:
+            state = UnDefType.NULL;
+            break;
+        case APPLIANCE_BATTERYLEVELLOW_CHANNEL:
+        case APPLIANCE_POWER_CHANNEL:
+        case APPLIANCE_LOCK_CHANNEL:
+            state = UnDefType.UNDEF;
+            break;
+        }
+        return state;
+    }
+
+    @Override
+    protected void refreshChannel(Appliance entity, ChannelUID channelUID) {
+        String channelID = channelUID.getIdWithoutGroup();
+        State state = getDefaultState(channelID);
+        PlugwiseHAThingConfig config = getPlugwiseThingConfig();
+
+        // TODO Fetch appliance from API to force refresh - use synchronized block to
+        // prevent multiple threads from calling
+
+        try {
+            switch (channelID) {
+            case APPLIANCE_SETPOINT_CHANNEL:
+                if (entity.getSetpointTemperature().isPresent()) {
+                    state = new DecimalType(entity.getSetpointTemperature().get());
+                }
+                break;
+            case APPLIANCE_TEMPERATURE_CHANNEL:
+                if (entity.getTemperature().isPresent()) {
+                    state = new DecimalType(entity.getTemperature().get());
+                }
+                break;
+            case APPLIANCE_BATTERYLEVEL_CHANNEL: {
+                Optional<Double> batteryLevelOptional = entity.getBatteryLevel();
+                Double batteryLevel = batteryLevelOptional.isPresent() ? batteryLevelOptional.get() * 100 : null;
+
+                if (batteryLevelOptional.isPresent()) {
+                    state = new DecimalType(batteryLevel.intValue());
+                    if (batteryLevel <= config.getLowBatteryPercentage()) {
+                        updateState(APPLIANCE_BATTERYLEVELLOW_CHANNEL, OnOffType.ON);
+                    } else {
+                        updateState(APPLIANCE_BATTERYLEVELLOW_CHANNEL, OnOffType.OFF);
+                    }
+                }
+                break;
+            }
+            case APPLIANCE_BATTERYLEVELLOW_CHANNEL: {
+                Double batteryLevel = entity.getBatteryLevel().orElse(null);
+
+                if (batteryLevel != null) {
+                    batteryLevel *= 100;
+                    if (batteryLevel <= config.getLowBatteryPercentage()) {
+                        state = OnOffType.ON;
+                    } else {
+                        state = OnOffType.OFF;
+                    }
+                }
+                break;
+            }
+            case APPLIANCE_POWER_USAGE_CHANNEL: {
+                if (entity.getPowerUsage().isPresent()) {
+                    state = new DecimalType(entity.getPowerUsage().get());
+                }
+                break;
+            }
+            case APPLIANCE_POWER_CHANNEL: {
+                String relayState = entity.getRelayState().orElse(null);
+
+                if (relayState != null) {
+                    switch (relayState.toLowerCase()) {
+                    case "on":
+                        state = OnOffType.ON;
+                        break;
+                    case "off":
+                        state = OnOffType.OFF;
+                        break;
+                    default:
+                        break;
+                    }
+                }
+                break;
+            }
+            case APPLIANCE_LOCK_CHANNEL: {
+                Boolean relayLockState = entity.getRelayLockState().orElse(null);
+
+                if (relayLockState != null) {
+                    if (relayLockState) {
+                        state = OnOffType.ON;
+                    } else {
+                        state = OnOffType.OFF;
+                    }
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        } catch (NullPointerException e) {
+            e.toString();
+            throw e;
+        }
+
+        if (state != UnDefType.NULL && state != UnDefType.UNDEF) {
+            updateState(channelID, state);
+        }
+    }
+
+    protected synchronized void addBatteryChannels() {
+        logger.debug("Battery operated appliance detected: adding 'Battery level' and 'Battery low level' channels");
+
+        ChannelUID channelUIDBatteryLevel = new ChannelUID(getThing().getUID(), APPLIANCE_BATTERYLEVEL_CHANNEL);
+        ChannelUID channelUIDBatteryLevelLow = new ChannelUID(getThing().getUID(), APPLIANCE_BATTERYLEVELLOW_CHANNEL);
+
+        boolean channelBatteryLevelExists = false;
+        boolean channelBatteryLowExists = false;
+
+        List<Channel> channels = getThing().getChannels();
+        for (Channel channel : channels) {
+            if (channel.getUID().equals(channelUIDBatteryLevel)) {
+                channelBatteryLevelExists = true;
+            } else if (channel.getUID().equals(channelUIDBatteryLevelLow)) {
+                channelBatteryLowExists = true;
+            }
+        }
+
+        if (!channelBatteryLevelExists) {
+            ThingBuilder thingBuilder = editThing();
+
+            Channel channelBatteryLevel = ChannelBuilder.create(channelUIDBatteryLevel, "Number")
+                    .withType(CHANNEL_TYPE_BATTERYLEVEL).withKind(ChannelKind.STATE).withLabel("Battery level")
+                    .withDescription("Represents the battery level as a percentage (0-100%)").build();
+
+            thingBuilder.withChannel(channelBatteryLevel);
+
+            updateThing(thingBuilder.build());
+        }
+
+        if (!channelBatteryLowExists) {
+            ThingBuilder thingBuilder = editThing();
+
+            Channel channelBatteryLow = ChannelBuilder.create(channelUIDBatteryLevelLow, "Switch:Battery")
+                    .withType(CHANNEL_TYPE_BATTERYLEVELLOW).withKind(ChannelKind.STATE).withLabel("Battery low level")
+                    .withDescription("Switches ON when battery level gets below threshold level").build();
+
+            thingBuilder.withChannel(channelBatteryLow);
+
+            updateThing(thingBuilder.build());
+        }
+    }
+
+    protected void setApplianceProperties() {
+        Map<String, String> properties = editProperties();
+        properties.put("description", this.appliance.getDescription());
+        properties.put("type", this.appliance.getType());
+        properties.put("functionalities", this.appliance.getActuatorFunctionalities().keySet().stream()
+                .map(e -> e.toString()).collect(Collectors.joining(", ")));
+        updateProperties(properties);
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHABaseHandler.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHABaseHandler.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.handler;
+
+import static org.eclipse.smarthome.core.thing.ThingStatus.*;
+
+import java.lang.reflect.ParameterizedType;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAController;
+import org.openhab.binding.plugwiseha.internal.config.PlugwiseHAThingConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHABaseHandler} abstract class provides common methods and
+ * properties for the ThingHandlers of this binding. Extends @{link
+ * BaseThingHandler}
+ *
+ * @author Bas van Wetten - Initial contribution
+ *
+ * @param <E> entity - the Plugwise Home Automation entity class used by this
+ *            thing handler
+ * @param <C> config - the Plugwise Home Automation config class used by this
+ *            thing handler
+ */
+public abstract class PlugwiseHABaseHandler<E, C extends PlugwiseHAThingConfig> extends BaseThingHandler {
+
+    // private @Nullable C config;
+
+    protected final Logger logger = LoggerFactory.getLogger(PlugwiseHABaseHandler.class);
+
+    // Abstract methods
+
+    protected abstract void initialize(@NonNull C config);
+
+    protected abstract @Nullable E getEntity(PlugwiseHAController controller);
+
+    protected abstract void refreshChannel(E entity, ChannelUID channelUID);
+
+    protected abstract void handleCommand(E entity, ChannelUID channelUID, Command command) throws PlugwiseHAException;
+
+    // Constructor
+
+    public PlugwiseHABaseHandler(Thing thing) {
+        super(thing);
+    }
+
+    // Overrides
+
+    @Override
+    public void initialize() {        
+        C config = getPlugwiseThingConfig();
+
+        if (checkConfig(config)) {
+            // logger.debug("Initializing Plugwise Home Automation thing handler with config = {}", config);
+
+            Bridge bridge = getBridge();
+            if (bridge == null || bridge.getHandler() == null
+                    || !(bridge.getHandler() instanceof PlugwiseHABridgeHandler)) {
+                updateStatus(OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "You must choose a Plugwise Home Automation bridge for this thing.");
+                return;
+            }
+    
+            if (bridge.getStatus() == OFFLINE) {
+                updateStatus(OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                        "The Plugwise Home Automation bridge is currently offline.");
+            }
+    
+            initialize(config);
+        } else {
+            logger.warn("Invalid config for Plugwise Home Automation thing handler with config = {}", config);
+        }
+    }
+
+    @Override
+    public final void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("Handling command = {} for channel = {}", command, channelUID);
+
+        if (getThing().getStatus() == ONLINE) {
+            PlugwiseHAController controller = getController();
+            if (controller != null) {
+                E entity = getEntity(controller);
+                if (entity != null) {
+                    if (this.isLinked(channelUID)) {
+                        if (command instanceof RefreshType) {
+                            refreshChannel(entity, channelUID);
+                        } else {
+                            try {
+                                handleCommand(entity, channelUID, command);
+                            } catch (PlugwiseHAException e) {
+                                logger.warn("Unexpected error handling command = {} for channel = {} : {}", command,
+                                        channelUID, e.getMessage());
+                            }
+
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Public member methods
+
+    public @Nullable PlugwiseHABridgeHandler getPlugwiseHABridge() {
+        Bridge bridge = this.getBridge();
+        if (bridge != null) {
+            return (PlugwiseHABridgeHandler) bridge.getHandler();
+        }
+ 
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public C getPlugwiseThingConfig() {
+        Class<?> clazz = (Class<?>) (((ParameterizedType) getClass().getGenericSuperclass())
+                .getActualTypeArguments()[1]);
+
+        return (C) getConfigAs(clazz);
+    }
+
+    // Private & protected methods
+
+    private final @Nullable PlugwiseHAController getController() {
+        Bridge bridge = getBridge();
+        if (bridge != null && bridge.getHandler() != null && (bridge.getHandler() instanceof PlugwiseHABridgeHandler)) {
+            return ((PlugwiseHABridgeHandler) bridge.getHandler()).getController();
+        }
+        return null;
+    }
+
+    /**
+     * Checks the configuration for validity, result is reflected in the status of
+     * the Thing
+     */
+    private boolean checkConfig(C config) {
+        if (config == null || !config.isValid()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Configuration is missing or corrupted");
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    protected final void refresh() {
+        if (getThing().getStatus() == ONLINE) {
+            PlugwiseHAController controller = getController();
+            if (controller != null) {
+                E entity = getEntity(controller);
+                if (entity != null) {
+                    for (Channel channel : getThing().getChannels()) {
+                        ChannelUID channelUID = channel.getUID();
+                        if (this.isLinked(channelUID)) {
+                            refreshChannel(entity, channelUID);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHABridgeHandler.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHABridgeHandler.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.handler;
+
+import static org.eclipse.smarthome.core.thing.ThingStatus.OFFLINE;
+import static org.eclipse.smarthome.core.thing.ThingStatus.ONLINE;
+import static org.eclipse.smarthome.core.thing.ThingStatusDetail.*;
+import static org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants.*;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHABadRequestException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHACommunicationException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAInvalidHostException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHANotAuthorizedException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHATimeoutException;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAUnauthorizedException;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAController;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Appliance;
+import org.openhab.binding.plugwiseha.internal.api.model.object.GatewayInfo;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAModel;
+import org.openhab.binding.plugwiseha.internal.config.PlugwiseHABridgeThingConfig;
+import org.openhab.binding.plugwiseha.internal.config.PlugwiseHAThingConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHABridgeHandler} class is responsible for handling
+ * commands and status updates for the Plugwise Home Automation bridge.
+ * Extends @{link BaseBridgeHandler}
+ *
+ * @author Bas van Wetten - Initial contribution
+ *
+ */
+@SuppressWarnings("unused")
+public class PlugwiseHABridgeHandler extends BaseBridgeHandler {
+
+    // Private Static error messages
+
+    private static final String STATUS_DESCRIPTION_COMMUNICATION_ERROR = "Error communicating with the Plugwise Home Automation controller";
+    private static final String STATUS_DESCRIPTION_TIMEOUT = "Communication timeout while communicating with the Plugwise Home Automation controller";
+    private static final String STATUS_DESCRIPTION_CONFIGURATION_ERROR = "Invalid or missing configuration";
+    private static final String STATUS_DESCRIPTION_INVALID_CREDENTIALS = "Invalid username and/or password - please double-check your configuration";
+    private static final String STATUS_DESCRIPTION_INVALID_HOSTNAME = "Invalid hostname - please double-check your configuration";
+
+    // Private member variables/constants
+
+    private PlugwiseHABridgeThingConfig config;
+    private GatewayInfo gatewayInfo;
+    private ScheduledFuture<?> refreshJob;
+    private volatile PlugwiseHAController controller;
+
+    private final HttpClient httpClient;
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHABridgeHandler.class);
+
+    // Constructor
+
+    public PlugwiseHABridgeHandler(Bridge bridge, HttpClient httpClient) {
+        super(bridge);
+        this.httpClient = httpClient;
+    }
+
+    // Public methods
+
+    @Override
+    public void initialize() {
+        // This method is also called whenever config changes
+        cancelRefreshJob();
+        this.config = getConfig().as(PlugwiseHABridgeThingConfig.class);
+
+        if (this.checkConfig()) {
+            logger.debug("Initializing the Plugwise Home Automation bridge handler with config = {}", this.config);
+            try {
+                this.controller = new PlugwiseHAController(httpClient, config.getHost(), config.getPort(),
+                        config.getUsername(), config.getsmileId());
+                this.controller.start(() -> {
+                    setBridgeProperties();
+                    updateStatus(ONLINE);
+                });
+            } catch (PlugwiseHAInvalidHostException e) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, STATUS_DESCRIPTION_INVALID_HOSTNAME);
+            } catch (PlugwiseHAUnauthorizedException | PlugwiseHANotAuthorizedException e) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, STATUS_DESCRIPTION_INVALID_CREDENTIALS);
+            } catch (PlugwiseHACommunicationException e) {
+                updateStatus(OFFLINE, COMMUNICATION_ERROR, STATUS_DESCRIPTION_COMMUNICATION_ERROR);
+            } catch (PlugwiseHAException e) {
+                logger.error("Unknown error while configuring the Plugwise Home Automation Controller", e);
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, e.getMessage());
+            }
+        } else {
+            logger.warn("Invalid config for the Plugwise Home Automation bridge handler with config = {}", this.config);
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        this.logger.warn(
+                "Ignoring command = {} for channel = {} - this channel for the Plugwise Home Automation binding is read-only!",
+                command, channelUID);
+    }
+
+    @Override
+    public void dispose() {
+        cancelRefreshJob();
+        if (this.controller != null) {
+            this.controller.stop();
+            this.controller = null;
+        }
+    }
+
+    @Override
+    public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+        super.childHandlerDisposed(childHandler, childThing);
+    }
+
+    @Override
+    public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
+        super.childHandlerInitialized(childHandler, childThing);
+    }
+
+    public static boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_BRIDGE_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    // Getters & setters
+
+    public synchronized @Nullable PlugwiseHAController getController() {
+        return this.controller;
+    }
+
+    // Protected and private methods
+
+    /**
+     * Checks the configuration for validity, result is reflected in the status of
+     * the Thing
+     */
+    private boolean checkConfig() {
+        if (this.config == null || !this.config.isValid()) {
+            updateStatus(OFFLINE, CONFIGURATION_ERROR, STATUS_DESCRIPTION_CONFIGURATION_ERROR);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void scheduleRefreshJob() {
+        synchronized (this) {
+            if (this.refreshJob == null) {
+                logger.debug("Scheduling refresh job every {}s", config.getRefresh());
+                this.refreshJob = scheduler.scheduleWithFixedDelay(this::run, 0, config.getRefresh(), TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void run() {
+        try {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Executing refresh job");
+            }
+
+            refresh();
+            updateStatus(ONLINE);
+        } catch (PlugwiseHAInvalidHostException e) {
+            updateStatus(OFFLINE, CONFIGURATION_ERROR, STATUS_DESCRIPTION_INVALID_HOSTNAME);
+        } catch (PlugwiseHAUnauthorizedException | PlugwiseHANotAuthorizedException e) {
+            updateStatus(OFFLINE, CONFIGURATION_ERROR, STATUS_DESCRIPTION_INVALID_CREDENTIALS);
+        } catch (PlugwiseHACommunicationException e) {
+            updateStatus(OFFLINE, COMMUNICATION_ERROR, STATUS_DESCRIPTION_COMMUNICATION_ERROR);
+        } catch (PlugwiseHATimeoutException e) {
+            updateStatus(OFFLINE, COMMUNICATION_ERROR, STATUS_DESCRIPTION_TIMEOUT);
+        } catch (Exception e) {
+            logger.warn("Unhandled exception while refreshing the Plugwise Home Automation Controller {} - {}",
+                    getThing().getUID(), e.getMessage());
+            updateStatus(OFFLINE, COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void refresh() throws PlugwiseHAException {
+        if (this.getController() != null) {
+            logger.debug("Refreshing the Plugwise Home Automation Controller {}", getThing().getUID());
+            this.config = getConfig().as(PlugwiseHABridgeThingConfig.class);
+            this.getController().refresh();
+
+            getThing().getThings().forEach((thing) -> {
+                ThingHandler thingHandler = thing.getHandler();
+                if (thingHandler instanceof PlugwiseHABaseHandler) {
+                    ((PlugwiseHABaseHandler<PlugwiseHAModel, PlugwiseHAThingConfig>) thingHandler).refresh();
+                }
+            });
+        }
+    }
+
+    private void cancelRefreshJob() {
+        synchronized (this) {
+            if (this.refreshJob != null) {
+                logger.debug("Cancelling refresh job");
+                this.refreshJob.cancel(true);
+                this.refreshJob = null;
+            }
+        }
+    }
+
+    @Override
+    protected void updateStatus(ThingStatus status, ThingStatusDetail statusDetail, @Nullable String description) {
+        if (status == ONLINE || (status == OFFLINE && statusDetail == COMMUNICATION_ERROR)) {
+            scheduleRefreshJob();
+        } else if (status == OFFLINE && statusDetail == CONFIGURATION_ERROR) {
+            cancelRefreshJob();
+        }
+
+        // Only update bridge status if statusInfo has changed
+        ThingStatusInfo statusInfo = ThingStatusInfoBuilder.create(status, statusDetail).withDescription(description)
+                .build();
+        if (!statusInfo.equals(getThing().getStatusInfo())) {
+            super.updateStatus(status, statusDetail, description);
+        }
+    }
+
+    protected void setBridgeProperties() {
+        try {
+            this.gatewayInfo = this.getController().getGatewayInfo();
+
+            Map<String, String> properties = editProperties();
+            properties.put(Thing.PROPERTY_FIRMWARE_VERSION, this.gatewayInfo.getFirmwareVersion());
+            properties.put(Thing.PROPERTY_HARDWARE_VERSION, this.gatewayInfo.getHardwareVersion());
+            properties.put(Thing.PROPERTY_MAC_ADDRESS, this.gatewayInfo.getMacAddress());
+            properties.put(Thing.PROPERTY_VENDOR, this.gatewayInfo.getVendorName());
+            properties.put(Thing.PROPERTY_MODEL_ID, this.gatewayInfo.getVendorModel());
+            updateProperties(properties);
+        } catch (PlugwiseHAException e) {
+            updateStatus(OFFLINE, COMMUNICATION_ERROR, STATUS_DESCRIPTION_COMMUNICATION_ERROR);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAZoneHandler.java
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/java/org/openhab/binding/plugwiseha/internal/handler/PlugwiseHAZoneHandler.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.plugwiseha.internal.handler;
+
+import static org.eclipse.smarthome.core.thing.ThingStatus.*;
+import static org.eclipse.smarthome.core.thing.ThingStatusDetail.CONFIGURATION_ERROR;
+import static org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants.*;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.measure.quantity.Temperature;
+
+import org.openhab.binding.plugwiseha.internal.PlugwiseHABindingConstants;
+import org.openhab.binding.plugwiseha.internal.api.exception.PlugwiseHAException;
+import org.openhab.binding.plugwiseha.internal.api.model.PlugwiseHAController;
+import org.openhab.binding.plugwiseha.internal.api.model.object.ActuatorFunctionalities;
+import org.openhab.binding.plugwiseha.internal.api.model.object.Location;
+import org.openhab.binding.plugwiseha.internal.config.PlugwiseHAThingConfig;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.plugwiseha.internal.handler.PlugwiseHABaseHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PlugwiseHAZoneHandler} class is responsible for handling commands
+ * and status updates for the Plugwise Home Automation zones/locations.
+ * Extends @{link PlugwiseHABaseHandler}
+ *
+ * @author Bas van Wetten - Initial contribution
+ *
+ */
+@SuppressWarnings("unused")
+public class PlugwiseHAZoneHandler extends PlugwiseHABaseHandler<Location, PlugwiseHAThingConfig> {
+
+    // private PlugwiseHAThingConfig config = new PlugwiseHAThingConfig();
+    private @Nullable Location location;
+    private final Logger logger = LoggerFactory.getLogger(PlugwiseHAZoneHandler.class);
+
+    // Constructor
+
+    public PlugwiseHAZoneHandler(Thing thing) {
+        super(thing);
+    }
+
+    public static boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return PlugwiseHABindingConstants.THING_TYPE_ZONE.equals(thingTypeUID);
+    }
+
+    // Overrides
+
+    @Override
+    protected synchronized void initialize(PlugwiseHAThingConfig config) {
+        if (thing.getStatus() == INITIALIZING) {
+            logger.debug("Initializing Plugwise Home Automation zone handler with config = {}", config);
+            if (!config.isValid()) {
+                updateStatus(OFFLINE, CONFIGURATION_ERROR,
+                        "Invalid configuration for Plugwise Home Automation zone handler.");
+                return;
+            }
+
+            Optional.ofNullable(this.getPlugwiseHABridge()).ifPresent(bridge -> {
+                Optional.ofNullable(bridge.getController()).ifPresent(controller -> {
+                    this.location = getEntity(controller);
+
+                    setLocationProperties();
+                    updateStatus(ONLINE);
+                });
+            });
+        }
+    }
+
+    @Override
+    protected @Nullable Location getEntity(PlugwiseHAController controller) {
+        PlugwiseHAThingConfig config = getPlugwiseThingConfig();
+        Location location = controller.getLocation(config.getId());
+
+        return location;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void handleCommand(Location entity, ChannelUID channelUID, Command command) throws PlugwiseHAException {
+        String channelID = channelUID.getIdWithoutGroup();
+        switch (channelID) {
+        case ZONE_SETPOINT_CHANNEL:
+            if (command instanceof QuantityType) {
+                QuantityType<Temperature> state = (QuantityType<Temperature>) command;
+
+                Optional.ofNullable(this.getPlugwiseHABridge()).ifPresent(bridge -> {
+                    Optional.ofNullable(bridge.getController()).ifPresent(controller -> {
+                        try {
+                            controller.setLocationThermostat(entity, state.doubleValue());
+                            updateState(ZONE_SETPOINT_CHANNEL, (State) command);
+                        } catch (PlugwiseHAException e) {
+                            logger.warn("Unable to update setpoint for zone '{}': {} -> {}", entity.getName(),
+                                    entity.getSetpointTemperature().orElse(null), state.doubleValue());
+                        }
+                    });
+                });
+            }
+            break;
+        default:
+            logger.warn("Ignoring unsupported command = {} for channel = {}", command, channelUID);
+        }
+    }
+
+    private State getDefaultState(String channelID) {
+        State state = UnDefType.NULL;
+        switch (channelID) {
+        case ZONE_SETPOINT_CHANNEL:
+        case ZONE_TEMPERATURE_CHANNEL:
+            state = UnDefType.NULL;
+            break;
+        }
+        return state;
+    }
+
+    @Override
+    protected void refreshChannel(Location entity, ChannelUID channelUID) {
+        String channelID = channelUID.getIdWithoutGroup();
+        State state = getDefaultState(channelID);
+
+        // TODO Fetch location from API to force refresh - use synchronized block to prevent multiple threads from calling
+
+        switch (channelID) {
+        case ZONE_SETPOINT_CHANNEL:
+            if (entity.getSetpointTemperature().isPresent()) {
+                state = new DecimalType(entity.getSetpointTemperature().get());
+            }
+            break;
+        case ZONE_TEMPERATURE_CHANNEL:
+            if (entity.getTemperature().isPresent()) {
+                state = new DecimalType(entity.getTemperature().get());
+            }
+            break;
+        default:
+            break;
+        }
+
+        if (state != UnDefType.NULL) {
+            updateState(channelID, state);
+        }
+    }
+
+    protected void setLocationProperties() {
+        if (this.location != null) {
+            Map<String, String> properties = editProperties();
+
+            Optional.ofNullable(this.location.getActuatorFunctionalities()).ifPresent(actuatorFunctionalities -> {
+                properties.put("functionalities", actuatorFunctionalities.keySet().stream().map(e -> e.toString())
+                        .collect(Collectors.joining(", ")));
+
+            });
+
+            properties.put("description", Optional.ofNullable(this.location.getDescription()).orElse(""));
+            properties.put("type", Optional.ofNullable(this.location.getType()).orElse(""));
+
+            updateProperties(properties);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="plugwiseha" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Plugwise Home Automation Binding</name>
+	<description>This binding supports the Plugwise Home Automation 'Adam' gateway. It allows users to access temperature controls of zones defined on the gateway</description>
+	<author>Bas van Wetten</author>	
+
+</binding:binding>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/config/config.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<!-- Bridge -->
+	<config-description uri="bridge-type:plugwiseha:gateway">
+			<parameter name="host" type="text" required="true">
+				<context>network-address</context>
+				<label>Host</label>
+				<description>Hostname or IP address of the boiler gateway</description>
+				<default>adam</default>
+			</parameter>
+			<parameter name="username" type="text" required="true">
+				<label>Username</label>
+				<description>Adam HA gateway username (default: smile)</description>
+				<default>smile</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="smileId" type="text" required="true">
+				<context>password</context>
+				<label>Smile ID</label>
+				<description>The Smile ID is the 8 letter code on the sticker on the back of the Adam boiler gateway</description>
+			</parameter>
+            <parameter name="refresh" type="integer" min="1" max="120" required="true" unit="s">
+                <label>Refresh interval</label>
+				<unitLabel>seconds</unitLabel>
+                <description>Refresh interval in seconds</description>
+                <default>5</default>
+				<advanced>true</advanced>
+            </parameter>
+	</config-description>
+
+	<!-- Zone thing -->
+	<config-description uri="thing-type:plugwiseha:zone">
+			<parameter name="id" type="text" required="true" readOnly="false">
+				<label>ID</label>
+				<description>Location ID for the zone</description>
+			</parameter>
+	</config-description>
+
+	<!-- Appliance: Radiator valve -->
+	<config-description uri="thing-type:plugwiseha:appliance_valve">
+			<parameter name="id" type="text" required="true" readOnly="false">
+				<label>ID</label>
+				<description>Appliance ID</description>
+			</parameter>
+            <parameter name="lowBatteryPercentage" type="integer" min="1" max="50" required="true" unit="s">
+                <label>Low battery threshold</label>
+				<unitLabel>%</unitLabel>
+                <description>Battery charge remaining at which to trigger battery low warning</description>
+                <default>15</default>
+				<advanced>true</advanced>
+            </parameter>			
+			<!-- <parameter name="name" type="text" required="true" readOnly="true">
+				<label>Name</label>
+				<description>Name of the radiator valve</description>
+			</parameter> -->
+	</config-description>
+
+	<!-- Appliance: Pump switch -->
+	<config-description uri="thing-type:plugwiseha:appliance_pump">
+			<parameter name="id" type="text" required="true" readOnly="false">
+				<label>ID</label>
+				<description>Appliance ID</description>
+			</parameter>
+			<!-- <parameter name="name" type="text" required="true" readOnly="true">
+				<label>Name</label>
+				<description>Name of the central heating pump</description>
+			</parameter> -->
+	</config-description>
+
+	<!-- Appliance: Radiator valve -->
+	<config-description uri="thing-type:plugwiseha:appliance_thermostat">
+			<parameter name="id" type="text" required="true" readOnly="false">
+				<label>ID</label>
+				<description>Appliance ID</description>
+			</parameter>
+            <parameter name="lowBatteryPercentage" type="integer" min="1" max="50" required="true" unit="s">
+                <label>Low battery threshold</label>
+				<unitLabel>%</unitLabel>
+                <description>Battery charge remaining at which to trigger battery low warning</description>
+                <default>15</default>
+				<advanced>true</advanced>
+            </parameter>			
+			<!-- <parameter name="name" type="text" required="true" readOnly="true">
+				<label>Name</label>
+				<description>Name of the radiator valve</description>
+			</parameter> -->
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/i18n/plugwiseha_xx_XX.properties
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/i18n/plugwiseha_xx_XX.properties
@@ -1,0 +1,17 @@
+# FIXME: please substitute the xx_XX with a proper locale, ie. de_DE
+# FIXME: please do not add the file to the repo if you add or change no content
+# binding
+binding.plugwiseha.name = <Your localized Binding name>
+binding.plugwiseha.description = <Your localized Binding description>
+
+# thing types
+thing-type.plugwiseha.sample.label = <Your localized Thing label>
+thing-type.plugwiseha.sample.description = <Your localized Thing description>
+
+# thing type config description
+thing-type.config.plugwiseha.sample.config1.label = <Your localized config parameter label>
+thing-type.config.plugwiseha.sample.config1.description = <Your localized config parameter description>
+
+# channel types
+channel-type.plugwiseha.sample-channel.label = <Your localized Channel label>
+channel-type.plugwiseha.sample-channel.description = <Your localized Channel description>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/thing/channels.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="plugwiseha" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0" xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="setpointTemperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Setpoint temperature</label>
+		<description>Gets or sets the set point of this zone</description>
+		<category>heating</category>
+		<state min="0.0" max="35.0" step="0.5" pattern="%.1f °C" />
+	</channel-type>
+
+	<channel-type id="temperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Zone temperature</label>
+		<description>Gets the temperature of this zone</description>
+		<category>heating</category>
+		<state readOnly="true" pattern="%.1f °C" />
+	</channel-type>
+
+	<channel-type id="power">
+		<item-type>Switch</item-type>
+		<label>Power</label>
+		<description>Switch the Plugwise Smart plug ON or OFF</description>
+		<category>switch</category>
+	</channel-type>
+
+	<channel-type id="lock">
+		<item-type>Switch</item-type>
+		<label>Lock</label>
+		<description>Locks the switch state of the Plugwise Smart plug</description>
+		<category>switch</category>
+	</channel-type>
+
+	<channel-type id="powerUsage">
+		<item-type>Number</item-type>
+		<label>Power usage</label>
+		<state pattern="%.2f W" readOnly="true"></state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="plugwiseha"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Bridge -->
+	<bridge-type id="gateway">
+		<label>Plugwise Home Automation Bridge</label>
+		<description>The Plugwise Home Automation Bridge is needed to connect to the Adam boiler gateway</description>
+
+		<config-description-ref uri="bridge-type:plugwiseha:gateway" />
+	</bridge-type>
+
+	<!-- Zone thing -->
+	<thing-type id="zone" listed="true">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+
+		<label>Plugwise zone</label>
+		<description>A Plugwise Home Automation heating zone</description>
+
+		<channels>
+			<channel id="setpointTemperature" typeId="setpointTemperature" />
+			<channel id="temperature" typeId="temperature" />
+		</channels>
+
+		<representation-property>id</representation-property>
+
+		<config-description-ref uri="thing-type:plugwiseha:zone" /> 
+	</thing-type>
+
+	<!-- Appliance: Radiator valve (Tom) -->
+	<thing-type id="appliance_valve" listed="true">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+
+		<label>Plugwise radiator valve</label>
+		<description>A Plugwise Home Automation radiator valve</description>
+
+		<channels>
+			<channel id="setpointTemperature" typeId="setpointTemperature" />
+			<channel id="temperature" typeId="temperature" />
+		</channels>
+
+		<representation-property>id</representation-property>
+
+		<config-description-ref uri="thing-type:plugwiseha:appliance_valve" /> 
+	</thing-type>
+
+	<!-- Appliance: Pump switch (Circle) -->
+	<thing-type id="appliance_pump" listed="true">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+
+		<label>Central heating pump</label>
+		<description>A Plugwise Home Automation smart plug switch connected to a central heating pump</description>
+
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="lock" typeId="lock" />			
+			<channel id="powerUsage" typeId="powerUsage" />
+		</channels>
+
+		<representation-property>id</representation-property>
+
+		<config-description-ref uri="thing-type:plugwiseha:appliance_pump" /> 
+	</thing-type>
+
+	<!-- Appliance: Zone thermostat (Lisa) -->
+	<thing-type id="appliance_thermostat" listed="true">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+
+		<label>Plugwise room thermostat</label>
+		<description>A Plugwise Home Automation room thermostat</description>
+
+		<channels>
+			<channel id="setpointTemperature" typeId="setpointTemperature" />
+			<channel id="temperature" typeId="temperature" />
+		</channels>
+
+		<representation-property>id</representation-property>
+
+		<config-description-ref uri="thing-type:plugwiseha:appliance_thermostat" /> 
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.plugwiseha/src/main/resources/domain_objects.xslt
+++ b/bundles/org.openhab.binding.plugwiseha/src/main/resources/domain_objects.xslt
@@ -1,0 +1,127 @@
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+        <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+        <xsl:strip-space elements="*"/>
+
+        <!-- modified identity transform -->
+        <xsl:template match="/domain_objects">
+            <xsl:element name="{local-name()}">        
+                <xsl:apply-templates select="gateway" />
+                <xsl:apply-templates select="appliance" />
+                <xsl:apply-templates select="location" />
+                <xsl:apply-templates select="module" />
+            </xsl:element>
+        </xsl:template>
+
+        <xsl:template match="node()">
+            <!-- prevent duplicate siblings -->
+            <xsl:if test="count(preceding-sibling::node()[name()=name(current())])=0">
+                <!-- copy element -->
+                <xsl:copy>
+                    <xsl:apply-templates select="@*|node()"/>
+                </xsl:copy>
+            </xsl:if>        
+        </xsl:template>
+
+        <xsl:template match="appliance">
+            <!-- copy element -->
+            <xsl:copy>
+                <xsl:apply-templates select="@*|node()"/>
+            </xsl:copy>     
+        </xsl:template>
+
+        <xsl:template match="location">
+            <!-- copy element -->
+            <xsl:copy>
+                <xsl:apply-templates select="@*|node()"/>
+            </xsl:copy>     
+        </xsl:template>
+
+        <xsl:template match="module">            
+            <!-- copy element -->
+            <xsl:copy>
+                <xsl:apply-templates select="protocols/node()[name()='zig_bee_node']"/>
+                <xsl:apply-templates select="@*|node()[name()!='protocols']"/>
+            </xsl:copy>     
+        </xsl:template>
+
+        <xsl:template match="location/appliances">
+            <!-- Apply identity transform on child elements of appliances -->
+            <xsl:for-each select="appliance">
+                <xsl:copy>
+                    <xsl:value-of select="@id"/>
+                </xsl:copy>
+            </xsl:for-each>
+        </xsl:template>
+
+        <xsl:template match="module/services">
+            <xsl:for-each select="./node()">
+                <xsl:element name="service">
+                    <xsl:element name="point_log">
+                        <xsl:value-of select="functionalities/point_log/@id"/>
+                    </xsl:element>                    
+                    <xsl:apply-templates select="@*|node()[name()!='functionalities']"/>
+                </xsl:element>
+            </xsl:for-each>
+        </xsl:template>
+
+        <!-- This matches 'appliance/logs' or 'location/logs' -->
+        <xsl:template match="*[name() = 'location' or name()='appliance']/logs">        
+            <!-- Apply identity transform on child elements of logs -->
+            <xsl:variable name="meter_id" select="point_log/*[substring(local-name(), string-length(local-name()) - string-length('_meter')+1) = '_meter']/@id"/>            
+            <xsl:apply-templates select="/domain_objects/module/services/*[@id=$meter_id]/../../protocols/zig_bee_node"/>
+            
+            <xsl:for-each select="point_log">            
+                <xsl:copy>                
+                    <xsl:apply-templates select="@*|node()"/>
+                </xsl:copy>
+            </xsl:for-each>
+        </xsl:template>
+
+        <xsl:template match="appliance/location">
+            <!-- Apply identity transform on child elements of location -->        
+            <xsl:copy>
+                <xsl:value-of select="@id"/>
+            </xsl:copy>        
+        </xsl:template>
+
+        <xsl:template match="logs/point_log/period">    
+            <xsl:element name="measurement_date">
+                <xsl:value-of select="measurement/@log_date"/>
+            </xsl:element>
+            <xsl:element name="measurement">
+                <xsl:value-of select="measurement/text()"/>
+            </xsl:element>
+        </xsl:template>
+
+        <xsl:template match="*[name() = 'location' or name()='appliance']/actuator_functionalities">
+            <xsl:for-each select="./*">
+                <xsl:element name="actuator_functionality">
+                    <xsl:if test="not(type)">
+                    <xsl:choose>
+                            <xsl:when test="local-name()='relay_functionality'">
+                                <xsl:element name="type">
+                                    <xsl:text>relay</xsl:text>
+                                </xsl:element>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:element name="type">
+                                    <xsl:value-of select="local-name()"/>
+                                </xsl:element>
+                            </xsl:otherwise>
+                        </xsl:choose>                    
+                    </xsl:if>
+                    <xsl:for-each select=".">
+                        <xsl:apply-templates select="@*|node()"/>
+                    </xsl:for-each>
+                </xsl:element>            
+            </xsl:for-each>
+        </xsl:template>
+
+        <!-- attributes to elements -->
+        <xsl:template match="@*">
+            <xsl:element name="{name()}">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:template>
+
+    </xsl:stylesheet>


### PR DESCRIPTION
This is an initial contribution for the 'Plguwise Home Automation' binding. There is a thread in the community forum about this binding (https://community.openhab.org/t/plugwise-home-automation-binding-for-openhab/81299) This binding was also submitted to the Eclpise IOT marketplace but not yet picked up or reviewed.

The Plugwise Home Automation binding adds support to openHAB for the Plugwise Home Automation ecosystem. This system is built around a gateway from Plugwise called the 'Adam' which incorporates a ZigBee controller to manage thermostatic radiator valves, room thermostats, floor heating pumps, et cetera.

Users can manage and control this system either via a web app or a mobile phone app developed by Plugwise. The (web) app allows users to define heating zone's (e.g. rooms) and add radiator valves to those rooms to manage and control their heating irrespective of other rooms.

Using the Plugwise Home Automation binding you can incorporate the management of these devices and heating zones into openHAB. The binding uses the same RESTfull API that both the mobile phone app and the web app use.

The binding requires users to have a working Plugwise Home Automation setup consisting of at least 1 gateway device (the 'Adam') and preferably 1 radiator valve as a bare minimum. The 'Adam' (from hereon called the gateway) needs to be accessible from the openHAB instance via a TCP/IP connection.

Location of JAR file for testing without having to compile the binding :

https://github.com/updev-it/openhab2-addons/releases/download/v0.2.0/org.openhab.binding.plugwiseha-2.5.0-SNAPSHOT.jar
