### PR TITLE
[mqtt] renenable outgoing formatting and address #6831

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/README.md
+++ b/bundles/org.openhab.binding.mqtt.generic/README.md
@@ -246,6 +246,23 @@ Here are a few examples:
   - For an output of *May 23, 1995* use "%1$**tb** %1$**te**,%1$**tY**".
   - For an output of *23.05.1995* use "%1$**td**.%1$**tm**.%1$**tY**".
   - For an output of *23:15* use "%1$**tH**:%1$**tM**".
+  
+Default pattern applied for each type:
+| Type             | Parameter                         | Pattern             | Comment |
+| ---------------- | --------------------------------- | ------------------- | ------- |
+| __string__       | String                            | "%s"                | 
+| __number__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
+| __dimmer__       | BigDecimal                        | "%f"                | The default will remove trailing zeros after the decimal point. 
+| __contact__      | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
+| __switch__       | String                            | --                  | No pattern supported. Always **on** and **off** strings. 
+| __colorRGB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **red**, **green** and **blue** components.
+| __colorHSB__     | BigDecimal, BigDecimal, BigDecimal| "%1$d,%2$d,%3$d"    | Parameters are **hue**, **saturation** and **brightness** components.
+| __location__     | BigDecimal, BigDecimal            | "%2$f,%3$f,%1$f"    | Parameters are **altitude**, **latitude** and **longitude**, altitude is only in default pattern, if value is not '0'.
+| __image__        | --                                | --                  | No publishing supported. 
+| __datetime__     | ZonedDateTime                     | "%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS.%1$tN" | Trailing zeros of the nanoseconds are removed.
+| __rollershutter__| String                            | "%s"                | No pattern supported. Always **up**, **down**, **stop** string or integer percent value.
+
+Any outgoing value transformation will **always** result in a __string__ value.
 
 ## Troubleshooting
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -14,7 +14,6 @@ package org.openhab.binding.mqtt.generic;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Formatter;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,11 +24,13 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
+import org.openhab.binding.mqtt.generic.values.TextValue;
 import org.openhab.binding.mqtt.generic.values.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,8 +159,7 @@ public class ChannelState implements MqttMessageSubscriber {
             if (transformedValue != null) {
                 strValue = transformedValue;
             } else {
-                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue,
-                        t.serviceName);
+                logger.debug("Transformation '{}' returned null on '{}', discarding message", strValue, t.serviceName);
                 receivedOrTimeout();
                 return;
             }
