### PR TITLE
[meteoblue] Fix directory handling for images

### DIFF
--- a/bundles/org.openhab.binding.meteoblue/README.md
+++ b/bundles/org.openhab.binding.meteoblue/README.md
@@ -125,7 +125,7 @@ Group weatherDay6 "Weather in 6 days"
 DateTime todayForecastDate  "Forecast for [%1$tY/%1$tm/%1$td]"  <calendar>  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#forecastDate"}
 String todayPCode    "Pictocode [%d]"  <iday>  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#condition"}
 String todayCond     "Condition [%s]"  <iday>  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#condition"}
-String todayIcon     "Icon [%s]"       (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#icon"}
+Image todayIcon     "Icon [%s]"       (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#icon"}
 Number todayUV       "UV Index [%d]"  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#UVIndex"}
 Number:Temperature  todayTempL  "Low Temp [%.2f °F]"   <temperature>  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#minTemperature"}
 Number:Temperature  todayTempH  "High Temp [%.2f °F]"  <temperature>  (weatherDay0)  {channel="meteoblue:weather:metBridge:A51:forecastToday#maxTemperature"}

--- a/bundles/org.openhab.binding.meteoblue/src/main/java/org/openhab/binding/meteoblue/internal/Forecast.java
+++ b/bundles/org.openhab.binding.meteoblue/src/main/java/org/openhab/binding/meteoblue/internal/Forecast.java
@@ -26,6 +26,7 @@ import java.util.TimeZone;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.openhab.binding.meteoblue.internal.json.JsonDataDay;
 import org.openhab.binding.meteoblue.internal.json.JsonMetadata;
 import org.openhab.binding.meteoblue.internal.json.JsonUnits;
@@ -456,7 +457,8 @@ public class Forecast {
 
     private Image loadImageIcon(String imageFileName) {
         BufferedImage buf = null;
-        File dataFile = new File(new File("../conf/icons/classic/"), imageFileName);
+        String configDirectory = ConfigConstants.getConfigFolder();
+        File dataFile = new File(new File(configDirectory, "icons/classic/"), imageFileName);
         if (!dataFile.exists()) {
             logger.debug("Image file '{}' does not exist. Unable to create imageIcon.", dataFile.getAbsolutePath());
             return null;


### PR DESCRIPTION
Fixes directory handling for the image icons by using the ConfigConstants.getConfigFolder() method.
Fixes #6840.

[Test jar with the fix](https://drive.google.com/open?id=1H1dnfmi3kbHO0aJB3EIxg1mRZIpyvrsy).

Signed-off-by: 9037568 <namraccr@gmail.com>

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
-->
