### PR TITLE
[squeezebox] Fix discovery names and properties

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -527,13 +527,13 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 player.setMacAddress(macAddress);
                 // populate the player state
                 for (String parameter : parameterList) {
-                    if (parameter.contains("ip")) {
+                    if (parameter.startsWith("ip:")) {
                         player.setIpAddr(parameter.substring(parameter.indexOf(":") + 1));
-                    } else if (parameter.contains("uuid")) {
+                    } else if (parameter.startsWith("uuid:")) {
                         player.setUuid(parameter.substring(parameter.indexOf(":") + 1));
-                    } else if (parameter.contains("name")) {
+                    } else if (parameter.startsWith("name:")) {
                         player.setName(parameter.substring(parameter.indexOf(":") + 1));
-                    } else if (parameter.contains("model")) {
+                    } else if (parameter.startsWith("model:")) {
                         player.setModel(parameter.substring(parameter.indexOf(":") + 1));
                     }
                 }


### PR DESCRIPTION
Currently in the discovery for players the "modelname" instead of the "name"
is taken, because of the `contains` method. Also the "modelname" can be
taken as the "model" because of the `contains`.

Result is that all discovery results are shown with the label "SqueezeLite"
instead of with their real names.

This commit fixes it for all used properties.


Signed-off-by: Stefan Triller <github@stefantriller.de>