### PR TITLE
[millheat] Added missing feature.xml

### DIFF
--- a/bundles/org.openhab.binding.millheat/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.millheat/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.millheat-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+    <feature name="openhab-binding-millheat" description="Millheat Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.millheat/${project.version}</bundle>
+    </feature>
+</features>


### PR DESCRIPTION
The binding does not show in the list of available bindings when installing from neither Habmin nor PaperUI. Installing via the addons folder works.

Assuming the missing file feature.xml is to blame, this PR adds it.

@J-N-K could you have a look?