### PR TITLE
[bluetooth.bluez] Bluez device discovery should be disabled by default

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/resources/ESH-INF/thing/bluez.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/resources/ESH-INF/thing/bluez.xml
@@ -16,9 +16,9 @@
 			</parameter>
 			<parameter name="discovery" type="boolean">
 				<label>Device Discovery</label>
-				<description>Whether this adapter actively participates in Bluetooth device discovery</description>
+				<description>Whether Bluetooth device discovery is always enabled for this adapter</description>
 				<advanced>true</advanced>
-				<default>true</default>
+				<default>false</default>
 			</parameter>
 		</config-description>
 


### PR DESCRIPTION
Discovery for bluez adapter should be disabled by default to prevent
overwhelming users when they first add a bluez thing. Since the user can
do manual scans when they need to there is no reason for discovery to be
enabled all the time. To make it worse, it is not intuitive for the user at all how to shut off bluetooth discovery.
So to make things better I suggest just having always-on discovery disabled by default.
