### PR TITLE
[hueemulation] Fixes to prevent Alexa errors when using voice commands and the app (#6690)

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
@@ -413,4 +413,48 @@ public class StateUtils {
         }
         return t;
     }
+
+    /**
+     * Compute the hue state from a given item state and a device type.
+     * If the item state matches the last command. the hue state is adjusted
+     * to use the values from the last hue state change. This is done to prevent
+     * Alexa reporting device errors.
+     * 
+     * @param itemState The item state
+     * @param deviceType The device type
+     * @param lastCommand The last command
+     * @param lastHueChange The last hue state change
+     * @return A hue light state
+     */
+    public static AbstractHueState adjustedColorStateFromItemState(State itemState, @Nullable DeviceType deviceType,
+            @Nullable Command lastCommand, @Nullable HueStateChange lastHueChange) {
+
+        AbstractHueState hueState = colorStateFromItemState(itemState, deviceType);
+
+        if (lastCommand != null && lastHueChange != null) {
+            if (lastCommand instanceof HSBType) {
+                if (itemState.as(HSBType.class).equals(lastCommand)) {
+                    HueStateColorBulb c = hueState.as(HueStateColorBulb.class);
+
+                    if (lastHueChange.bri != null) {
+                        c.bri = lastHueChange.bri;
+                    }
+                    if (lastHueChange.hue != null) {
+                        c.hue = lastHueChange.hue;
+                    }
+                    if (lastHueChange.sat != null) {
+                        c.sat = lastHueChange.sat;
+                    }
+                }
+            } else if (lastCommand instanceof PercentType) {
+                if (itemState.as(PercentType.class).equals(lastCommand)) {
+                    if (lastHueChange.bri != null) {
+                        hueState.as(HueStateBulb.class).bri = lastHueChange.bri;
+                    }
+                }
+            }
+        }
+
+        return hueState;
+    }
 }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
