### PR TITLE
[pulseaudio] fix invalid regex not matching pactl output

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -6,7 +6,7 @@ This binding integrates pulseaudio devices.
 
 The Pulseaudio bridge is required as a "bridge" for accessing any other Pulseaudio devices.
 
-You need a running pulseaudio server whith module module-cli-protocol-tcp loaded and accessible by the server which runs your openHAB instance. The following pulseaudio devices are supported:
+You need a running pulseaudio server whith module **module-cli-protocol-tcp** loaded and accessible by the server which runs your openHAB instance. The following pulseaudio devices are supported:
 
 *   Sink
 *   Source
@@ -21,6 +21,7 @@ The Pulseaudio bridge is discovered through mDNS in the local network.
 ## Thing Configuration
 
 The Pulseaudio bridge requires the ip address (or a hostname) and a port (default: 4712) as a configuration value in order for the binding to know where to access it.
+You can use `pactl -s <hostname> list-sinks | grep "name:"` to find the name of a sink.
 
 ## Channels
 
@@ -34,6 +35,21 @@ All devices support some of the following channels:
 | slaves          | String    | Slave sinks of a combined sink                                          |
 | routeToSink     | String    | Shows the sink a sink-input is currently routed to                      |
 
-<!--ToDO - needs an example.  It was left with the "## Full Example header, but everything after that was blank..."
 ## Full Example
+### pulseaudio.things
+```
+Bridge pulseaudio:bridge:<bridgname> "<Bridge Label>" @ "<Room>" [ ipAddress="<ipAddress>", port=4712 ] {
+  Things:
+  	Thing sink          multiroom       "Snapcast"           @ "Room"       [name="alsa_card.pci-0000_00_1f.3"] // this name corresponds to pactl list-sinks output
+	Thing source        microphone      "microphone"         @ "Room"       [name="alsa_input.pci-0000_00_14.2.analog-stereo"]
+	Thing sink-input    openhabTTS      "OH-Voice"           @ "Room"       [name="alsa_output.pci-0000_00_1f.3.hdmi-stereo-extra1"]
+	Thing source-output remotePulseSink "Other Room Speaker" @ "Other Room" [name="alsa_input.pci-0000_00_14.2.analog-stereo"]
+	Thing combined-sink hdmiAndAnalog   "Zone 1+2"           @ "Room"       [name="combined"]
+  }
+```
+<!--
+### pulseaudio.items
+```
+
+```
 -->

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(Parser.class);
 
-    private static final Pattern PATTERN = Pattern.compile("^\\s+([a-z\\s._]+)[:=]\\s*<?\"?([^>\"]+)\"?>?$");
+    private static final Pattern PATTERN = Pattern.compile("^\\s*([a-z\\s._]+)[:=]\\s*<?\\\"?([^>\\\"]+)\\\"?>?$");
     private static final Pattern VOLUME_PATTERN = Pattern
             .compile("^([\\w\\-]+):( *[\\d]+ \\/)? *([\\d]+)% *\\/? *([\\d\\-., dB]+)?$");
     private static final Pattern FALL_BACK_PATTERN = Pattern


### PR DESCRIPTION
This pull request comes after a long day of looking for the reasons behind the pulseaudio binding not being able to talk to the pulseaudio servers, resulting in `Pulseaudio server  localhost: 0 modules and 0 items updated`

As is typical for a long search, the error is quite minute and to be found in the incorrect escaping of backslash charactes in the matching pattern that matches pactl output against a given sink name.

EDIT: the key change is the 5th char in the string from `+` to `*`-
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
