### PR TITLE
[miio] Xiaomi Robot Vacuum Channel "state_code" and "error_code" added

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoBindingConstants.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoBindingConstants.java
@@ -47,11 +47,13 @@ public final class MiIoBindingConstants {
     public static final String CHANNEL_CLEAN_AREA = "status#clean_area";
     public static final String CHANNEL_CLEAN_TIME = "status#clean_time";
     public static final String CHANNEL_DND_ENABLED = "status#dnd_enabled";
+    public static final String CHANNEL_ERROR = "status#error";
     public static final String CHANNEL_ERROR_CODE = "status#error_code";
     public static final String CHANNEL_FAN_POWER = "status#fan_power";
     public static final String CHANNEL_IN_CLEANING = "status#in_cleaning";
     public static final String CHANNEL_MAP_PRESENT = "status#map_present";
     public static final String CHANNEL_STATE = "status#state";
+    public static final String CHANNEL_STATE_CODE = "status#state_code";
 
     public static final String CHANNEL_CONTROL = "actions#control";
     public static final String CHANNEL_COMMAND = "actions#commands";

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoBindingConstants.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/MiIoBindingConstants.java
@@ -47,13 +47,13 @@ public final class MiIoBindingConstants {
     public static final String CHANNEL_CLEAN_AREA = "status#clean_area";
     public static final String CHANNEL_CLEAN_TIME = "status#clean_time";
     public static final String CHANNEL_DND_ENABLED = "status#dnd_enabled";
-    public static final String CHANNEL_ERROR = "status#error";
     public static final String CHANNEL_ERROR_CODE = "status#error_code";
+    public static final String CHANNEL_ERROR_ID = "status#error_id";
     public static final String CHANNEL_FAN_POWER = "status#fan_power";
     public static final String CHANNEL_IN_CLEANING = "status#in_cleaning";
     public static final String CHANNEL_MAP_PRESENT = "status#map_present";
     public static final String CHANNEL_STATE = "status#state";
-    public static final String CHANNEL_STATE_CODE = "status#state_code";
+    public static final String CHANNEL_STATE_ID = "status#state_id";
 
     public static final String CHANNEL_CONTROL = "actions#control";
     public static final String CHANNEL_COMMAND = "actions#commands";

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -131,13 +131,13 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_CLEAN_TIME,
                 new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
-        VacuumErrorType error_code = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
-        updateState(CHANNEL_ERROR, new StringType(error_code.getDescription()));
+        VacuumErrorType errorCode = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
+        updateState(CHANNEL_ERROR, new StringType(errorCode.getDescription()));
         updateState(CHANNEL_ERROR_CODE, new DecimalType(statusData.get("error_code").getAsInt()));
         int fanLevel = statusData.get("fan_power").getAsInt();
-        FanModeType fanpower = FanModeType.getType(fanLevel);
+        FanModeType fanPower = FanModeType.getType(fanLevel);
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));
-        updateState(CHANNEL_FAN_CONTROL, new DecimalType(fanpower.getId()));
+        updateState(CHANNEL_FAN_CONTROL, new DecimalType(fanPower.getId()));
         updateState(CHANNEL_IN_CLEANING, new DecimalType(statusData.get("in_cleaning").getAsBigDecimal()));
         updateState(CHANNEL_MAP_PRESENT, new DecimalType(statusData.get("map_present").getAsBigDecimal()));
         StatusType state = StatusType.getType(statusData.get("state").getAsInt());

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -132,8 +132,8 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
                 new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
         VacuumErrorType errorCode = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
-        updateState(CHANNEL_ERROR, new StringType(errorCode.getDescription()));
-        updateState(CHANNEL_ERROR_CODE, new DecimalType(statusData.get("error_code").getAsInt()));
+        updateState(CHANNEL_ERROR_CODE, new StringType(errorCode.getDescription()));
+        updateState(CHANNEL_ERROR_ID, new DecimalType(statusData.get("error_code").getAsInt()));
         int fanLevel = statusData.get("fan_power").getAsInt();
         FanModeType fanPower = FanModeType.getType(fanLevel);
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));
@@ -142,7 +142,7 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_MAP_PRESENT, new DecimalType(statusData.get("map_present").getAsBigDecimal()));
         StatusType state = StatusType.getType(statusData.get("state").getAsInt());
         updateState(CHANNEL_STATE, new StringType(state.getDescription()));
