### PR TITLE
[onewiregpio] Added precision parameter to OneWireGpio Binding

### DIFF
--- a/bundles/org.openhab.binding.onewiregpio/README.md
+++ b/bundles/org.openhab.binding.onewiregpio/README.md
@@ -22,10 +22,12 @@ By default all OneWire GPIO devices are stored in /sys/bus/w1/devices/DEVICE_ID_
 and the temperature value is available in the file "w1_slave". The Thing needs full path to the w1_slave file.
 Note the values in sysfs are in Celsius.
 
+Optional parameter precision makes it easier to lower precision of the sensor value, i.e. precision 1 makes sensor value to show only one digit after the floating point, precision 2 - shows 2 digits. It makes precision reduction with round up, i.e. 20.534C with precision 1 will be 20.5C, 20.555 with same precision will be 20.6C. Allowed values are from 0 to 3. Default value of parameter is 3(max precision).
+
 In the thing file, this looks e.g. like
 
 ```
-Thing onewiregpio:sensor:livingRoom "Living room" [gpio_bus_file="/sys/bus/w1/devices/28-0000061b587b/w1_slave",refresh_time=30]
+Thing onewiregpio:sensor:livingRoom "Living room" [gpio_bus_file="/sys/bus/w1/devices/28-0000061b587b/w1_slave",refresh_time=30,precision=1]
 ```
 
 ## Channels

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGPIOBindingConstants.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGPIOBindingConstants.java
@@ -31,16 +31,11 @@ public class OneWireGPIOBindingConstants {
     public static final String TEMPERATURE = "temperature";
 
     /**
-     * The refresh time in seconds.
-     */
-    public static final String REFRESH_TIME = "refresh_time";
-
-    /**
      * The default auto refresh time in seconds.
      */
     public static final Integer DEFAULT_REFRESH_TIME = Integer.valueOf(120);
 
-    public static final String GPIO_BUS_FILE = "gpio_bus_file";
+    public static final int MAX_PRECISION_VALUE = 3;
 
     public static final String FILE_TEMP_MARKER = "t=";
 

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGpioConfiguration.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGpioConfiguration.java
@@ -12,8 +12,11 @@
  */
 package org.openhab.binding.onewiregpio.internal;
 
+import java.math.BigDecimal;
+
 /**
- * The {@link OneWireGpioConfiguration} Configuration class for easier configuration read through the reflection method in
+ * The {@link OneWireGpioConfiguration} Configuration class for easier configuration read through the reflection method
+ * in
  * the framework.
  *
  * @author Konstantin Polihronov - Initial contribution
@@ -21,5 +24,5 @@ package org.openhab.binding.onewiregpio.internal;
 public class OneWireGpioConfiguration {
     public String gpio_bus_file;
     public Integer refresh_time;
-    public Integer precision;
+    public BigDecimal precision;
 }

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGpioConfiguration.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/OneWireGpioConfiguration.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.onewiregpio.internal;
+
+/**
+ * The {@link OneWireGpioConfiguration} Configuration class for easier configuration read through the reflection method in
+ * the framework.
+ *
+ * @author Konstantin Polihronov - Initial contribution
+ */
+public class OneWireGpioConfiguration {
+    public String gpio_bus_file;
+    public Integer refresh_time;
+    public Integer precision;
+}

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.onewiregpio.internal.OneWireGPIOBindingConstan
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
@@ -26,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -38,6 +38,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.onewiregpio.internal.OneWireGPIOBindingConstants;
+import org.openhab.binding.onewiregpio.internal.OneWireGpioConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Anatol Ogorek - Initial contribution
+ * @author Konstantin Polihronov - Changed configuration handling and added new parameter - precision
  */
 public class OneWireGPIOHandler extends BaseThingHandler {
 
@@ -53,6 +55,8 @@ public class OneWireGPIOHandler extends BaseThingHandler {
 
     private String gpioBusFile;
     private Integer refreshTime;
+    private Integer precision;
+
     private ScheduledFuture<?> sensorRefreshJob;
 
     public OneWireGPIOHandler(Thing thing) {
@@ -73,6 +77,11 @@ public class OneWireGPIOHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
+        OneWireGpioConfiguration configuration = getConfigAs(OneWireGpioConfiguration.class);
+        gpioBusFile = configuration.gpio_bus_file;
+        refreshTime = configuration.refresh_time;
+        precision = configuration.precision;
+
         if (checkConfiguration()) {
             startAutomaticRefresh();
             updateStatus(ThingStatus.ONLINE);
@@ -84,8 +93,6 @@ public class OneWireGPIOHandler extends BaseThingHandler {
      * When invalid parameter is found, default value is assigned.
      */
     private boolean checkConfiguration() {
-        Configuration configuration = getConfig();
-        gpioBusFile = (String) configuration.get(GPIO_BUS_FILE);
         if (StringUtils.isEmpty(gpioBusFile)) {
             logger.debug("GPIO_BUS_FILE not set. Please check configuration, and set proper path to w1_slave file.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -93,12 +100,18 @@ public class OneWireGPIOHandler extends BaseThingHandler {
             return false;
         }
 
-        refreshTime = ((Number) configuration.get(REFRESH_TIME)).intValue();
-        if (refreshTime.intValue() <= 0) {
-            logger.warn("Refresh time [{}] is not valid. Falling back to default value: {}.", refreshTime,
+        if (refreshTime <= 0) {
+            logger.debug("Refresh time [{}] is not valid. Falling back to default value: {}.", refreshTime,
                     DEFAULT_REFRESH_TIME);
             refreshTime = DEFAULT_REFRESH_TIME;
         }
+
+        if (precision < 0 || precision > MAX_PRECISION_VALUE) {
+            logger.debug("Precision value {} is outside allowed values [0 - 3]. Falling back to default value: {}.",
+                    precision, MAX_PRECISION_VALUE);
+            precision = MAX_PRECISION_VALUE;
+        }
+
         return true;
     }
 
@@ -147,7 +160,7 @@ public class OneWireGPIOHandler extends BaseThingHandler {
                 if (getThing().getStatus() != ThingStatus.ONLINE) {
                     updateStatus(ThingStatus.ONLINE);
                 }
-                return BigDecimal.valueOf(intTemp).movePointLeft(3);
+                return calculateValue(intTemp);
             } else {
                 logger.debug(
                         "GPIO file didn't contain line with 't=' where temperature value should be available. Check if configuration points to the proper file");
@@ -159,6 +172,15 @@ public class OneWireGPIOHandler extends BaseThingHandler {
             return null;
         }
 
+    }
+
+    private BigDecimal calculateValue(Integer intTemp) {
+        BigDecimal result = BigDecimal.valueOf(intTemp).movePointLeft(3);
+        if (precision != MAX_PRECISION_VALUE) {
+            result = result.setScale(precision, RoundingMode.HALF_UP);
+        }
+        logger.debug("Thing = {}, temperature value = {}.", getThing().getUID(), result);
+        return result;
     }
 
     @Override

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
@@ -80,7 +80,8 @@ public class OneWireGPIOHandler extends BaseThingHandler {
         OneWireGpioConfiguration configuration = getConfigAs(OneWireGpioConfiguration.class);
         gpioBusFile = configuration.gpio_bus_file;
         refreshTime = configuration.refresh_time;
-        precision = configuration.precision;
+        precision = configuration.precision.intValue();
+        logger.debug("GPIO Busfile={}, RefreshTime={}, precision={}", gpioBusFile, refreshTime, precision);
 
         if (checkConfiguration()) {
             startAutomaticRefresh();

--- a/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/java/org/openhab/binding/onewiregpio/internal/handler/OneWireGPIOHandler.java
@@ -107,7 +107,8 @@ public class OneWireGPIOHandler extends BaseThingHandler {
         }
 
         if (precision < 0 || precision > MAX_PRECISION_VALUE) {
-            logger.debug("Precision value {} is outside allowed values [0 - 3]. Falling back to default value: {}.",
+            logger.debug(
+                    "Precision value {} is outside allowed values [0 - {}]. Falling back to maximum precision value.",
                     precision, MAX_PRECISION_VALUE);
             precision = MAX_PRECISION_VALUE;
         }

--- a/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -22,17 +22,10 @@
 				<default>600</default>
 			</parameter>
 
-			<parameter name="precision" type="integer">
+			<parameter name="precision" type="integer" min="0" max="3">
 				<label>Sensor Precision</label>
 				<description>Sensor precision after floating point.</description>
 				<required>false</required>
-				<options>
-					<option value="0">0</option>
-					<option value="1">1</option>
-					<option value="2">2</option>
-					<option value="3">3</option>
-				</options>
-				<limitToOptions>true</limitToOptions>
 				<default>3</default>
 			</parameter>
 

--- a/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -26,6 +26,13 @@
 				<label>Sensor Precision</label>
 				<description>Sensor precision after floating point.</description>
 				<required>false</required>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
 				<default>3</default>
 			</parameter>
 

--- a/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -22,6 +22,13 @@
 				<default>600</default>
 			</parameter>
 
+			<parameter name="precision" type="integer">
+				<label>Sensor precision</label>
+				<description>Sensor precision after floating point.</description>
+				<required>false</required>
+				<default>3</default>
+			</parameter>
+
 		</config-description>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.onewiregpio/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -23,7 +23,7 @@
 			</parameter>
 
 			<parameter name="precision" type="integer">
-				<label>Sensor precision</label>
+				<label>Sensor Precision</label>
 				<description>Sensor precision after floating point.</description>
 				<required>false</required>
 				<default>3</default>


### PR DESCRIPTION
Upon a request from a friend of mine I've added additional parameter to the binding which allows you to lower the precision of the received temperature number from the filesystem. 

A bit of background about the binding itself - the binding reads files inside /sys/bus/w1/devices/DEVICE_ID_FOLDER/w1_slave. 
If there is t=xxxxx, where xxxxx is integer value. Then the binding makes a BigDecimal.valueOf(xxxxx).movePointLeft(3) and returns the value. This makes tha maximum possible precision after the floating point to be total of 3 (i.e. the digits after the floating point). 
The precision parameter allows you to reduce this number down to 0, 1, 2 or 3(the default value is the max value) with round half up rounding strategy. This allows you not to spam event bus on every small change of the sensors and disables triggering of different rules without need (with too small changes of the number).

Saw that the original author is Anathol Ogorek but was not able to request a review from him as I couldn't find him on the Reviewers list. :( 

The changes from the commit:
* Added precision parameter which allows to lower precision of value
read from the file system
* Implemented configuration class for easier read of configuration
through the reflection method in the framework
* Moved the read of configuration parameters to initialize method
leaving the checkConfiguration method to do only validation
* Updated the README

Cheers,
Konstantin