### PR TITLE
[lutron] Add support for mDNS bridge discovery

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -14,7 +14,7 @@ Each is described in a separate section below.
 
 **Note:** While the integration protocol used by this binding should largely be compatible with other current Lutron systems, this binding has only been fully tested with RadioRA 2, HomeWorks QS, and Caseta with Smart Bridge Pro.
 Homeworks QS support is still a work in progress, since not all features/devices are supported yet.
-RA2 Select has been reported to work with the binding, but support is unconfirmed.
+RA2 Select systems have been reported to work with the binding, but full support is still unconfirmed.
 The binding has not been tested with Quantum, QS Standalone, or myRoom Plus systems.
 
 **Note:** Caseta support is only possible with the Smart Bridge **Pro** hub.
@@ -52,7 +52,10 @@ Discovered repeaters/processors will be accessed using the default integration c
 These can be changed in the bridge thing configuration.
 Discovered keypad devices should now have their model parameters automatically set to the correct value.
 
-Hubs and their connected devices in Caseta and RA2 Select systems need to be configured manually.
+Caseta Smart Bridge PRO 2 hubs should now be discovered automatically via mDNS.
+Devices attached to them still need to be configured manually.
+
+Other supported Lutron systems must be configured manually.
 
 ## Binding Configuration
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -73,6 +73,11 @@ public class LutronBindingConstants {
     public static final String SERIAL_NUMBER = "serialNumber";
     public static final String DISCOVERY_FILE = "discoveryFile";
 
+    public static final String PROPERTY_PRODFAM = "productFamily";
+    public static final String PROPERTY_PRODTYP = "productType";
+    public static final String PROPERTY_CODEVER = "version";
+    public static final String PROPERTY_MACADDR = "macAddress";
+
     // Thing config properties
     public static final String INTEGRATION_ID = "integrationId";
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -75,8 +75,6 @@ public class LutronBindingConstants {
 
     public static final String PROPERTY_PRODFAM = "productFamily";
     public static final String PROPERTY_PRODTYP = "productType";
-    public static final String PROPERTY_CODEVER = "version";
-    public static final String PROPERTY_MACADDR = "macAddress";
 
     // Thing config properties
     public static final String INTEGRATION_ID = "integrationId";

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
@@ -183,6 +183,7 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
             String productFamily = bridgeProperties.get("PRODFAM");
             String productType = bridgeProperties.get("PRODTYPE");
             String codeVersion = bridgeProperties.get("CODEVER");
+            String macAddress = bridgeProperties.get("MACADDR");
 
             if (StringUtils.isNotBlank(ipAddress) && StringUtils.isNotBlank(serialNumber)) {
                 Map<String, Object> properties = new HashMap<>();
@@ -191,15 +192,22 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
                 properties.put(SERIAL_NUMBER, serialNumber);
 
                 if (PRODFAM_RA2.equals(productFamily)) {
-                    properties.put("productFamily", "RadioRA 2");
+                    properties.put(PROPERTY_PRODFAM, "RadioRA 2");
                 } else if (PRODFAM_HWQS.equals(productFamily)) {
-                    properties.put("productFamily", "HomeWorks QS");
+                    properties.put(PROPERTY_PRODFAM, "HomeWorks QS");
                 } else {
-                    properties.put("productFamily", productFamily);
+                    properties.put(PROPERTY_PRODFAM, productFamily);
                 }
 
-                properties.put("productType", productType);
-                properties.put("version", codeVersion);
+                if (StringUtils.isNotBlank(productType)) {
+                    properties.put(PROPERTY_PRODTYP, productType);
+                }
+                if (StringUtils.isNotBlank(codeVersion)) {
+                    properties.put(PROPERTY_CODEVER, codeVersion);
+                }
+                if (StringUtils.isNotBlank(macAddress)) {
+                    properties.put(PROPERTY_MACADDR, macAddress);
+                }
 
                 ThingUID uid = new ThingUID(THING_TYPE_IPBRIDGE, serialNumber);
                 String label = generateLabel(productFamily, productType);

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
@@ -29,13 +29,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
@@ -171,7 +171,7 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
                     StandardCharsets.US_ASCII);
 
             Matcher matcher = BRIDGE_PROP_PATTERN.matcher(data);
-            Map<String, String> bridgeProperties = new HashMap<>();
+            Map<String, @Nullable String> bridgeProperties = new HashMap<>();
 
             while (matcher.find()) {
                 bridgeProperties.put(matcher.group(1), matcher.group(2));
@@ -185,7 +185,8 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
             String codeVersion = bridgeProperties.get("CODEVER");
             String macAddress = bridgeProperties.get("MACADDR");
 
-            if (StringUtils.isNotBlank(ipAddress) && StringUtils.isNotBlank(serialNumber)) {
+            if (ipAddress != null && !ipAddress.trim().isEmpty() && serialNumber != null
+                    && !serialNumber.trim().isEmpty()) {
                 Map<String, Object> properties = new HashMap<>();
 
                 properties.put(HOST, ipAddress);
@@ -196,17 +197,19 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
                 } else if (PRODFAM_HWQS.equals(productFamily)) {
                     properties.put(PROPERTY_PRODFAM, "HomeWorks QS");
                 } else {
-                    properties.put(PROPERTY_PRODFAM, productFamily);
+                    if (productFamily != null) {
+                        properties.put(PROPERTY_PRODFAM, productFamily);
+                    }
                 }
 
-                if (StringUtils.isNotBlank(productType)) {
+                if (productType != null && !productType.trim().isEmpty()) {
                     properties.put(PROPERTY_PRODTYP, productType);
                 }
-                if (StringUtils.isNotBlank(codeVersion)) {
-                    properties.put(PROPERTY_CODEVER, codeVersion);
+                if (codeVersion != null && !codeVersion.trim().isEmpty()) {
+                    properties.put(Thing.PROPERTY_FIRMWARE_VERSION, codeVersion);
                 }
-                if (StringUtils.isNotBlank(macAddress)) {
-                    properties.put(PROPERTY_MACADDR, macAddress);
+                if (macAddress != null && !macAddress.trim().isEmpty()) {
+                    properties.put(Thing.PROPERTY_MAC_ADDRESS, macAddress);
                 }
 
                 ThingUID uid = new ThingUID(THING_TYPE_IPBRIDGE, serialNumber);
@@ -220,8 +223,9 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
             }
         }
 
-        private String generateLabel(String productFamily, String productType) {
-            if (StringUtils.isNotBlank(productFamily) && StringUtils.isNotBlank(productType)) {
+        private String generateLabel(@Nullable String productFamily, @Nullable String productType) {
+            if (productFamily != null && !productFamily.trim().isEmpty() && productType != null
+                    && !productType.trim().isEmpty()) {
                 return productFamily + " " + productType;
             }
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.lutron.internal.discovery;
+
+import static org.openhab.binding.lutron.internal.LutronBindingConstants.*;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link LutronMdnsBridgeDiscoveryService} discovers Lutron Caseta Smart Bridge and RA2 Select Main Repeater
+ * devices on the network using mDNS.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@Component(immediate = true)
+@NonNullByDefault
+public class LutronMdnsBridgeDiscoveryService implements MDNSDiscoveryParticipant {
+
+    // Lutron mDNS service <app>.<protocol>.<servicedomain>
+    private static final String LUTRON_MDNS_SERVICE_TYPE = "_lutron._tcp.local.";
+
+    private static final String PRODFAM_CASETA = "Caseta";
+    private static final String PRODTYP_CASETA_SBP2 = "Smart Bridge Pro 2";
+    private static final String DEVCLASS_CASETA_SBP2 = "08050100";
+    private static final String DEFAULT_LABEL = "Unknown Lutron bridge";
+
+    private static final Pattern HOSTNAME_REGEX = Pattern.compile("lutron-([0-9a-f]+)\\."); // ex: lutron-01f1529a.local
+
+    private final Logger logger = LoggerFactory.getLogger(LutronMdnsBridgeDiscoveryService.class);
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return Collections.singleton(THING_TYPE_IPBRIDGE);
+    }
+
+    @Override
+    public String getServiceType() {
+        return LUTRON_MDNS_SERVICE_TYPE;
+    }
+
+    @Override
+    public @Nullable DiscoveryResult createResult(ServiceInfo service) {
+        if (!service.hasData()) {
+            return null;
+        }
+
+        String nice = service.getNiceTextString();
+        String qualifiedName = service.getQualifiedName();
+
+        InetAddress[] ipAddresses = service.getInetAddresses();
+        String devclass = service.getPropertyString("DEVCLASS");
+        String codever = service.getPropertyString("CODEVER");
+        String macaddr = service.getPropertyString("MACADDR");
+
+        logger.debug("Lutron mDNS bridge discovery notified of Lutron mDNS service: {}", nice);
+        logger.trace("Lutron mDNS service qualifiedName: {}", qualifiedName);
+        logger.trace("Lutron mDNS service ipAddresses: {} ({})", ipAddresses, ipAddresses.length);
+        logger.trace("Lutron mDNS service property DEVCLASS: {}", devclass);
+        logger.trace("Lutron mDNS service property CODEVER: {}", codever);
+        logger.trace("Lutron mDNS service property MACADDR: {}", macaddr);
+
+        Map<String, Object> properties = new HashMap<>();
+        String label = DEFAULT_LABEL;
+
+        if (ipAddresses.length < 1) {
+            return null;
+        }
+        if (ipAddresses.length > 1) {
+            logger.info("Multiple addresses found for discovered Lutron bridge device. Using only the first.");
+        }
+        properties.put(HOST, ipAddresses[0].getHostAddress());
+
+        String bridgeHostName = ipAddresses[0].getHostName();
+        logger.trace("Lutron mDNS bridge hostname: {}", bridgeHostName);
+
+        if (devclass != null && devclass.equals(DEVCLASS_CASETA_SBP2)) {
+            properties.put(PROPERTY_PRODFAM, PRODFAM_CASETA);
+            properties.put(PROPERTY_PRODTYP, PRODTYP_CASETA_SBP2);
+            label = PRODFAM_CASETA + " " + PRODTYP_CASETA_SBP2;
+        } else {
+            return null; // For now, exit if service has unknown DEVCLASS
+        }
+
+        if (!bridgeHostName.equals(ipAddresses[0].getHostAddress())) {
+            label = label + " " + bridgeHostName;
+        }
+
+        if (codever != null) {
+            properties.put(PROPERTY_CODEVER, codever);
+        }
+
+        if (macaddr != null) {
+            properties.put(PROPERTY_MACADDR, macaddr);
+        }
+
+        String sn = getSerial(service);
+        logger.trace("Lutron mDNS bridge serial number: {}", sn);
+        if (sn != null) {
+            properties.put(SERIAL_NUMBER, sn);
+        }
+
+        ThingUID uid = getThingUID(service);
+        if (uid != null) {
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withLabel(label).withProperties(properties)
+                    .withRepresentationProperty(SERIAL_NUMBER).build();
+            logger.debug("Discovered Lutron bridge device via mDNS {}", uid);
+            return result;
+        } else {
+            logger.trace("Failed to successfully discover bridge via mDNS");
+            return null;
+        }
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(ServiceInfo service) {
+        String serial = getSerial(service);
+        if (serial == null) {
+            return null;
+        } else {
+            return new ThingUID(THING_TYPE_IPBRIDGE, serial);
+        }
+    }
+
+    /**
+     * Return the serial number from the mDNS service. Extracts serial number from the mDNS service hostname or uses MAC
+     * address if serial number is unavailable. Used as unique thing representation property.
+     *
+     * @param service Lutron mDNS service
+     * @return String containing serial number or MAC, or null if neither can be determined
+     */
+    private @Nullable String getSerial(ServiceInfo service) {
+        InetAddress[] ipAddresses = service.getInetAddresses();
+        if (ipAddresses.length < 1) {
+            return null;
+        }
+        Matcher matcher = HOSTNAME_REGEX.matcher(ipAddresses[0].getHostName());
+        boolean matched = matcher.find();
+        String serialnum = null;
+
+        if (matched) {
+            serialnum = matcher.group(1);
+        }
+        if (matched && serialnum != null && !serialnum.isEmpty()) {
+            return serialnum;
+        } else {
+            String macaddr = service.getPropertyString("MACADDR");
+            String strippedMac = stripMac(macaddr);
+            if (strippedMac != null) {
+                return strippedMac;
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Utility routine to strip colon characters from MAC address
+     *
+     * @param mac String containing the MAC address to strip
+     * @return String containing stripped MAC address or null if mac is null or empty
+     */
+    private @Nullable String stripMac(@Nullable String mac) {
+        if (mac == null || mac.isEmpty()) {
+            return null;
+        }
+        return mac.replace(":", ""); // strip colon chars from MAC address
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
@@ -118,11 +119,11 @@ public class LutronMdnsBridgeDiscoveryService implements MDNSDiscoveryParticipan
         }
 
         if (codever != null) {
-            properties.put(PROPERTY_CODEVER, codever);
+            properties.put(Thing.PROPERTY_FIRMWARE_VERSION, codever);
         }
 
         if (macaddr != null) {
-            properties.put(PROPERTY_MACADDR, macaddr);
+            properties.put(Thing.PROPERTY_MAC_ADDRESS, macaddr);
         }
 
         String sn = getSerial(service);


### PR DESCRIPTION
This update allows Caseta Smart Bridge Pro 2 devices to be automatically discovered via mDNS through the use of a MDNSDiscoveryParticipant service.

The new discovery service should also be able to find other recent Lutron devices discoverable via mDNS/DNS-SD (not all of which are supported by openHAB) such as Caseta Smart Bridge 1, RA2 Select main repeaters, and the Lutron Connect Bridge (CONNECT-BDG2). Discovery of these should currently not result in the creation of a discovered thing in the inbox, but instead will cause a log message such as the following to be generated;

```Lutron device with unknown DEVCLASS discovered via mDNS: XXXXXXXX. Configure device manually.```

As users report DEVCLASS information from currently unrecognized devices, discovery support for these can be added as well.

A test build has been available here:
https://github.com/bobadair/openhab2-addons/releases/tag/mdns-beta3