-        updateState(CHANNEL_STATE_CODE, new DecimalType(statusData.get("state").getAsInt()));
+        updateState(CHANNEL_STATE_ID, new DecimalType(statusData.get("state").getAsInt()));
         State vacuum = OnOffType.OFF;
         String control;
         switch (state) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -133,7 +133,7 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
         VacuumErrorType error_code = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
         updateState(CHANNEL_ERROR, new StringType(error_code.getDescription()));
-        updateState(CHANNEL_ERROR_CODE, new DecimalType(error_code.getId()));
+        updateState(CHANNEL_ERROR_CODE, new DecimalType(statusData.get("error_code").getAsInt()));
         int fanLevel = statusData.get("fan_power").getAsInt();
         FanModeType fanpower = FanModeType.getType(fanLevel);
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));
@@ -142,7 +142,7 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_MAP_PRESENT, new DecimalType(statusData.get("map_present").getAsBigDecimal()));
         StatusType state = StatusType.getType(statusData.get("state").getAsInt());
         updateState(CHANNEL_STATE, new StringType(state.getDescription()));
-        updateState(CHANNEL_STATE_CODE, new DecimalType(state.getId()));
+        updateState(CHANNEL_STATE_CODE, new DecimalType(statusData.get("state").getAsInt()));
         State vacuum = OnOffType.OFF;
         String control;
         switch (state) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -128,16 +128,13 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
     private boolean updateVacuumStatus(JsonObject statusData) {
         updateState(CHANNEL_BATTERY, new DecimalType(statusData.get("battery").getAsBigDecimal()));
         updateState(CHANNEL_CLEAN_AREA, new DecimalType(statusData.get("clean_area").getAsDouble() / 1000000.0));
-        updateState(CHANNEL_CLEAN_TIME,
-                new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
+        updateState(CHANNEL_CLEAN_TIME, new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
-        VacuumErrorType errorCode = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
-        updateState(CHANNEL_ERROR_CODE, new StringType(errorCode.getDescription()));
+        updateState(CHANNEL_ERROR_CODE, new StringType(VacuumErrorType.getType(statusData.get("error_code").getAsInt()).getDescription()));
         updateState(CHANNEL_ERROR_ID, new DecimalType(statusData.get("error_code").getAsInt()));
         int fanLevel = statusData.get("fan_power").getAsInt();
-        FanModeType fanPower = FanModeType.getType(fanLevel);
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));
-        updateState(CHANNEL_FAN_CONTROL, new DecimalType(fanPower.getId()));
+        updateState(CHANNEL_FAN_CONTROL, new DecimalType(FanModeType.getType(fanLevel).getId()));
         updateState(CHANNEL_IN_CLEANING, new DecimalType(statusData.get("in_cleaning").getAsBigDecimal()));
         updateState(CHANNEL_MAP_PRESENT, new DecimalType(statusData.get("map_present").getAsBigDecimal()));
         StatusType state = StatusType.getType(statusData.get("state").getAsInt());

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -131,8 +131,9 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_CLEAN_TIME,
                 new DecimalType(TimeUnit.SECONDS.toMinutes(statusData.get("clean_time").getAsLong())));
         updateState(CHANNEL_DND_ENABLED, new DecimalType(statusData.get("dnd_enabled").getAsBigDecimal()));
-        updateState(CHANNEL_ERROR_CODE,
-                new StringType(VacuumErrorType.getType(statusData.get("error_code").getAsInt()).getDescription()));
+        VacuumErrorType error_code = VacuumErrorType.getType(statusData.get("error_code").getAsInt());
+        updateState(CHANNEL_ERROR, new StringType(error_code.getDescription()));
+        updateState(CHANNEL_ERROR_CODE, new DecimalType(error_code.getId()));
         int fanLevel = statusData.get("fan_power").getAsInt();
         FanModeType fanpower = FanModeType.getType(fanLevel);
         updateState(CHANNEL_FAN_POWER, new DecimalType(fanLevel));
@@ -141,6 +142,7 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         updateState(CHANNEL_MAP_PRESENT, new DecimalType(statusData.get("map_present").getAsBigDecimal()));
         StatusType state = StatusType.getType(statusData.get("state").getAsInt());
         updateState(CHANNEL_STATE, new StringType(state.getDescription()));
