### PR TITLE
[telegram] Do not format message if no formatting args are passed

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -254,18 +254,18 @@ public class TelegramActions implements ThingActions {
 
     @RuleAction(label = "Telegram message", description = "Sends a Telegram via Telegram API")
     public boolean sendTelegram(@ActionInput(name = "chatId") @Nullable Long chatId,
-            @ActionInput(name = "message") @Nullable String format,
+            @ActionInput(name = "message") @Nullable String message,
             @ActionInput(name = "args") @Nullable Object... args) {
-        return sendTelegram(chatId, String.format(format, args));
+        return sendTelegram(chatId, args == null || args.length == 0 ? message : String.format(message, args));
     }
 
     @RuleAction(label = "Telegram message", description = "Sends a Telegram via Telegram API")
-    public boolean sendTelegram(@ActionInput(name = "message") @Nullable String format,
+    public boolean sendTelegram(@ActionInput(name = "message") @Nullable String message,
             @ActionInput(name = "args") @Nullable Object... args) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
             for (Long chatId : localHandler.getChatIds()) {
-                if (!sendTelegram(chatId, format, args)) {
+                if (!sendTelegram(chatId, message, args)) {
                     return false;
                 }
             }
@@ -394,10 +394,10 @@ public class TelegramActions implements ThingActions {
 
     // legacy delegate methods
     /* APIs without chatId parameter */
-    public static boolean sendTelegram(@Nullable ThingActions actions, @Nullable String format,
+    public static boolean sendTelegram(@Nullable ThingActions actions, @Nullable String message,
             @Nullable Object... args) {
         if (actions instanceof TelegramActions) {
-            return ((TelegramActions) actions).sendTelegram(format, args);
+            return ((TelegramActions) actions).sendTelegram(message, args);
         } else {
             throw new IllegalArgumentException("Instance is not a TelegramActions class.");
         }
@@ -441,10 +441,10 @@ public class TelegramActions implements ThingActions {
 
     /* APIs with chatId parameter */
 
-    public static boolean sendTelegram(@Nullable ThingActions actions, @Nullable Long chatId, @Nullable String format,
+    public static boolean sendTelegram(@Nullable ThingActions actions, @Nullable Long chatId, @Nullable String message,
             @Nullable Object... args) {
         if (actions instanceof TelegramActions) {
-            return ((TelegramActions) actions).sendTelegram(chatId, format, args);
+            return ((TelegramActions) actions).sendTelegram(chatId, message, args);
         } else {
             throw new IllegalArgumentException("Instance is not a TelegramActions class.");
         }


### PR DESCRIPTION
If the user calls `sendTelegram(chatId, message)` or `sendTelegram(message)`, the message is always formatted even if no formatting args are passed.
In many cases, this doesn't harm anything and the result of `String.format(message)` is the same as the `message `itself, but as soon you pass e.g. a "%" symbol, you'll get an error.

Solution: Do not call `String.format()` if no formatting args were passed.