### PR TITLE
[bluetooth.bluez] Add missing null checks

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -241,11 +241,16 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         return false;
     }
 
+    private void ensureConnected() {
+        if (device == null || !device.getConnected()) {
+            throw new IllegalStateException("TinyB device is not set or not connected");
+        }
+    }
+
     @Override
     public boolean readCharacteristic(BluetoothCharacteristic characteristic) {
-        if (device == null) {
-            throw new IllegalStateException("TinyB device is not yet set");
-        }
+        ensureConnected();
+
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
         if (c == null) {
             logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
@@ -269,9 +274,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
 
     @Override
     public boolean writeCharacteristic(BluetoothCharacteristic characteristic) {
-        if (device == null) {
-            throw new IllegalStateException("TinyB device is not yet set");
-        }
+        ensureConnected();
+
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
         if (c == null) {
             logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
@@ -284,8 +288,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
                         : BluetoothCompletionStatus.ERROR;
                 notifyListeners(BluetoothEventType.CHARACTERISTIC_WRITE_COMPLETE, characteristic, successStatus);
             } catch (BluetoothException e) {
-                logger.debug("Exception occurred when trying to read characteristic '{}': {}", characteristic.getUuid(),
-                        e.getMessage());
+                logger.debug("Exception occurred when trying to write characteristic '{}': {}",
+                        characteristic.getUuid(), e.getMessage());
                 notifyListeners(BluetoothEventType.CHARACTERISTIC_WRITE_COMPLETE, characteristic,
                         BluetoothCompletionStatus.ERROR);
             }
@@ -295,9 +299,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
 
     @Override
     public boolean enableNotifications(BluetoothCharacteristic characteristic) {
-        if (device == null || !device.getConnected()) {
-            throw new IllegalStateException("TinyB device is not set or not connected");
-        }
+        ensureConnected();
+
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
         if (c != null) {
             try {
@@ -326,9 +329,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
 
     @Override
     public boolean disableNotifications(BluetoothCharacteristic characteristic) {
-        if (device == null || !device.getConnected()) {
-            throw new IllegalStateException("TinyB device is not set or not connected");
-        }
+        ensureConnected();
+
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
         if (c != null) {
             c.disableValueNotifications();
@@ -341,9 +343,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
 
     @Override
     public boolean enableNotifications(BluetoothDescriptor descriptor) {
-        if (device == null || !device.getConnected()) {
-            throw new IllegalStateException("TinyB device is not set or not connected");
-        }
+        ensureConnected();
+
         BluetoothGattDescriptor d = getTinybDescriptorByUUID(descriptor.getUuid().toString());
         if (d != null) {
             d.enableValueNotifications(value -> {
@@ -361,9 +362,8 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
 
     @Override
     public boolean disableNotifications(BluetoothDescriptor descriptor) {
-        if (device == null) {
-            throw new IllegalStateException("TinyB device is not yet set");
-        }
+        ensureConnected();
+
         BluetoothGattDescriptor d = getTinybDescriptorByUUID(descriptor.getUuid().toString());
         if (d != null) {
             d.disableValueNotifications();

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -247,6 +247,10 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
             throw new IllegalStateException("TinyB device is not yet set");
         }
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
+        if (c == null) {
+            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
+            return false;
+        }
         scheduler.submit(() -> {
             try {
                 byte[] value = c.readValue();
@@ -269,6 +273,10 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
             throw new IllegalStateException("TinyB device is not yet set");
         }
         BluetoothGattCharacteristic c = getTinybCharacteristicByUUID(characteristic.getUuid().toString());
+        if (c == null) {
+            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
+            return false;
+        }
         scheduler.submit(() -> {
             try {
                 BluetoothCompletionStatus successStatus = c.writeValue(characteristic.getByteValue())


### PR DESCRIPTION
I've encountered NPE in these methods before and noticed that the enableNotifications have checks for them, but not these ones. So I'm adding them as part of this PR.