+        updateState(CHANNEL_STATE_CODE, new DecimalType(state.getId()));
         State vacuum = OnOffType.OFF;
         String control;
         switch (state) {

--- a/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
@@ -115,7 +115,7 @@
 	</channel-type>
 	<channel-type id="error_code">
 		<item-type>Number</item-type>
-		<label>Error</label>
+		<label>Error Code</label>
 		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="fan_power">
@@ -146,7 +146,7 @@
 	</channel-type>
 	<channel-type id="state_code">
 		<item-type>Number</item-type>
-		<label>State</label>
+		<label>State Code</label>
 		<state readOnly="true" />
 	</channel-type>
 

--- a/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
@@ -40,12 +40,14 @@
 			<channel id="battery" typeId="system.battery-level" />
 			<channel id="clean_area" typeId="clean_area" />
 			<channel id="clean_time" typeId="clean_time" />
+			<channel id="error" typeId="error" />
 			<channel id="error_code" typeId="error_code" />
 			<channel id="fan_power" typeId="fan_power" />
 			<channel id="in_cleaning" typeId="in_cleaning" />
 			<channel id="dnd_enabled" typeId="dnd_enabled" />
 			<channel id="map_present" typeId="map_present" />
 			<channel id="state" typeId="state" />
+			<channel id="state_code" typeId="state_code" />
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="consumables">
@@ -106,8 +108,13 @@
 		<item-type>Switch</item-type>
 		<label>Do Not Disturb</label>
 	</channel-type>
-	<channel-type id="error_code">
+	<channel-type id="error">
 		<item-type>String</item-type>
+		<label>Error</label>
+		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="error_code">
+		<item-type>Number</item-type>
 		<label>Error</label>
 		<state readOnly="true" />
 	</channel-type>
@@ -134,6 +141,11 @@
 	</channel-type>
 	<channel-type id="state">
 		<item-type>String</item-type>
+		<label>State</label>
+		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="state_code">
+		<item-type>Number</item-type>
 		<label>State</label>
 		<state readOnly="true" />
 	</channel-type>

--- a/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
@@ -40,14 +40,14 @@
 			<channel id="battery" typeId="system.battery-level" />
 			<channel id="clean_area" typeId="clean_area" />
 			<channel id="clean_time" typeId="clean_time" />
-			<channel id="error" typeId="error" />
 			<channel id="error_code" typeId="error_code" />
+			<channel id="error_id" typeId="error_id" />
 			<channel id="fan_power" typeId="fan_power" />
 			<channel id="in_cleaning" typeId="in_cleaning" />
 			<channel id="dnd_enabled" typeId="dnd_enabled" />
 			<channel id="map_present" typeId="map_present" />
 			<channel id="state" typeId="state" />
-			<channel id="state_code" typeId="state_code" />
+			<channel id="state_id" typeId="state_id" />
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="consumables">
@@ -108,14 +108,14 @@
 		<item-type>Switch</item-type>
 		<label>Do Not Disturb</label>
 	</channel-type>
-	<channel-type id="error">
+	<channel-type id="error_code">
 		<item-type>String</item-type>
-		<label>Error</label>
+		<label>Error Code</label>
 		<state readOnly="true" />
 	</channel-type>
-	<channel-type id="error_code">
+	<channel-type id="error_id">
 		<item-type>Number</item-type>
-		<label>Error Code</label>
+		<label>Error ID</label>
 		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="fan_power">
@@ -144,9 +144,9 @@
 		<label>State</label>
 		<state readOnly="true" />
 	</channel-type>
-	<channel-type id="state_code">
+	<channel-type id="state_id">
 		<item-type>Number</item-type>
-		<label>State Code</label>
+		<label>State ID</label>
 		<state readOnly="true" />
 	</channel-type>
 


### PR DESCRIPTION
Up to now, the status and error codes have only been output as text. On the one hand, this makes it complicated to create a mapping for your own status/error message (for example, in another language), and on the other hand, messages that are not yet implemented are only passed on as "UNKNOWN".

The two channels state_code and error_code now output the integers directly, so a mapping to numbers can be easily done and new codes are also output.

Signed-off-by: Markus Schraufstetter <markus.schraufstetter@gmail.com>