### PR TITLE
Fixed missing 2.5.2-SNAPSHOT changes

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -11,7 +11,7 @@ IF %ARGC% NEQ 3 (
 )
 
 SET OpenhabCoreVersion="2.5.0"
-SET OpenhabVersion="2.5.1-SNAPSHOT"
+SET OpenhabVersion="2.5.2-SNAPSHOT"
 
 SET BindingIdInCamelCase=%~1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -3,7 +3,7 @@
 [ $# -lt 3 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author> <GitHub Username>"; exit 1; }
 
 openHABCoreVersion=2.5.0
-openHABVersion=2.5.1-SNAPSHOT
+openHABVersion=2.5.2-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/color-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/color-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:color_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,34 +66,38 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="on" type="text">
 			<label>On/Open Value</label>
-			<description>A number (like 1, 10) or a string (like "enabled") that is recognised as on/open state. You can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
+			<description>A number (like 1, 10) or a string (like "enabled") that is recognised as on/open state. You can use this
+				parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
 			<default>1</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="off" type="text">
 			<label>Off/Closed Value</label>
-			<description>A number (like 0, -10) or a string (like "disabled") that is recognised as off/closed state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
+			<description>A number (like 0, -10) or a string (like "disabled") that is recognised as off/closed state. You can use
+				this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
 			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="onBrightness" type="integer" min="1" max="100">
 			<label>Initial Brightness</label>
 			<description>If you connect this channel to a Switch item and turn it on,
-			color and saturation are preserved from the last state, but
-			the brightness will be set to this configured initial brightness percentage.</description>
+				color and saturation are preserved from the last state, but
+				the brightness will be set to this configured initial brightness percentage.</description>
 			<default>10</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/dimmer-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/dimmer-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:dimmer_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,39 +66,46 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="min" type="decimal">
 			<label>Absolute Minimum</label>
-			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals zero percent.</description>
+			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals
+				zero percent.</description>
 		</parameter>
 		<parameter name="max" type="decimal">
 			<label>Absolute Maximum</label>
-			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals one-hundred percent.</description>
+			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals
+				one-hundred percent.</description>
 		</parameter>
 		<parameter name="step" type="decimal">
 			<label>Delta Value</label>
-			<description>A number/dimmer channel can receive INCREASE/DECREASE commands and computes the target number by adding or subtracting this delta value.</description>
+			<description>A number/dimmer channel can receive INCREASE/DECREASE commands and computes the target number by adding
+				or subtracting this delta value.</description>
 			<default>1.0</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="on" type="text">
 			<label>Custom On/Open Value</label>
-			<description>A number (like 1, 10) or a string (like "enabled") that is additionally recognised as on/open state. You can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
+			<description>A number (like 1, 10) or a string (like "enabled") that is additionally recognised as on/open state. You
+				can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
 			<default>1</default>
 		</parameter>
 		<parameter name="off" type="text">
 			<label>Custom Off/Closed Value</label>
-			<description>A number (like 0, -10) or a string (like "disabled") that is additionally recognised as off/closed state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
+			<description>A number (like 0, -10) or a string (like "disabled") that is additionally recognised as off/closed
+				state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
 			<default>0</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/number-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/number-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:number_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,35 +66,41 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="min" type="decimal">
 			<label>Absolute Minimum</label>
-			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals zero percent.</description>
+			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals
+				zero percent.</description>
 		</parameter>
 		<parameter name="max" type="decimal">
 			<label>Absolute Maximum</label>
-			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals one-hundred percent.</description>
+			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals
+				one-hundred percent.</description>
 		</parameter>
 		<parameter name="step" type="decimal">
 			<label>Delta Value</label>
-			<description>A number/dimmer channel can receive INCREASE/DECREASE commands and computes the target number by adding or subtracting this delta value.</description>
+			<description>A number/dimmer channel can receive INCREASE/DECREASE commands and computes the target number by adding
+				or subtracting this delta value.</description>
 			<default>1.0</default>
 			<advanced>true</advanced>
 		</parameter>
-        <parameter name="unit" type="text">
-            <label>Unit Of Measurement</label>
-            <description>Unit of measurement (optional). The unit is used for representing the value in the GUI as well as for converting incoming values (like from '°F' to '°C'). Examples: "°C", "°F"</description>
-            <advanced>true</advanced>
-        </parameter>
+		<parameter name="unit" type="text">
+			<label>Unit Of Measurement</label>
+			<description>Unit of measurement (optional). The unit is used for representing the value in the GUI as well as for
+				converting incoming values (like from '°F' to '°C'). Examples: "°C", "°F"</description>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/rollershutter-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/rollershutter-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:rollershutter_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,29 +66,34 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="on" type="text">
 			<label>Up Value</label>
-			<description>A string (like "OPEN") that is recognised as UP state. You can use this parameter for a second keyword, next to UP.</description>
+			<description>A string (like "OPEN") that is recognised as UP state. You can use this parameter for a second keyword,
+				next to UP.</description>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="off" type="text">
 			<label>Down Value</label>
-			<description>A string (like "CLOSE") that is recognised as DOWN state. You can use this parameter for a second keyword, next to DOWN.</description>
+			<description>A string (like "CLOSE") that is recognised as DOWN state. You can use this parameter for a second
+				keyword, next to DOWN.</description>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="stop" type="text">
 			<label>Stop Value</label>
-			<description>A string (like "STOP") that is recognised as stop state. Will set the rollershutter state to undefined, because the current position is unknown at that point.</description>
+			<description>A string (like "STOP") that is recognised as stop state. Will set the rollershutter state to undefined,
+				because the current position is unknown at that point.</description>
 			<default>STOP</default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/string-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/string-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:string_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,20 +66,23 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="allowedStates" type="text">
 			<label>Allowed States</label>
-			<description>If your MQTT topic is limited to a set of one or more specific commands or specific states, define those states here. Separate multiple states with commas. An example for a light bulb state set: ON,DIMMED,OFF</description>
+			<description>If your MQTT topic is limited to a set of one or more specific commands or specific states, define those
+				states here. Separate multiple states with commas. An example for a light bulb state set: ON,DIMMED,OFF</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/switch-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/config/switch-channel-config.xml
@@ -7,13 +7,15 @@
 	<config-description uri="thing-type:mqtt:switch_channel">
 		<parameter-group name="transformations">
 			<label>Transform Values</label>
-			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a received value is assigned to an item.</description>
+			<description>These configuration parameters allow you to alter a value before it is published to MQTT or before a
+				received value is assigned to an item.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="stateTopic" type="text">
 			<label>MQTT State Topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the
+				channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT Command Topic</label>
@@ -25,7 +27,7 @@
 			Applies transformations to an incoming MQTT topic value.
 			A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for
 			a json {device: {status: { temperature: 23.2 }}}.
-			
+
 			You can chain transformations by separating them with the intersection character ∩.
 			]]></description>
 			<advanced>true</advanced>
