### PR TITLE
[bluetooth] Changed Bluetooth logs to use hexadecimal (#6914)

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -294,8 +294,6 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         if (c != null) {
             try {
                 c.enableValueNotifications(value -> {
-                    logger.debug("Received new value '{}' for characteristic '{}' of device '{}'", value,
-                            characteristic.getUuid(), address);
                     characteristic.setValue(value);
                     notifyListeners(BluetoothEventType.CHARACTERISTIC_UPDATED, characteristic);
                 });
@@ -339,8 +337,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         BluetoothGattDescriptor d = getTinybDescriptorByUUID(descriptor.getUuid().toString());
         if (d != null) {
             d.enableValueNotifications(value -> {
-                logger.debug("Received new value '{}' for descriptor '{}' of device '{}'", value, descriptor.getUuid(),
-                        address);
+                logger.debug("Received new value '{}' for descriptor '{}' of device '{}'", HexUtils.bytesToHex(value),
+                        descriptor.getUuid(), address);
                 descriptor.setValue(value);
                 notifyListeners(BluetoothEventType.DESCRIPTOR_UPDATED, descriptor);
             });

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -337,8 +337,6 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         BluetoothGattDescriptor d = getTinybDescriptorByUUID(descriptor.getUuid().toString());
         if (d != null) {
             d.enableValueNotifications(value -> {
-                logger.debug("Received new value '{}' for descriptor '{}' of device '{}'", HexUtils.bytesToHex(value),
-                        descriptor.getUuid(), address);
                 descriptor.setValue(value);
                 notifyListeners(BluetoothEventType.DESCRIPTOR_UPDATED, descriptor);
             });

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -192,26 +192,31 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
             if (GattCharacteristic.BATTERY_LEVEL.equals(characteristic.getGattCharacteristic())) {
                 updateBatteryLevel(characteristic);
             } else {
-                logger.debug("Characteristic {} from {} has been read - value {}", characteristic.getUuid(), address,
-                        HexUtils.bytesToHex(characteristic.getByteValue()));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Characteristic {} from {} has been read - value {}", characteristic.getUuid(),
+                            address, HexUtils.bytesToHex(characteristic.getByteValue()));
+                }
             }
         } else {
             logger.debug("Characteristic {} from {} has been read - ERROR", characteristic.getUuid(), address);
-            return;
         }
     }
 
     @Override
     public void onCharacteristicWriteComplete(BluetoothCharacteristic characteristic,
             BluetoothCompletionStatus status) {
-        logger.debug("Wrote {} to characteristic {} of device {}: {}",
-                HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address, status);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Wrote {} to characteristic {} of device {}: {}",
+                    HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address, status);
+        }
     }
 
     @Override
     public void onCharacteristicUpdate(BluetoothCharacteristic characteristic) {
-        logger.debug("Recieved update {} to characteristic {} of device {}",
-                HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Recieved update {} to characteristic {} of device {}",
+                    HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address);
+        }
         if (GattCharacteristic.BATTERY_LEVEL.equals(characteristic.getGattCharacteristic())) {
             updateBatteryLevel(characteristic);
         }
@@ -219,8 +224,10 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
 
     @Override
     public void onDescriptorUpdate(BluetoothDescriptor descriptor) {
-        logger.debug("Received update {} to descriptor {} of device {}", HexUtils.bytesToHex(descriptor.getValue()),
-                descriptor.getUuid(), address);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Received update {} to descriptor {} of device {}", HexUtils.bytesToHex(descriptor.getValue()),
+                    descriptor.getUuid(), address);
+        }
     }
 
     protected void updateBatteryLevel(BluetoothCharacteristic characteristic) {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -210,11 +210,17 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
 
     @Override
     public void onCharacteristicUpdate(BluetoothCharacteristic characteristic) {
-        logger.debug("Recieved update {} to characteristic {} of device {}",
+        logger.debug("Recieved update {} to characteristic {} of device '{}'",
                 HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address);
         if (GattCharacteristic.BATTERY_LEVEL.equals(characteristic.getGattCharacteristic())) {
             updateBatteryLevel(characteristic);
         }
+    }
+
+    @Override
+    public void onDescriptorUpdate(BluetoothDescriptor descriptor) {
+        logger.debug("Received update {} to descriptor {} of device {}", HexUtils.bytesToHex(descriptor.getValue()),
+                descriptor.getUuid(), address);
     }
 
     protected void updateBatteryLevel(BluetoothCharacteristic characteristic) {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -210,7 +210,7 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
 
     @Override
     public void onCharacteristicUpdate(BluetoothCharacteristic characteristic) {
-        logger.debug("Recieved update {} to characteristic {} of device '{}'",
+        logger.debug("Recieved update {} to characteristic {} of device {}",
                 HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address);
         if (GattCharacteristic.BATTERY_LEVEL.equals(characteristic.getGattCharacteristic())) {
             updateBatteryLevel(characteristic);

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.util.HexUtils;
 import org.openhab.binding.bluetooth.BluetoothCharacteristic.GattCharacteristic;
 import org.openhab.binding.bluetooth.BluetoothDevice.ConnectionState;
 import org.openhab.binding.bluetooth.notification.BluetoothConnectionStatusNotification;
@@ -192,7 +193,7 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
                 updateBatteryLevel(characteristic);
             } else {
                 logger.debug("Characteristic {} from {} has been read - value {}", characteristic.getUuid(), address,
-                        characteristic.getValue());
+                        HexUtils.bytesToHex(characteristic.getByteValue()));
             }
         } else {
             logger.debug("Characteristic {} from {} has been read - ERROR", characteristic.getUuid(), address);
@@ -203,12 +204,14 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
     @Override
     public void onCharacteristicWriteComplete(BluetoothCharacteristic characteristic,
             BluetoothCompletionStatus status) {
-        logger.debug("Wrote {} to characteristic {} of device {}: {}", characteristic.getByteValue(),
-                characteristic.getUuid(), address, status);
+        logger.debug("Wrote {} to characteristic {} of device {}: {}",
+                HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address, status);
     }
 
     @Override
     public void onCharacteristicUpdate(BluetoothCharacteristic characteristic) {
+        logger.debug("Recieved update {} to characteristic {} of device {}",
+                HexUtils.bytesToHex(characteristic.getByteValue()), characteristic.getUuid(), address);
         if (GattCharacteristic.BATTERY_LEVEL.equals(characteristic.getGattCharacteristic())) {
             updateBatteryLevel(characteristic);
         }


### PR DESCRIPTION
This will conflict with some of my other PRs but I'll deal with the conflicts then they come.

Besides changing all the byte array outputs to hex in the logs, I've also moved the notification logging out of BlueZBluetoothDevice and into the ConnectedBluetoothHandler where all of the value logging can be centralized.