### PR TITLE
List spotless plugin in plugins section, not only pluginManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,10 @@ Import-Package: \\
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
     </plugins>
     <extensions>
        <extension>


### PR DESCRIPTION
Plugin was only defined/configured, not prepared for actual lifecycle use (listed in the build/plugins section)

Related to https://github.com/openhab/openhab-core/pull/1303 only this is for the addons repo