@@ -34,7 +36,7 @@
 			<label>Outgoing Value Transformation</label>
 			<description><![CDATA[
 			Applies a transformation before publishing a MQTT topic value.
-			
+
 			Transformations are specialised in extracting a value, but some transformations like
 			the MAP one could be useful.
 			]]></description>
@@ -45,7 +47,7 @@
 			<description><![CDATA[
 			Format a value before it is published to the MQTT broker.
 			The default is to just pass the channel/item state.
-			
+
 			If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s".
 			If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 			]]></description>
@@ -64,25 +66,29 @@
 		</parameter>
 		<parameter name="retained" type="boolean">
 			<label>Retained</label>
-			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the
+				broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="postCommand" type="boolean">
 			<label>Is Command</label>
-			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable
+				this option.</description>
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="on" type="text">
 			<label>Custom On/Open Value</label>
-			<description>A number (like 1, 10) or a string (like "enabled") that is additionally recognised as on/open state. You can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
+			<description>A number (like 1, 10) or a string (like "enabled") that is additionally recognised as on/open state. You
+				can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
 			<default>1</default>
 		</parameter>
 		<parameter name="off" type="text">
 			<label>Custom Off/Closed Value</label>
-			<description>A number (like 0, -10) or a string (like "disabled") that is additionally recognised as off/closed state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
+			<description>A number (like 0, -10) or a string (like "disabled") that is additionally recognised as off/closed
+				state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
 			<default>0</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/ESH-INF/thing/generic-thing.xml
@@ -4,13 +4,15 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="topic" extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB,datetime,image,location,rollershutter">
+	<thing-type id="topic"
+		extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB,datetime,image,location,rollershutter">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker" />
 			<bridge-type-ref id="systemBroker" />
 		</supported-bridge-type-refs>
 		<label>Generic MQTT Thing</label>
