### PR TITLE
[digitalstrom] Bugfix for apartment scene calls (#6839)

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/serverconnection/impl/DsAPIImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/serverconnection/impl/DsAPIImpl.java
@@ -147,7 +147,7 @@ public class DsAPIImpl implements DsAPI {
         if (sceneNumber != null && isValidApartmentSceneNumber(sceneNumber.getSceneNumber())) {
             String response = transport.execute(SimpleRequestBuilder.buildNewJsonRequest(ClassKeys.APARTMENT)
                     .addFunction(FunctionKeys.CALL_SCENE).addDefaultGroupParameter(token, groupID, groupName)
-                    .addParameter(ParameterKeys.SCENENUMBER, sceneNumber.toString())
+                    .addParameter(ParameterKeys.SCENENUMBER, sceneNumber.getSceneNumber().toString())
                     .addParameter(ParameterKeys.FORCE, force.toString()).buildRequestString());
             return JSONResponseHandler.checkResponse(JSONResponseHandler.toJsonObject(response));
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->
[digitalSTROM] bugfix for apartment scene calls (#6839)
<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->
Fixes a type mismatch in the api implementation where the enum name was used as parameter instead of the numerical id. It seems like it was kind of a typo in this specific call. All the other methods for zone or named scenes had the conversion correct implemented. Instead of executing the call the server responds with a message

{
  "ok": false,
  "message": "Invalid sceneNumber: 'ABSENT'"
} 

Unfortunately, the response handler is not implemented very well and it swallows this kind of response from the digitalSTROM server. Therefore the bug was not so obvious to spot in the log files.

I'll have a look at the response handler later, but will submit that in another pull request.

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->
The topic was submitted to the community first (https://community.openhab.org/t/calling-digitalstrom-appscenes/88763). I'll hope this bug fix for issue (#6839) makes it into the 2.5.2 release of openHAB.

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
