### PR TITLE
[bluetooth] Add thread safety to characteristic write/notify (#6935)

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -417,6 +417,8 @@ public class BlueGigaBluetoothDevice extends BluetoothDevice implements BlueGiga
             if (characteristic == null) {
                 logger.debug("BlueGiga didn't find characteristic for event {}", event);
             } else {
+                // create a copy of characteristic to make sure we don't interfere with writes
+                characteristic = characteristic.copy();
                 characteristic.setValue(valueEvent.getValue().clone());
 
                 // If this is the characteristic we were reading, then send a read completion

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -241,8 +241,10 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         scheduler.submit(() -> {
             try {
                 byte[] value = c.readValue();
-                characteristic.setValue(value);
-                notifyListeners(BluetoothEventType.CHARACTERISTIC_READ_COMPLETE, characteristic,
+                // create a copy of characteristic to make sure we don't interfere with writes
+                BluetoothCharacteristic copyChar = characteristic.copy();
+                copyChar.setValue(value);
+                notifyListeners(BluetoothEventType.CHARACTERISTIC_READ_COMPLETE, copyChar,
                         BluetoothCompletionStatus.SUCCESS);
             } catch (BluetoothException e) {
                 logger.debug("Exception occurred when trying to read characteristic '{}': {}", characteristic.getUuid(),
@@ -287,8 +289,10 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
         if (c != null) {
             try {
                 c.enableValueNotifications(value -> {
-                    characteristic.setValue(value);
-                    notifyListeners(BluetoothEventType.CHARACTERISTIC_UPDATED, characteristic);
+                    // create a copy of characteristic to make sure we don't interfere with writes
+                    BluetoothCharacteristic copyChar = characteristic.copy();
+                    copyChar.setValue(value);
+                    notifyListeners(BluetoothEventType.CHARACTERISTIC_UPDATED, copyChar);
                 });
             } catch (BluetoothException e) {
                 if (e.getMessage().contains("Already notifying")) {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -14,6 +14,7 @@ package org.openhab.binding.bluetooth;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +97,21 @@ public class BluetoothCharacteristic {
     protected BluetoothService service;
 
     /**
+     * Creates a copy of a BluetoothCharacteristic.
+     *
+     * @param copy the {@link BluetoothCharacteristic} to copy from
+     */
+    public BluetoothCharacteristic(BluetoothCharacteristic copy) {
+        this.uuid = copy.uuid;
+        this.handle = copy.handle;
+        this.instance = copy.instance;
+        this.properties = copy.properties;
+        this.permissions = copy.permissions;
+        this.writeType = copy.writeType;
+        this.value = copy.value != null ? Arrays.copyOf(value, copy.value.length) : null;
+    }
+
+    /**
      * Create a new BluetoothCharacteristic.
      *
      * @param uuid the {@link UUID} of the new characteristic
@@ -104,6 +120,14 @@ public class BluetoothCharacteristic {
     public BluetoothCharacteristic(UUID uuid, int handle) {
         this.uuid = uuid;
         this.handle = handle;
+    }
+
+    /**
+     * Returns a copy of this BluetoothCharacteristic.
+     *
+     */
+    public BluetoothCharacteristic copy() {
+        return new BluetoothCharacteristic(this);
     }
 
     /**

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -109,6 +109,7 @@ public class BluetoothCharacteristic {
         this.permissions = copy.permissions;
         this.writeType = copy.writeType;
         this.value = copy.value != null ? Arrays.copyOf(value, copy.value.length) : null;
+        this.service = copy.service;
     }
 
     /**


### PR DESCRIPTION
This is an alternate way to fix #6935. Unlike PR #6936, this is a much simpler and doesn't affect other bluetooth PRs, but it has the disadvantage of forcing binding developers to be responsible for handling concurrent writes of a characteristic. I personally dislike this particular fix (the less developers have to worry about concurrency the better) but it has the bonus of being a lot easier to review while still solving the issue.

So pick either this or #6936.