### PR TITLE
[mqtt] Fix increment commands in PercentageValue.

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -53,6 +53,7 @@ public class PercentageValue extends Value {
     private final BigDecimal max;
     private final BigDecimal span;
     private final BigDecimal step;
+    private final BigDecimal stepPercent;
     private final @Nullable String onValue;
     private final @Nullable String offValue;
 
@@ -69,6 +70,7 @@ public class PercentageValue extends Value {
         }
         this.span = this.max.subtract(this.min);
         this.step = step == null ? BigDecimal.ONE : step;
+        this.stepPercent = this.step.multiply(HUNDRED).divide(this.span, MathContext.DECIMAL128);
     }
 
     @Override
@@ -96,11 +98,11 @@ public class PercentageValue extends Value {
                // Increase or decrease by "step"
         if (command instanceof IncreaseDecreaseType) {
             if (((IncreaseDecreaseType) command) == IncreaseDecreaseType.INCREASE) {
-                final BigDecimal v = oldvalue.toBigDecimal().add(step);
-                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
+                final BigDecimal v = oldvalue.toBigDecimal().add(stepPercent);
+                state = v.compareTo(HUNDRED) <= 0 ? new PercentType(v) : PercentType.HUNDRED;
             } else {
-                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
-                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(stepPercent);
+                state = v.compareTo(BigDecimal.ZERO) >= 0 ? new PercentType(v) : PercentType.ZERO;
             }
         } else //
                // On/Off equals 100 or 0 percent
@@ -110,11 +112,11 @@ public class PercentageValue extends Value {
               // Increase or decrease by "step"
         if (command instanceof UpDownType) {
             if (((UpDownType) command) == UpDownType.UP) {
-                final BigDecimal v = oldvalue.toBigDecimal().add(step);
-                state = new PercentType(v.compareTo(max) <= 0 ? v : max);
+                final BigDecimal v = oldvalue.toBigDecimal().add(stepPercent);
+                state = v.compareTo(HUNDRED) <= 0 ? new PercentType(v) : PercentType.HUNDRED;
             } else {
-                final BigDecimal v = oldvalue.toBigDecimal().subtract(step);
-                state = new PercentType(v.compareTo(min) >= 0 ? v : min);
+                final BigDecimal v = oldvalue.toBigDecimal().subtract(stepPercent);
+                state = v.compareTo(BigDecimal.ZERO) >= 0 ? new PercentType(v) : PercentType.ZERO;
             }
         } else //
                // Check against custom on/off values

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -203,9 +203,9 @@ public class ChannelStateTests {
         assertThat(value.getChannelState().toString(), is("50"));
 
         c.processMessage("state", "INCREASE".getBytes());
-        assertThat(value.getChannelState().toString(), is("60"));
-        assertThat(value.getMQTTpublishValue(null), is("20"));
-        assertThat(value.getMQTTpublishValue("%03.0f"), is("020"));
+        assertThat(value.getChannelState().toString(), is("55"));
+        assertThat(value.getMQTTpublishValue(null), is("10"));
+        assertThat(value.getMQTTpublishValue("%03.0f"), is("010"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -250,6 +251,60 @@ public class ValueTests {
         assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
         v.update(new DecimalType(0.2));
         assertEquals(((PercentType) v.getChannelState()).floatValue(), 11.11f, 0.01f);
+    }
+
+    @Test
+    public void increaseDecreaseCalc() {
+        PercentageValue v = new PercentageValue(new BigDecimal("1.0"), new BigDecimal("11.0"), new BigDecimal("0.5"),
+                null, null);
+
+        // Normal operation.
+        v.update(new DecimalType("6.0"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 50.0f, 0.01f);
+        v.update(IncreaseDecreaseType.INCREASE);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 55.0f, 0.01f);
+        v.update(IncreaseDecreaseType.DECREASE);
+        v.update(IncreaseDecreaseType.DECREASE);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 45.0f, 0.01f);
+
+        // Lower limit.
+        v.update(new DecimalType("1.1"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 1.0f, 0.01f);
+        v.update(IncreaseDecreaseType.DECREASE);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 0.0f, 0.01f);
+
+        // Upper limit.
+        v.update(new DecimalType("10.8"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 98.0f, 0.01f);
+        v.update(IncreaseDecreaseType.INCREASE);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 100.0f, 0.01f);
+    }
+
+    @Test
+    public void upDownCalc() {
+        PercentageValue v = new PercentageValue(new BigDecimal("1.0"), new BigDecimal("11.0"), new BigDecimal("0.5"),
+                null, null);
+
+        // Normal operation.
+        v.update(new DecimalType("6.0"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 50.0f, 0.01f);
+        v.update(UpDownType.UP);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 55.0f, 0.01f);
+        v.update(UpDownType.DOWN);
+        v.update(UpDownType.DOWN);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 45.0f, 0.01f);
+
+        // Lower limit.
+        v.update(new DecimalType("1.1"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 1.0f, 0.01f);
+        v.update(UpDownType.DOWN);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 0.0f, 0.01f);
+
+        // Upper limit.
+        v.update(new DecimalType("10.8"));
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 98.0f, 0.01f);
+        v.update(UpDownType.UP);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 100.0f, 0.01f);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
[mqtt] Fix increment commands in PercentageValue.

The MQTT Things and Channels plugin specifies channels with a min, max, and a step size (such as the dimmer type here: https://www.openhab.org/addons/bindings/mqtt.generic/#channel-type-dimmer).  The internal openhab percentages are converted to this range when commands are sent and values are received.

This PR fixes a bug where the step size used as a percentage, rather than in the min/max range, and the limits of the INCREASE/DECREASE/UP/DOWN commands are compared against min and max, rather than the percentages, meaning the value can go out of bounds in either direction and raise internal errors.  The PR converts the step size to a percentage before using, and compares against 0/100 instead of min/max, ensuring the increment commands work as expected from the documentation.
