### PR TITLE
[mqtt] (Re)Add outgoing format for OnOffValues

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
@@ -88,6 +88,11 @@ public class OnOffValue extends Value {
 
     @Override
     public String getMQTTpublishValue(@Nullable String pattern) {
-        return (state == OnOffType.ON) ? onCommand : offCommand;
+        String formatPattern = pattern;
+        if (formatPattern == null) {
+            formatPattern = "%s";
+        }
+
+        return String.format(formatPattern, state == OnOffType.ON ? onCommand : offCommand);
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OpenCloseValue.java
@@ -71,6 +71,11 @@ public class OpenCloseValue extends Value {
 
     @Override
     public String getMQTTpublishValue(@Nullable String pattern) {
-        return (state == OpenClosedType.OPEN) ? openString : closeString;
+        String formatPattern = pattern;
+        if (formatPattern == null) {
+            formatPattern = "%s";
+        }
+
+        return String.format(formatPattern, state == OpenClosedType.OPEN ? openString : closeString);
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -121,9 +121,11 @@ public class ValueTests {
         // Test with custom string, setup in the constructor
         v.update(new StringType("fancyOff"));
         assertThat(v.getMQTTpublishValue(null), is("fancyOff"));
+        assertThat(v.getMQTTpublishValue("=%s"), is("=fancyOff"));
         assertThat(v.getChannelState(), is(OnOffType.OFF));
         v.update(new StringType("fancyON"));
         assertThat(v.getMQTTpublishValue(null), is("fancyON"));
+        assertThat(v.getMQTTpublishValue("=%s"), is("=fancyON"));
         assertThat(v.getChannelState(), is(OnOffType.ON));
     }
 


### PR DESCRIPTION
Fix for #6933

Sorry, I somehow thought, that a format would not be needed, as the string values can be changed.
I did not think about a device which expects a different value than the one it sends....