### PR TITLE
Changed Corentium AS Bluetooth company id to Airthings AS

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCompanyIdentifiers.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCompanyIdentifiers.java
@@ -850,7 +850,7 @@ public class BluetoothCompanyIdentifiers {
         CIC.put(817, "3flares Technologies Inc.");
         CIC.put(818, "Electrocompaniet A.S.");
         CIC.put(819, "Mul-T-Lock");
-        CIC.put(820, "Airthings AS");
+        CIC.put(820, "Corentium/Airthings AS");
         CIC.put(821, "Enlighted Inc");
         CIC.put(822, "GISTIC");
         CIC.put(823, "AJP2 Holdings, LLC");

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCompanyIdentifiers.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCompanyIdentifiers.java
@@ -850,7 +850,7 @@ public class BluetoothCompanyIdentifiers {
         CIC.put(817, "3flares Technologies Inc.");
         CIC.put(818, "Electrocompaniet A.S.");
         CIC.put(819, "Mul-T-Lock");
-        CIC.put(820, "Corentium AS");
+        CIC.put(820, "Airthings AS");
         CIC.put(821, "Enlighted Inc");
         CIC.put(822, "GISTIC");
         CIC.put(823, "AJP2 Holdings, LLC");


### PR DESCRIPTION
Corentium is rebranded to Airthings in 2016. Reference
https://www.airthings.com/en/about-us

Bluetooth binding discovers devices as a Corentium brand, which can be
tricky from user perspective.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