@@ -332,7 +332,7 @@ public class ChannelState implements MqttMessageSubscriber {
     public CompletableFuture<Boolean> publishValue(Command command) {
         cachedValue.update(command);
 
-        String mqttCommandValue = cachedValue.getMQTTpublishValue();
+        Value mqttCommandValue = cachedValue;
 
         final MqttBrokerConnection connection = this.connection;
 
@@ -352,9 +352,12 @@ public class ChannelState implements MqttMessageSubscriber {
 
         // Outgoing transformations
         for (ChannelStateTransformation t : transformationsOut) {
-            String transformedValue = t.processValue(mqttCommandValue);
+            String commandString = mqttCommandValue.getMQTTpublishValue(null);
+            String transformedValue = t.processValue(commandString);
             if (transformedValue != null) {
-                mqttCommandValue = transformedValue;
+                Value textValue = new TextValue();
+                textValue.update(new StringType(transformedValue));
+                mqttCommandValue = textValue;
             } else {
                 logger.debug("Transformation '{}' returned null on '{}', discarding message", mqttCommandValue,
                         t.serviceName);
@@ -362,19 +365,23 @@ public class ChannelState implements MqttMessageSubscriber {
             }
         }
 
+        String commandString;
+
         // Formatter: Applied before the channel state value is published to the MQTT broker.
         if (config.formatBeforePublish.length() > 0) {
-            try (Formatter formatter = new Formatter()) {
-                Formatter format = formatter.format(config.formatBeforePublish, mqttCommandValue);
-                mqttCommandValue = format.toString();
+            try {
+                commandString = mqttCommandValue.getMQTTpublishValue(config.formatBeforePublish);
             } catch (IllegalFormatException e) {
                 logger.debug("Format pattern incorrect for {}", channelUID, e);
+                commandString = mqttCommandValue.getMQTTpublishValue(null);
             }
+        } else {
+            commandString = mqttCommandValue.getMQTTpublishValue(null);
         }
 
         int qos = (config.qos != null) ? config.qos : connection.getQos();
 
-        return connection.publish(config.commandTopic, mqttCommandValue.getBytes(), qos, config.retained);
+        return connection.publish(config.commandTopic, commandString.getBytes(), qos, config.retained);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/ColorValue.java
@@ -109,22 +109,24 @@ public class ColorValue extends Value {
     private static BigDecimal factor = new BigDecimal(2.5);
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
 
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            formatPattern = "%1$d,%2$d,%3$d";
+        }
+        // ignore the pattern. Don't know
         if (isRGB) {
             PercentType[] rgb = ((HSBType) state).toRGB();
-            StringBuilder b = new StringBuilder();
-            b.append(rgb[0].toBigDecimal().multiply(factor).intValue());
-            b.append(',');
-            b.append(rgb[1].toBigDecimal().multiply(factor).intValue());
-            b.append(',');
-            b.append(rgb[2].toBigDecimal().multiply(factor).intValue());
-            return b.toString();
-        } else {
-            return state.toString();
+            return String.format(formatPattern, rgb[0].toBigDecimal().multiply(factor).intValue(),
+                    rgb[1].toBigDecimal().multiply(factor).intValue(),
+                    rgb[2].toBigDecimal().multiply(factor).intValue());
         }
+        HSBType type = (HSBType) state;
+        return String.format(formatPattern, type.getHue().intValue(), type.getSaturation().intValue(),
+                type.getBrightness().intValue());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/DateTimeValue.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -44,11 +45,14 @@ public class DateTimeValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
-
-        return ((DateTimeType) state).getZonedDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".contentEquals(formatPattern)) {
+            return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(((DateTimeType) state).getZonedDateTime());
+        }
+        return String.format(formatPattern, ((DateTimeType) state).getZonedDateTime());
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/LocationValue.java
@@ -12,10 +12,14 @@
  */
 package org.openhab.binding.mqtt.generic.values;
 
+import java.math.BigDecimal;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.PointType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -30,6 +34,22 @@ import org.eclipse.smarthome.core.types.Command;
 public class LocationValue extends Value {
     public LocationValue() {
         super(CoreItemFactory.LOCATION, Stream.of(PointType.class, StringType.class).collect(Collectors.toList()));
+    }
+
+    @Override
+    public @NonNull String getMQTTpublishValue(@Nullable String pattern) {
+        String formatPattern = pattern;
+        PointType point = ((PointType) state);
+
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            if (point.getAltitude().toBigDecimal().equals(BigDecimal.ZERO)) {
+                formatPattern = "%2$f,%3$f";
+            } else {
+                formatPattern = "%2$f,%3$f,%1$f";
+            }
+        }
+        return String.format(Locale.ROOT, formatPattern, point.getAltitude().toBigDecimal(),
+                point.getLatitude().toBigDecimal(), point.getLongitude().toBigDecimal());
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -56,7 +56,7 @@ public class NumberValue extends Value {
                 .collect(Collectors.toList()));
         this.min = min;
         this.max = max;
-        this.step = step == null ? new BigDecimal(1.0) : step;
+        this.step = step == null ? BigDecimal.ONE : step;
         this.unit = unit == null ? "" : unit;
     }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -56,7 +56,7 @@ public class NumberValue extends Value {
                 .collect(Collectors.toList()));
         this.min = min;
         this.max = max;
-        this.step = step == null ? BigDecimal.ONE : step;
+        this.step = step == null ? new BigDecimal(1.0) : step;
         this.unit = unit == null ? "" : unit;
     }
 
@@ -71,6 +71,20 @@ public class NumberValue extends Value {
         }
 
         return true;
+    }
+
+    @Override
+    public String getMQTTpublishValue(@Nullable String pattern) {
+        if (state == UnDefType.UNDEF) {
+            return "";
+        }
+
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            formatPattern = "%f";
+        }
+
+        return state.format(formatPattern);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
@@ -87,7 +87,7 @@ public class OnOffValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         return (state == OnOffType.ON) ? onCommand : offCommand;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
@@ -70,7 +70,7 @@ public class OpenCloseValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         return (state == OpenClosedType.OPEN) ? openString : closeString;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -14,7 +14,6 @@ package org.openhab.binding.mqtt.generic.values;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -146,14 +145,11 @@ public class PercentageValue extends Value {
                 .add(min).stripTrailingZeros();
 
         String formatPattern = pattern;
-        if (formatPattern == null || "%s".equals(formatPattern)) {
-            if (value.scale() > 0) {
-                formatPattern = "%." + value.scale() + "f";
-            } else {
-                formatPattern = "%.0f";
-            }
+        if (formatPattern == null) {
+            formatPattern = "%s";
         }
-        return String.format(Locale.ROOT, formatPattern, value);
+
+        return new DecimalType(value).format(formatPattern);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -48,7 +48,7 @@ import tec.uom.se.unit.Units;
  */
 @NonNullByDefault
 public class PercentageValue extends Value {
-    private static final BigDecimal DB100 = BigDecimal.valueOf(100);
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
     private final BigDecimal min;
     private final BigDecimal max;
     private final BigDecimal span;
@@ -63,7 +63,7 @@ public class PercentageValue extends Value {
         this.onValue = onValue;
         this.offValue = offValue;
         this.min = min == null ? BigDecimal.ZERO : min;
-        this.max = max == null ? DB100 : max;
+        this.max = max == null ? HUNDRED : max;
         if (this.min.compareTo(this.max) >= 0) {
             throw new IllegalArgumentException("Min need to be smaller than max!");
         }
@@ -81,7 +81,7 @@ public class PercentageValue extends Value {
                // A decimal type need to be converted according to the current min/max values
         if (command instanceof DecimalType) {
             BigDecimal v = ((DecimalType) command).toBigDecimal();
-            v = v.subtract(min).multiply(DB100).divide(max.subtract(min), MathContext.DECIMAL128).stripTrailingZeros();
+            v = v.subtract(min).multiply(HUNDRED).divide(max.subtract(min), MathContext.DECIMAL128);
             state = new PercentType(v);
         } else //
                // A quantity type need to be converted according to the current min/max values
@@ -89,8 +89,7 @@ public class PercentageValue extends Value {
             QuantityType<?> qty = ((QuantityType<?>) command).toUnit(Units.PERCENT);
             if (qty != null) {
                 BigDecimal v = qty.toBigDecimal();
-                v = v.subtract(min).multiply(DB100).divide(max.subtract(min), MathContext.DECIMAL128)
-                        .stripTrailingZeros();
+                v = v.subtract(min).multiply(HUNDRED).divide(max.subtract(min), MathContext.DECIMAL128);
                 state = new PercentType(v);
             }
         } else //
@@ -141,7 +140,7 @@ public class PercentageValue extends Value {
         // Formula: From percentage to custom min/max: value*span/100+min
         // Calculation need to happen with big decimals to either return a straight integer or a decimal depending on
         // the value.
-        BigDecimal value = ((PercentType) state).toBigDecimal().multiply(span).divide(DB100, MathContext.DECIMAL128)
+        BigDecimal value = ((PercentType) state).toBigDecimal().multiply(span).divide(HUNDRED, MathContext.DECIMAL128)
                 .add(min).stripTrailingZeros();
 
         String formatPattern = pattern;

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.mqtt.generic.values;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -47,10 +49,11 @@ import tec.uom.se.unit.Units;
  */
 @NonNullByDefault
 public class PercentageValue extends Value {
-    private final double min;
-    private final double max;
-    private final double span;
-    private final double step;
+    private static final BigDecimal DB100 = BigDecimal.valueOf(100);
+    private final BigDecimal min;
+    private final BigDecimal max;
+    private final BigDecimal span;
+    private final BigDecimal step;
     private final @Nullable String onValue;
     private final @Nullable String offValue;
 
@@ -60,13 +63,13 @@ public class PercentageValue extends Value {
                 OnOffType.class, UpDownType.class, StringType.class).collect(Collectors.toList()));
         this.onValue = onValue;
         this.offValue = offValue;
-        this.min = min == null ? 0.0 : min.doubleValue();
-        this.max = max == null ? 100.0 : max.doubleValue();
-        if (this.min >= this.max) {
+        this.min = min == null ? BigDecimal.ZERO : min;
+        this.max = max == null ? DB100 : max;
+        if (this.min.compareTo(this.max) >= 0) {
             throw new IllegalArgumentException("Min need to be smaller than max!");
         }
-        this.span = this.max - this.min;
-        this.step = step == null ? 1.0 : step.doubleValue();
+        this.span = this.max.subtract(this.min);
+        this.step = step == null ? BigDecimal.ONE : step;
     }
 
     @Override
@@ -78,27 +81,28 @@ public class PercentageValue extends Value {
         } else //
                // A decimal type need to be converted according to the current min/max values
         if (command instanceof DecimalType) {
-            double v = ((DecimalType) command).doubleValue();
-            v = (v - min) * 100.0 / (max - min);
-            state = new PercentType(new BigDecimal(v));
+            BigDecimal v = ((DecimalType) command).toBigDecimal();
+            v = v.subtract(min).multiply(DB100).divide(max.subtract(min), MathContext.DECIMAL128).stripTrailingZeros();
+            state = new PercentType(v);
         } else //
                // A quantity type need to be converted according to the current min/max values
         if (command instanceof QuantityType) {
             QuantityType<?> qty = ((QuantityType<?>) command).toUnit(Units.PERCENT);
             if (qty != null) {
-                double v = qty.doubleValue();
-                v = (v - min) * 100.0 / (max - min);
-                state = new PercentType(new BigDecimal(v));
+                BigDecimal v = qty.toBigDecimal();
+                v = v.subtract(min).multiply(DB100).divide(max.subtract(min), MathContext.DECIMAL128)
+                        .stripTrailingZeros();
+                state = new PercentType(v);
             }
         } else //
                // Increase or decrease by "step"
         if (command instanceof IncreaseDecreaseType) {
             if (((IncreaseDecreaseType) command) == IncreaseDecreaseType.INCREASE) {
-                final double v = oldvalue.doubleValue() + step;
-                state = new PercentType(new BigDecimal(v <= max ? v : max));
+                final BigDecimal v = oldvalue.toBigDecimal().add(step);
+                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
             } else {
-                double v = oldvalue.doubleValue() - step;
-                state = new PercentType(new BigDecimal(v >= min ? v : min));
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
+                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
             }
         } else //
                // On/Off equals 100 or 0 percent
@@ -108,19 +112,19 @@ public class PercentageValue extends Value {
               // Increase or decrease by "step"
         if (command instanceof UpDownType) {
             if (((UpDownType) command) == UpDownType.UP) {
-                final double v = oldvalue.doubleValue() + step;
-                state = new PercentType(new BigDecimal(v <= max ? v : max));
+                final BigDecimal v = oldvalue.toBigDecimal().add(step);
+                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
             } else {
-                final double v = oldvalue.doubleValue() - step;
-                state = new PercentType(new BigDecimal(v >= min ? v : min));
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
+                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
             }
         } else //
                // Check against custom on/off values
         if (command instanceof StringType) {
             if (onValue != null && command.toString().equals(onValue)) {
-                state = new PercentType(new BigDecimal(max));
+                state = new PercentType(max);
             } else if (offValue != null && command.toString().equals(offValue)) {
-                state = new PercentType(new BigDecimal(min));
+                state = new PercentType(min);
             } else {
                 throw new IllegalStateException("Unknown String!");
             }
@@ -131,20 +135,30 @@ public class PercentageValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         if (state == UnDefType.UNDEF) {
             return "";
         }
-        // Formular: From percentage to custom min/max: value*span/100+min
+        // Formula: From percentage to custom min/max: value*span/100+min
         // Calculation need to happen with big decimals to either return a straight integer or a decimal depending on
         // the value.
-        return ((PercentType) state).toBigDecimal().multiply(BigDecimal.valueOf(span)).divide(BigDecimal.valueOf(100))
-                .add(BigDecimal.valueOf(min)).toString();
+        BigDecimal value = ((PercentType) state).toBigDecimal().multiply(span).divide(DB100, MathContext.DECIMAL128)
+                .add(min).stripTrailingZeros();
+
+        String formatPattern = pattern;
+        if (formatPattern == null || "%s".equals(formatPattern)) {
+            if (value.scale() > 0) {
+                formatPattern = "%." + value.scale() + "f";
+            } else {
+                formatPattern = "%.0f";
+            }
+        }
+        return String.format(Locale.ROOT, formatPattern, value);
     }
 
     @Override
     public StateDescriptionFragmentBuilder createStateDescription(boolean readOnly) {
-        return super.createStateDescription(readOnly).withMaximum(new BigDecimal(max)).withMinimum(new BigDecimal(min))
-                .withStep(new BigDecimal(step)).withPattern("%s %%");
+        return super.createStateDescription(readOnly).withMaximum(max).withMinimum(min).withStep(step)
+                .withPattern("%s %%");
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/RollershutterValue.java
@@ -113,7 +113,7 @@ public class RollershutterValue extends Value {
     }
 
     @Override
-    public String getMQTTpublishValue() {
+    public String getMQTTpublishValue(@Nullable String pattern) {
         final String upString = this.upString;
         final String downString = this.downString;
         if (this.nextIsStop) {

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
@@ -93,8 +93,11 @@ public abstract class Value {
         return state;
     }
 
-    public String getMQTTpublishValue() {
-        return state.toString();
+    public String getMQTTpublishValue(@Nullable String pattern) {
+        if (pattern == null) {
+            return state.format("%s");
+        }
+        return state.format(pattern);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -204,6 +204,8 @@ public class ChannelStateTests {
 
         c.processMessage("state", "INCREASE".getBytes());
         assertThat(value.getChannelState().toString(), is("60"));
+        assertThat(value.getMQTTpublishValue(null), is("20"));
+        assertThat(value.getMQTTpublishValue("%03.0f"), is("020"));
     }
 
     @Test
@@ -214,22 +216,23 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("25,25,25"));
+        assertThat(value.getMQTTpublishValue(null), is("25,25,25"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
         c.processMessage("state", "12,18,231".getBytes());
         assertThat(value.getChannelState(), is(t)); // HSB
         // rgb -> hsv -> rgb is quite lossy
-        assertThat(value.getMQTTpublishValue(), is("13,20,225"));
+        assertThat(value.getMQTTpublishValue(null), is("13,20,225"));
+        assertThat(value.getMQTTpublishValue("%3$d,%2$d,%1$d"), is("225,20,13"));
     }
 
     @Test
@@ -240,19 +243,19 @@ public class ChannelStateTests {
 
         c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
 
         c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,0"));
 
         c.processMessage("state", "10".getBytes()); // Brightness only
         assertThat(value.getChannelState().toString(), is("0,0,10"));
-        assertThat(value.getMQTTpublishValue(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue(null), is("0,0,10"));
 
         c.processMessage("state", "12,18,100".getBytes());
         assertThat(value.getChannelState().toString(), is("12,18,100"));
-        assertThat(value.getMQTTpublishValue(), is("12,18,100"));
+        assertThat(value.getMQTTpublishValue(null), is("12,18,100"));
     }
 
     @Test
@@ -263,7 +266,7 @@ public class ChannelStateTests {
 
         c.processMessage("state", "46.833974, 7.108433".getBytes());
         assertThat(value.getChannelState().toString(), is("46.833974,7.108433"));
-        assertThat(value.getMQTTpublishValue(), is("46.833974,7.108433"));
+        assertThat(value.getMQTTpublishValue(null), is("46.833974,7.108433"));
     }
 
     @Test
@@ -280,7 +283,7 @@ public class ChannelStateTests {
         String channelState = value.getChannelState().toString();
         assertTrue("Expected '" + channelState + "' to start with '" + datetime + "'",
                 channelState.startsWith(datetime));
-        assertThat(value.getMQTTpublishValue(), is(datetime));
+        assertThat(value.getMQTTpublishValue(null), is(datetime));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
@@ -104,26 +105,26 @@ public class ValueTests {
         OnOffValue v = new OnOffValue("fancyON", "fancyOff");
         // Test with command
         v.update(OnOffType.OFF);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(OnOffType.ON);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with string, representing the command
         v.update(new StringType("OFF"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("ON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
     }
 
@@ -132,26 +133,26 @@ public class ValueTests {
         OpenCloseValue v = new OpenCloseValue("fancyON", "fancyOff");
         // Test with command
         v.update(OpenClosedType.CLOSED);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(OpenClosedType.OPEN);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with string, representing the command
         v.update(new StringType("CLOSED"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("OPEN"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
     }
 
@@ -160,21 +161,21 @@ public class ValueTests {
         RollershutterValue v = new RollershutterValue("fancyON", "fancyOff", "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(new StringType("fancyON"));
-        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyON"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(new StringType("fancyOff"));
-        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(), is("27"));
+        assertThat(v.getMQTTpublishValue(null), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
@@ -183,21 +184,21 @@ public class ValueTests {
         RollershutterValue v = new RollershutterValue(null, null, "fancyStop");
         // Test with command
         v.update(UpDownType.UP);
-        assertThat(v.getMQTTpublishValue(), is("0"));
+        assertThat(v.getMQTTpublishValue(null), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(UpDownType.DOWN);
-        assertThat(v.getMQTTpublishValue(), is("100"));
+        assertThat(v.getMQTTpublishValue(null), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
 
         // Test with custom string
         v.update(PercentType.ZERO);
-        assertThat(v.getMQTTpublishValue(), is("0"));
+        assertThat(v.getMQTTpublishValue(null), is("0"));
         assertThat(v.getChannelState(), is(PercentType.ZERO));
         v.update(PercentType.HUNDRED);
-        assertThat(v.getMQTTpublishValue(), is("100"));
+        assertThat(v.getMQTTpublishValue(null), is("100"));
         assertThat(v.getChannelState(), is(PercentType.HUNDRED));
         v.update(new PercentType(27));
-        assertThat(v.getMQTTpublishValue(), is("27"));
+        assertThat(v.getMQTTpublishValue(null), is("27"));
         assertThat(v.getChannelState(), is(new PercentType(27)));
     }
 
@@ -205,12 +206,12 @@ public class ValueTests {
     public void percentCalc() {
         PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), null,
                 null);
-        v.update(new DecimalType(110.0));
+        v.update(new DecimalType("110.0"));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
-        assertThat(v.getMQTTpublishValue(), is("110.0"));
+        assertThat(v.getMQTTpublishValue(null), is("110"));
         v.update(new DecimalType(10.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
-        assertThat(v.getMQTTpublishValue(), is("10.0"));
+        assertThat(v.getMQTTpublishValue(null), is("10"));
 
         v.update(OnOffType.ON);
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
@@ -219,9 +220,19 @@ public class ValueTests {
     }
 
     @Test
+    public void percentMQTTValue() {
+        PercentageValue v = new PercentageValue(null, null, null, null, null);
+        v.update(new QuantityType<>("70 %"));
+        assertThat(v.getMQTTpublishValue(null), is("70"));
+
+        v.update(new DecimalType(10.0));
+        assertThat(v.getMQTTpublishValue(null), is("10"));
+    }
+
+    @Test
     public void percentCustomOnOff() {
-        PercentageValue v = new PercentageValue(new BigDecimal(0.0), new BigDecimal(100.0), new BigDecimal(1.0), "on",
-                "off");
+        PercentageValue v = new PercentageValue(new BigDecimal("0.0"), new BigDecimal("100.0"), new BigDecimal("1.0"),
+                "on", "off");
         v.update(new StringType("on"));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new StringType("off"));
@@ -230,8 +241,8 @@ public class ValueTests {
 
     @Test
     public void decimalCalc() {
-        PercentageValue v = new PercentageValue(new BigDecimal(0.1), new BigDecimal(1.0), new BigDecimal(0.1), null,
-                null);
+        PercentageValue v = new PercentageValue(new BigDecimal("0.1"), new BigDecimal("1.0"), new BigDecimal("0.1"),
+                null, null);
         v.update(new DecimalType(1.0));
         assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new DecimalType(0.1));

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.PercentType;
-import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
@@ -222,11 +221,13 @@ public class ValueTests {
     @Test
     public void percentMQTTValue() {
         PercentageValue v = new PercentageValue(null, null, null, null, null);
-        v.update(new QuantityType<>("70 %"));
-        assertThat(v.getMQTTpublishValue(null), is("70"));
+        v.update(new DecimalType("10.10000"));
+        assertThat(v.getMQTTpublishValue(null), is("10.1"));
+        for (int i = 0; i <= 100; i++) {
+            v.update(new DecimalType(i));
+            assertThat(v.getMQTTpublishValue(null), is("" + i));
+        }
 
-        v.update(new DecimalType(10.0));
-        assertThat(v.getMQTTpublishValue(null), is("10"));
     }
 
     @Test


### PR DESCRIPTION
I am a bit confused...

for one thing, I seemed to have a bigger problem handling multiple PRs in parallel. With my last PR I undid the one before :-(

So this PR redoes #6755 .

I was not able to reproduce the described problems with the code versions I found.
Before #6755, the dimmer would always use `BigDecimal.toString()` and ignore the format altogether.
With #6755, dimmer would replace `%s` with `%.0f` for integer values....

Now the `PercentValue` will utilize the `DecimalType.format()` function.

Also a unit test is added.
