### PR TITLE
[dwdunwetter] Fix periodic data refresh failure

### DIFF
--- a/bundles/org.openhab.binding.dwdunwetter/README.md
+++ b/bundles/org.openhab.binding.dwdunwetter/README.md
@@ -8,7 +8,7 @@ Regions outside of Germany are not supported.
 ## Supported Things
 
 This binding supports one thing, the Weather Warning.
-Each Thin provides one or more warnings for a city.
+Each Thing provides one or more warnings for a city.
 
 
 ## Thing Configuration

--- a/bundles/org.openhab.binding.dwdunwetter/README.md
+++ b/bundles/org.openhab.binding.dwdunwetter/README.md
@@ -1,27 +1,26 @@
 # DwdUnwetter Binding
 
 Binding to retrieve the Weather Warnings of the "Deutscher Wetterdienstes" from the [DWD Geoserver](https://maps.dwd.de/geoserver/web/).
-The DWD provides weather warnings for the German area. 
+The DWD provides weather warnings for Germany.
 Regions outside of Germany are not supported.
+
 
 ## Supported Things
 
-This binding supports exactly one thing - Weather Warning.
-One Thing provides one or multiple warnings for a city.
-
+This binding supports one thing, the Weather Warning.
+Each Thin provides one or more warnings for a city.
 
 
 ## Thing Configuration
 
 | Property     | Default | Required | Description                                                                                                                                                                                                                                                                                                 |
 |--------------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cellId       | -       | Yes      | Id of the area to retrieve weather warnings. For a list of valid IDs look at https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.csv. With the % sign at the end it is possible to query multiple cells at once. For example with 8111% are cells retrieved that starts with 8111. |
-| refresh      | 30      | No       | Time between to API requests in minutes. Minimum 15 minutes.                                                                                                                                                                                                                                                |
-| warningCount | 1       | No       | Number of warnings to provide. For each warning there will multiple channels.                                                                                                                                                                                                                               |
+| cellId       | -       | Yes      | ID of the area to retrieve weather warnings. See [this list](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.csv) of valid IDs. Using the percent sign (%) as a wildcard, it is possible to query multiple cells. For example, the value `8111%` retrieves all cell IDs that start with `8111`. |
+| refresh      | 30      | No       | Time between API requests in minutes. Minimum 15 minutes.                                                                                                                                                                                                                                                   |
+| warningCount | 1       | No       | Number of warnings to provide.                                                                                                                                                                                                                                                                              |
 
-The plugin will deliver no warnings if the number of retrieved warnings for one thing is to big. 
-This can only happen if you select to many Cells with the %-Operator. 
-It will happen if the area contains about 300+ warnings.
+The binding will deliver no warnings if the number of retrieved warnings for one Thing is too big.
+This can only happen if you select too many cell IDs (more than about 300) with the percent wildcard.
 
 Example:
 
@@ -33,38 +32,39 @@ dwdunwetter:dwdwarnings:cologne "Warnings Cologne" [ cellId="105315000", refresh
 ## Channels
 
 The are multiple channels for every weather warning.
-The channels are numbered, so channels ending in 1 are for the first warning, ending with 2 are for the second warning and so on.
-The warnings will be sorted by severity and for warnings with same severity by the valid from date.
-This ensures that in the channels for the first warning will always be the highest severity.
-If the API returns more warnings than the configured number in the thing, the warnings with the lowest severity will be dropped.  
+The channels are numbered, with channel names ending in 1 for the first warning, 2 for the second warning, and so on.
+The warnings will be sorted first by `Severity` and then by the `Valid From` date.
+This ensures that the channels for the first warning will always be the highest Severity.
+If the API returns more warnings than the configured number in the Thing, the warnings with the lowest Severity will be dropped.
  
 | Channel      | Type            | Description                                                                      |
 |--------------|-----------------|----------------------------------------------------------------------------------|
-| warningN     | Switch          | ON if a warning is present, OFF else                                             |
-| UpdatedN     | Trigger Channel | Triggers NEW if a warning is send the first time                                 |
-| severityN    | String          | Severity of the warning. Possible values are Minor, Moderate, Severe and Extreme |
-| headlineN    | String          | Headline of the warning like "Amtliche Warnung vor FROST"                        |
+| warningN     | Switch          | ON if a warning is present                                                       |
+| UpdatedN     | Trigger Channel | Triggers NEW when a warning is sent the first time                               |
+| severityN    | String          | Severity of the warning. Possible values are Minor, Moderate, Severe, and Extreme|
+| headlineN    | String          | Headline of the warning (e.g. "Amtliche Warnung vor FROST")                      |
 | descriptionN | String          | Textual description of the warning                                               |
-| eventN       | String          | Type of the warning, e.g. FROST                                                  |
+| eventN       | String          | Type of the warning (e.g. FROST)                                                 |
 | effectiveN   | DateTime        | Issued Date and Time                                                             |
 | onsetN       | DateTime        | Start Date and Time for which the warning is valid                               |
 | expiresN     | DateTime        | End Date and Time for which the warning is valid                                 |
 | altitudeN    | Number:Length   | Lower Height above sea level for which the warning is valid                      |
 | ceilingN     | Number:Length   | Upper Height above sea level for which the warning is valid                      |
-| urgencyN     | String          | Urgency of the warning Possible values are Future and Immediate                  |
-| instructionN | String          | Additional instructions and safety informations                                  |
+| urgencyN     | String          | Urgency of the warning. Possible values are Future and Immediate                 |
+| instructionN | String          | Additional instructions and safety information                                   |
 
-All channels are readonly!
+All channels are readonly.
 
-The main purpose of the channel _warning_ is to be used for controlling visibility in sitemaps.
+The main purpose of the channel `warningN` is to be used for controlling visibility in sitemaps.
 The channel can also be used in rules to check if there is a warning present. 
 It should not be used for rules that need to fire if a new warning shows up. 
-If a warning is replaced by another warning, that channel stays at ON, there will be no state change. 
-For rules the need to fire if a new warning show up there is the trigger channel _updatedN_. 
-That trigger channel fires an event whenever a warning is send the first time to that thing.
-That channel triggers if a warning is replaced by another.
+If a warning is replaced by another warning, that channel stays at ON, and there will be no state change. 
+For rules that need to fire if a new warning occurs, there is the trigger channel `updatedN`. 
+That trigger channel fires an event whenever a warning is sent for the first time.
+It also triggers if a warning is replaced by another.
 
-More explanations about the specific values of the channels can be found in the documentation of the DWD at: [CAP DWD Profile 1.2](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_dwd_profile_de_pdf.pdf?__blob=publicationFile&v=7)   
+More explanations about the specific values of the channels can be found in the documentation of the DWD at: [CAP DWD Profile 1.2](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_dwd_profile_de_pdf.pdf?__blob=publicationFile&v=7)
+
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningCache.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningCache.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import org.openhab.binding.dwdunwetter.internal.DwdUnwetterBindingConstants;
-
 /**
  * Cache of Warnings to update the {@link DwdUnwetterBindingConstants#CHANNEL_UPDATED} if a new warning is sent to a
  * channel.

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningDataAccess.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningDataAccess.java
@@ -35,10 +35,10 @@ public class DwdWarningDataAccess {
 
     /**
      * Returns the raw Data from the Endpoint.
-     * In case of errors or empty cellId hValue the Method returns an {@link StringUtils#EMPTY Empty String}.
+     * In case of errors or empty cellId value, returns an {@link StringUtils#EMPTY Empty String}.
      *
      * @param cellId The warnCell-Id for which the warnings should be returned
-     * @return The raw data.
+     * @return The raw data received or an empty string.
      */
     public String getDataFromEndpoint(String cellId) {
         try {
@@ -46,6 +46,7 @@ public class DwdWarningDataAccess {
                 logger.warn("No cellId provided");
                 return StringUtils.EMPTY;
             }
+
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append(DWD_URL);
             stringBuilder.append("&CQL_FILTER=");
@@ -53,10 +54,14 @@ public class DwdWarningDataAccess {
                     .append(URLEncoder.encode("WARNCELLID LIKE '" + cellId + "'", StandardCharsets.UTF_8.toString()));
             logger.debug("Refreshing Data: {}", stringBuilder);
             String rawData = HttpUtil.executeUrl("GET", stringBuilder.toString(), 5000);
+            logger.trace("Raw response:\r\n{}", rawData);
+
             return rawData;
         } catch (IOException e) {
-            logger.debug("Communication error occurred while getting data", e);
+            logger.warn("Communication error occurred while getting data");
+            logger.debug("Communication error trace", e);
         }
+
         return StringUtils.EMPTY;
     }
 

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningDataAccess.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningDataAccess.java
@@ -52,13 +52,14 @@ public class DwdWarningDataAccess {
             stringBuilder.append("&CQL_FILTER=");
             stringBuilder
                     .append(URLEncoder.encode("WARNCELLID LIKE '" + cellId + "'", StandardCharsets.UTF_8.toString()));
-            logger.debug("Refreshing Data: {}", stringBuilder);
+            logger.debug("Refreshing Data for cell {}", cellId);
             String rawData = HttpUtil.executeUrl("GET", stringBuilder.toString(), 5000);
-            logger.trace("Raw response:\r\n{}", rawData);
+            logger.trace("Raw request: {}", stringBuilder);
+            logger.trace("Raw response: {}", rawData);
 
             return rawData;
         } catch (IOException e) {
-            logger.warn("Communication error occurred while getting data");
+            logger.warn("Communication error occurred while getting data: {}", e.getMessage());
             logger.debug("Communication error trace", e);
         }
 

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningsData.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningsData.java
@@ -200,9 +200,11 @@ public class DwdWarningsData {
                 }
             }
         } catch (XMLStreamException e) {
-            logger.debug("Exception while parsing the XML Response", e);
+            logger.warn("Exception occurred while parsing the XML response: {}", e.getMessage());
+            logger.debug("Exception trace", e);
             return false;
         }
+
         Collections.sort(cityData, new SeverityComparator());
         return true;
     }

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdXmlTag.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/java/org/openhab/binding/dwdunwetter/internal/data/DwdXmlTag.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang.StringUtils;
  */
 public enum DwdXmlTag {
 
-    UNKOWN(""),
+    UNKNOWN(""),
     SEVERITY("SEVERITY"),
     DESCRIPTION("DESCRIPTION"),
     EFFECTIVE("EFFECTIVE"),
@@ -53,7 +53,7 @@ public enum DwdXmlTag {
 
     public static DwdXmlTag getDwdXmlTag(String tag) {
         return Arrays.asList(DwdXmlTag.values()).stream().filter(t -> StringUtils.equals(t.getTag(), tag)).findFirst()
-                .orElse(UNKOWN);
+                .orElse(UNKNOWN);
     }
 
 }

--- a/bundles/org.openhab.binding.dwdunwetter/src/main/resources/ESH-INF/i18n/dwdunwetter_de.properties
+++ b/bundles/org.openhab.binding.dwdunwetter/src/main/resources/ESH-INF/i18n/dwdunwetter_de.properties
@@ -1,6 +1,6 @@
 # binding
 binding.dwdunwetter.name = DWD Unwetter Binding
-binding.tankerkoenig.description = Das DWD Unwetter Binding ermöglicht es über die API des DWD aktuelle Unwetterwarnungen abzurufen
+binding.dwdunwetter.description = Das DWD Unwetter Binding ermöglicht es über die API des DWD aktuelle Unwetterwarnungen abzurufen
 
 # thing types
 thing-type.dwdunwetter.dwdwarnings.label = DWD Unwetter Warnungen


### PR DESCRIPTION
Fixes #6924. 

This is mainly to address a defect where the periodic data refresh would stop occurring after a data retrieval failure.  This was happening because the `inRefresh` flag was not being reset properly.

Also cleaned up compiler warnings and fixed the description tag in the German language properties file.

See also the two community threads linked in that ticket.

I plan to propose an additional PR to make the binding surface the count of warnings received so that users don't think it's failing to retrieve data just because it's not receiving any warnings.  If someone thinks that should be done in this PR, that's fine with me, but I didn't want to overload it.

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/
-->
