### PR TITLE
[Loxone] Fix for deadlock when sending commands from the Miniserver's state handler

### DIFF
--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxWebSocket.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxWebSocket.java
@@ -240,7 +240,7 @@ public class LxWebSocket {
                         while (length > 0) {
                             Double value = ByteBuffer.wrap(data, offset + 16, 8).order(ByteOrder.LITTLE_ENDIAN)
                                     .getDouble();
-                            thingHandler.updateStateValue(new LxUuid(data, offset), value);
+                            thingHandler.queueStateUpdate(new LxUuid(data, offset), value);
                             offset += 24;
                             length -= 24;
                         }
@@ -251,7 +251,7 @@ public class LxWebSocket {
                             int textLen = ByteBuffer.wrap(data, offset + 32, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
                             String value = new String(data, offset + 36, textLen);
                             int size = 36 + (textLen % 4 > 0 ? textLen + 4 - (textLen % 4) : textLen);
-                            thingHandler.updateStateValue(new LxUuid(data, offset), value);
+                            thingHandler.queueStateUpdate(new LxUuid(data, offset), value);
                             offset += size;
                             length -= size;
                         }
@@ -594,6 +594,7 @@ public class LxWebSocket {
             }
             if (!awaitingCommand.equals(control)) {
                 logger.warn("[{}] Waiting for another response: {}", debugId, awaitingCommand);
+                return;
             }
             awaitedResponse.subResponse = resp.subResponse;
             if (syncRequest) {
@@ -622,7 +623,6 @@ public class LxWebSocket {
             awaitingConfiguration = true;
             if (sendCmdNoResp(CMD_GET_APP_CONFIG, false)) {
                 startResponseTimeout();
-                // startKeepAlive();
             } else {
                 disconnect(LxErrorCode.INTERNAL_ERROR, "Error sending get config command.");
             }

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxStateUpdate.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxStateUpdate.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.loxone.internal.types;
+
+/**
+ * A state update event. It is used to defer and queue processing of Loxone state updates, so they are not processed in
+ * the websocket thread.
+ *
+ * @author Pawel Pieczul - initial contribution
+ *
+ */
+public class LxStateUpdate {
+    private final LxUuid uuid;
+    private final Object value;
+
+    public LxStateUpdate(LxUuid uuid, Object value) {
+        this.uuid = uuid;
+        this.value = value;
+    }
+
+    public LxUuid getUuid() {
+        return uuid;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
The issue was reported at the forum: https://community.openhab.org/t/loxone-anyone/15712/53
It is caused by a deadlock in binding. When a web-socket binary message is received from Miniserver with a state update indicating a position change of a rollershutter and binding decides it should stop the rollershutter movement, because it reached target position, binding attempts to send a websocket message to the Miniserver. This message is sent from the websocket thread where state update was received and this causes indefinite waiting for the message acknowledgement from the Miniserver, which is never received, as the websocket thread waits for it.

The solution is to add a queue for state updates received from the miniserver and process all state updates in the main binding thread, currently used for sending periodic keep-alive messages. This thread was modified to be used for both state update processing and still sending the keep-alive messages.

This change was tested by me and the submitter for a few days (https://community.openhab.org/u/HALLO01).

Signed-off-by: Pawel Pieczul <pieczul@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
