### PR TITLE
[epsonprojector] Port of the OH 1.x epsonprojector binding

### DIFF
--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -201,6 +201,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.epsonprojector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.evohome</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.epsonprojector/.classpath
+++ b/bundles/org.openhab.binding.epsonprojector/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.epsonprojector/.project
+++ b/bundles/org.openhab.binding.epsonprojector/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.epsonprojector</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.epsonprojector/NOTICE
+++ b/bundles/org.openhab.binding.epsonprojector/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -1,0 +1,109 @@
+# Epson Projector Binding
+
+This binding is compatible with Epson projectors which support the ESC/VP21 protocol over a serial port.
+Alternatively you can connect to your projector via a TCP connection if you are using some kind of converter like `ser2net`.
+
+## Supported Things
+
+This binding supports only one thing: `projector`.
+
+## Thing Configuration
+
+The projector thing cannot be auto-discovered, it has to be configured by setting some of the following parameters:
+
+- _serialPort_: Serial port device name that is connected to the Epson projector to control, e.g. COM1 on Windows, /dev/ttyS0 on Linux or /dev/tty.PL2303-0000103D on Mac
+- _host_: IP address (for serial communication over TCP, leave the serial port parameter blank)
+- _port_: Port (for serial communication over TCP, leave the serial port parameter blank)
+- _pollingInterval_: Polling interval in milliseconds to update channel states
+
+## Channels
+
+| Channel       | Item Type           | Purpose  | Note  |
+| ------------- | ------------------- | -------- | ----- |
+| Power | Switch | Powers the device on or off. |  | 
+| PowerState | String | Retrieves the actual power state of the device. |  | 
+| LampTime | Number | Retrieves the lamp hours. |  | 
+| KeyCode | Number |  |  | 
+| VerticalKeystone | Number |  |  | 
+| HorizontalKeystone | Number |  |  | 
+| AutoKeystone | Number |  |  | 
+| AspectRatio | String | Retrieves or set the aspect ratio. |  | 
+| Luminance | String | Retrieves or set the ECO mode. |  | 
+| Source | String | Retrieves or select the input source. |  | 
+| DirectSource | Number |  |  | 
+| Brightness | Number |  |  | 
+| Contrast | Number |  |  | 
+| Density | Number |  |  | 
+| Tint | Number |  |  | 
+| Sharpness | Number |  |  | 
+| ColorTemperature | Number |  |  | 
+| FleshTemperature | Number |  |  | 
+| ColorMode | String | Retrieves or set the color mode. |  | 
+| HorizontalPosition | Number |  |  | 
+| VerticalPosition | Number |  |  | 
+| Tracking | Number |  |  | 
+| Sync | Number |  |  | 
+| OffsetRed | Number |  |  | 
+| OffsetGreen | Number |  |  | 
+| OffsetBlue | Number |  |  | 
+| GainRed | Number |  |  | 
+| GainGreen | Number |  |  | 
+| GainBlue | Number |  |  | 
+| Gamma | String |  |  | 
+| GammaStep | Number |  |  | 
+| Color | String |  |  | 
+| Mute | Switch |  |  | 
+| HorizontalReverse | Switch |  |  | 
+| VerticalReverse | Switch |  |  | 
+| Background | String |  |  | 
+| ErrCode | Number | Retrieves the last error code. |  | 
+| ErrMessage | String | Retrieves the description of the last error. |  | 
+
+## Full Example
+
+items/epson.items
+
+```
+Switch epsonPower                          { channel="epsonprojector:hometheater:power" }
+String epsonSource        "Source [%s]"    { channel="epsonprojector:hometheater:source" }
+Number epsonDirectSource  "Direct Source"  { channel="epsonprojector:hometheater:directsource"}
+
+Switch epsonMute               { channel="epsonprojector:hometheater:mute" }
+
+Switch epsonHorizontalReverse  { channel="epsonprojector:hometheater:horizontalreverse" }
+Switch epsonVerticalReverse    { channel="epsonprojector:hometheater:verticalreverse" }
+
+String epsonAspectRatio       "AspectRatio [%s]"        { channel="epsonprojector:hometheater:aspectratio" }
+String epsonColorMode         "ColorMode [%s]"          { channel="epsonprojector:hometheater:colormode" }
+Number epsonColorTemperature  "Color Temperature [%d]"  <colorwheel>   { channel="epsonprojector:hometheater:colortemperature" }
+
+Number epsonLampTime    "Lamp Time [%d h]"  <switch>       { channel="epsonprojector:hometheater:lamptime" }
+Number epsonErrCode     "ErrCode [%d]"      <"siren-on">   { channel="epsonprojector:hometheater:errcode" }
+String epsonErrMessage  "ErrMessage [%s]"   <"siren-off">  { channel="epsonprojector:hometheater:errmessage" }
+```
+
+sitemaps/epson.sitemap
+
+```
+sitemap epson label="Epson Projector Demo"
+{
+    Frame label="Controls" {
+        Switch     item=epsonPower         label="Power"
+        Text       item=epsonSource
+        Selection  item=epsonDirectSource  label="DirectSource" mappings=[20="COMPONENT", 32="PC", 48=HDMI1, 160=HDMI2, 65=VIDEO, 66=SVIDEO]
+        Switch     item=epsonMute label="Mute"
+    }
+    Frame label="Flip Projection" {
+        Switch  item=epsonHorizontalReverse label="Horizontal Reverse"
+        Switch  item=epsonVerticalReverse   label="Vertical Reverse"
+    }
+    Frame label="Info" {
+        Text  item=epsonAspectRatio
+        Text  item=epsonColorMode
+        Text  item=epsonColorTemperature
+        Text  item=epsonLampTime
+        Text  item=epsonErrCode
+        Text  item=epsonErrMessage
+    }
+}
+```

