### PR TITLE
[rfxcom] Changed logging level

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComBridgeHandler.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/handler/RFXComBridgeHandler.java
@@ -240,7 +240,7 @@ public class RFXComBridgeHandler extends BaseBridgeHandler {
                     RFXComInterfaceMessage msg = (RFXComInterfaceMessage) message;
                     if (msg.subType == SubType.RESPONSE) {
                         if (msg.command == Commands.GET_STATUS) {
-                            logger.info("RFXCOM transceiver/receiver type: {}, hw version: {}.{}, fw version: {}",
+                            logger.debug("RFXCOM transceiver/receiver type: {}, hw version: {}.{}, fw version: {}",
                                     msg.transceiverType, msg.hardwareVersion1, msg.hardwareVersion2,
                                     msg.firmwareVersion);
                             thing.setProperty(Thing.PROPERTY_HARDWARE_VERSION,


### PR DESCRIPTION
Changed transceiver type logging level from info to debug. This was only info level logging, which is rather useless for normal user.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
