### PR TITLE
[denonmarantz] Fix setting volumeDB for zones 2 and 3

### DIFF
--- a/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/handler/DenonMarantzHandler.java
+++ b/bundles/org.openhab.binding.denonmarantz/src/main/java/org/openhab/binding/denonmarantz/internal/handler/DenonMarantzHandler.java
@@ -134,7 +134,7 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
                     connector.sendVolumeCommand(command, 2);
                     break;
                 case CHANNEL_ZONE2_VOLUME_DB:
-                    connector.sendVolumeCommand(command, 2);
+                    connector.sendVolumeDbCommand(command, 2);
                     break;
                 case CHANNEL_ZONE2_INPUT:
                     connector.sendInputCommand(command, 2);
@@ -150,7 +150,7 @@ public class DenonMarantzHandler extends BaseThingHandler implements DenonMarant
                     connector.sendVolumeCommand(command, 3);
                     break;
                 case CHANNEL_ZONE3_VOLUME_DB:
-                    connector.sendVolumeCommand(command, 3);
+                    connector.sendVolumeDbCommand(command, 3);
                     break;
                 case CHANNEL_ZONE3_INPUT:
                     connector.sendInputCommand(command, 3);


### PR DESCRIPTION
Setting the volumeDB didn't work in my zone 2 of my Denon AVR2000. Luckily the bug is easy to fix.

Signed-off-by: Thomas Freudenberg <info@thomasfreudenberg.com>