### PR TITLE
[squeezebox] Add source channel

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -97,6 +97,7 @@ All devices support some of the following channels:
 | stop                    | Switch    | Stop the current title                                                                 |
 | control                 | Player    | Control the Zone Player, e.g.  play/pause/next/previous/ffward/rewind                  |
 | stream                  | String    | Play the given HTTP or file stream (file:// or http://)                                |
+| source                  | String    | Shows the source of the currently playing playlist entry. (i.e. http://radio.org/radio.mp3 |
 | sync                    | String    | Add another player to your device for synchronized playback (other player mac address) |
 | playListIndex           | Number    | Playlist Index                                                                         |
 | currentPlayingTime      | Number    | Current Playing Time                                                                   |

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
@@ -44,6 +44,7 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_PREV = "prev";
     public static final String CHANNEL_CONTROL = "control";
     public static final String CHANNEL_STREAM = "stream";
+    public static final String CHANNEL_SOURCE = "source";
     public static final String CHANNEL_SYNC = "sync";
     public static final String CHANNEL_UNSYNC = "unsync";
     public static final String CHANNEL_PLAYLIST_INDEX = "playListIndex";

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -200,4 +200,8 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
     @Override
     public void updateFavoritesListEvent(List<Favorite> favorites) {
     }
+
+    @Override
+    public void sourceChangeEvent(String mac, String source) {
+    }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
@@ -212,4 +212,8 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
     @Override
     public void updateFavoritesListEvent(List<Favorite> favorites) {
     }
+
+    @Override
+    public void sourceChangeEvent(String mac, String source) {
+    }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
@@ -78,4 +78,6 @@ public interface SqueezeBoxPlayerEventListener {
     void irCodeChangeEvent(String mac, String ircode);
 
     void updateFavoritesListEvent(List<Favorite> favorites);
+
+    void sourceChangeEvent(String mac, String source);
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -323,6 +323,11 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     }
 
     @Override
+    public void sourceChangeEvent(String mac, String source) {
+        updateChannel(mac, CHANNEL_SOURCE, StringType.valueOf(source));
+    }
+
+    @Override
     public void absoluteVolumeChangeEvent(String mac, int volume) {
         int newVolume = volume;
         newVolume = Math.min(100, newVolume);

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -853,6 +853,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 mode = messageParts[3].equals("0") ? "play" : "pause";
             } else if (action.equals("stop")) {
                 mode = "stop";
+            } else if ("play".equals(action) && "playlist".equals(messageParts[1])) {
+                String playListUrl = messageParts[3];
+                handleSourceChangeMessage(mac, playListUrl);
+                return;
             } else {
                 // Added so that actions (such as delete, index, jump, open) are not treated as "play"
                 logger.trace("Unhandled playlist message type '{}'", Arrays.toString(messageParts));
@@ -864,6 +868,20 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 @Override
                 public void updateListener(SqueezeBoxPlayerEventListener listener) {
                     listener.modeChangeEvent(mac, value);
+                }
+
+            });
+        }
+
+        private void handleSourceChangeMessage(String mac, String rawSource) {
+            String source = URLDecoder.decode(rawSource);
+
+            final String value = source;
+            updatePlayer(new PlayerUpdateEvent() {
+
+                @Override
+                public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                    listener.sourceChangeEvent(mac, value);
                 }
 
             });

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -854,8 +854,9 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             } else if (action.equals("stop")) {
                 mode = "stop";
             } else if ("play".equals(action) && "playlist".equals(messageParts[1])) {
-                String playListUrl = messageParts[3];
-                handleSourceChangeMessage(mac, playListUrl);
+                if (messageParts.length >= 4) {
+                    handleSourceChangeMessage(mac, messageParts[3]);
+                }
                 return;
             } else {
                 // Added so that actions (such as delete, index, jump, open) are not treated as "play"
@@ -876,12 +877,11 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         private void handleSourceChangeMessage(String mac, String rawSource) {
             String source = URLDecoder.decode(rawSource);
 
-            final String value = source;
             updatePlayer(new PlayerUpdateEvent() {
 
                 @Override
                 public void updateListener(SqueezeBoxPlayerEventListener listener) {
-                    listener.sourceChangeEvent(mac, value);
+                    listener.sourceChangeEvent(mac, source);
                 }
 
             });

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -62,6 +62,7 @@
 			<channel id="prev" typeId="prev" />
 			<channel id="control" typeId="control" />
 			<channel id="stream" typeId="stream" />
+			<channel id="source" typeId="source" />
 			<channel id="sync" typeId="sync" />
 			<channel id="unsync" typeId="unsync" />
 			<channel id="playListIndex" typeId="playListIndex" />
@@ -180,6 +181,12 @@
 		<item-type>String</item-type>
 		<label>Stream URL</label>
 		<description>Play the given HTTP or file stream (file:// or http://). </description>
+	</channel-type>
+	<channel-type id="source" advanced="true">
+	<item-type>String</item-type>
+		<label>Source</label>
+		<description>Shows the source of the currently playing playlist entry.</description>
+		<state readOnly="true" pattern="%s"></state>
 	</channel-type>
 	<channel-type id="sync" advanced="true">
 		<item-type>String</item-type>


### PR DESCRIPTION
The source channel shows from where the current playlist entry is played
from. For web radios this will be the URL, i.e.
http://www.myradio.org/radio.mp3.

This is particularly helpful if one wants to know the current source to
play something else and afterwards revert to the source before.

For announcements via the openHAB "say" infrastructure this works out of
the box with ONE squeezebox sink. It cannot work if one synchronizes
multiple sinks, because the Logitech Media Server will then use the source
from the squeezebox instance where the other instances were synchronized to.
So the other instances will play whatever was played in the instance they
were synchronized to.

With the new source channel one is able to restore the last played source
before the announcement using the stream channel in case a stream was played
before.

Signed-off-by: Stefan Triller <github@stefantriller.de>