### PR TITLE
Enabled 'spotless:check' by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
 
     <feature.directory>src/main/feature/feature.xml</feature.directory>
     <spotless.version>1.24.3</spotless.version>
-    <spotless.check.skip>true</spotless.check.skip> <!-- Spotless disabled for now -->
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
- Enabled 'spotless:check' by default

Depends on #6873 and a cherry-pick of #6867 into master branch.

// CC: @seime for review

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>