### PR TITLE
[dsmr] Fixed typo in emucs thing xml

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/resources/ESH-INF/thing/meter_device_emucs_v1_0.xml
+++ b/bundles/org.openhab.binding.dsmr/src/main/resources/ESH-INF/thing/meter_device_emucs_v1_0.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="device_v1_0" listed="false">
+	<thing-type id="device_emucs_v1_0" listed="false">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="dsmrBridge" />
 		</supported-bridge-type-refs>


### PR DESCRIPTION
thing-type id in xml file didn't match with id used in code.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>
