### PR TITLE
[lgwebos] Added rcButton channel

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/README.md
+++ b/bundles/org.openhab.binding.lgwebos/README.md
@@ -62,6 +62,33 @@ Thing lgwebos:WebOSTV:tv1 [host="192.168.2.119", key="6ef1dff6c7c936c8dc5056fc85
 | mediaPlayer     | Player    | Media control player                                                                                                                                                                                                    | W          |
 | mediaStop       | Switch    | Media control stop                                                                                                                                                                                                      | W          |
 | appLauncher     | String    | Application ID of currently running application. This also allows to start applications on the TV by sending a specific Application ID to this channel.                                                                 | RW         |
+| rcButton        | String    | Simulates pressing of a button on the TV's remote control. See below for a list of button names.                                                                                                                        | W          |
+
+### Remote Control Buttons
+The rcButton channel has only been tested on an LGUJ657A TV. and this is a list of button codes that are known to work with this device.
+This list has been compiled mostly through trial and error. Your mileage may vary.
+
+| Code String | Description                                              |
+|-------------|----------------------------------------------------------|
+| LEFT        | Left button in cursor control group                      |
+| RIGHT       | Right button in cursor control group                     |
+| UP          | Up button in cursor control group                        |
+| DOWN        | Down button in cursor control group                      |
+| ENTER       | "OK" button in the center of the cursor control group    |
+| BACK        | "BACK" button                                            |
+| EXIT        | "EXIT" button                                            |
+| 0-9         | Number buttons                                           |
+| HOME        | "HOME" button                                            |
+| RED         | "RED"  button                                            |
+| GREEN       | "GREEN" button                                           |
+| YELLOW      | "YELLOW" button                                          |
+| BLUE        | "BLUE" button                                            |
+| PLAY        | "PLAY" button                                            |
+| PAUSE       | "PAUSE" button                                           |
+| STOP        | "STOP" button                                            |
+
+
+A sample HABPanel remote control widget can be found [in this github repository.](https://github.com/bbrodt/openhab2-misc)
 
 ## Example
 

--- a/bundles/org.openhab.binding.lgwebos/README.md
+++ b/bundles/org.openhab.binding.lgwebos/README.md
@@ -65,6 +65,7 @@ Thing lgwebos:WebOSTV:tv1 [host="192.168.2.119", key="6ef1dff6c7c936c8dc5056fc85
 | rcButton        | String    | Simulates pressing of a button on the TV's remote control. See below for a list of button names.                                                                                                                        | W          |
 
 ### Remote Control Buttons
+
 The rcButton channel has only been tested on an LGUJ657A TV. and this is a list of button codes that are known to work with this device.
 This list has been compiled mostly through trial and error. Your mileage may vary.
 

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/action/LGWebOSActions.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/action/LGWebOSActions.java
@@ -237,6 +237,12 @@ public class LGWebOSActions implements ThingActions {
         getConnectedSocket().ifPresent(control -> control.channelDown(createResponseListener()));
     }
 
+    @RuleAction(label = "@text/actionSendRCButtonLabel", description = "@text/actionSendRCButtonDesc")
+    public void sendRCButton(
+            @ActionInput(name = "text", label = "@text/actionSendRCButtonInputTextLabel", description = "@text/actionSendRCButtonInputTextDesc") String rcButton) {
+        getConnectedSocket().ifPresent(control -> control.executeMouse(s -> s.button(rcButton)));
+    }
+
     private Optional<LGWebOSTVSocket> getConnectedSocket() {
         LGWebOSHandler lgWebOSHandler = getLGWebOSHandler();
         final LGWebOSTVSocket socket = lgWebOSHandler.getSocket();
@@ -356,6 +362,14 @@ public class LGWebOSActions implements ThingActions {
     public static void decreaseChannel(@Nullable ThingActions actions) {
         if (actions instanceof LGWebOSActions) {
             ((LGWebOSActions) actions).decreaseChannel();
+        } else {
+            throw new IllegalArgumentException("Instance is not an LGWebOSActions class.");
+        }
+    }
+
+    public static void sendRCButton(@Nullable ThingActions actions, String rcButton) {
+        if (actions instanceof LGWebOSActions) {
+            ((LGWebOSActions) actions).sendRCButton(rcButton);
         } else {
             throw new IllegalArgumentException("Instance is not an LGWebOSActions class.");
         }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSBindingConstants.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LGWebOSBindingConstants.java
@@ -69,4 +69,5 @@ public class LGWebOSBindingConstants {
     public static final String CHANNEL_MEDIA_PLAYER = "mediaPlayer";
     public static final String CHANNEL_MEDIA_STOP = "mediaStop";
     public static final String CHANNEL_APP_LAUNCHER = "appLauncher";
+    public static final String CHANNEL_RCBUTTON = "rcButton";
 }

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/RCButtonControl.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/RCButtonControl.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lgwebos.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.lgwebos.internal.handler.LGWebOSHandler;
+import org.openhab.binding.lgwebos.internal.handler.core.CommandConfirmation;
+
+/**
+ * Handles rcButton Control Command. This allows to send IR Remote Control button presses to the TV.
+ *
+ * @author Robert Brodt - Initial contribution
+ */
+@NonNullByDefault
+public class RCButtonControl extends BaseChannelHandler<CommandConfirmation> {
+
+    @Override
+    public void onReceiveCommand(String channelId, LGWebOSHandler handler, Command command) {
+        handler.getSocket().sendRCButton(command.toString(), getDefaultResponseListener());
+    }
+}

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSHandler.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSHandler.java
@@ -40,6 +40,7 @@ import org.openhab.binding.lgwebos.internal.LauncherApplication;
 import org.openhab.binding.lgwebos.internal.MediaControlPlayer;
 import org.openhab.binding.lgwebos.internal.MediaControlStop;
 import org.openhab.binding.lgwebos.internal.PowerControlPower;
+import org.openhab.binding.lgwebos.internal.RCButtonControl;
 import org.openhab.binding.lgwebos.internal.TVControlChannel;
 import org.openhab.binding.lgwebos.internal.TVControlChannelName;
 import org.openhab.binding.lgwebos.internal.ToastControlToast;
@@ -99,6 +100,7 @@ public class LGWebOSHandler extends BaseThingHandler implements LGWebOSTVSocket.
         handlers.put(CHANNEL_MEDIA_STOP, new MediaControlStop());
         handlers.put(CHANNEL_TOAST, new ToastControlToast());
         handlers.put(CHANNEL_MEDIA_PLAYER, new MediaControlPlayer());
+        handlers.put(CHANNEL_RCBUTTON, new RCButtonControl());
         channelHandlers = Collections.unmodifiableMap(handlers);
     }
 

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -811,6 +811,14 @@ public class LGWebOSTVSocket {
 
     }
 
+    // Simulate Remote Control Button press
+
+    public void sendRCButton(String rcButton, ResponseListener<CommandConfirmation> listener) {
+        executeMouse(s -> s.button(rcButton));
+    }
+
+    //
+
     public interface ConfigProvider {
         void storeKey(String key);
 

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -817,8 +817,6 @@ public class LGWebOSTVSocket {
         executeMouse(s -> s.button(rcButton));
     }
 
-    //
-
     public interface ConfigProvider {
         void storeKey(String key);
 

--- a/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/i18n/lgwebos.properties
+++ b/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/i18n/lgwebos.properties
@@ -38,3 +38,8 @@ actionIncreaseChannelDesc=TV will switch one channel up in the current channel l
 
 actionDecreaseChannelLabel=Channel Down
 actionDecreaseChannelDesc=TV will switch one channel down in the current channel list.
+
+actionSendRCButtonLabel=Remote Control button press
+actionSendRCButtonDesc=Simulates pressing of a Remote Control Button.
+actionSendRCButtonInputTextLabel=Remote Control button name
+actionSendRCButtonInputTextDesc=The Remote Control button name to send to the WebOS device.

--- a/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lgwebos/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -18,6 +18,7 @@
 			<channel id="mediaPlayer" typeId="mediaPlayerType" />
 			<channel id="mediaStop" typeId="mediaStopType" />
 			<channel id="appLauncher" typeId="appLauncherChannelType" />
+			<channel id="rcButton" typeId="rcButtonType" />
 		</channels>
 
 		<properties>
@@ -84,6 +85,11 @@
 		<item-type>String</item-type>
 		<label>Application</label>
 		<description>Start application and monitor running applications.</description>
+	</channel-type>
+	<channel-type id="rcButtonType">
+		<item-type>String</item-type>
+		<label>RCButton</label>
+		<description>Simulate a Remote Control button press</description>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
This PR adds a new channel ("IRCode") to the LG WebOS binding, which simulates some of the button presses on the LG infrared remote control. Inspiration for this enhancement came [from the discussion here.](https://community.openhab.org/t/lgwebos-binding-sendbutton-question/85872/8)

Here is a list of IR codes that I have found to work. Note that this list has been compiled mostly through trial and error, and I may have missed some of the buttons. I have only been able to test this on an LGUJ657A TV so your mileage may vary.

Code String | Description
-- | --
LEFT | Left button in cursor control group
RIGHT | Right button in cursor control group
UP | Up button in cursor control group
DOWN | Down button in cursor control group
ENTER | "OK" button in the center of the cursor control group
BACK | "BACK" button
EXIT | "EXIT" button
0-9 | Number buttons
HOME | "HOME" button
RED | "RED" button
GREEN | "GREEN" button
YELLOW | "YELLOW" button
BLUE | "BLUE" button
PLAY | "PLAY" button
PAUSE | "PAUSE" button
STOP | "STOP" button

A sample HABPanel remote control widget can be found [in this github repository.](https://github.com/bbrodt/openhab2-misc)