--- a/bundles/org.openhab.binding.epsonprojector/pom.xml
+++ b/bundles/org.openhab.binding.epsonprojector/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.epsonprojector</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Epson Projector Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.epsonprojector/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.epsonprojector-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+    <feature name="openhab-binding-epsonprojector" description="Epson Projector Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-transport-serial</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.epsonprojector/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorBindingConstants.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorBindingConstants.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link EpsonProjectorBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+@NonNullByDefault
+public class EpsonProjectorBindingConstants {
+
+    private static final String BINDING_ID = "epsonprojector";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_PROJECTOR = new ThingTypeUID(BINDING_ID, "projector");
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import java.io.InvalidClassException;
+
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.library.items.StringItem;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+
+/**
+ * Represents all valid command types which could be processed by this
+ * binding.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public enum EpsonProjectorCommandType {
+
+    POWER("Power", SwitchItem.class),
+    POWER_STATE("PowerState", StringItem.class),
+    LAMP_TIME("LampTime", NumberItem.class),
+    KEY_CODE("KeyCode", NumberItem.class),
+    VKEYSTONE("VerticalKeystone", NumberItem.class),
+    HKEYSTONE("HorizontalKeystone", NumberItem.class),
+    AKEYSTONE("AutoKeystone", NumberItem.class),
+    ASPECT_RATIO("AspectRatio", StringItem.class),
+    LUMINANCE("Luminance", StringItem.class),
+    SOURCE("Source", StringItem.class),
+    DIRECT_SOURCE("DirectSource", NumberItem.class),
+    BRIGHTNESS("Brightness", NumberItem.class),
+    CONTRAST("Contrast", NumberItem.class),
+    DENSITY("Density", NumberItem.class),
+    TINT("Tint", NumberItem.class),
+    SHARP("Sharpness", NumberItem.class),
+    COLOR_TEMP("ColorTemperature", NumberItem.class),
+    FLESH_TEMP("FleshTemperature", NumberItem.class),
+    COLOR_MODE("ColorMode", StringItem.class),
+    HPOSITION("HorizontalPosition", NumberItem.class),
+    VPOSITION("VerticalPosition", NumberItem.class),
+    TRACKING("Tracking", NumberItem.class),
+    SYNC("Sync", NumberItem.class),
+    OFFSET_RED("OffsetRed", NumberItem.class),
+    OFFSET_GREEN("OffsetGreen", NumberItem.class),
+    OFFSET_BLUE("OffsetBlue", NumberItem.class),
+    GAIN_RED("GainRed", NumberItem.class),
+    GAIN_GREEN("GainGreen", NumberItem.class),
+    GAIN_BLUE("GainBlue", NumberItem.class),
+    GAMMA("Gamma", StringItem.class),
+    GAMMA_STEP("GammaStep", NumberItem.class),
+    COLOR("Color", StringItem.class),
+    MUTE("Mute", SwitchItem.class),
+    HREVERSE("HorizontalReverse", SwitchItem.class),
+    VREVERSE("VerticalReverse", SwitchItem.class),
+    BACKGROUND("Background", StringItem.class),
+    ERR_CODE("ErrCode", NumberItem.class),
+    ERR_MESSAGE("ErrMessage", StringItem.class),;
+
+    private final String text;
+    private Class<? extends Item> itemClass;
+
+    private EpsonProjectorCommandType(final String text, Class<? extends Item> itemClass) {
+        this.text = text;
+        this.itemClass = itemClass;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+
+    public Class<? extends Item> getItemClass() {
+        return itemClass;
+    }
+
+    /**
+     * Procedure to validate command type string.
+     *
+     * @param commandTypeText
+     *            command string e.g. RawData, Command, Brightness
+     * @return true if item is valid.
+     * @throws IllegalArgumentException
+     *             Not valid command type.
+     * @throws InvalidClassException
+     *             Not valid class for command type.
+     */
+    public static boolean validateBinding(String commandTypeText, Class<? extends Item> itemClass)
+            throws IllegalArgumentException, InvalidClassException {
+
+        for (EpsonProjectorCommandType c : EpsonProjectorCommandType.values()) {
+            if (c.text.equalsIgnoreCase(commandTypeText)) {
+
+                if (c.getItemClass().equals(itemClass)) {
+                    return true;
+                } else {
+                    throw new InvalidClassException("Not valid class for command type");
+                }
+            }
+        }
+
+        throw new IllegalArgumentException("Not valid command type");
+
+    }
+
+    /**
+     * Procedure to convert command type string to command type class.
+     *
+     * @param commandTypeText
+     *            command string e.g. RawData, Command, Brightness
+     * @return corresponding command type.
+     * @throws InvalidClassException
+     *             Not valid class for command type.
+     */
+    public static EpsonProjectorCommandType getCommandType(String commandTypeText) throws IllegalArgumentException {
+
+        for (EpsonProjectorCommandType c : EpsonProjectorCommandType.values()) {
+            if (c.text.equalsIgnoreCase(commandTypeText)) {
+                return c;
+            }
+        }
+
+        throw new IllegalArgumentException("Not valid command type");
+    }
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
@@ -26,7 +26,6 @@ import org.eclipse.smarthome.core.library.items.SwitchItem;
  * @author Pauli Anttila - Initial contribution
  */
 public enum EpsonProjectorCommandType {
-
     POWER("Power", SwitchItem.class),
     POWER_STATE("PowerState", StringItem.class),
     LAMP_TIME("LampTime", NumberItem.class),
@@ -96,10 +95,8 @@ public enum EpsonProjectorCommandType {
      */
     public static boolean validateBinding(String commandTypeText, Class<? extends Item> itemClass)
             throws IllegalArgumentException, InvalidClassException {
-
         for (EpsonProjectorCommandType c : EpsonProjectorCommandType.values()) {
             if (c.text.equalsIgnoreCase(commandTypeText)) {
-
                 if (c.getItemClass().equals(itemClass)) {
                     return true;
                 } else {
@@ -109,7 +106,6 @@ public enum EpsonProjectorCommandType {
         }
 
         throw new IllegalArgumentException("Not valid command type");
-
     }
 
     /**
@@ -122,7 +118,6 @@ public enum EpsonProjectorCommandType {
      *             Not valid class for command type.
      */
     public static EpsonProjectorCommandType getCommandType(String commandTypeText) throws IllegalArgumentException {
-
         for (EpsonProjectorCommandType c : EpsonProjectorCommandType.values()) {
             if (c.text.equalsIgnoreCase(commandTypeText)) {
                 return c;

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorConfiguration.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorConfiguration.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+/**
+ * The {@link EpsonProjectorConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+public class EpsonProjectorConfiguration {
+
+    /**
+     * Serial port used for communication.
+     */
+    public String serialPort;
+
+    /**
+     * Host or IP address used for communication over a TCP link (if serialPort is not set).
+     */
+    public String host;
+
+    /**
+     * Port used for communication over a TCP link (if serialPort is not set).
+     */
+    public int port;
+
+    /**
+     * Polling interval to refresh states.
+     */
+    public int pollingInterval;
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorConfiguration.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorConfiguration.java
@@ -12,22 +12,26 @@
  */
 package org.openhab.binding.epsonprojector.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link EpsonProjectorConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author Yannick Schaus - Initial contribution
  */
+@NonNullByDefault
 public class EpsonProjectorConfiguration {
 
     /**
      * Serial port used for communication.
      */
-    public String serialPort;
+    public @Nullable String serialPort;
 
     /**
      * Host or IP address used for communication over a TCP link (if serialPort is not set).
      */
-    public String host;
+    public @Nullable String host;
 
     /**
      * Port used for communication over a TCP link (if serialPort is not set).

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -1,0 +1,1091 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.binding.epsonprojector.internal.connector.EpsonProjectorConnector;
+import org.openhab.binding.epsonprojector.internal.connector.EpsonProjectorSerialConnector;
+import org.openhab.binding.epsonprojector.internal.connector.EpsonProjectorTcpConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provide high level interface to Epson projector.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class EpsonProjectorDevice {
+    public enum AspectRatio {
+        NORMAL(0x00),
+        AUTO(0x30),
+        FULL(0x40),
+        ZOOM(0x50),
+        WIDE(0x70),
+        ANAMORPHIC(0x80),
+        SQUEEZE(0x90),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, AspectRatio> typesByValue = new HashMap<Integer, AspectRatio>();
+
+        static {
+            for (AspectRatio type : AspectRatio.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private AspectRatio(int value) {
+            this.value = value;
+        }
+
+        public static AspectRatio forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+    }
+
+    public enum Luminance {
+        NORMAL(0x00),
+        ECO(0x01),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Luminance> typesByValue = new HashMap<Integer, Luminance>();
+
+        static {
+            for (Luminance type : Luminance.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Luminance(int value) {
+            this.value = value;
+        }
+
+        public static Luminance forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum Source {
+        COMPONENT(0x14),
+        PC_DSUB(0x20),
+        HDMI1(0x30),
+        HDMI2(0xA0),
+        VIDEO(0x41),
+        SVIDEO(0x42),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Source> typesByValue = new HashMap<Integer, Source>();
+
+        static {
+            for (Source type : Source.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Source(int value) {
+            this.value = value;
+        }
+
+        public static Source forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+    }
+
+    public enum ColorMode {
+        CINEMANIGHT(0x05),
+        DYNAMIC(0x06),
+        NATURAL(0x07),
+        HD(0x09),
+        SILVER(0x0A),
+        XVCOLOR(0x0B),
+        LIVINGROOM(0x0C),
+        THX(0x13),
+        CINEMA(0x15),
+        CINEMA3D(0x17),
+        DYNAMIC3D(0x18),
+        THX3D(0x19),
+        BWCINEMA(0x20),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, ColorMode> typesByValue = new HashMap<Integer, ColorMode>();
+
+        static {
+            for (ColorMode type : ColorMode.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private ColorMode(int value) {
+            this.value = value;
+        }
+
+        public static ColorMode forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+    }
+
+    public enum PowerStatus {
+        STANDBY(0x00),
+        ON(0x01),
+        WARPUP(0x02),
+        COOLDOWN(0x03),
+        STANDBYNETWORKON(0x04),
+        ABNORMALSTANDBY(0x05),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, PowerStatus> typesByValue = new HashMap<Integer, PowerStatus>();
+
+        static {
+            for (PowerStatus type : PowerStatus.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private PowerStatus(int value) {
+            this.value = value;
+        }
+
+        public static PowerStatus forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+    }
+
+    public enum Sharpness {
+        STANDARD(0x00),
+        HIGHPASS(0x01),
+        LOWPASS(0x02),
+        HORIZONTAL(0x04),
+        VERTICAL(0x05),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Sharpness> typesByValue = new HashMap<Integer, Sharpness>();
+
+        static {
+            for (Sharpness type : Sharpness.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Sharpness(int value) {
+            this.value = value;
+        }
+
+        public static Sharpness forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum GammaStep {
+        TONE1(0x00),
+        TONE2(0x01),
+        TONE3(0x02),
+        TONE4(0x03),
+        TONE5(0x04),
+        TONE6(0x05),
+        TONE7(0x06),
+        TONE8(0x07),
+        TONE9(0x08),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, GammaStep> typesByValue = new HashMap<Integer, GammaStep>();
+
+        static {
+            for (GammaStep type : GammaStep.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private GammaStep(int value) {
+            this.value = value;
+        }
+
+        public static GammaStep forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum Color {
+        RGB_RGBCMY(0x07),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Color> typesByValue = new HashMap<Integer, Color>();
+
+        static {
+            for (Color type : Color.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Color(int value) {
+            this.value = value;
+        }
+
+        public static Color forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum Gamma {
+        G2_0(0x20),
+        G2_1(0x21),
+        G2_2(0x22),
+        G2_3(0x23),
+        G2_4(0x24),
+        CUSTOM(0xF0),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Gamma> typesByValue = new HashMap<Integer, Gamma>();
+
+        static {
+            for (Gamma type : Gamma.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Gamma(int value) {
+            this.value = value;
+        }
+
+        public static Gamma forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum Background {
+        BLACK(0x00),
+        BLUE(0x01),
+        LOGO(0x02),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, Background> typesByValue = new HashMap<Integer, Background>();
+
+        static {
+            for (Background type : Background.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private Background(int value) {
+            this.value = value;
+        }
+
+        public static Background forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum CommunicationSpeed {
+        S9600(0x00),
+        S18200(0x01),
+        S38400(0x02),
+        S57600(0x03),
+        ERROR(0xFF);
+
+        private int value;
+        private static final Map<Integer, CommunicationSpeed> typesByValue = new HashMap<Integer, CommunicationSpeed>();
+
+        static {
+            for (CommunicationSpeed type : CommunicationSpeed.values()) {
+                typesByValue.put(type.value, type);
+            }
+        }
+
+        private CommunicationSpeed(int value) {
+            this.value = value;
+        }
+
+        public static CommunicationSpeed forValue(int value) {
+            return typesByValue.get(value);
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+    }
+
+    public enum Switch {
+        ON,
+        OFF;
+    }
+
+    public enum Messages {
+
+        EpsonProjectorBinding_NO_ERROR("No error"),
+        EpsonProjectorBinding_ERROR1("Fan error"),
+        EpsonProjectorBinding_ERROR3("Lamp failure at power on"),
+        EpsonProjectorBinding_ERROR4("High internal temperature error"),
+        EpsonProjectorBinding_ERROR6("Lamp error"),
+        EpsonProjectorBinding_ERROR7("Open Lamp cover door error"),
+        EpsonProjectorBinding_ERROR8("Cinema filter error"),
+        EpsonProjectorBinding_ERROR9("Electric dual-layered capacitor is disconnected"),
+        EpsonProjectorBinding_ERROR10("Auto iris error"),
+        EpsonProjectorBinding_ERROR11("Subsystem error"),
+        EpsonProjectorBinding_ERROR12("Low air flow error"),
+        EpsonProjectorBinding_ERROR13("Air filter air flow sensor error"),
+        EpsonProjectorBinding_ERROR14("Power supply unit error (ballast)"),
+        EpsonProjectorBinding_ERROR15("Shutter error"),
+        EpsonProjectorBinding_ERROR16("Cooling system error (peltier element)"),
+        EpsonProjectorBinding_ERROR17("Cooling system error (pump)"),
+        EpsonProjectorBinding_ERROR18("Static iris error"),
+        EpsonProjectorBinding_ERROR19("Power supply unit error (disagreement of ballast)"),
+        EpsonProjectorBinding_ERROR20("Exhaust shutter error"),
+        EpsonProjectorBinding_ERROR21("Obstacle detection error"),
+        EpsonProjectorBinding_ERROR22("IF board discernment error"),
+        EpsonProjectorBinding_UNKNOWN_ERROR("Unknown error");
+
+        private final String message;
+
+        Messages(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    final private int defaultTimeout = 5 * 1000;
+    final private int powerOnTimeout = 100 * 1000;
+    final private int powerOffTimeout = 130 * 1000;
+
+    private static Logger logger = LoggerFactory.getLogger(EpsonProjectorDevice.class);
+
+    private EpsonProjectorConnector connection = null;
+    private boolean connected = false;
+
+    public EpsonProjectorDevice(String serialPort) {
+        connection = new EpsonProjectorSerialConnector(serialPort);
+    }
+
+    public EpsonProjectorDevice(String ip, int port) {
+        connection = new EpsonProjectorTcpConnector(ip, port);
+    }
+
+    private synchronized String sendQuery(String query, int timeout) throws EpsonProjectorException {
+
+        logger.debug("Query: '{}'", query);
+        String response = connection.sendMessage(query, timeout);
+
+        if (response == null || response.length() == 0) {
+            throw new EpsonProjectorException("No response received");
+        }
+
+        response = response.replace("\r:", "");
+        logger.debug("Response: '{}'", response);
+
+        if (response.equals("ERR")) {
+            throw new EpsonProjectorException("Error response received");
+        }
+
+        if ("PWR OFF".equals(query) && ":".equals(response)) {
+            // When PWR OFF command is sent, next command can be send after 10 seconds after the colon is received
+            logger.debug("Waiting 10 seconds to power OFF completion");
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                // just exit
+            }
+        }
+
+        return response;
+    }
+
+    @SuppressWarnings("unused")
+    private String sendQuery(String query) throws EpsonProjectorException {
+        return sendQuery(query, defaultTimeout);
+    }
+
+    protected void sendCommand(String command, int timeout) throws EpsonProjectorException {
+        sendQuery(command, timeout);
+    }
+
+    protected void sendCommand(String command) throws EpsonProjectorException {
+        sendCommand(command, defaultTimeout);
+    }
+
+    protected int queryInt(String query, int timeout, int radix) throws EpsonProjectorException {
+
+        String response = sendQuery(query, timeout);
+
+        if (response != null && !response.equals("")) {
+
+            try {
+                String[] pieces = response.split("=");
+                String str = pieces[1].trim();
+
+                return Integer.parseInt(str, radix);
+
+            } catch (Exception e) {
+                throw new EpsonProjectorException("Illegal response");
+            }
+        } else {
+            throw new EpsonProjectorException("No response received");
+        }
+
+    }
+
+    protected int queryInt(String query, int timeout) throws EpsonProjectorException {
+        return queryInt(query, timeout, 10);
+    }
+
+    protected int queryInt(String query) throws EpsonProjectorException {
+        return queryInt(query, defaultTimeout, 10);
+    }
+
+    protected int queryHexInt(String query, int timeout) throws EpsonProjectorException {
+        return queryInt(query, timeout, 16);
+    }
+
+    protected int queryHexInt(String query) throws EpsonProjectorException {
+        return queryInt(query, defaultTimeout, 16);
+    }
+
+    public void connect() throws EpsonProjectorException {
+        connection.connect();
+        connected = true;
+    }
+
+    public void disconnect() throws EpsonProjectorException {
+        connection.disconnect();
+        connected = false;
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+
+    /*
+     * Power
+     */
+    public PowerStatus getPowerStatus() throws EpsonProjectorException {
+        int val = queryInt("PWR?");
+        PowerStatus retval = PowerStatus.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to PowerStatus");
+        }
+    }
+
+    public void setPower(Switch value) throws EpsonProjectorException {
+        sendCommand(String.format("PWR %s", value.name()), value == Switch.ON ? powerOnTimeout : powerOffTimeout);
+    }
+
+    /*
+     * Key code
+     */
+    public void sendKeyCode(int value) throws EpsonProjectorException {
+        sendCommand(String.format("KEY %02X", value));
+    }
+
+    /*
+     * Vertical Keystone
+     */
+    public int getVerticalKeystone() throws EpsonProjectorException {
+        return queryInt("VKEYSTONE?");
+    }
+
+    public void setVerticalKeystone(int value) throws EpsonProjectorException {
+        sendCommand(String.format("VKEYSTONE %d", value));
+    }
+
+    /*
+     * Horizontal Keystone
+     */
+    public int getHorizontalKeystone() throws EpsonProjectorException {
+        return queryInt("HKEYSTONE?");
+    }
+
+    public void setHorizontalKeystone(int value) throws EpsonProjectorException {
+        sendCommand(String.format("HKEYSTONE %d", value));
+    }
+
+    /*
+     * Auto Keystone
+     */
+    public int getAutoKeystone() throws EpsonProjectorException {
+        return queryInt("AUTOKEYSTONE?");
+    }
+
+    public void setAutoKeystone(int value) throws EpsonProjectorException {
+        sendCommand(String.format("HKEYSTONE %d", value));
+    }
+
+    /*
+     * Aspect Ratio
+     */
+    public AspectRatio getAspectRatio() throws EpsonProjectorException {
+        int val = queryHexInt("ASPECT?");
+        AspectRatio retval = AspectRatio.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to AspectRatio");
+        }
+    }
+
+    public void setAspectRatio(AspectRatio value) throws EpsonProjectorException {
+        sendCommand(String.format("ASPECT %02X", value.toInt()));
+    }
+
+    /*
+     * Luminance
+     */
+    public Luminance getLuminance() throws EpsonProjectorException {
+        int val = queryHexInt("LUMINANCE?");
+        Luminance retval = Luminance.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Luminance");
+        }
+    }
+
+    public void setLuminance(Luminance value) throws EpsonProjectorException {
+        sendCommand(String.format("LUMINANCE %02X", value.toInt()));
+    }
+
+    /*
+     * Source
+     */
+    public Source getSource() throws EpsonProjectorException {
+        int val = queryHexInt("SOURCE?");
+        Source retval = Source.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Source");
+        }
+    }
+
+    public void setSource(Source value) throws EpsonProjectorException {
+        sendCommand(String.format("SOURCE %02X", value.toInt()));
+    }
+
+    public int getDirectSource() throws EpsonProjectorException {
+        return queryHexInt("SOURCE?");
+    }
+
+    public void setDirectSource(int value) throws EpsonProjectorException {
+        sendCommand(String.format("SOURCE %02X", value));
+    }
+
+    /*
+     * Brightness
+     */
+    public int getBrightness() throws EpsonProjectorException {
+        return queryInt("BRIGHT?");
+    }
+
+    public void setBrightness(int value) throws EpsonProjectorException {
+        sendCommand(String.format("BRIGHT %d", value));
+    }
+
+    /*
+     * Contrast
+     */
+    public int getContrast() throws EpsonProjectorException {
+        return queryInt("CONTRAST?");
+    }
+
+    public void setContrast(int value) throws EpsonProjectorException {
+        sendCommand(String.format("CONTRAST %d", value));
+    }
+
+    /*
+     * Density
+     */
+    public int getDensity() throws EpsonProjectorException {
+        return queryInt("DENSITY?");
+    }
+
+    public void setDensity(int value) throws EpsonProjectorException {
+        sendCommand(String.format("DENSITY %d", value));
+    }
+
+    /*
+     * Tint
+     */
+    public int getTint() throws EpsonProjectorException {
+        return queryInt("TINT?");
+    }
+
+    public void setTint(int value) throws EpsonProjectorException {
+        sendCommand(String.format("TINT %d", value));
+    }
+
+    /*
+     * Sharpness
+     */
+    public int getSharpness(Sharpness sharpness) throws EpsonProjectorException {
+        return queryHexInt("SHARP? %02X", sharpness.toInt());
+    }
+
+    public void setSharpness(Sharpness sharpness, int value) throws EpsonProjectorException {
+        sendCommand(String.format("SHARP %d %02X", value, sharpness.toInt()));
+    }
+
+    /*
+     * Color Temperature
+     */
+    public int getColorTemperature() throws EpsonProjectorException {
+        return queryInt("CTEMP?");
+    }
+
+    public void setColorTemperature(int value) throws EpsonProjectorException {
+        sendCommand(String.format("CTEMP %d", value));
+    }
+
+    /*
+     * Flesh Color
+     */
+    public int getFleshColor() throws EpsonProjectorException {
+        return queryHexInt("FCOLOR?");
+    }
+
+    public void setFleshColor(int value) throws EpsonProjectorException {
+        sendCommand(String.format("FCOLOR %02X", value));
+    }
+
+    /*
+     * Color Mode
+     */
+    public ColorMode getColorMode() throws EpsonProjectorException {
+        int val = queryHexInt("CMODE?");
+        ColorMode retval = ColorMode.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to ColorMode");
+        }
+    }
+
+    public void setColorMode(ColorMode value) throws EpsonProjectorException {
+        sendCommand(String.format("CMODE %02X", value.toInt()));
+    }
+
+    /*
+     * Horizontal Position
+     */
+    public int getHorizontalPosition() throws EpsonProjectorException {
+        return queryInt("HPOS?");
+    }
+
+    public void setHorizontalPosition(int value) throws EpsonProjectorException {
+        sendCommand(String.format("HPOS %d", value));
+    }
+
+    /*
+     * Vertical Position
+     */
+    public int getVerticalPosition() throws EpsonProjectorException {
+        return queryInt("VPOS?");
+    }
+
+    public void setVerticalPosition(int value) throws EpsonProjectorException {
+        sendCommand(String.format("VPOS %d", value));
+    }
+
+    /*
+     * Tracking
+     */
+    public int getTracking() throws EpsonProjectorException {
+        return queryInt("TRACKIOK?");
+    }
+
+    public void setTracking(int value) throws EpsonProjectorException {
+        sendCommand(String.format("TRACKIOK %d", value));
+    }
+
+    /*
+     * Sync
+     */
+    public int getSync() throws EpsonProjectorException {
+        return queryInt("SYNC?");
+    }
+
+    public void setSync(int value) throws EpsonProjectorException {
+        sendCommand(String.format("SYNC %d", value));
+    }
+
+    /*
+     * Offset Red
+     */
+    public int getOffsetRed() throws EpsonProjectorException {
+        return queryInt("OFFSETR?");
+    }
+
+    public void setOffsetRed(int value) throws EpsonProjectorException {
+        sendCommand(String.format("OFFSETR %d", value));
+    }
+
+    /*
+     * Offset Green
+     */
+    public int getOffsetGreen() throws EpsonProjectorException {
+        return queryInt("OFFSETG?");
+    }
+
+    public void setOffsetGreen(int value) throws EpsonProjectorException {
+        sendCommand(String.format("OFFSETG %d", value));
+    }
+
+    /*
+     * Offset Blue
+     */
+    public int getOffsetBlue() throws EpsonProjectorException {
+        return queryInt("OFFSETB?");
+    }
+
+    public void setOffsetBlue(int value) throws EpsonProjectorException {
+        sendCommand(String.format("OFFSETB %d", value));
+    }
+
+    /*
+     * Gain Red
+     */
+    public int getGainRed() throws EpsonProjectorException {
+        return queryInt("GAINR?");
+    }
+
+    public void setGainRed(int value) throws EpsonProjectorException {
+        sendCommand(String.format("GAINR %d", value));
+    }
+
+    /*
+     * Gain Green
+     */
+    public int getGainGreen() throws EpsonProjectorException {
+        return queryInt("GAING?");
+    }
+
+    public void setGainGreen(int value) throws EpsonProjectorException {
+        sendCommand(String.format("GAING %d", value));
+    }
+
+    /*
+     * Gain Blue
+     */
+    public int getGainBlue() throws EpsonProjectorException {
+        return queryInt("GAINB?");
+    }
+
+    public void setGainBlue(int value) throws EpsonProjectorException {
+        sendCommand(String.format("GAINB %d", value));
+    }
+
+    /*
+     * Gamma
+     */
+    public Gamma getGamma() throws EpsonProjectorException {
+        int val = queryHexInt("GAMMA?");
+        Gamma retval = Gamma.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Gamma");
+        }
+    }
+
+    public void setGamma(Gamma value) throws EpsonProjectorException {
+        sendCommand(String.format("GAMMA %02X", value.toInt()));
+    }
+
+    /*
+     * Gamma Step
+     */
+    public int getGammaStep(GammaStep step) throws EpsonProjectorException {
+        return queryHexInt(String.format("GAMMALV? %02X", step.toInt()));
+    }
+
+    public void setGammaStep(GammaStep step, int value) throws EpsonProjectorException {
+        sendCommand(String.format("GAMMALV %02X %d", step.toInt(), value));
+    }
+
+    /*
+     * Memory
+     */
+    public void LoadMemory(int number) throws EpsonProjectorException {
+        sendCommand(String.format("POPMEM 02 %02X", number));
+    }
+
+    public void SaveMemory(int number) throws EpsonProjectorException {
+        sendCommand(String.format("PUSHMEM 02 %02X", number));
+    }
+
+    public void EraseAllMemory() throws EpsonProjectorException {
+        sendCommand("ERASEMEM 00");
+    }
+
+    public void EraseMemory(int number) throws EpsonProjectorException {
+        sendCommand(String.format("ERASEMEM 02 %02X", number));
+    }
+
+    /*
+     * Color
+     */
+    public Color getColor() throws EpsonProjectorException {
+        int val = queryHexInt("CSEL?");
+        Color retval = Color.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Color");
+        }
+    }
+
+    public void setColor(Color value) throws EpsonProjectorException {
+        sendCommand(String.format("CSEL %02X", value.toInt()));
+    }
+
+    /*
+     * Mute
+     */
+    public Switch getMute() throws EpsonProjectorException {
+        int val = queryInt("MUTE?");
+        try {
+            return Switch.values()[val];
+        } catch (Exception e) {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Switch");
+        }
+    }
+
+    public void setMute(Switch value) throws EpsonProjectorException {
+        sendCommand(String.format("MUTE %s", value.name()), defaultTimeout);
+    }
+
+    /*
+     * Horizontal Reverse
+     */
+    public Switch getHorizontalReverse() throws EpsonProjectorException {
+        int val = queryInt("HREVERSE?");
+        try {
+            return Switch.values()[val];
+        } catch (Exception e) {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Switch");
+        }
+    }
+
+    public void setHorizontalReverse(Switch value) throws EpsonProjectorException {
+        sendCommand(String.format("HREVERSE %s", value.name()));
+    }
+
+    /*
+     * Vertical Reverse
+     */
+    public Switch getVerticalReverse() throws EpsonProjectorException {
+        int val = queryInt("VREVERSE?");
+        try {
+            return Switch.values()[val];
+        } catch (Exception e) {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Switch");
+        }
+    }
+
+    public void setVerticalReverse(Switch value) throws EpsonProjectorException {
+        sendCommand(String.format("VREVERSE %s", value.name()));
+    }
+
+    /*
+     * Background
+     */
+    public Background getBackground() throws EpsonProjectorException {
+        int val = queryHexInt("MSEL?");
+        Background retval = Background.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to Background");
+        }
+    }
+
+    public void setBackground(Background value) throws EpsonProjectorException {
+        sendCommand(String.format("MSEL %02X", value.toInt()));
+    }
+
+    /*
+     * Reset all
+     */
+    public void ResetAll() throws EpsonProjectorException {
+        sendCommand("INITALL");
+    }
+
+    /*
+     * Speed
+     */
+    public CommunicationSpeed getCommunicationSpeed() throws EpsonProjectorException {
+        int val = queryInt("SPEED?");
+        CommunicationSpeed retval = CommunicationSpeed.forValue(val);
+        if (retval != null) {
+            return retval;
+        } else {
+            throw new EpsonProjectorException("Can't convert value" + val + " to CommunicationSpeed");
+        }
+    }
+
+    public void setCommunicationSpeed(CommunicationSpeed value) throws EpsonProjectorException {
+        sendCommand(String.format("SPEED %s", value.toInt()));
+    }
+
+    /*
+     * Lamp Time
+     */
+    public int getLampTime() throws EpsonProjectorException {
+        return queryInt("LAMP?");
+    }
+
+    /*
+     * Error
+     */
+    public int getError() throws EpsonProjectorException {
+        return queryHexInt("ERR?");
+    }
+
+    /*
+     * Error
+     */
+    public String getErrorString() throws EpsonProjectorException {
+        String errString = null;
+
+        int err = queryInt("ERR?");
+
+        switch (err) {
+            case 0:
+                errString = Messages.EpsonProjectorBinding_NO_ERROR.getMessage();
+                break;
+            case 1:
+                errString = Messages.EpsonProjectorBinding_ERROR1.getMessage();
+                break;
+            case 3:
+                errString = Messages.EpsonProjectorBinding_ERROR3.getMessage();
+                break;
+            case 4:
+                errString = Messages.EpsonProjectorBinding_ERROR4.getMessage();
+                break;
+            case 6:
+                errString = Messages.EpsonProjectorBinding_ERROR6.getMessage();
+                break;
+            case 7:
+                errString = Messages.EpsonProjectorBinding_ERROR7.getMessage();
+                break;
+            case 8:
+                errString = Messages.EpsonProjectorBinding_ERROR8.getMessage();
+                break;
+            case 9:
+                errString = Messages.EpsonProjectorBinding_ERROR9.getMessage();
+                break;
+            case 10:
+                errString = Messages.EpsonProjectorBinding_ERROR10.getMessage();
+                break;
+            case 11:
+                errString = Messages.EpsonProjectorBinding_ERROR11.getMessage();
+                break;
+            case 12:
+                errString = Messages.EpsonProjectorBinding_ERROR12.getMessage();
+                break;
+            case 13:
+                errString = Messages.EpsonProjectorBinding_ERROR13.getMessage();
+                break;
+            case 14:
+                errString = Messages.EpsonProjectorBinding_ERROR14.getMessage();
+                break;
+            case 15:
+                errString = Messages.EpsonProjectorBinding_ERROR15.getMessage();
+                break;
+            case 16:
+                errString = Messages.EpsonProjectorBinding_ERROR16.getMessage();
+                break;
+            case 17:
+                errString = Messages.EpsonProjectorBinding_ERROR17.getMessage();
+                break;
+            case 18:
+                errString = Messages.EpsonProjectorBinding_ERROR18.getMessage();
+                break;
+            case 19:
+                errString = Messages.EpsonProjectorBinding_ERROR19.getMessage();
+                break;
+            case 20:
+                errString = Messages.EpsonProjectorBinding_ERROR20.getMessage();
+                break;
+            case 21:
+                errString = Messages.EpsonProjectorBinding_ERROR21.getMessage();
+                break;
+            case 22:
+                errString = Messages.EpsonProjectorBinding_ERROR22.getMessage();
+                break;
+            default:
+                errString = String.format(Messages.EpsonProjectorBinding_UNKNOWN_ERROR + " %d", err);
+        }
+
+        return errString;
+    }
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -50,9 +50,9 @@ public class EpsonProjectorDevice {
     protected final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(THING_HANDLER_THREADPOOL_NAME);
 
-    private final int defaultTimeout = 5 * 1000;
-    private final int powerOnTimeout = 100 * 1000;
-    private final int powerOffTimeout = 130 * 1000;
+    private static final int DEFAULT_TIMEOUT = 5 * 1000;
+    private static final int POWER_ON_TIMEOUT = 100 * 1000;
+    private static final int POWER_OFF_TIMEOUT = 130 * 1000;
 
     private Logger logger = LoggerFactory.getLogger(EpsonProjectorDevice.class);
 
@@ -78,7 +78,7 @@ public class EpsonProjectorDevice {
         logger.debug("Query: '{}'", query);
         String response = connection.sendMessage(query, timeout);
 
-        if (response == null || response.length() == 0) {
+        if (response.length() == 0) {
             throw new EpsonProjectorException("No response received");
         }
 
@@ -106,7 +106,7 @@ public class EpsonProjectorDevice {
     }
 
     protected void sendCommand(String command) throws EpsonProjectorException {
-        sendCommand(command, defaultTimeout);
+        sendCommand(command, DEFAULT_TIMEOUT);
     }
 
     protected int queryInt(String query, int timeout, int radix) throws EpsonProjectorException {
@@ -127,7 +127,7 @@ public class EpsonProjectorDevice {
     }
 
     protected int queryInt(String query) throws EpsonProjectorException {
-        return queryInt(query, defaultTimeout, 10);
+        return queryInt(query, DEFAULT_TIMEOUT, 10);
     }
 
     protected int queryHexInt(String query, int timeout) throws EpsonProjectorException {
@@ -135,7 +135,7 @@ public class EpsonProjectorDevice {
     }
 
     protected int queryHexInt(String query) throws EpsonProjectorException {
-        return queryInt(query, defaultTimeout, 16);
+        return queryInt(query, DEFAULT_TIMEOUT, 16);
     }
 
     public void connect() throws EpsonProjectorException {
@@ -162,7 +162,7 @@ public class EpsonProjectorDevice {
     }
 
     public void setPower(Switch value) throws EpsonProjectorException {
-        sendCommand(String.format("PWR %s", value.name()), value == Switch.ON ? powerOnTimeout : powerOffTimeout);
+        sendCommand(String.format("PWR %s", value.name()), value == Switch.ON ? POWER_ON_TIMEOUT : POWER_OFF_TIMEOUT);
     }
 
     /*
@@ -494,11 +494,11 @@ public class EpsonProjectorDevice {
      */
     public Switch getMute() throws EpsonProjectorException {
         int val = queryInt("MUTE?");
-        return Switch.values()[val];
+        return val == 0 ? Switch.OFF : Switch.ON;
     }
 
     public void setMute(Switch value) throws EpsonProjectorException {
-        sendCommand(String.format("MUTE %s", value.name()), defaultTimeout);
+        sendCommand(String.format("MUTE %s", value.name()), DEFAULT_TIMEOUT);
     }
 
     /*
@@ -506,7 +506,7 @@ public class EpsonProjectorDevice {
      */
     public Switch getHorizontalReverse() throws EpsonProjectorException {
         int val = queryInt("HREVERSE?");
-        return Switch.values()[val];
+        return val == 0 ? Switch.OFF : Switch.ON;
     }
 
     public void setHorizontalReverse(Switch value) throws EpsonProjectorException {
@@ -518,7 +518,7 @@ public class EpsonProjectorDevice {
      */
     public Switch getVerticalReverse() throws EpsonProjectorException {
         int val = queryInt("VREVERSE?");
-        return Switch.values()[val];
+        return val == 0 ? Switch.OFF : Switch.ON;
     }
 
     public void setVerticalReverse(Switch value) throws EpsonProjectorException {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorException.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+/**
+ * Exception for Epson projector errors.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class EpsonProjectorException extends Exception {
+
+    private static final long serialVersionUID = -8048415193494625295L;
+
+    public EpsonProjectorException() {
+        super();
+    }
+
+    public EpsonProjectorException(String message) {
+        super(message);
+    }
+
+    public EpsonProjectorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EpsonProjectorException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorException.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorException.java
@@ -12,18 +12,17 @@
  */
 package org.openhab.binding.epsonprojector.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Exception for Epson projector errors.
  *
  * @author Pauli Anttila - Initial contribution
  */
+@NonNullByDefault
 public class EpsonProjectorException extends Exception {
 
     private static final long serialVersionUID = -8048415193494625295L;
-
-    public EpsonProjectorException() {
-        super();
-    }
 
     public EpsonProjectorException(String message) {
         super(message);
@@ -36,5 +35,4 @@ public class EpsonProjectorException extends Exception {
     public EpsonProjectorException(Throwable cause) {
         super(cause);
     }
-
 }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
@@ -1,0 +1,451 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.AspectRatio;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Background;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Color;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.ColorMode;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Gamma;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Luminance;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.PowerStatus;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Source;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorDevice.Switch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link EpsonProjectorHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Pauli Anttila, Yannick Schaus - Initial contribution
+ */
+@NonNullByDefault
+public class EpsonProjectorHandler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(EpsonProjectorHandler.class);
+
+    private @Nullable EpsonProjectorConfiguration config;
+
+    private @Nullable EpsonProjectorDevice device;
+    private @Nullable ScheduledFuture<?> pollingJob;
+
+    public EpsonProjectorHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        String channelId = channelUID.getId();
+        if (command instanceof RefreshType) {
+            Channel channel = this.thing.getChannel(channelUID);
+            if (channel != null) {
+                updateChannelState(channel);
+            }
+        } else {
+            EpsonProjectorCommandType epsonCommand = EpsonProjectorCommandType.getCommandType(channelId);
+            sendDataToDevice(epsonCommand, command);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(EpsonProjectorConfiguration.class);
+
+        updateStatus(ThingStatus.UNKNOWN);
+
+        scheduler.execute(() -> {
+            if (StringUtils.isNotEmpty(config.serialPort)) {
+                device = new EpsonProjectorDevice(config.serialPort);
+            } else if (StringUtils.isNotEmpty(config.host) && config.port > 0) {
+                device = new EpsonProjectorDevice(config.host, config.port);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+                return;
+            }
+
+            try {
+                device.connect();
+                updateStatus(ThingStatus.ONLINE);
+
+                int pollingInterval = config.pollingInterval;
+                if (pollingInterval == 0) {
+                    pollingInterval = 10000;
+                }
+
+                List<Channel> channels = this.thing.getChannels();
+
+                pollingJob = scheduler.scheduleAtFixedRate(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (Channel channel : channels) {
+                            updateChannelState(channel);
+                        }
+                    }
+                }, 0, pollingInterval, TimeUnit.MILLISECONDS);
+
+            } catch (EpsonProjectorException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void dispose() {
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+        }
+        closeConnection();
+        super.dispose();
+    }
+
+    private void updateChannelState(Channel channel) {
+        try {
+            if (!isLinked(channel.getUID())) {
+                return;
+            }
+
+            EpsonProjectorCommandType epsonCommand = EpsonProjectorCommandType.getCommandType(channel.getUID().getId());
+
+            State state = queryDataFromDevice(epsonCommand);
+
+            updateState(channel.getUID(), state);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Illegal command {}", channel.getUID().getId());
+        }
+    }
+
+    private State queryDataFromDevice(EpsonProjectorCommandType commmandType) {
+
+        EpsonProjectorDevice remoteController = device;
+
+        if (remoteController == null) {
+            logger.error("Device is not initialized: '{}'", this.thing.getUID());
+            return UnDefType.UNDEF;
+        }
+
+        try {
+            if (remoteController.isConnected() == false) {
+                remoteController.connect();
+            }
+
+            switch (commmandType) {
+                case AKEYSTONE:
+                    int autoKeystone = remoteController.getAutoKeystone();
+                    return new DecimalType(autoKeystone);
+                case ASPECT_RATIO:
+                    AspectRatio aspectRatio = remoteController.getAspectRatio();
+                    return new StringType(aspectRatio.toString());
+                case BACKGROUND:
+                    Background background = remoteController.getBackground();
+                    return new StringType(background.toString());
+                case BRIGHTNESS:
+                    int brightness = remoteController.getBrightness();
+                    return new DecimalType(brightness);
+                case COLOR:
+                    Color color = remoteController.getColor();
+                    return new StringType(color.toString());
+                case COLOR_MODE:
+                    ColorMode colorMode = remoteController.getColorMode();
+                    return new StringType(colorMode.toString());
+                case COLOR_TEMP:
+                    int ctemp = remoteController.getColorTemperature();
+                    return new DecimalType(ctemp);
+                case CONTRAST:
+                    int contrast = remoteController.getContrast();
+                    return new DecimalType(contrast);
+                case DENSITY:
+                    int density = remoteController.getDensity();
+                    return new DecimalType(density);
+                case DIRECT_SOURCE:
+                    int directSource = remoteController.getDirectSource();
+                    return new DecimalType(directSource);
+                case ERR_CODE:
+                    int err = remoteController.getError();
+                    return new DecimalType(err);
+                case ERR_MESSAGE:
+                    String errString = remoteController.getErrorString();
+                    return new StringType(errString);
+                case FLESH_TEMP:
+                    int fleshColor = remoteController.getFleshColor();
+                    return new DecimalType(fleshColor);
+                case GAIN_BLUE:
+                    int gainBlue = remoteController.getGainBlue();
+                    return new DecimalType(gainBlue);
+                case GAIN_GREEN:
+                    int gainGreen = remoteController.getGainGreen();
+                    return new DecimalType(gainGreen);
+                case GAIN_RED:
+                    int gainRed = remoteController.getGainRed();
+                    return new DecimalType(gainRed);
+                case GAMMA:
+                    Gamma gamma = remoteController.getGamma();
+                    return new StringType(gamma.toString());
+                case GAMMA_STEP:
+                    logger.warn("Get '{}' not implemented!", commmandType.toString());
+                    return UnDefType.UNDEF;
+                case HKEYSTONE:
+                    int hKeystone = remoteController.getHorizontalKeystone();
+                    return new DecimalType(hKeystone);
+                case HPOSITION:
+                    int hPosition = remoteController.getHorizontalPosition();
+                    return new DecimalType(hPosition);
+                case HREVERSE:
+                    Switch hReverse = remoteController.getHorizontalReverse();
+                    return hReverse == Switch.ON ? OnOffType.ON : OnOffType.OFF;
+                case KEY_CODE:
+                    break;
+                case LAMP_TIME:
+                    int lampTime = remoteController.getLampTime();
+                    return new DecimalType(lampTime);
+                case LUMINANCE:
+                    Luminance luminance = remoteController.getLuminance();
+                    return new StringType(luminance.toString());
+                case MUTE:
+                    Switch mute = remoteController.getMute();
+                    return mute == Switch.ON ? OnOffType.ON : OnOffType.OFF;
+                case OFFSET_BLUE:
+                    int offsetBlue = remoteController.getOffsetBlue();
+                    return new DecimalType(offsetBlue);
+                case OFFSET_GREEN:
+                    int offsetGreen = remoteController.getOffsetGreen();
+                    return new DecimalType(offsetGreen);
+                case OFFSET_RED:
+                    int offsetRed = remoteController.getOffsetRed();
+                    return new DecimalType(offsetRed);
+                case POWER:
+                    PowerStatus powerStatus = remoteController.getPowerStatus();
+
+                    if (powerStatus == PowerStatus.ON) {
+                        return OnOffType.ON;
+                    } else {
+                        return OnOffType.OFF;
+                    }
+                case POWER_STATE:
+                    PowerStatus powerStatus1 = remoteController.getPowerStatus();
+                    return new StringType(powerStatus1.toString());
+                case SHARP:
+                    logger.warn("Get '{}' not implemented!", commmandType.toString());
+                    return UnDefType.UNDEF;
+                case SOURCE:
+                    Source source = remoteController.getSource();
+                    return new StringType(source.toString());
+                case SYNC:
+                    int sync = remoteController.getSync();
+                    return new DecimalType(sync);
+                case TINT:
+                    int tint = remoteController.getTint();
+                    return new DecimalType(tint);
+                case TRACKING:
+                    int tracking = remoteController.getTracking();
+                    return new DecimalType(tracking);
+                case VKEYSTONE:
+                    int vKeystone = remoteController.getVerticalKeystone();
+                    return new DecimalType(vKeystone);
+                case VPOSITION:
+                    int vPosition = remoteController.getVerticalPosition();
+                    return new DecimalType(vPosition);
+                case VREVERSE:
+                    Switch vReverse = remoteController.getVerticalReverse();
+                    return vReverse == Switch.ON ? OnOffType.ON : OnOffType.OFF;
+                default:
+                    logger.warn("Unknown '{}' command!", commmandType);
+                    return UnDefType.UNDEF;
+            }
+
+        } catch (EpsonProjectorException e) {
+            logger.debug("Couldn't execute command '{}', {}", commmandType.toString(), e.getMessage());
+            // closeConnection();
+        } catch (Exception e) {
+            logger.warn("Couldn't retrieve state for command '{}', {}", commmandType.toString(), e.getMessage());
+            return UnDefType.UNDEF;
+        }
+
+        return UnDefType.UNDEF;
+    }
+
+    private void sendDataToDevice(EpsonProjectorCommandType commmandType, Command command) {
+
+        EpsonProjectorDevice remoteController = device;
+
+        if (remoteController == null) {
+            logger.error("Device is not initialized: '{}'", this.thing.getUID());
+            return;
+        }
+
+        try {
+
+            if (remoteController.isConnected() == false) {
+                remoteController.connect();
+            }
+
+            switch (commmandType) {
+                case AKEYSTONE:
+                    remoteController.setAutoKeystone(((DecimalType) command).intValue());
+                    break;
+                case ASPECT_RATIO:
+                    remoteController.setAspectRatio(AspectRatio.valueOf(command.toString()));
+                    break;
+                case BACKGROUND:
+                    remoteController.setBackground(Background.valueOf(command.toString()));
+                    break;
+                case BRIGHTNESS:
+                    remoteController.setBrightness(((DecimalType) command).intValue());
+                    break;
+                case COLOR:
+                    remoteController.setColor(Color.valueOf(command.toString()));
+                    break;
+                case COLOR_MODE:
+                    remoteController.setColorMode(ColorMode.valueOf(command.toString()));
+                    break;
+                case COLOR_TEMP:
+                    remoteController.setColorTemperature(((DecimalType) command).intValue());
+                    break;
+                case CONTRAST:
+                    remoteController.setContrast(((DecimalType) command).intValue());
+                    break;
+                case DENSITY:
+                    remoteController.setDensity(((DecimalType) command).intValue());
+                    break;
+                case DIRECT_SOURCE:
+                    remoteController.setDirectSource(((DecimalType) command).intValue());
+                    break;
+                case ERR_CODE:
+                    logger.error("'{}' is read only parameter", commmandType);
+                    break;
+                case ERR_MESSAGE:
+                    logger.error("'{}' is read only parameter", commmandType);
+                    break;
+                case FLESH_TEMP:
+                    remoteController.setFleshColor(((DecimalType) command).intValue());
+                    break;
+                case GAIN_BLUE:
+                    remoteController.setGainBlue(((DecimalType) command).intValue());
+                    break;
+                case GAIN_GREEN:
+                    remoteController.setGainGreen(((DecimalType) command).intValue());
+                    break;
+                case GAIN_RED:
+                    remoteController.setGainRed(((DecimalType) command).intValue());
+                    break;
+                case GAMMA:
+                    remoteController.setGamma(Gamma.valueOf(command.toString()));
+                    break;
+                case GAMMA_STEP:
+                    logger.warn("Set '{}' not implemented!", commmandType.toString());
+                    break;
+                case HKEYSTONE:
+                    remoteController.setHorizontalKeystone(((DecimalType) command).intValue());
+                    break;
+                case HPOSITION:
+                    remoteController.setHorizontalPosition(((DecimalType) command).intValue());
+                    break;
+                case HREVERSE:
+                    remoteController.setHorizontalReverse((command == OnOffType.ON ? Switch.ON : Switch.OFF));
+                    break;
+                case KEY_CODE:
+                    remoteController.sendKeyCode(((DecimalType) command).intValue());
+                    break;
+                case LAMP_TIME:
+                    logger.error("'{}' is read only parameter", commmandType);
+                    break;
+                case LUMINANCE:
+                    remoteController.setLuminance(Luminance.valueOf(command.toString()));
+                    break;
+                case MUTE:
+                    remoteController.setMute((command == OnOffType.ON ? Switch.ON : Switch.OFF));
+                    break;
+                case OFFSET_BLUE:
+                    remoteController.setOffsetBlue(((DecimalType) command).intValue());
+                    break;
+                case OFFSET_GREEN:
+                    remoteController.setOffsetGreen(((DecimalType) command).intValue());
+                    break;
+                case OFFSET_RED:
+                    remoteController.setOffsetRed(((DecimalType) command).intValue());
+                    break;
+                case POWER:
+                    remoteController.setPower((command == OnOffType.ON ? Switch.ON : Switch.OFF));
+                    break;
+                case POWER_STATE:
+                    logger.error("'{}' is read only parameter", commmandType);
+                    break;
+                case SHARP:
+                    logger.warn("Set '{}' not implemented!", commmandType.toString());
+                    break;
+                case SOURCE:
+                    remoteController.setSource(Source.valueOf(command.toString()));
+                    break;
+                case SYNC:
+                    remoteController.setSync(((DecimalType) command).intValue());
+                    break;
+                case TINT:
+                    remoteController.setTint(((DecimalType) command).intValue());
+                    break;
+                case TRACKING:
+                    remoteController.setTracking(((DecimalType) command).intValue());
+                    break;
+                case VKEYSTONE:
+                    remoteController.setVerticalKeystone(((DecimalType) command).intValue());
+                    break;
+                case VPOSITION:
+                    remoteController.setVerticalPosition(((DecimalType) command).intValue());
+                    break;
+                case VREVERSE:
+                    remoteController.setVerticalReverse((command == OnOffType.ON ? Switch.ON : Switch.OFF));
+                    break;
+                default:
+                    logger.warn("Unknown '{}' command!", commmandType);
+                    break;
+            }
+
+        } catch (EpsonProjectorException e) {
+            logger.warn("Couldn't execute command '{}', {}", commmandType, e.getMessage());
+            // closeConnection();
+        }
+    }
+
+    private void closeConnection() {
+        EpsonProjectorDevice remoteController = device;
+
+        if (remoteController != null) {
+            try {
+                logger.debug("Closing connection to device '{}'", this.thing.getUID());
+                remoteController.disconnect();
+            } catch (EpsonProjectorException e) {
+                logger.debug("Error occurred when closing connection to device '{}'", this.thing.getUID());
+            }
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
@@ -133,7 +133,7 @@ public class EpsonProjectorHandler extends BaseThingHandler {
 
             updateState(channel.getUID(), state);
         } catch (IllegalArgumentException e) {
-            logger.warn("Illegal command {}", channel.getUID().getId());
+            logger.warn("Unknown channel {}", channel.getUID().getId());
         }
     }
 
@@ -272,9 +272,6 @@ public class EpsonProjectorHandler extends BaseThingHandler {
             // some commands are invalid depending on the state of the device, for instance if it's in standby mode
             logger.debug("Couldn't execute command '{}'", commandType, e);
             // closeConnection();
-        } catch (Exception e) {
-            logger.warn("Couldn't retrieve state for command '{}'", commandType, e);
-            return UnDefType.UNDEF;
         }
 
         return UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -82,9 +81,7 @@ public class EpsonProjectorHandler extends BaseThingHandler {
     public void initialize() {
         scheduler.execute(() -> {
             EpsonProjectorConfiguration config = getConfigAs(EpsonProjectorConfiguration.class);
-            @NonNull
             String serialPort = (config.serialPort != null) ? config.serialPort : "";
-            @NonNull
             String host = (config.host != null) ? config.host : "";
             if (StringUtils.isNotEmpty(serialPort)) {
                 device = new EpsonProjectorDevice(serialPort);

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandler.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -81,7 +82,9 @@ public class EpsonProjectorHandler extends BaseThingHandler {
     public void initialize() {
         scheduler.execute(() -> {
             EpsonProjectorConfiguration config = getConfigAs(EpsonProjectorConfiguration.class);
+            @NonNull
             String serialPort = (config.serialPort != null) ? config.serialPort : "";
+            @NonNull
             String host = (config.host != null) ? config.host : "";
             if (StringUtils.isNotEmpty(serialPort)) {
                 device = new EpsonProjectorDevice(serialPort);

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandlerFactory.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorHandlerFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal;
+
+import static org.openhab.binding.epsonprojector.internal.EpsonProjectorBindingConstants.THING_TYPE_PROJECTOR;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link EpsonProjectorHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.epsonprojector", service = ThingHandlerFactory.class)
+public class EpsonProjectorHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_PROJECTOR);
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_PROJECTOR.equals(thingTypeUID)) {
+            return new EpsonProjectorHandler(thing);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorConnector.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.connector;
+
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
+
+/**
+ * Base class for Epson projector communication.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public interface EpsonProjectorConnector {
+
+    /**
+     * Procedure for connecting to projector.
+     *
+     * @throws EpsonProjectorException
+     */
+    void connect() throws EpsonProjectorException;
+
+    /**
+     * Procedure for disconnecting to projector controller.
+     *
+     * @throws EpsonProjectorException
+     */
+    void disconnect() throws EpsonProjectorException;
+
+    /**
+     * Procedure for send raw data to projector.
+     *
+     * @param data
+     *            Message to send.
+     *
+     * @param timeout
+     *            timeout to wait response in milliseconds.
+     *
+     * @throws EpsonProjectorException
+     */
+    String sendMessage(String data, int timeout) throws EpsonProjectorException;
+
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorConnector.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.epsonprojector.internal.connector;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
 
 /**
@@ -19,6 +20,7 @@ import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
  *
  * @author Pauli Anttila - Initial contribution
  */
+@NonNullByDefault
 public interface EpsonProjectorConnector {
 
     /**

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorSerialConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorSerialConnector.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.connector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+
+import org.apache.commons.io.IOUtils;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gnu.io.CommPort;
+import gnu.io.CommPortIdentifier;
+import gnu.io.SerialPort;
+import gnu.io.SerialPortEvent;
+import gnu.io.SerialPortEventListener;
+
+/**
+ * Connector for serial port communication.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class EpsonProjectorSerialConnector implements EpsonProjectorConnector, SerialPortEventListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(EpsonProjectorSerialConnector.class);
+
+    String serialPortName = null;
+    InputStream in = null;
+    OutputStream out = null;
+    SerialPort serialPort = null;
+
+    public EpsonProjectorSerialConnector(String serialPort) {
+        serialPortName = serialPort;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void connect() throws EpsonProjectorException {
+
+        try {
+            logger.debug("Open connection to serial port '{}'", serialPortName);
+            CommPortIdentifier portIdentifier = CommPortIdentifier.getPortIdentifier(serialPortName);
+
+            CommPort commPort = portIdentifier.open(this.getClass().getName(), 2000);
+
+            serialPort = (SerialPort) commPort;
+            serialPort.setSerialPortParams(9600, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
+            serialPort.enableReceiveThreshold(1);
+            serialPort.disableReceiveTimeout();
+
+            in = serialPort.getInputStream();
+            out = serialPort.getOutputStream();
+
+            out.flush();
+            if (in.markSupported()) {
+                in.reset();
+            }
+
+            // RXTX serial port library causes high CPU load
+            // Start event listener, which will just sleep and slow down event loop
+            serialPort.addEventListener(this);
+            serialPort.notifyOnDataAvailable(true);
+        } catch (Exception e) {
+            throw new EpsonProjectorException(e);
+        }
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disconnect() throws EpsonProjectorException {
+        if (out != null) {
+            logger.debug("Close serial out stream");
+            IOUtils.closeQuietly(out);
+            out = null;
+        }
+        if (in != null) {
+            logger.debug("Close serial in stream");
+            IOUtils.closeQuietly(in);
+            in = null;
+        }
+        if (serialPort != null) {
+            logger.debug("Close serial port");
+            serialPort.close();
+            serialPort.removeEventListener();
+            serialPort = null;
+        }
+
+        logger.debug("Closed");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String sendMessage(String data, int timeout) throws EpsonProjectorException {
+        if (in == null || out == null) {
+            connect();
+        }
+
+        try {
+            // flush input stream
+            if (in.markSupported()) {
+                in.reset();
+            } else {
+
+                while (in.available() > 0) {
+
+                    int availableBytes = in.available();
+
+                    if (availableBytes > 0) {
+
+                        byte[] tmpData = new byte[availableBytes];
+                        in.read(tmpData, 0, availableBytes);
+                    }
+                }
+            }
+
+            return sendMmsg(data, timeout);
+
+        } catch (IOException e) {
+
+            logger.debug("IO error occurred...reconnect and resend ones");
+            disconnect();
+            connect();
+
+            try {
+                return sendMmsg(data, timeout);
+            } catch (IOException e1) {
+                throw new EpsonProjectorException(e);
+            }
+
+        } catch (Exception e) {
+            throw new EpsonProjectorException(e);
+        }
+    }
+
+    @Override
+    public void serialEvent(SerialPortEvent arg0) {
+        try {
+            logger.trace("RXTX library CPU load workaround, sleep forever");
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    private String sendMmsg(String data, int timeout) throws IOException, EpsonProjectorException {
+        out.write(data.getBytes());
+        out.write("\r\n".getBytes());
+        out.flush();
+
+        String resp = "";
+
+        long startTime = System.currentTimeMillis();
+        long elapsedTime = 0;
+
+        while (elapsedTime < timeout) {
+            int availableBytes = in.available();
+            if (availableBytes > 0) {
+                byte[] tmpData = new byte[availableBytes];
+                int readBytes = in.read(tmpData, 0, availableBytes);
+                resp = resp.concat(new String(tmpData, 0, readBytes));
+
+                if (resp.contains(":")) {
+                    return resp;
+                }
+            } else {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new EpsonProjectorException(e);
+                }
+            }
+
+            elapsedTime = Math.abs((new Date()).getTime() - startTime);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorSerialConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorSerialConnector.java
@@ -41,10 +41,10 @@ public class EpsonProjectorSerialConnector implements EpsonProjectorConnector, S
 
     private final Logger logger = LoggerFactory.getLogger(EpsonProjectorSerialConnector.class);
 
-    final String serialPortName;
-    InputStream in = null;
-    OutputStream out = null;
-    SerialPort serialPort = null;
+    private final String serialPortName;
+    private InputStream in = null;
+    private OutputStream out = null;
+    private SerialPort serialPort = null;
 
     public EpsonProjectorSerialConnector(String serialPort) {
         serialPortName = serialPort;

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.connector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Date;
+
+import org.apache.commons.io.IOUtils;
+import org.openhab.binding.epsonprojector.internal.EpsonProjectorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Connector for TCP communication.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
+
+    private static final Logger logger = LoggerFactory.getLogger(EpsonProjectorTcpConnector.class);
+
+    String ip = null;
+    int port = 10000;
+    Socket socket = null;
+    InputStream in = null;
+    OutputStream out = null;
+
+    public EpsonProjectorTcpConnector(String ip, int port) {
+        this.ip = ip;
+        this.port = port;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void connect() throws EpsonProjectorException {
+        logger.debug("Open connection to address'{}:{}'", ip, port);
+
+        try {
+            socket = new Socket(ip, port);
+            in = socket.getInputStream();
+            out = socket.getOutputStream();
+        } catch (Exception e) {
+            throw new EpsonProjectorException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disconnect() throws EpsonProjectorException {
+        if (out != null) {
+            logger.debug("Close tcp out stream");
+            IOUtils.closeQuietly(out);
+        }
+        if (in != null) {
+            logger.debug("Close tcp in stream");
+            IOUtils.closeQuietly(in);
+        }
+        if (socket != null) {
+            logger.debug("Closing socket");
+            try {
+                socket.close();
+            } catch (IOException e) {
+                logger.warn("Error occurred when closing tcp socket", e);
+            }
+        }
+
+        socket = null;
+        out = null;
+        in = null;
+
+        logger.debug("Closed");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String sendMessage(String data, int timeout) throws EpsonProjectorException {
+        if (in == null || out == null) {
+            connect();
+        }
+
+        try {
+            // flush input stream
+            if (in.markSupported()) {
+                in.reset();
+            } else {
+
+                while (in.available() > 0) {
+
+                    int availableBytes = in.available();
+
+                    if (availableBytes > 0) {
+
+                        byte[] tmpData = new byte[availableBytes];
+                        in.read(tmpData, 0, availableBytes);
+                    }
+                }
+            }
+
+            return sendMmsg(data, timeout);
+
+        } catch (IOException e) {
+
+            logger.debug("IO error occurred...reconnect and resend ones");
+            disconnect();
+            connect();
+
+            try {
+                return sendMmsg(data, timeout);
+            } catch (IOException e1) {
+                throw new EpsonProjectorException(e);
+            }
+
+        } catch (Exception e) {
+            throw new EpsonProjectorException(e);
+        }
+    }
+
+    private String sendMmsg(String data, int timeout) throws IOException, EpsonProjectorException {
+        out.write(data.getBytes());
+        out.write("\r\n".getBytes());
+        out.flush();
+
+        String resp = "";
+
+        long startTime = System.currentTimeMillis();
+        long elapsedTime = 0;
+
+        while (elapsedTime < timeout) {
+            int availableBytes = in.available();
+            if (availableBytes > 0) {
+                byte[] tmpData = new byte[availableBytes];
+                int readBytes = in.read(tmpData, 0, availableBytes);
+                resp = resp.concat(new String(tmpData, 0, readBytes));
+
+                if (resp.contains(":")) {
+                    return resp;
+                }
+            } else {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new EpsonProjectorException(e);
+                }
+            }
+
+            elapsedTime = Math.abs((new Date()).getTime() - startTime);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
 
-    private static final Logger logger = LoggerFactory.getLogger(EpsonProjectorTcpConnector.class);
+    private final Logger logger = LoggerFactory.getLogger(EpsonProjectorTcpConnector.class);
 
-    String ip = null;
-    int port = 10000;
+    final String ip;
+    final int port;
     Socket socket = null;
     InputStream in = null;
     OutputStream out = null;
@@ -43,9 +43,6 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
         this.port = port;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void connect() throws EpsonProjectorException {
         logger.debug("Open connection to address'{}:{}'", ip, port);
@@ -54,14 +51,11 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             socket = new Socket(ip, port);
             in = socket.getInputStream();
             out = socket.getOutputStream();
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new EpsonProjectorException(e);
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void disconnect() throws EpsonProjectorException {
         if (out != null) {
@@ -88,9 +82,6 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
         logger.debug("Closed");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String sendMessage(String data, int timeout) throws EpsonProjectorException {
         if (in == null || out == null) {
@@ -102,13 +93,10 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             if (in.markSupported()) {
                 in.reset();
             } else {
-
                 while (in.available() > 0) {
-
                     int availableBytes = in.available();
 
                     if (availableBytes > 0) {
-
                         byte[] tmpData = new byte[availableBytes];
                         in.read(tmpData, 0, availableBytes);
                     }
@@ -116,9 +104,7 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             }
 
             return sendMmsg(data, timeout);
-
         } catch (IOException e) {
-
             logger.debug("IO error occurred...reconnect and resend ones");
             disconnect();
             connect();
@@ -128,7 +114,6 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             } catch (IOException e1) {
                 throw new EpsonProjectorException(e);
             }
-
         } catch (Exception e) {
             throw new EpsonProjectorException(e);
         }

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/connector/EpsonProjectorTcpConnector.java
@@ -32,11 +32,11 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
 
     private final Logger logger = LoggerFactory.getLogger(EpsonProjectorTcpConnector.class);
 
-    final String ip;
-    final int port;
-    Socket socket = null;
-    InputStream in = null;
-    OutputStream out = null;
+    private final String ip;
+    private final int port;
+    private Socket socket = null;
+    private InputStream in = null;
+    private OutputStream out = null;
 
     public EpsonProjectorTcpConnector(String ip, int port) {
         this.ip = ip;

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/AspectRatio.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/AspectRatio.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for AspectRatio.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum AspectRatio {
+    NORMAL(0x00),
+    AUTO(0x30),
+    FULL(0x40),
+    ZOOM(0x50),
+    WIDE(0x70),
+    ANAMORPHIC(0x80),
+    SQUEEZE(0x90),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private AspectRatio(int value) {
+        this.value = value;
+    }
+
+    public static AspectRatio forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/AspectRatio.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/AspectRatio.java
@@ -37,7 +37,7 @@ public enum AspectRatio {
     }
 
     public static AspectRatio forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Background.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Background.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Background.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Background {
+    BLACK(0x00),
+    BLUE(0x01),
+    LOGO(0x02),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Background(int value) {
+        this.value = value;
+    }
+
+    public static Background forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Background.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Background.java
@@ -33,7 +33,7 @@ public enum Background {
     }
 
     public static Background forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Color.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Color.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Color.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Color {
+    RGB_RGBCMY(0x07),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Color(int value) {
+        this.value = value;
+    }
+
+    public static Color forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Color.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Color.java
@@ -31,7 +31,7 @@ public enum Color {
     }
 
     public static Color forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for ColorMode.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum ColorMode {
+    CINEMANIGHT(0x05),
+    DYNAMIC(0x06),
+    NATURAL(0x07),
+    HD(0x09),
+    SILVER(0x0A),
+    XVCOLOR(0x0B),
+    LIVINGROOM(0x0C),
+    THX(0x13),
+    CINEMA(0x15),
+    CINEMA3D(0x17),
+    DYNAMIC3D(0x18),
+    THX3D(0x19),
+    BWCINEMA(0x20),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private ColorMode(int value) {
+        this.value = value;
+    }
+
+    public static ColorMode forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
@@ -43,7 +43,7 @@ public enum ColorMode {
     }
 
     public static ColorMode forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/CommunicationSpeed.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/CommunicationSpeed.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for CommunicationSpeed.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum CommunicationSpeed {
+    S9600(0x00),
+    S18200(0x01),
+    S38400(0x02),
+    S57600(0x03),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private CommunicationSpeed(int value) {
+        this.value = value;
+    }
+
+    public static CommunicationSpeed forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/CommunicationSpeed.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/CommunicationSpeed.java
@@ -34,7 +34,7 @@ public enum CommunicationSpeed {
     }
 
     public static CommunicationSpeed forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ErrorMessage.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ErrorMessage.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Messages for documented error codes.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum ErrorMessage {
+
+    NO_ERROR(0, "No error"),
+    ERROR1(1, "Fan error"),
+    ERROR3(3, "Lamp failure at power on"),
+    ERROR4(4, "High internal temperature error"),
+    ERROR6(6, "Lamp error"),
+    ERROR7(7, "Open Lamp cover door error"),
+    ERROR8(8, "Cinema filter error"),
+    ERROR9(9, "Electric dual-layered capacitor is disconnected"),
+    ERROR10(10, "Auto iris error"),
+    ERROR11(11, "Subsystem error"),
+    ERROR12(12, "Low air flow error"),
+    ERROR13(13, "Air filter air flow sensor error"),
+    ERROR14(14, "Power supply unit error (ballast)"),
+    ERROR15(15, "Shutter error"),
+    ERROR16(16, "Cooling system error (peltier element)"),
+    ERROR17(17, "Cooling system error (pump)"),
+    ERROR18(18, "Static iris error"),
+    ERROR19(19, "Power supply unit error (disagreement of ballast)"),
+    ERROR20(20, "Exhaust shutter error"),
+    ERROR21(21, "Obstacle detection error"),
+    ERROR22(22, "IF board discernment error");
+
+    private final int code;
+    private final String message;
+
+    ErrorMessage(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static String forCode(int code) {
+        Optional<ErrorMessage> error = Arrays.stream(values()).filter(e -> e.code == code).findFirst();
+        return (error.isPresent()) ? error.get().getMessage() : "Unknown error";
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Gamma.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Gamma.java
@@ -36,7 +36,7 @@ public enum Gamma {
     }
 
     public static Gamma forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Gamma.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Gamma.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Gamma.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Gamma {
+    G2_0(0x20),
+    G2_1(0x21),
+    G2_2(0x22),
+    G2_3(0x23),
+    G2_4(0x24),
+    CUSTOM(0xF0),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Gamma(int value) {
+        this.value = value;
+    }
+
+    public static Gamma forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/GammaStep.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/GammaStep.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for GammaStep.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum GammaStep {
+    TONE1(0x00),
+    TONE2(0x01),
+    TONE3(0x02),
+    TONE4(0x03),
+    TONE5(0x04),
+    TONE6(0x05),
+    TONE7(0x06),
+    TONE8(0x07),
+    TONE9(0x08),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private GammaStep(int value) {
+        this.value = value;
+    }
+
+    public static GammaStep forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/GammaStep.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/GammaStep.java
@@ -39,7 +39,7 @@ public enum GammaStep {
     }
 
     public static GammaStep forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Luminance.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Luminance.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Luminance.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Luminance {
+    NORMAL(0x00),
+    ECO(0x01),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Luminance(int value) {
+        this.value = value;
+    }
+
+    public static Luminance forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Luminance.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Luminance.java
@@ -32,7 +32,7 @@ public enum Luminance {
     }
 
     public static Luminance forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
@@ -36,7 +36,7 @@ public enum PowerStatus {
     }
 
     public static PowerStatus forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for PowerStatus.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum PowerStatus {
+    STANDBY(0x00),
+    ON(0x01),
+    WARMUP(0x02),
+    COOLDOWN(0x03),
+    STANDBYNETWORKON(0x04),
+    ABNORMALSTANDBY(0x05),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private PowerStatus(int value) {
+        this.value = value;
+    }
+
+    public static PowerStatus forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Sharpness.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Sharpness.java
@@ -35,7 +35,7 @@ public enum Sharpness {
     }
 
     public static Sharpness forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Sharpness.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Sharpness.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Sharpness.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Sharpness {
+    STANDARD(0x00),
+    HIGHPASS(0x01),
+    LOWPASS(0x02),
+    HORIZONTAL(0x04),
+    VERTICAL(0x05),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Sharpness(int value) {
+        this.value = value;
+    }
+
+    public static Sharpness forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Source.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Source.java
@@ -36,7 +36,7 @@ public enum Source {
     }
 
     public static Source forValue(int value) {
-        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().get();
     }
 
     public int toInt() {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Source.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Source.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+import java.util.Arrays;
+
+/**
+ * Valid values for Source.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Source {
+    COMPONENT(0x14),
+    PC_DSUB(0x20),
+    HDMI1(0x30),
+    HDMI2(0xA0),
+    VIDEO(0x41),
+    SVIDEO(0x42),
+    ERROR(0xFF);
+
+    private final int value;
+
+    private Source(int value) {
+        this.value = value;
+    }
+
+    public static Source forValue(int value) {
+        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElseThrow();
+    }
+
+    public int toInt() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Switch.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/Switch.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.epsonprojector.internal.enums;
+
+/**
+ * Valid values for Epson switch commands.
+ *
+ * @author Pauli Anttila - Initial contribution
+ * @author Yannick Schaus - Refactoring
+ */
+public enum Switch {
+    ON,
+    OFF;
+}

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="epsonprojector" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Epson Projector Binding</name>
+	<description>This binding is compatible with Epson projectors which support the ESC/VP21 protocol over a serial port.</description>
+	<author>Pauli Anttila, Yannick Schaus</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="epsonprojector"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="projector">
+		<label>Epson Projector</label>
+		<description>An Epson projector which supports the ESC/VP21 protocol over a serial port</description>
+
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="powerstate" typeId="powerstate" />
+			<channel id="lamptime" typeId="lamptime" />
+			<channel id="keycode" typeId="keycode" />
+			<channel id="verticalkeystone" typeId="verticalkeystone" />
+			<channel id="horizontalkeystone" typeId="horizontalkeystone" />
+			<channel id="autokeystone" typeId="autokeystone" />
+			<channel id="aspectratio" typeId="aspectratio" />
+			<channel id="luminance" typeId="luminance" />
+			<channel id="source" typeId="source" />
+			<channel id="directsource" typeId="directsource" />
+			<channel id="brightness" typeId="brightness" />
+			<channel id="contrast" typeId="contrast" />
+			<channel id="density" typeId="density" />
+			<channel id="tint" typeId="tint" />
+			<channel id="sharpness" typeId="sharpness" />
+			<channel id="colortemperature" typeId="colortemperature" />
+			<channel id="fleshtemperature" typeId="fleshtemperature" />
+			<channel id="colormode" typeId="colormode" />
+			<channel id="horizontalposition" typeId="horizontalposition" />
+			<channel id="verticalposition" typeId="verticalposition" />
+			<channel id="tracking" typeId="tracking" />
+			<channel id="sync" typeId="sync" />
+			<channel id="offsetred" typeId="offsetred" />
+			<channel id="offsetgreen" typeId="offsetgreen" />
+			<channel id="offsetblue" typeId="offsetblue" />
+			<channel id="gainred" typeId="gainred" />
+			<channel id="gaingreen" typeId="gaingreen" />
+			<channel id="gainblue" typeId="gainblue" />
+			<channel id="gamma" typeId="gamma" />
+			<channel id="gammastep" typeId="gammastep" />
+			<channel id="color" typeId="color" />
+			<channel id="mute" typeId="mute" />
+			<channel id="horizontalreverse" typeId="horizontalreverse" />
+			<channel id="verticalreverse" typeId="verticalreverse" />
+			<channel id="background" typeId="background" />
+			<channel id="errcode" typeId="errcode" />
+			<channel id="errmessage" typeId="errmessage" />
+		</channels>
+
+		<config-description>
+			<parameter name="serialPort" type="text" required="false">
+				<label>Serial Port</label>
+				<description>Serial port device name that is connected to the Epson projector to control, e.g. COM1 on Windows, /dev/ttyS0 on Linux or /dev/tty.PL2303-0000103D on Mac</description>
+			</parameter>
+			<parameter name="host" type="text" required="false">
+				<label>Host</label>
+				<description>IP address (for serial communication over TCP, leave the serial port parameter blank)</description>
+			</parameter>
+			<parameter name="port" type="integer" required="false">
+				<label>Port</label>
+				<description>Port (for serial communication over TCP, leave the serial port parameter blank)</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" required="false">
+				<label>Polling interval</label>
+				<description>Polling interval in milliseconds to update channel states</description>
+				<default>10000</default>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<channel-type id="power">
+		<item-type>Switch</item-type>
+		<label>Power</label>
+		<description>Powers the device on or off.</description>
+	</channel-type>
+	<channel-type id="powerstate">
+		<item-type>String</item-type>
+		<label>Power State</label>
+		<description>Retrieves the actual power state of the device.</description>
+		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="lamptime">
+		<item-type>Number</item-type>
+		<label>Lamp Time</label>
+		<description>Retrieves the lamp hours.</description>
+		<state readOnly="true" pattern="%d h" />
+	</channel-type>
+	<channel-type id="keycode" advanced="true">
+		<item-type>Number</item-type>
+		<label>KeyCode</label>
+		<description>Handles the KeyCode Epson command</description>
+	</channel-type>
+	<channel-type id="verticalkeystone" advanced="true">
+		<item-type>Number</item-type>
+		<label>VerticalKeystone</label>
+		<description>Handles the VerticalKeystone Epson command</description>
+	</channel-type>
+	<channel-type id="horizontalkeystone" advanced="true">
+		<item-type>Number</item-type>
+		<label>HorizontalKeystone</label>
+		<description>Handles the HorizontalKeystone Epson command</description>
+	</channel-type>
+	<channel-type id="autokeystone" advanced="true">
+		<item-type>Number</item-type>
+		<label>AutoKeystone</label>
+		<description>Handles the AutoKeystone Epson command</description>
+	</channel-type>
+	<channel-type id="aspectratio" advanced="true">
+		<item-type>String</item-type>
+		<label>Aspect Ratio</label>
+		<description>Retrieves or set the aspect ratio.</description>
+		<state>
+			<options>
+				<option value="NORMAL">NORMAL</option>
+				<option value="AUTO">AUTO</option>
+				<option value="FULL">FULL</option>
+				<option value="ZOOM">ZOOM</option>
+				<option value="WIDE">WIDE</option>
+				<option value="ANAMORPHIC">ANAMORPHIC</option>
+				<option value="SQUEEZE">SQUEEZE</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="luminance">
+		<item-type>String</item-type>
+		<label>Luminance</label>
+		<description>Retrieves or set the ECO mode.</description>
+		<state>
+			<options>
+				<option value="NORMAL">NORMAL</option>
+				<option value="ECO">ECO</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="source">
+		<item-type>String</item-type>
+		<label>Source</label>
+		<description>Retrieves or select the input source.</description>
+		<state>
+			<options>
+				<option value="HDMI1">HDMI1</option>
+				<option value="HDMI2">HDMI2</option>
+				<option value="COMPONENT">COMPONENT</option>
+				<option value="PC_DSUB">PC_DSUB</option>
+				<option value="VIDEO">VIDEO</option>
+				<option value="SVIDEO">SVIDEO</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="directsource" advanced="true">
+		<item-type>Number</item-type>
+		<label>DirectSource</label>
+		<description>Handles the DirectSource Epson command</description>
+	</channel-type>
+	<channel-type id="brightness" advanced="true">
+		<item-type>Number</item-type>
+		<label>Brightness</label>
+		<description>Handles the Brightness Epson command</description>
+	</channel-type>
+	<channel-type id="contrast" advanced="true">
+		<item-type>Number</item-type>
+		<label>Contrast</label>
+		<description>Handles the Contrast Epson command</description>
+	</channel-type>
+	<channel-type id="density" advanced="true">
+		<item-type>Number</item-type>
+		<label>Density</label>
+		<description>Handles the Density Epson command</description>
+	</channel-type>
+	<channel-type id="tint" advanced="true">
+		<item-type>Number</item-type>
+		<label>Tint</label>
+		<description>Handles the Tint Epson command</description>
+	</channel-type>
+	<channel-type id="sharpness" advanced="true">
+		<item-type>Number</item-type>
+		<label>Sharpness</label>
+		<description>Handles the Sharpness Epson command</description>
+	</channel-type>
+	<channel-type id="colortemperature" advanced="true">
+		<item-type>Number</item-type>
+		<label>ColorTemperature</label>
+		<description>Handles the ColorTemperature Epson command</description>
+	</channel-type>
+	<channel-type id="fleshtemperature" advanced="true">
+		<item-type>Number</item-type>
+		<label>FleshTemperature</label>
+		<description>Handles the FleshTemperature Epson command</description>
+	</channel-type>
+	<channel-type id="colormode">
+		<item-type>String</item-type>
+		<label>Color Mode</label>
+		<description>Retrieves or set the color mode.</description>
+		<state>
+			<options>
+				<option value="DYNAMIC">DYNAMIC</option>
+				<option value="LIVINGROOM">LIVINGROOM</option>
+				<option value="NATURAL">NATURAL</option>
+				<option value="CINEMA">CINEMA</option>
+				<option value="CINEMANIGHT">CINEMANIGHT</option>
+				<option value="BWCINEMA">BWCINEMA</option>
+				<option value="HD">HD</option>
+				<option value="THX">THX</option>
+				<option value="CINEMA3D">CINEMA3D</option>
+				<option value="DYNAMIC3D">DYNAMIC3D</option>
+				<option value="THX3D">THX3D</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="horizontalposition" advanced="true">
+		<item-type>Number</item-type>
+		<label>HorizontalPosition</label>
+		<description>Handles the HorizontalPosition Epson command</description>
+	</channel-type>
+	<channel-type id="verticalposition" advanced="true">
+		<item-type>Number</item-type>
+		<label>VerticalPosition</label>
+		<description>Handles the VerticalPosition Epson command</description>
+	</channel-type>
+	<channel-type id="tracking" advanced="true">
+		<item-type>Number</item-type>
+		<label>Tracking</label>
+		<description>Handles the Tracking Epson command</description>
+	</channel-type>
+	<channel-type id="sync" advanced="true">
+		<item-type>Number</item-type>
+		<label>Sync</label>
+		<description>Handles the Sync Epson command</description>
+	</channel-type>
+	<channel-type id="offsetred" advanced="true">
+		<item-type>Number</item-type>
+		<label>OffsetRed</label>
+		<description>Handles the OffsetRed Epson command</description>
+	</channel-type>
+	<channel-type id="offsetgreen" advanced="true">
+		<item-type>Number</item-type>
+		<label>OffsetGreen</label>
+		<description>Handles the OffsetGreen Epson command</description>
+	</channel-type>
+	<channel-type id="offsetblue" advanced="true">
+		<item-type>Number</item-type>
+		<label>OffsetBlue</label>
+		<description>Handles the OffsetBlue Epson command</description>
+	</channel-type>
+	<channel-type id="gainred" advanced="true">
+		<item-type>Number</item-type>
+		<label>GainRed</label>
+		<description>Handles the GainRed Epson command</description>
+	</channel-type>
+	<channel-type id="gaingreen" advanced="true">
+		<item-type>Number</item-type>
+		<label>GainGreen</label>
+		<description>Handles the GainGreen Epson command</description>
+	</channel-type>
+	<channel-type id="gainblue" advanced="true">
+		<item-type>Number</item-type>
+		<label>GainBlue</label>
+		<description>Handles the GainBlue Epson command</description>
+	</channel-type>
+	<channel-type id="gamma" advanced="true">
+		<item-type>String</item-type>
+		<label>Gamma</label>
+		<description>Handles the Gamma Epson command</description>
+	</channel-type>
+	<channel-type id="gammastep" advanced="true">
+		<item-type>Number</item-type>
+		<label>GammaStep</label>
+		<description>Handles the GammaStep Epson command</description>
+	</channel-type>
+	<channel-type id="color" advanced="true">
+		<item-type>String</item-type>
+		<label>Color</label>
+		<description>Handles the Color Epson command</description>
+	</channel-type>
+	<channel-type id="mute" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Mute</label>
+		<description>Handles the Mute Epson command</description>
+	</channel-type>
+	<channel-type id="horizontalreverse" advanced="true">
+		<item-type>Switch</item-type>
+		<label>HorizontalReverse</label>
+		<description>Handles the HorizontalReverse Epson command</description>
+	</channel-type>
+	<channel-type id="verticalreverse" advanced="true">
+		<item-type>Switch</item-type>
+		<label>VerticalReverse</label>
+		<description>Handles the VerticalReverse Epson command</description>
+	</channel-type>
+	<channel-type id="background" advanced="true">
+		<item-type>String</item-type>
+		<label>Background</label>
+		<description>Handles the Background Epson command</description>
+		<state>
+			<options>
+				<option value="BLACK">BLACK</option>
+				<option value="BLUE">BLUE</option>
+				<option value="LOGO">LOGO</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="errcode" advanced="true">
+		<item-type>Number</item-type>
+		<label>ErrCode</label>
+		<description>Retrieves the last error code.</description>
+	</channel-type>
+	<channel-type id="errmessage" advanced="true">
+		<item-type>String</item-type>
+		<label>ErrMessage</label>
+		<description>Retrieves the description of the last error.</description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -74,6 +74,7 @@
     <module>org.openhab.binding.elerotransmitterstick</module>
     <module>org.openhab.binding.enocean</module>
     <module>org.openhab.binding.enturno</module>
+    <module>org.openhab.binding.epsonprojector</module>
     <module>org.openhab.binding.evohome</module>
     <module>org.openhab.binding.exec</module>
     <module>org.openhab.binding.feed</module>


### PR DESCRIPTION
This is a straightforward port of the epsonprojector binding
from OH 1.x by Pauli Anttila.

Next to no changes were made to the connector code so the
binding should have the same features as the original.
Already supported Epson command types are mapped as channels.

The only missing feature is that it is not possible anymore
to configure individual polling intervals for each command
type/channel; there's a global polling interval only.

Signed-off-by: Yannick Schaus <github@schaus.net>