### PR TITLE
[pulseaudio] [wip] fix #6410 Wrong hardcoded default port

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -117,7 +117,7 @@ public class PulseaudioClient {
     private static final String MODULE_COMBINE_SINK = "module-combine-sink";
 
     public PulseaudioClient() throws IOException {
-        this("localhost", 4712);
+        this("localhost", 4713);
     }
 
     public PulseaudioClient(String host, int port) throws IOException {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDiscoveryParticipant.java
@@ -61,11 +61,12 @@ public class PulseaudioDiscoveryParticipant implements MDNSDiscoveryParticipant 
             }
             // remove the domain from the name
             String hostname = info.getServer().replace("." + info.getDomain() + ".", "");
-            try (Socket testSocket = new Socket(hostname, 4712)) {
-                logger.debug("testing connection to pulseaudio server {}:4712", hostname);
+            try (Socket testSocket = new Socket(hostname, 4713)) {
+                logger.debug("testing connection to pulseaudio server {}:4713", hostname);
 
                 if (testSocket.isConnected()) {
                     properties.put(PulseaudioBindingConstants.BRIDGE_PARAMETER_HOST, hostname);
+                    // below comment does not make sense to me since the default port is 4713 according do pulseaudio documentation
                     // we do not read the port here because the given port is 4713 and we need 4712 to query the server
                     result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label).build();
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
@@ -52,7 +52,7 @@ public class PulseaudioBridgeHandler extends BaseBridgeHandler {
             .singleton(PulseaudioBindingConstants.BRIDGE_THING_TYPE);
 
     public String host = "localhost";
-    public int port = 4712;
+    public int port = 4713;
 
     public int refreshInterval = 30000;
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/ESH-INF/thing/bridge.xml
@@ -16,7 +16,7 @@
 			<parameter name="port" type="integer">
 				<label>Port</label>
 				<description>Port of the pulseaudio server</description>
-				<default>4712</default>
+				<default>4713</default>
 				<required>false</required>
 			</parameter>
 			<parameter name="refreshInterval" type="integer">


### PR DESCRIPTION
This PR takes on the issue of a wrongly hardcoded default port in the binding source
see https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Network/

help is needed regarding the comment in PulseaudioDiscoveryParticipant:70 that mentions port 4712. My git mojo doesn't allow me to find out who wrote that piece.

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
