### PR TITLE
[yamahareceiver] connect timed out since 2.5M4 fix

### DIFF
--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaZoneThingHandler.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/handler/YamahaZoneThingHandler.java
@@ -722,6 +722,7 @@ public class YamahaZoneThingHandler extends BaseThingHandler
             try {
                 stateUpdatable.update();
             } catch (IOException e) {
+                logger.debug("State update error. Changing thing to offline", e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
             } catch (ReceivedMessageParseException e) {
                 updateProperty(PROPERTY_LAST_PARSE_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithNavigationControlXML.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithNavigationControlXML.java
@@ -21,6 +21,7 @@ import org.openhab.binding.yamahareceiver.internal.protocol.ReceivedMessageParse
 import org.openhab.binding.yamahareceiver.internal.state.DeviceInformationState;
 import org.openhab.binding.yamahareceiver.internal.state.NavigationControlState;
 import org.openhab.binding.yamahareceiver.internal.state.NavigationControlStateListener;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -47,6 +48,8 @@ import org.w3c.dom.Node;
  * @author Tomasz Maruszak - Refactor
  */
 public class InputWithNavigationControlXML extends AbstractInputControlXML implements InputWithNavigationControl {
+
+    private final Logger logger = LoggerFactory.getLogger(InputWithNavigationControlXML.class);
 
     public static final int MAX_PER_PAGE = 8;
     private boolean useAlternativeBackToHomeCmd = false;
@@ -297,8 +300,10 @@ public class InputWithNavigationControlXML extends AbstractInputControlXML imple
 
             totalWaitingTime += YamahaReceiverBindingConstants.MENU_RETRY_DELAY;
             if (totalWaitingTime > YamahaReceiverBindingConstants.MENU_MAX_WAITING_TIME) {
-                throw new IOException(
-                        "Menu still not ready after " + YamahaReceiverBindingConstants.MENU_MAX_WAITING_TIME + "ms");
+                logger.info("Menu still not ready after " + YamahaReceiverBindingConstants.MENU_MAX_WAITING_TIME + "ms. The menu state will be out of sync.");
+                // ToDo: this needs to redesigned to allow for some sort of async update
+                // Note: there is not really that much we can do here.
+                return;
             }
 
             try {

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLConnection.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/XMLConnection.java
@@ -47,6 +47,8 @@ public class XMLConnection extends AbstractConnection {
     private static final String XML_END = "</YAMAHA_AV>";
     private static final String HEADER_CHARSET_PART = "charset=";
 
+    private static final int CONNECTION_TIMEOUT_MS = 5000;
+
     public XMLConnection(String host) {
         super(host);
     }
@@ -74,7 +76,7 @@ public class XMLConnection extends AbstractConnection {
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Length", Integer.toString(message.length()));
 
-            connection.setConnectTimeout(5); // set a timeout in case the device is not reachable (went offline)
+            connection.setConnectTimeout(CONNECTION_TIMEOUT_MS); // set a timeout in case the device is not reachable (went offline)
             connection.setUseCaches(false);
             connection.setDoInput(true);
             connection.setDoOutput(true);

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXML.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXML.java
@@ -81,8 +81,8 @@ public class ZoneControlXML implements ZoneControl {
     protected boolean dialogueLevelSupported = false;
 
     public ZoneControlXML(AbstractConnection con, Zone zone, YamahaZoneConfig zoneSettings,
-            ZoneControlStateListener observer, DeviceInformationState deviceInformationState,
-            Supplier<InputConverter> inputConverterSupplier) {
+                          ZoneControlStateListener observer, DeviceInformationState deviceInformationState,
+                          Supplier<InputConverter> inputConverterSupplier) {
 
         this.comReference = new WeakReference<>(con);
         this.zone = zone;
@@ -132,22 +132,19 @@ public class ZoneControlXML implements ZoneControl {
 
         try {
             // Note: Detection for RX-V3900, which has a different XML node for surround program
-            Node basicStatusNode = getZoneResponse(comReference.get(), getZone(), ZONE_BASIC_STATUS_CMD,
-                    ZONE_BASIC_STATUS_PATH);
+            Node basicStatusNode = getZoneResponse(comReference.get(), getZone(), ZONE_BASIC_STATUS_CMD, ZONE_BASIC_STATUS_PATH);
             String surroundProgram = getNodeContentOrEmpty(basicStatusNode, "Surr/Pgm_Sel/Pgm");
 
             if (StringUtils.isNotEmpty(surroundProgram)) {
-                surroundSelProgram = new CommandTemplate(
-                        "<Surr><Pgm_Sel><Straight>Off</Straight><Pgm>%s</Pgm></Pgm_Sel></Surr>", "Surr/Pgm_Sel/Pgm");
+                surroundSelProgram = new CommandTemplate("<Surr><Pgm_Sel><Straight>Off</Straight><Pgm>%s</Pgm></Pgm_Sel></Surr>", "Surr/Pgm_Sel/Pgm");
                 logger.debug("Zone {} - adjusting command to: {}", getZone(), surroundSelProgram);
 
-                surroundSelStraight = new CommandTemplate("<Surr><Pgm_Sel><Straight>On</Straight></Pgm_Sel></Surr>",
-                        "Surr/Pgm_Sel/Straight");
+                surroundSelStraight = new CommandTemplate("<Surr><Pgm_Sel><Straight>On</Straight></Pgm_Sel></Surr>", "Surr/Pgm_Sel/Straight");
                 logger.debug("Zone {} - adjusting command to: {}", getZone(), surroundSelStraight);
             }
 
         } catch (ReceivedMessageParseException | IOException e) {
-            logger.warn("Could not perform feature detection for RX-V3900", e);
+            logger.debug("Could not perform feature detection for RX-V3900");
         }
     }
 


### PR DESCRIPTION
Fixes #6328

As per #6328 and [thread here](https://community.openhab.org/t/yamaha-receiver-binding-connect-timed-out/84267/26) community tested on few devices and it seems to resolve the issue.

The jar build for testing is available [here](https://www.dropbox.com/sh/pa069i3bnbsptzj/AABqgJSrQ0lISfDNkUCbwWUma?dl=0).

-----

This is rebased against the 2.5.x branch, I hope this can get in as a 2.5.2 release (the bug is critical).