@@ -433,8 +433,8 @@ public class StateUtils {
 
         if (lastCommand != null && lastHueChange != null) {
             if (lastCommand instanceof HSBType) {
-                if (itemState.as(HSBType.class).equals(lastCommand)) {
-                    HueStateColorBulb c = hueState.as(HueStateColorBulb.class);
+                if (hueState instanceof HueStateColorBulb && itemState.as(HSBType.class).equals(lastCommand)) {
+                    HueStateColorBulb c = (HueStateColorBulb) hueState;
 
                     if (lastHueChange.bri != null) {
                         c.bri = lastHueChange.bri;
@@ -445,11 +445,17 @@ public class StateUtils {
                     if (lastHueChange.sat != null) {
                         c.sat = lastHueChange.sat;
                     }
+                    // Although we can't set a colour temperature in OH
+                    // this keeps Alexa happy when asking to turn a light
+                    // to white.
+                    if (lastHueChange.ct != null) {
+                        c.ct = lastHueChange.ct;
+                    }
                 }
             } else if (lastCommand instanceof PercentType) {
-                if (itemState.as(PercentType.class).equals(lastCommand)) {
+                if (hueState instanceof HueStateBulb && itemState.as(PercentType.class).equals(lastCommand)) {
                     if (lastHueChange.bri != null) {
-                        hueState.as(HueStateBulb.class).bri = lastHueChange.bri;
+                        ((HueStateBulb) hueState).bri = lastHueChange.bri;
                     }
                 }
             }

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueLightEntry.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueLightEntry.java
@@ -18,8 +18,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.library.items.StringItem;
+import org.eclipse.smarthome.core.types.Command;
 import org.openhab.io.hueemulation.internal.DeviceType;
 import org.openhab.io.hueemulation.internal.StateUtils;
+import org.openhab.io.hueemulation.internal.dto.changerequest.HueStateChange;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
@@ -52,6 +54,8 @@ public class HueLightEntry {
     /** Associated item UID */
     public @NonNullByDefault({}) transient GenericItem item;
     public transient DeviceType deviceType;
+    public transient @Nullable Command lastCommand = null;
+    public transient @Nullable HueStateChange lastHueChange = null;
 
     public static class Config {
         public final String archetype = "classicbulb";
@@ -166,7 +170,8 @@ public class HueLightEntry {
         @Override
         public JsonElement serialize(HueLightEntry product, Type type, JsonSerializationContext context) {
 
-            product.state = StateUtils.colorStateFromItemState(product.item.getState(), product.deviceType);
+            product.state = StateUtils.adjustedColorStateFromItemState(product.item.getState(), product.deviceType,
+                    product.lastCommand, product.lastHueChange);
             String label = product.item.getLabel();
             if (label != null) {
                 product.name = label;
@@ -186,6 +191,9 @@ public class HueLightEntry {
     public void updateItem(GenericItem element) {
         item = element;
         state = StateUtils.colorStateFromItemState(item.getState(), deviceType);
+        
+        lastCommand = null;
+        lastHueChange = null;
 
         String label = element.getLabel();
         if (label != null) {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateBulb.java
@@ -36,7 +36,7 @@ public class HueStateBulb extends HueStatePlug {
 
     public HueStateBulb(boolean on) {
         super(on);
-        this.bri = on ? MAX_BRI : 0;
+        this.bri = on ? MAX_BRI : 1;
     }
 
     /**
@@ -47,7 +47,7 @@ public class HueStateBulb extends HueStatePlug {
      */
     public HueStateBulb(PercentType brightness, boolean on) {
         super(on);
-        this.bri = (int) (brightness.intValue() * MAX_BRI / 100.0 + 0.5);
+        this.bri = Math.max(1, (int) (brightness.intValue() * MAX_BRI / 100.0 + 0.5));
     }
 
     public PercentType toBrightnessType() {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/HueStateColorBulb.java
@@ -51,7 +51,6 @@ public class HueStateColorBulb extends HueStateBulb {
 
     public HueStateColorBulb(boolean on) {
         super(on);
-        this.bri = on ? MAX_BRI : 0;
         colormode = ColorMode.ct;
     }
 
@@ -72,10 +71,9 @@ public class HueStateColorBulb extends HueStateBulb {
      * @param hsb Color information. Sets the hue state to "on" if brightness is > 0.
      */
     public HueStateColorBulb(HSBType hsb) {
-        super(hsb.getBrightness().intValue() > 0);
+        super(hsb.getBrightness(), hsb.getBrightness().intValue() > 0);
         this.hue = (int) (hsb.getHue().intValue() * MAX_HUE / 360.0 + 0.5);
         this.sat = (int) (hsb.getSaturation().intValue() * MAX_SAT / 100.0 + 0.5);
-        this.bri = (int) (hsb.getBrightness().intValue() * MAX_BRI / 100.0 + 0.5);
         colormode = this.sat > 0 ? ColorMode.hs : ColorMode.ct;
     }
 
@@ -126,11 +124,13 @@ public class HueStateColorBulb extends HueStateBulb {
             }
             double hueSat = Math.floor((delta / maxValue) * 254.0d);
             int percentSat = (int) ((100.0d * hueSat) / (MAX_SAT));
+            
+            int bri = this.bri * 100 / MAX_BRI;
             if (!this.on) {
-                this.bri = 0;
+                bri = 0;
             }
             return new HSBType(new DecimalType((Math.floor(182.04d * h) * 360.0d) / (MAX_HUE)),
-                    new PercentType(percentSat), new PercentType((this.bri * 100) / MAX_BRI));
+                    new PercentType(percentSat), new PercentType(bri));
 
         } else {
             int bri = this.bri * 100 / MAX_BRI;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
@@ -380,6 +380,8 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
             } else {
                 logger.warn("No event publisher. Cannot post item '{}' command!", itemUID);
             }
+            hueDevice.lastCommand = command;
+            hueDevice.lastHueChange = newState;
         }
 
         return Response.ok(cs.gson.toJson(responses, new TypeToken<List<?>>() {

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -247,7 +247,7 @@ public class LightsAndGroupsTests {
     public void changeOnAndBriValues() {
 
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(0));
+        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(1));
 
         String body = "{'on':true,'bri':200}";
         Response response = commonSetup.client.target(commonSetup.basePath + "/testuser/lights/2/state").request()
@@ -303,7 +303,7 @@ public class LightsAndGroupsTests {
     @Test
     public void switchOnWithXY() {
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(false));
-        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(0));
+        assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(1));
 
         String body = "{'on':true,'bri':200,'xy':[0.5119,0.4147]}";
         Response response = commonSetup.client.target(commonSetup.basePath + "/testuser/lights/2/state").request()


### PR DESCRIPTION
Fixes #6690 #5897

When Alexa changes the state of a bulb it seems to immediately request the state of the bulb and after three requests will report an error with the device if the state does not match what it expects.

The issue is due to the conversion from hue state to OH state and back again, e.g. Alexa sends a brightness of 128 which is converted to an OH brightness of 50. However, 50 converts back to 127 and Alexa is expecting to see the brightness change to 128.

This change caches the last hue state change so that the same values can be reflected back for the status of the bulb.

Also the minimum hue brightness as stated in the API should be 1 not 0. Changing this has fixed the issue with all off bulbs being reported in the Alexa app with "Device does not support requested value"

Tested with Alexa voice commands and also Alex app. Also tested with Logitech Harmony remote. Checked bulbs which are off but now reporting brightness of 1 are considered off in both Alexa and Harmony app/remote.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>