-		<description>You need a configured Broker first. Dynamically add channels of various types to this Thing. Link different MQTT topics to each channel.</description>
+		<description>You need a configured Broker first. Dynamically add channels of various types to this Thing. Link
+			different MQTT topics to each channel.</description>
 	</thing-type>
 
 </thing:thing-descriptions>

--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -23,11 +23,11 @@ Fragment-Host: org.openhab.binding.astro
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.astro;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.astro.tests;version='[2.5.1,2.5.2)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.astro;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.astro.tests;version='[2.5.2,2.5.3)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -33,8 +33,8 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
-	org.openhab.binding.avmfritz;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.avmfritz.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.avmfritz;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.avmfritz.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core.config.discovery.upnp;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -32,8 +32,8 @@ Fragment-Host: org.openhab.binding.feed
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
-	org.openhab.binding.feed;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.feed.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.feed;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.feed.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -30,8 +30,8 @@ Fragment-Host: org.openhab.binding.hue
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
-	org.openhab.binding.hue;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.hue.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.hue;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.hue.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -28,8 +28,8 @@ Fragment-Host: org.openhab.binding.max
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.openhab.binding.max;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.max.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.max;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.max.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -40,10 +40,10 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.mqtt;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.generic;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.homeassistant;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.homeassistant.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.generic;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.homeassistant;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.homeassistant.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homeassistant.tests</artifactId>

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -39,10 +39,10 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.paho.client.mqttv3;version='[1.2.1,1.2.2)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.mqtt;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.generic;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.homie;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.mqtt.homie.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.mqtt;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.generic;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.homie;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.mqtt.homie.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homie.tests</artifactId>

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -41,8 +41,8 @@ Fragment-Host: org.openhab.binding.nest
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	org.openhab.binding.nest;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.nest.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.nest;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.nest.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -29,8 +29,8 @@ Fragment-Host: org.openhab.binding.ntp
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.ntp;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.ntp.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.ntp;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.ntp.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -25,8 +25,8 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.openhab.binding.systeminfo;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.systeminfo.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.systeminfo;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.systeminfo.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -36,8 +36,8 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.binding.tradfri;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.tradfri.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.tradfri;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.tradfri.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core.config.discovery.mdns;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mdns;version='[2.5.0,2.5.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -31,8 +31,8 @@ Fragment-Host: org.openhab.binding.wemo
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.jupnp;version='[2.5.2,2.5.3)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.openhab.binding.wemo;version='[2.5.1,2.5.2)',\
-	org.openhab.binding.wemo.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.binding.wemo;version='[2.5.2,2.5.3)',\
+	org.openhab.binding.wemo.tests;version='[2.5.2,2.5.3)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.io.hueemulation.tests/itest.bndrun
+++ b/itests/org.openhab.io.hueemulation.tests/itest.bndrun
@@ -34,8 +34,8 @@ Fragment-Host: org.openhab.io.hueemulation
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.io.hueemulation;version='[2.5.1,2.5.2)',\
-	org.openhab.io.hueemulation.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.io.hueemulation;version='[2.5.2,2.5.3)',\
+	org.openhab.io.hueemulation.tests;version='[2.5.2,2.5.3)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
@@ -49,8 +49,8 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mqtt;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.io.mqttembeddedbroker;version='[2.5.1,2.5.2)',\
-	org.openhab.io.mqttembeddedbroker.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.io.mqttembeddedbroker;version='[2.5.2,2.5.3)',\
+	org.openhab.io.mqttembeddedbroker.tests;version='[2.5.2,2.5.3)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.io.mqttembeddedbroker.tests</artifactId>

--- a/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
+++ b/itests/org.openhab.persistence.mapdb.tests/itest.bndrun
@@ -23,8 +23,8 @@ Fragment-Host: org.openhab.persistence.mapdb
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.persistence;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.persistence.mapdb;version='[2.5.1,2.5.2)',\
-	org.openhab.persistence.mapdb.tests;version='[2.5.1,2.5.2)',\
+	org.openhab.persistence.mapdb;version='[2.5.2,2.5.3)',\
+	org.openhab.persistence.mapdb.tests;version='[2.5.2,2.5.3)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <packaging>pom</packaging>
 
-  <name>openHAB 2 Add-ons</name>
+  <name>openHAB Add-ons</name>
   <description>This project contains the official add-ons of openHAB</description>
 
   <organization>


### PR DESCRIPTION
- Fixed itest bnd versions in tests
- Fixed pom of disabled itests
- Fixed version in skeleton scripts.