### PR TITLE
[bluetooth] Added hasListeners method to BluetoothDevice

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -490,6 +490,15 @@ public abstract class BluetoothDevice {
     }
 
     /**
+     * Checks if this device has any listeners
+     * 
+     * @return true if this device has listeners
+     */
+    public boolean hasListeners() {
+        return !eventListeners.isEmpty();
+    }
+
+    /**
      * Notify the listeners of an event
      *
      * @param event the {@link BluetoothEventType} of this event


### PR DESCRIPTION
This PR adds the `hasListeners` method to the BluetoothDevice class which is required for both #6916 and #6921. 