### PR TITLE
New Presence binding

### DIFF
--- a/bundles/org.openhab.binding.presence/.classpath
+++ b/bundles/org.openhab.binding.presence/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.presence/.project
+++ b/bundles/org.openhab.binding.presence/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.presence</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.presence/NOTICE
+++ b/bundles/org.openhab.binding.presence/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/bundles/org.openhab.binding.presence/README.md
+++ b/bundles/org.openhab.binding.presence/README.md
@@ -1,0 +1,189 @@
+# Presence Binding
+
+This binding allows checking whether a device is currently available on the network.
+It supports checking for generic devices by using [ping](https://en.wikipedia.org/wiki/Ping_%28networking_utility%29), [arping](https://en.wikipedia.org/wiki/Arping), or by a successful TCP connection to a specified port.
+It can also detect a running SMTP server by connecting to a specified port and checking for a valid HELO/EHLO response code. [SMTP Example](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_transport_example)
+Parts of this binding were derived from the openHAB Network Binding. While this binding shares several features of the Network Binding, Presence is geared more towards, and usually excels at, just detecting the presence of devices, where the Network Binding has more general purpose network utility. Presence can also be extended in the future with more technologies such as Bluetooth or Computer Vision.
+
+## Supported Things
+
+- **pingdevice:** Detects device presence by using ICMP pings, arpings and dhcp packet sniffing.
+- **tcpportdevice:** Detects device presence by scanning for a specific open tcp port.
+- **smtpdevice:** Detects device presence by connecting to a specified port and evaluating the response code
+
+## Discovery
+
+Auto-discovery is currently not implemented.
+
+## Binding Configuration
+
+The binding has the following configuration options:
+
+-   **allowDHCPlisten:**  If devices leave and reenter a network, they usually request their last IPv4 address by using DHCP requests. By listening for those messages, the status update can be more "real-time" without having to wait for the next refresh cycle. Default is true. The DHCP listener will first attempt to bind to port 67. If this fails, it will fall back to binding to port 6776.
+-   **arpPingToolPath:** If the arping tool is not called `arping` and cannot be found in the PATH environment variable, the absolute path can be configured here. Default is `arping`.
+-   **pingToolPath:** If the ping tool is not called `ping` and cannot be found in the PATH environment variable, the absolute path can be configured here. Default is `ping`.
+
+Create a `<openHAB-conf>/services/presence.cfg` file and use the above options like this:
+
+```
+binding.presence:allowDHCPlisten=false
+binding.presence:arpPingToolPath=arping
+binding.presence:pingToolPath=ping
+```
+
+## Thing Configuration
+
+```
+presence:pingdevice:one_device [ hostname="192.168.0.64" ]
+presence:pingdevice:second_device [ hostname="192.168.0.65", timeout=5000, refreshInterval=60000 ]
+presence:tcportdevice:important_server [ hostname="192.168.0.62", port=1234 ]
+presence:smtpdevice:important_server [ hostname="192.168.0.62", port=25 ]
+```
+
+Use the following options for a **presence:pingdevice**:
+
+-   **hostname:** IP address or hostname of the device
+-   **retry:** After how many refresh interval cycles the device will be assumed to be offline. Default: `1`
+-   **timeout:** How long the ping will wait for an answer, in milliseconds. Default: `5000` (5 seconds).
+-   **refreshInterval:** How often the device will be checked, in milliseconds. Default: `60000` (one minute).
+
+Use the following additional options for a **presence:tcpportdevice** or **presence:smtpdevice**:
+
+-   **port:** Must not be 0. The destination port needs to be a TCP service.
+
+## Presence detection - Configure target device
+
+Devices may need to be configured to be reachable, as a device may not answer ping requests by default.
+This is the case with Windows 10 equipped systems or Android and iOS devices in deep sleep mode.
+
+### Respond to pings on Windows 10+
+
+Pings on Windows 10 are usually blocked by the internal firewall.
+Windows 10 must be configured to allow "Echo Request for ICMPv4" so that it can respond to pings.
+
+### Android and iOS devices
+
+Because mobile devices put themselves in a deep sleep mode after some inactivity, they do not react to normal ICMP pings.
+Configure ARP ping to realize presence detection for those devices.
+This only works if the devices have WiFi enabled, have been configured to use the WiFi network, and have the option "Disable WiFi in standby" disabled (default).
+Use DHCP listen for an almost immediate presence detection for phones and tablets when they (re)join the home Wifi network.
+
+### iPhones, iPads
+
+Apple iOS devices are usually in a deep sleep mode and do not respond to ARP pings under all conditions, but to Bonjour service discovery messages (UDP port 5353).
+Therefore first a Bonjour message is sent, before the ARP presence detection is performed.
+The binding always assumes the target device is an iOS device.
+To check if the binding has correctly recognized a device, have a look at the properties of the Thing. They will list
+the output of the different detection methods.
+
+### Use open TCP ports
+
+Many devices provide services on TCP ports (web-frontends, streaming servers, etc.), which can be used to confirm their presence in the network.
+Most operating systems have options to list open ports.
+On a Linux-based system, *nmap* may be used to discover all open TCP ports on the device with the specified IP address:
+
+```
+$ sudo nmap -Pn -sT -p- 192.168.0.42
+
+Starting Nmap 6.47 ( http://nmap.org ) at 2016-07-31 20:00 CEST
+Nmap scan report for linuxPC (192.168.0.42)
+Host is up (0.0011s latency).
+Not shown: 65531 filtered ports
+PORT      STATE SERVICE
+554/tcp   open  rtsp
+8089/tcp  open  unknown
+8090/tcp  open  unknown
+8889/tcp  open  ddi-tcp-2
+
+Nmap done: 1 IP address (1 host up) scanned in 106.17 seconds
+```
+
+In this example, there are four suitable ports to use.
+The port 554 (Windows network file sharing service) is open on most Windows PCs and Windows compatible Linux systems.
+Port 1025 (MS RPC) is open on XBox systems. Port 548 (Apple Filing Protocol (AFP)) is open on Mac OS X systems.
+
+Please don't forget to open the required ports in the system's firewall setup.
+
+## Presence detection - Configure your openHAB installation
+
+Because external tools are used for some of the presence detection mechanism or need elevated permissions for others, the openHAB installation needs to be altered.
+
+### Arping
+
+For arp pings to work, a separate tool called "arping" is used.
+Linux has three different tools:
+
+*   arp-scan (not yet supported by this binding)
+*   arping of the ip-utils (Ubuntu/Debian: `apt-get install iputils-arping`)
+*   arping by Thomas Habets (Ubuntu/Debian: `apt-get install arping`)
+*   arp-ping by Eli Fulkerson (Windows: https://www.elifulkerson.com/projects/arp-ping.php)
+
+arping by Thomas Habets runs on Windows and macOS as well.
+
+Make sure the tool is available in the PATH, or in the same path as the openHAB executable.
+
+On Linux and macOS elevated access permissions may be needed, for instance by making the executable a suid executable (`chmod u+s /usr/sbin/arping`).
+Just test the executable on the command line; if `sudo` is required, grant elevated permissions.
+
+## Ping
+
+On Linux and macOS elevated access permissions may be needed to execute the `ping` command. To do this, make the executable a suid executable (`chmod u+s /usr/bin/ping`).
+Just test the executable on the command line; if `sudo` is required, grant elevated permissions.
+
+### DHCP Listen
+
+Some operating systems such as Linux restrict applications to only use ports >= 1024 without elevated privileges.
+If the binding is not able to use port 67 (DHCP) because of such a restriction, or because the same system is used as a DHCP server, port 6776 will be used instead.
+Check the property *dhcp_state* on the Thing for such a hint. In this case, establish port forwarding:
+
+```shell
+sysctl -w net.ipv4.ip_forward=1
+iptables -A INPUT -p udp --dport 6767 -j ACCEPT
+iptables -t nat -A PREROUTING -p udp --dport 67 -j REDIRECT --to-ports 6767
+```
+
+If a DHCP server is operating on port 67, duplicate the received traffic and forward it to port 6767:
+
+```shell
+iptables -A PREROUTING -t mangle -p udp ! -s 127.0.0.1 --dport 67 -j TEE --gateway 127.0.0.1
+iptables -A OUTPUT -t nat -p udp -s 127.0.0.1/32 --dport 67 -j DNAT --to 127.0.0.1:6767
+```
+
+## Channels
+
+Things support the following channels:
+
+Channel Type ID | Item Type   | Description
+:---------------|:------------|:------------
+online          | Switch      | This channel indicates whether a device is online
+lastseen        | DateTime    | The last seen date/time of the device in question. May be 1. Jan 1970 if no time is known
+firstseen       | DateTime    | The initial date/time that the device in question was detected. May be 1. Jan 1970 if no time is known
+
+## Full Example
+
+demo.things:
+
+```xtend
+Thing presence:pingdevice:devicename [ hostname="192.168.0.42", timeout=5000, refreshInterval=15000, retry=2 ]
+Thing presence:tcpportdevice:service [ hostname="192.168.0.43", port=443 ]
+Thing presence:smtpdevice:mta [ hostname="192.168.0.44", port=25 ]
+```
+
+demo.items:
+
+```xtend
+Switch MyDevice { channel="presence:pingdevice:devicename:online" }
+DateTime MyDeviceLastSeen "My Device Last Seen [%1$ta, %1$tb %1$te %1$tT]" { channel="presence:pingdevice:devicename:lastseen" }
+```
+
+demo.sitemap:
+
+```xtend
+sitemap demo label="Main Menu"
+{
+    Frame {
+        Text item=MyDevice label="Device [%s]"
+        Text item=MyDeviceLastSeen
+    }
+}
+```

--- a/bundles/org.openhab.binding.presence/pom.xml
+++ b/bundles/org.openhab.binding.presence/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.presence</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Presence Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.presence/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.presence/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.presence-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+    <feature name="openhab-binding-presence" description="Presence Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.presence/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/BaseConfiguration.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/BaseConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal;
+
+/**
+ * The {@link BaseConfiguration} class contains fields mapping common thing configuration parameters.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+public class BaseConfiguration {
+    // Dotted IP address or hostname of device
+    public String hostname;
+
+    // How often to refresh in millis
+    public long refreshInterval;
+
+    // How often to refresh when gone in millis
+    public long refreshIntervalWhenGone;
+
+    // How many OFF states do we see before we transition from ON to OFF
+    public int retry;
+
+    // How long to wait for a response from the device while pinging (in millis)
+    public long timeout;
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/BaseHandler.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/BaseHandler.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal;
+
+import static org.openhab.binding.presence.internal.binding.PresenceBindingConstants.*;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BaseHandler} is responsible for providing common methods for
+ * many of the child handlers.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public abstract class BaseHandler extends BaseThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(BaseHandler.class);
+
+    private @NonNullByDefault({}) BaseConfiguration baseConfig;
+
+    protected PresenceBindingConfiguration bindingConfiguration;
+
+    private @Nullable ScheduledFuture<?> processLifecyleFuture;
+
+    private @NonNullByDefault({}) ScheduledExecutorService sched;
+    private @NonNullByDefault({}) AtomicInteger c;
+    private volatile State lastKnownState = UnDefType.UNDEF;
+    private volatile State lastSeen = UnDefType.UNDEF;
+    private volatile State firstSeen = UnDefType.UNDEF;
+    private int retryCount;
+    private int maxSchedulerThreads;
+    private volatile boolean disposing = false;
+    protected int shortestInterval;
+    private int awayCount;
+    private int presentCount;
+
+    /*
+     * Don't do too much here other than some basic static initialization. Things get reused when their config changes
+     */
+    public BaseHandler(Thing thing, int maxSchedulerThreads, PresenceBindingConfiguration bindingConfiguration) {
+        super(thing);
+        baseConfig = getConfigAs(BaseConfiguration.class);
+        this.maxSchedulerThreads = maxSchedulerThreads;
+        this.bindingConfiguration = bindingConfiguration;
+        logger.debug("in constructor: {}", thing.getUID().getAsString());
+    }
+
+    // Provide a method for the child class to provide their logger
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    protected abstract void getStatus();
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (CHANNEL_ONLINE.equals(channelUID.getId())) {
+            if (command instanceof RefreshType) {
+                getLogger().trace("Refresh requested for {}, returning cached value: {}", channelUID.getAsString(),
+                        lastKnownState.toString());
+                // updateState(CHANNEL_ONLINE, lastKnownState);
+            }
+        }
+        if (CHANNEL_LAST_SEEN.equals(channelUID.getId())) {
+            if (command instanceof RefreshType) {
+                getLogger().trace("Refresh requested for {}, returning cached value: {}", channelUID.getAsString(),
+                        lastSeen.toString());
+                // updateState(CHANNEL_LAST_SEEN, lastSeen);
+            }
+        }
+        if (CHANNEL_FIRST_SEEN.equals(channelUID.getId())) {
+            if (command instanceof RefreshType) {
+                getLogger().trace("Refresh requested for {}, returning cached value: {}", channelUID.getAsString(),
+                        firstSeen.toString());
+                // updateState(CHANNEL_FIRST_SEEN, firstSeen);
+            }
+        }
+    }
+
+    private int findGCD(int n1, int n2) {
+        return n2 == 0 ? n1 : findGCD(n2, n1 % n2);
+    }
+
+    private void getStatusCheck() {
+        if (++awayCount >= (baseConfig.refreshIntervalWhenGone / shortestInterval)) {
+            awayCount = 0;
+            if (lastKnownState != OnOffType.ON) {
+                logger.debug("Time for away timer to run for {}", baseConfig.hostname);
+            }
+        }
+        if (++presentCount >= (baseConfig.refreshInterval / shortestInterval)) {
+            presentCount = 0;
+            if (lastKnownState == OnOffType.ON) {
+                logger.debug("Time for present timer to run for {}", baseConfig.hostname);
+            }
+        }
+
+        if ((lastKnownState == OnOffType.ON && presentCount == 0)
+                || (lastKnownState != OnOffType.ON && awayCount == 0)) {
+            this.getStatus();
+        }
+    }
+
+    @Override
+    public void initialize() {
+        disposing = false;
+        c = new AtomicInteger(0);
+        lastKnownState = lastSeen = firstSeen = UnDefType.UNDEF;
+        retryCount = 0;
+        baseConfig = getConfigAs(BaseConfiguration.class);
+        getLogger().debug("initializing thing {}", baseConfig.hostname);
+        updateStatus(ThingStatus.UNKNOWN);
+
+        long refreshIntervalWhileAway = baseConfig.refreshIntervalWhenGone;
+        if (refreshIntervalWhileAway < 0) {
+            refreshIntervalWhileAway = baseConfig.refreshInterval;
+        }
+
+        shortestInterval = findGCD((int) baseConfig.refreshInterval, (int) refreshIntervalWhileAway);
+        awayCount = presentCount = -1;
+
+        // Initialize our thread pool and schedule our update process
+        this.sched = Executors.newScheduledThreadPool(maxSchedulerThreads, (r) -> {
+            return new Thread(r, "Presence-" + baseConfig.hostname + "-scheduler-" + c.addAndGet(1));
+        });
+        this.processLifecyleFuture = this.sched.scheduleAtFixedRate(this::getStatusCheck, 250, shortestInterval,
+                TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void dispose() {
+        updateStateIfChanged(UnDefType.UNDEF);
+        disposing = true;
+        // Cancel our scheduled processes. 'cancel' will interrupt the threads
+        if (this.processLifecyleFuture != null) {
+            this.processLifecyleFuture.cancel(true);
+            this.processLifecyleFuture = null;
+        }
+
+        // Wait for the scheduled processes to exit gracefully, but only for 10 seconds
+        this.sched.shutdown();
+        try {
+            this.sched.awaitTermination(10000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            getLogger().debug("Interrupted while waiting for scheduler to terminate");
+        }
+        this.sched = null;
+        getLogger().debug("Thing is being disposed of: {}", baseConfig.hostname);
+    }
+
+    /*
+     * A helper function to only update the status if it's different from our cached value.
+     */
+    protected void updateStateIfChanged(State state) {
+        if (!disposing) {
+            if (lastKnownState == OnOffType.ON && state == OnOffType.OFF) {
+                if (++retryCount < baseConfig.retry) {
+                    // Ignore this change until we hit our maxRetries
+                    return;
+                }
+            }
+            if (lastKnownState != OnOffType.ON && state == OnOffType.ON) {
+                firstSeen = new DateTimeType();
+                updateState(CHANNEL_FIRST_SEEN, firstSeen);
+            }
+
+            lastKnownState = state;
+            updateState(CHANNEL_ONLINE, state);
+
+            if (state == OnOffType.ON) {
+                retryCount = 0;
+                lastSeen = new DateTimeType();
+                updateState(CHANNEL_LAST_SEEN, lastSeen);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceBindingConfiguration.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceBindingConfiguration.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.binding;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.presence.internal.dhcp.DHCPListener;
+import org.openhab.binding.presence.internal.utils.NetworkUtils;
+
+/**
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class PresenceBindingConfiguration {
+    public String arpPingToolPath = "arping";
+    public String pingToolPath = "ping";
+    public @NonNullByDefault({}) ArpPingUtilEnum arpPingUtilMethod;
+    public IpPingMethodEnum ipPingMethod = IpPingMethodEnum.JAVA_PING;
+    public boolean allowDHCPListen = true;
+
+    // This executor uses a cached thread pool that can grow as needed and does not server "Scheduled" tasks
+    public volatile ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public enum ArpPingUtilEnum {
+        UNKNOWN_TOOL,
+        IPUTILS_ARPING,
+        THOMAS_HABET_ARPING,
+        THOMAS_HABET_ARPING_WITHOUT_TIMEOUT,
+        ELI_FULKERSON_ARP_PING_FOR_WINDOWS
+    }
+
+    public enum IpPingMethodEnum {
+        JAVA_PING,
+        WINDOWS_PING,
+        IPUTILS_LINUX_PING,
+        MAC_OS_PING
+    }
+
+    AtomicInteger c = new AtomicInteger(0);
+
+    public void update(PresenceBindingConfiguration newConfig) {
+        this.arpPingToolPath = newConfig.arpPingToolPath;
+        this.pingToolPath = newConfig.pingToolPath;
+        this.allowDHCPListen = newConfig.allowDHCPListen;
+        if (!allowDHCPListen) {
+            DHCPListener.shutdown();
+        }
+
+        this.arpPingUtilMethod = NetworkUtils.determineNativeARPpingMethod(arpPingToolPath);
+        this.ipPingMethod = NetworkUtils.determinePingMethod(pingToolPath);
+
+        executor.shutdown();
+        executor = Executors.newCachedThreadPool((r) -> {
+            return new Thread(r, "PresenceBindingWorker-" + c.addAndGet(1));
+        });
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceBindingConstants.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceBindingConstants.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.binding;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link PresenceBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class PresenceBindingConstants {
+
+    private static final String BINDING_ID = "presence";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_PINGDEVICE = new ThingTypeUID(BINDING_ID, "pingdevice");
+    public static final ThingTypeUID THING_TYPE_TCPPORTDEVICE = new ThingTypeUID(BINDING_ID, "tcpportdevice");
+    public static final ThingTypeUID THING_TYPE_SMTPDEVICE = new ThingTypeUID(BINDING_ID, "smtpdevice");
+
+    // List of all Channel ids
+    public static final String CHANNEL_ONLINE = "online";
+    public static final String CHANNEL_LAST_SEEN = "lastseen";
+    public static final String CHANNEL_FIRST_SEEN = "firstseen";
+
+    // Parameters of Things
+    public static final String PARAMETER_HOSTNAME = "hostname";
+    public static final String PARAMETER_RETRY = "retry";
+    public static final String PARAMETER_TIMEOUT = "timeout";
+    public static final String PARAMETER_REFRESH_INTERVAL = "refreshInterval";
+
+    // Properties of things
+    public static final String PROPERTY_PREFERRED_INTERFACE = "preferred_interface";
+    public static final String PROPERTY_PREFERRED_METHOD = "preferred_method";
+    public static final String PROPERTY_ARP_STATE = "arp_state";
+    public static final String PROPERTY_ICMP_STATE = "icmp_state";
+    public static final String PROPERTY_DHCP_STATE = "dhcp_state";
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceHandlerFactory.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/binding/PresenceHandlerFactory.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.binding;
+
+import static org.openhab.binding.presence.internal.binding.PresenceBindingConstants.*;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.openhab.binding.presence.internal.ping.PingHandler;
+import org.openhab.binding.presence.internal.smtp.SMTPHandler;
+import org.openhab.binding.presence.internal.tcpport.TCPPortHandler;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * The {@link PresenceHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.presence", service = ThingHandlerFactory.class)
+public class PresenceHandlerFactory extends BaseThingHandlerFactory {
+    final PresenceBindingConfiguration configuration = new PresenceBindingConfiguration();
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .of(THING_TYPE_PINGDEVICE, THING_TYPE_TCPPORTDEVICE, THING_TYPE_SMTPDEVICE).collect(Collectors.toSet());
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_PINGDEVICE.equals(thingTypeUID)) {
+            return new PingHandler(thing, configuration);
+        } else if (THING_TYPE_TCPPORTDEVICE.equals(thingTypeUID)) {
+            return new TCPPortHandler(thing, configuration);
+        } else if (THING_TYPE_SMTPDEVICE.equals(thingTypeUID)) {
+            return new SMTPHandler(thing, configuration);
+        }
+
+        return null;
+    }
+
+    // The activate component call is used to access the bindings configuration
+    @Activate
+    protected void activate(ComponentContext componentContext, Map<String, Object> config) {
+        super.activate(componentContext);
+        modified(config);
+    }
+
+    @Override
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) {
+        super.deactivate(componentContext);
+    }
+
+    @Modified
+    protected void modified(Map<String, Object> config) {
+        // We update instead of replace the configuration object, so that if the user updates the
+        // configuration, the values are automatically available in all handlers. Because they all
+        // share the same instance.
+        configuration.update(new Configuration(config).as(PresenceBindingConfiguration.class));
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/dhcp/DHCPListener.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/dhcp/DHCPListener.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.dhcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class encapsulates a DHCP packet listener. It will listen for packets from devices requesting
+ * an IPv4 address. If it's sees an IP address being delivered, it will callback the registered Ping
+ * client that is listening for the IP address so that Ping handler can update its state to online.
+ *
+ * @author mdabbs - Initial contribution with help from Network binding
+ */
+@NonNullByDefault
+public class DHCPListener extends Thread {
+
+    private static final Logger logger = LoggerFactory.getLogger(DHCPListener.class);
+
+    static public volatile @Nullable DHCPListener instance;
+    static public volatile int port;
+    static Map<String, Callback> listeners = new HashMap<>();
+
+    public static interface Callback {
+        void dhcpReceived();
+    }
+
+    private static interface ServiceCallback {
+        void dhcpReceived(String ipAddress);
+    }
+
+    /*
+     * This is the callback from the listening thread when a valid IP address is found.
+     * It searches the list of registered listeners for the IP address and notifies
+     * the listener if found
+     */
+    @SuppressWarnings("null")
+    private static ServiceCallback serviceCallback = (ipAddress -> {
+        synchronized (listeners) {
+            Callback listener = listeners.get(ipAddress);
+            if (listener != null) {
+                listener.dhcpReceived();
+            }
+        }
+    });
+
+    /*
+     * This method is used to register a ping device listener. If this is the first listener
+     * it starts the DHCP listening thread.
+     */
+    public static synchronized void register(String hostname, Callback callback) {
+        if (instance == null) {
+            try {
+                instance = new DHCPListener();
+                instance.start();
+            } catch (SocketException e) {
+                logger.warn("Failed to start listening for DHCP traffic", e);
+            }
+        }
+
+        synchronized (listeners) {
+            listeners.put(hostname, callback);
+        }
+    }
+
+    /*
+     * This method will shutdown the DHCP listening thread. This is only called when the Binding configuration
+     * changes and allowDHCPListening is disabled.
+     */
+    public static synchronized void shutdown() {
+        if (instance != null) {
+            instance.interrupt();
+        }
+    }
+
+    /*
+     * This method is called when a ping device is going away or changing parameters. It removes them
+     * from the list of listeners. If the list is subsequently empty, then DHCP listening thread is shutdown.
+     */
+    public static void unregister(String hostname) {
+        synchronized (listeners) {
+            listeners.remove(hostname);
+            if (listeners.isEmpty() && instance != null) {
+                instance.interrupt();
+            }
+        }
+    }
+
+    private DatagramSocket socket;
+
+    @SuppressWarnings("null")
+    @Override
+    public void interrupt() {
+        super.interrupt();
+        logger.trace("DHCP Listener is shutting down");
+        socket.close();
+        try {
+            instance.join();
+            logger.debug("DHCP Listener has shut down");
+        } catch (InterruptedException e) {
+            logger.error("DHCP Listener was interrupted while shutting down", e);
+        }
+        instance = null;
+    }
+
+    public DHCPListener() throws SocketException {
+        try {
+            socket = new DatagramSocket(null);
+            socket.setReuseAddress(true);
+            socket.setBroadcast(true);
+            socket.bind(new InetSocketAddress(67));
+            port = 67;
+            logger.info("Listening on port 67");
+        } catch (SocketException e) {
+            socket = new DatagramSocket(null);
+            socket.setReuseAddress(true);
+            socket.setBroadcast(true);
+            socket.bind(new InetSocketAddress(6776));
+            port = 6776;
+            logger.info("Listening on port 6776");
+        }
+        this.setName("PresenceDHCPListener");
+    }
+
+    @Override
+    public void run() {
+        final byte[] buffer = new byte[1526];
+        DatagramPacket p = new DatagramPacket(buffer, buffer.length);
+        while (true) {
+            try {
+                socket.receive(p);
+                logger.debug("Received a packet on DHCPListener port, length {}", p.getLength());
+                processPacket(p);
+            } catch (IOException e) {
+                logger.trace("DHCP Listener detected shutdown request");
+                break;
+            }
+        }
+    }
+
+    // Magic cookie
+    private static final int MAGIC_COOKIE = 0x63825363;
+    private static final byte BOOTREQUEST = 1;
+    private static final byte DHCP_REQUESTED_ADDRESS = 50;
+    private static final byte DHCP_MESSAGE_TYPE = 53;
+    private static final byte PAD = 0;
+    private static final byte END = -1;
+
+    /** DHCP MESSAGE CODES **/
+    private static final byte DHCPREQUEST = 3;
+
+    private void doCallback(boolean gotType, @Nullable InetAddress address) {
+        if (gotType && address != null) {
+            try {
+                DHCPListener.serviceCallback.dhcpReceived(address.getHostAddress());
+            } catch (Exception e) {
+            }
+            return;
+        }
+    }
+
+    private void processPacket(DatagramPacket p) {
+        ByteArrayInputStream is = new ByteArrayInputStream(p.getData());
+        DataInputStream in = new DataInputStream(is);
+
+        try {
+            byte op = in.readByte();
+            if (op != BOOTREQUEST) {
+                return;
+            }
+            in.skip(235);
+
+            // check for DHCP MAGIC_COOKIE
+            if (in.readInt() != MAGIC_COOKIE) {
+                logger.debug("Magic cookie mismatch");
+                return;
+            }
+
+            boolean gotType = false;
+            InetAddress address = null;
+
+            // int cc = 50;
+            // while (cc > 0) {
+            int b, l, cc = 50;
+            do {
+                b = in.read();
+                if (b == DHCP_MESSAGE_TYPE) {
+                    if ((l = in.read()) != 1) {
+                        logger.debug("Invalid length for DHCP Message Type option");
+                        return;
+                    }
+                    if ((l = in.read()) != DHCPREQUEST) {
+                        return;
+                    }
+                    gotType = true;
+                    doCallback(gotType, address);
+                } else if (b == DHCP_REQUESTED_ADDRESS) {
+                    if ((l = in.read()) != 4) {
+                        logger.debug("Invalid length for DHCP Requested Address option");
+                        return;
+                    }
+                    byte[] addr = new byte[4];
+                    if (in.read(addr) != 4) {
+                        logger.debug("Truncated IP address");
+                        return;
+                    }
+                    address = InetAddress.getByAddress(addr);
+                    doCallback(gotType, address);
+                } else if (b > 0 && b != PAD) {
+                    if ((l = in.read()) > 0) {
+                        if (in.skip(l) != l) {
+                            logger.debug("Truncated/invalid packet");
+                            return;
+                        }
+                    }
+                }
+            } while (b > 0 && b != END && --cc > 0);
+            // }
+        } catch (IOException e) {
+        }
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/ping/PingConfiguration.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/ping/PingConfiguration.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.ping;
+
+import org.openhab.binding.presence.internal.BaseConfiguration;
+
+/**
+ * The {@link PingConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+public class PingConfiguration extends BaseConfiguration {
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/ping/PingHandler.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/ping/PingHandler.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.ping;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.presence.internal.BaseHandler;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConstants;
+import org.openhab.binding.presence.internal.dhcp.DHCPListener;
+import org.openhab.binding.presence.internal.utils.NetworkUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PingHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class PingHandler extends BaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PingHandler.class);
+
+    private @NonNullByDefault({}) PingConfiguration config;
+
+    private @NonNullByDefault({}) String dottedAddress;
+
+    /*
+     * Don't do too much here other than some basic static initialization. Things get reused when their config changes
+     */
+    public PingHandler(Thing thing, PresenceBindingConfiguration bindingConfiguration) {
+        super(thing, 2, bindingConfiguration);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(PingConfiguration.class);
+        logger.debug("Start initializing {}", config.hostname);
+
+        // Look up and cache our IP address
+        try {
+            InetAddress addr = InetAddress.getByName(config.hostname);
+            dottedAddress = addr.getHostAddress();
+        } catch (UnknownHostException e) {
+            logger.error("Invalid hostname: {} (Won't resolve to an InetAddress)", config.hostname);
+        }
+
+        super.initialize();
+
+        logger.debug("Updating status to online");
+        updateStatus(ThingStatus.ONLINE);
+
+        // If allowDHCPListen is true, register with the listener
+        if (bindingConfiguration.allowDHCPListen) {
+            DHCPListener.register(dottedAddress, () -> {
+                logger.debug("Got a DHCP packet for {}", config.hostname);
+                updateStateIfChanged(OnOffType.ON);
+            });
+        }
+
+        logger.debug("Finished initializing");
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+
+        // Unregister with DHCP listener. Its ok to call if it was not enabled
+        DHCPListener.unregister(dottedAddress);
+    }
+
+    /*
+     * This method creates a CompletableFuture that only collects the output of a process.
+     * It is mostly used for debugging but the output of the process is also stored in one of
+     * the properties of the Thing so the user can see it if desired.
+     */
+    private CompletableFuture<String> getOutputCollectingFuture(Process p, String name) {
+
+        StringBuffer arPingOutout = new StringBuffer(
+                System.lineSeparator() + name + " output:" + System.lineSeparator());
+        return CompletableFuture.supplyAsync(() -> p).thenApplyAsync(process -> {
+            try (BufferedReader br1 = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                String line;
+                while ((line = br1.readLine()) != null) {
+                    line = line.replaceAll("Timeout\\s*", "");
+                    arPingOutout.append(line).append(System.lineSeparator());
+                }
+            } catch (IOException e1) {
+            }
+            return arPingOutout.toString();
+        }, bindingConfiguration.executor);
+    }
+
+    /*
+     * This is the main process for detecting the presence of a device via ping. It launches multiple
+     * background Process objects, then waits for them all to complete, and finally reduces the results
+     * down to a single ON/OFF status. The output of the processes are stored in the properties of the Thing
+     * so the user can troubleshoot. If the underlying Future that this method is running under is
+     * cancelled, then we will get an InterruptedException. If this occurs, we can forcibly destroy all
+     * of the Processes we launched and clean up nicely. This only happens when the Thing is being disposed of.
+     */
+    @Override
+    protected void getStatus() {
+        try {
+            logger.debug("starting detection process for {}", config.hostname);
+
+            Map<String, Process> processes = new HashMap<>();
+
+            Map<String, String> properties = editProperties();
+
+            String preferredMethod = properties.get(PresenceBindingConstants.PROPERTY_PREFERRED_METHOD);
+
+            // If we have no preferred method , or it is ping, then start a ping process
+            if ("ping".equals(preferredMethod) || preferredMethod.length() == 0) {
+                processes.put("ping", NetworkUtils.getPingProcess(bindingConfiguration.ipPingMethod,
+                        bindingConfiguration.pingToolPath, config.hostname, (int) config.timeout));
+            }
+
+            // If we have no preferred method , or it is arping, then start arping processes
+            if ("arping".equals(preferredMethod) || preferredMethod.length() == 0) {
+                List<String> ifcs;
+                // If we have a preferred interface, then just use that
+                String preferredInterfaces = properties.get(PresenceBindingConstants.PROPERTY_PREFERRED_INTERFACE);
+                if (preferredInterfaces.length() == 0) {
+                    ifcs = NetworkUtils.getInterfaceNames();
+                } else {
+                    ifcs = Arrays.asList(preferredInterfaces.split(","));
+                }
+
+                for (String ifc : ifcs) {
+                    processes.put("arping-" + ifc, NetworkUtils.getArpProcess(bindingConfiguration.arpPingUtilMethod,
+                            bindingConfiguration.arpPingToolPath, ifc, config.hostname, (int) config.timeout));
+                }
+            }
+
+            Future<Boolean> javaPingFuture = null;
+            try {
+                logger.debug("waiting for detection of {}", config.hostname);
+
+                // Send the bonjour packet to the address
+                NetworkUtils.wakeUpIOS(config.hostname);
+
+                // Create an outputCollectingFuture for each process so we capture the output
+                Map<String, CompletableFuture<String>> m = processes.entrySet().stream().collect(
+                        Collectors.toMap(e -> e.getKey(), e -> getOutputCollectingFuture(e.getValue(), e.getKey())));
+
+                // Create a java ping future if have no preferred method
+                if (preferredMethod.length() == 0) {
+                    try {
+                        javaPingFuture = bindingConfiguration.executor.submit(() -> {
+                            return NetworkUtils.performJavaPing(config.hostname, (int) config.timeout);
+                        });
+                    } catch (RejectedExecutionException e) {
+                        logger.debug("Unable to execute java ping process");
+                    }
+                }
+
+                // Wait for the processes to complete
+                for (Process p : processes.values()) {
+                    p.waitFor();
+                }
+
+                if (logger.isTraceEnabled()) {
+                    // log the output of each process
+                    m.entrySet().stream().forEach(e -> {
+                        try {
+                            logger.trace("{} {}", e.getKey(), e.getValue().get());
+                        } catch (InterruptedException | ExecutionException e1) {
+                        }
+                    });
+                }
+
+                Set<String> newIfcs = new HashSet<String>();
+                boolean f = javaPingFuture != null ? javaPingFuture.get() : false;
+
+                logger.trace("javaPingOutput (if started): {}", f);
+                logger.debug("detection complete for {}", config.hostname);
+
+                // Check all processes for a zero exit code and save the interface if found via arping
+                for (Entry<String, Process> e : processes.entrySet()) {
+                    int i = e.getValue().exitValue();
+                    if (!f && i == 0) {
+                        f = true;
+                    }
+                    if (i == 0 && !e.getKey().equals("ping")) {
+                        newIfcs.add(e.getKey().substring(e.getKey().indexOf('-') + 1));
+                    }
+                }
+
+                // Update our state
+                updateStateIfChanged(f ? OnOffType.ON : OnOffType.OFF);
+
+                // Update our properties
+                properties.put(PresenceBindingConstants.PROPERTY_PREFERRED_INTERFACE, String.join(",", newIfcs));
+
+                if (f) {
+                    if (newIfcs.size() > 0) {
+                        properties.put(PresenceBindingConstants.PROPERTY_PREFERRED_METHOD, "arping");
+                    } else {
+                        properties.put(PresenceBindingConstants.PROPERTY_PREFERRED_METHOD, "ping");
+                    }
+                }
+
+                properties.put(PresenceBindingConstants.PROPERTY_DHCP_STATE,
+                        DHCPListener.instance != null ? "listening on port " + DHCPListener.port : "disabled");
+
+                // Save the output of the processes
+                properties.put(PresenceBindingConstants.PROPERTY_ARP_STATE,
+                        m.entrySet().stream().filter(e -> e.getKey().startsWith("arping")).map(e -> {
+                            try {
+                                return e.getValue().get();
+                            } catch (InterruptedException | ExecutionException e1) {
+                                return "";
+                            }
+                        }).collect(Collectors.joining(System.lineSeparator())));
+                properties.put(PresenceBindingConstants.PROPERTY_ICMP_STATE,
+                        m.entrySet().stream().filter(e -> e.getKey().equalsIgnoreCase("ping")).findAny().map(e -> {
+                            try {
+                                return e.getValue().get();
+                            } catch (InterruptedException | ExecutionException e1) {
+                                return "";
+                            }
+                        }).orElse(""));
+
+                // Clear the "preferred" properties if we're not seen so we check all the things next time
+                if (!f) {
+                    properties.put(PresenceBindingConstants.PROPERTY_PREFERRED_INTERFACE, "");
+                    properties.put(PresenceBindingConstants.PROPERTY_PREFERRED_METHOD, "");
+                }
+                updateProperties(properties);
+
+            } catch (InterruptedException e) {
+                // If we get here, our over-arching Future was cancelled.
+                // We need to go UNDEFined and gracefully clean up all of our background Processes
+                logger.debug("waitFor was interrupted");
+                if (javaPingFuture != null) {
+                    javaPingFuture.cancel(true);
+                }
+                processes.values().forEach(p -> p.destroyForcibly());
+            }
+
+        } catch (Exception e1) {
+            // This is just a general exception catch in case something went wrong while creating a Process
+            // os limits and such
+            logger.debug("starting process threw excpetion: ", e1);
+            updateStateIfChanged(UnDefType.UNDEF);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/smtp/SMTPConfiguration.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/smtp/SMTPConfiguration.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.smtp;
+
+import org.openhab.binding.presence.internal.BaseConfiguration;
+
+/**
+ * The {@link SMTPConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+public class SMTPConfiguration extends BaseConfiguration {
+
+    // The network port to connect to
+    public int port;
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/smtp/SMTPHandler.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/smtp/SMTPHandler.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.smtp;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.presence.internal.BaseHandler;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SMTPHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class SMTPHandler extends BaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(SMTPHandler.class);
+
+    private @NonNullByDefault({}) SMTPConfiguration config;
+
+    public SMTPHandler(Thing thing, PresenceBindingConfiguration bindingConfiguration) {
+        super(thing, 1, bindingConfiguration);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Start initializing");
+        config = getConfigAs(SMTPConfiguration.class);
+
+        super.initialize();
+
+        updateStatus(ThingStatus.ONLINE);
+
+        logger.debug("Finished initializing");
+    }
+
+    private static final Pattern respPattern = Pattern.compile("^(\\d{3}) .*");
+
+    /*
+     * This is the main process for detecting the presence of the SMTP service. It uses an asynchronous socket
+     * to attempt to connect to, then read from the SMTP service. If a connection is made and
+     * a response containing a 200 response code is returned, then the service is considered ON.
+     *
+     * If the underlying Future that this method is running under is
+     * cancelled, then we will get an InterruptedException.
+     * This only happens when the Thing is being disposed of.
+     */
+    @Override
+    protected void getStatus() {
+        logger.debug("Starting SMTP detection process for {}", config.hostname);
+
+        try (AsynchronousSocketChannel client = AsynchronousSocketChannel.open()) {
+
+            // First try to connect
+            Future<Void> result = client.connect(new InetSocketAddress(config.hostname, config.port));
+
+            // Wait for connection
+            result.get(config.timeout, TimeUnit.MILLISECONDS);
+
+            // Now read the HELO message
+            ByteBuffer buffer = ByteBuffer.wrap(new byte[2048]);
+            Future<Integer> readval = client.read(buffer);
+            State newState = OnOffType.OFF;
+            if (readval.get(config.timeout, TimeUnit.MILLISECONDS) > 0) {
+                String resp = new String(buffer.array()).trim();
+                logger.debug("Received from server: {}", resp);
+                Matcher m = respPattern.matcher(resp);
+                if (m.matches()) {
+                    int rc = Integer.parseInt(m.group(1));
+                    if (rc >= 200 && rc < 300) {
+                        newState = OnOffType.ON;
+                    }
+                }
+            }
+            updateStateIfChanged(newState);
+        } catch (ExecutionException | IOException | TimeoutException e) {
+            if (!(e.getCause() instanceof NoRouteToHostException) && !(e.getCause() instanceof ConnectException)) {
+                logger.debug("SMTP connect threw an exception", e);
+            }
+            updateStateIfChanged(OnOffType.OFF);
+        } catch (InterruptedException e) {
+            // If we get here, our over-arching Future was cancelled.
+            // We need to go UNDEFined but there's nothing to clean up. The async socket will get closed
+            logger.debug("connect interrupted");
+        }
+        logger.debug("SMTP detection process completed {}", config.hostname);
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/tcpport/TCPPortConfiguration.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/tcpport/TCPPortConfiguration.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.tcpport;
+
+import org.openhab.binding.presence.internal.BaseConfiguration;
+
+/**
+ * The {@link TCPPortConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+public class TCPPortConfiguration extends BaseConfiguration {
+    // The port to try to connect to
+    public int port;
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/tcpport/TCPPortHandler.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/tcpport/TCPPortHandler.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.tcpport;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.openhab.binding.presence.internal.BaseHandler;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link TCPPortHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class TCPPortHandler extends BaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(TCPPortHandler.class);
+
+    private @NonNullByDefault({}) TCPPortConfiguration config;
+
+    public TCPPortHandler(Thing thing, PresenceBindingConfiguration bindingConfiguration) {
+        super(thing, 2, bindingConfiguration);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Start initializing");
+        config = getConfigAs(TCPPortConfiguration.class);
+
+        super.initialize();
+
+        updateStatus(ThingStatus.ONLINE);
+
+        logger.debug("Finished initializing");
+    }
+
+    /*
+     * This is the main process for detecting the presence of a service on a port.
+     * It uses an asynchronous socket to attempt to connect to the specified port. If a connection is made
+     * then the service is considered ON.
+     *
+     * If the underlying Future that this method is running under is
+     * cancelled, then we will get an InterruptedException.
+     * This only happens when the Thing is being disposed of.
+     */
+    @Override
+    protected void getStatus() {
+        logger.debug("starting TCP port detection process for {}", config.hostname);
+
+        try (AsynchronousSocketChannel client = AsynchronousSocketChannel.open()) {
+
+            // Try to connect
+            Future<Void> result = client.connect(new InetSocketAddress(config.hostname, config.port));
+
+            // Wait for response
+            result.get(config.timeout, TimeUnit.MILLISECONDS);
+            updateStateIfChanged(OnOffType.ON);
+        } catch (ExecutionException | IOException | TimeoutException e) {
+            if (!(e.getCause() instanceof NoRouteToHostException) && !(e.getCause() instanceof ConnectException)) {
+                logger.debug("connect threw an exception", e);
+            }
+            updateStateIfChanged(OnOffType.OFF);
+        } catch (InterruptedException e) {
+            // If we get here, then our over-arching Future was cancelled and we are shutting down
+            logger.debug("connect interrupted");
+        }
+        logger.debug("TCP port detection process completed {}", config.hostname);
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.presence/src/main/java/org/openhab/binding/presence/internal/utils/NetworkUtils.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.presence.internal.utils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.PortUnreachableException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.io.net.exec.ExecUtil;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration.ArpPingUtilEnum;
+import org.openhab.binding.presence.internal.binding.PresenceBindingConfiguration.IpPingMethodEnum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Mike Dabbs - Initial contribution
+ */
+@NonNullByDefault
+public class NetworkUtils {
+    private static final Logger logger = LoggerFactory.getLogger(NetworkUtils.class);
+
+    /**
+     * Return true if the external arp ping utility (arping) is available and executable on the given path.
+     */
+    static public ArpPingUtilEnum determineNativeARPpingMethod(String arpToolPath) {
+        String result = ExecUtil.executeCommandLineAndWaitResponse(arpToolPath + " --help", 1000);
+        if (StringUtils.isBlank(result)) {
+            logger.trace("using unknown arping tool");
+            return ArpPingUtilEnum.UNKNOWN_TOOL;
+        } else if (result.contains("Thomas Habets")) {
+            if (result.matches("(?s)(.*)w sec Specify a timeout(.*)")) {
+                logger.trace("using thomas habet arping tool");
+                return ArpPingUtilEnum.THOMAS_HABET_ARPING;
+            } else {
+                logger.trace("using thomas habet arping without timeout tool");
+                return ArpPingUtilEnum.THOMAS_HABET_ARPING_WITHOUT_TIMEOUT;
+            }
+        } else if (result.contains("-w timeout")) {
+            logger.trace("using iptools tool");
+            return ArpPingUtilEnum.IPUTILS_ARPING;
+        } else if (result.contains("Usage: arp-ping.exe")) {
+            logger.trace("using eli fulkerson tool");
+            return ArpPingUtilEnum.ELI_FULKERSON_ARP_PING_FOR_WINDOWS;
+        }
+        logger.trace("using unknown tool: {}", result);
+        return ArpPingUtilEnum.UNKNOWN_TOOL;
+    }
+
+    /**
+     * Return the working method for the native system ping. If no native ping
+     * works JavaPing is returned.
+     */
+    static public IpPingMethodEnum determinePingMethod(String pingPath) {
+        IpPingMethodEnum method;
+        if (SystemUtils.IS_OS_WINDOWS) {
+            method = IpPingMethodEnum.WINDOWS_PING;
+        } else if (SystemUtils.IS_OS_MAC) {
+            method = IpPingMethodEnum.MAC_OS_PING;
+        } else if (SystemUtils.IS_OS_UNIX) {
+            method = IpPingMethodEnum.IPUTILS_LINUX_PING;
+        } else {
+            // We cannot estimate the command line for any other operating system and just return false
+            return IpPingMethodEnum.JAVA_PING;
+        }
+
+        try {
+            if (nativePing(method, pingPath, "127.0.0.1", 2000, false)) {
+                return method;
+            }
+        } catch (IOException ignored) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Reset interrupt flag
+        }
+        return IpPingMethodEnum.JAVA_PING;
+    }
+
+    /**
+     * Use the native ping utility of the operating system to detect device presence.
+     *
+     * @param hostname The DNS name, IPv4 or IPv6 address. Must not be null.
+     * @param timeoutInMS Timeout in milliseconds. Be aware that DNS resolution is not part of this timeout.
+     * @return Returns true if the device responded
+     * @throws IOException The ping command could probably not be found
+     */
+    static private boolean nativePing(@Nullable IpPingMethodEnum method, String pingPath, String hostname,
+            int timeoutInMS, boolean quiet) throws IOException, InterruptedException {
+        Process proc;
+        if (method == null) {
+            logger.trace("Unable to use system ping, ping method is null");
+            return false;
+        }
+        // Yes, all supported operating systems have their own ping utility with a different command line
+        switch (method) {
+            case IPUTILS_LINUX_PING:
+                proc = new ProcessBuilder(pingPath, "-w", String.valueOf(timeoutInMS / 1000), "-c", "1", hostname)
+                        .start();
+                break;
+            case MAC_OS_PING:
+                proc = new ProcessBuilder(pingPath, "-t", String.valueOf(timeoutInMS / 1000), "-c", "1", hostname)
+                        .start();
+                break;
+            case WINDOWS_PING:
+                proc = new ProcessBuilder(pingPath, "-w", String.valueOf(timeoutInMS), "-n", "1", hostname).start();
+                break;
+            case JAVA_PING:
+            default:
+                // We cannot estimate the command line for any other operating system and just return false
+                return false;
+        }
+
+        // The return code is 0 for a successful ping, 1 if device didn't
+        // respond, and 2 if there is another error like network interface
+        // not ready.
+        // Exception: return code is also 0 in Windows for all requests on the local subnet.
+        // see https://superuser.com/questions/403905/ping-from-windows-7-get-no-reply-but-sets-errorlevel-to-0
+        if (method != IpPingMethodEnum.WINDOWS_PING) {
+            // capture the output for debugging
+            BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+            BufferedReader ereader = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
+            StringBuilder builder = new StringBuilder();
+            StringBuilder ebuilder = new StringBuilder();
+            String line = null;
+            while (proc.isAlive()) {
+                Thread.yield();
+            }
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+                builder.append(System.getProperty("line.separator"));
+            }
+            String result = builder.toString();
+            while ((line = ereader.readLine()) != null) {
+                ebuilder.append(line);
+                ebuilder.append(System.getProperty("line.separator"));
+            }
+            String eresult = ebuilder.toString();
+
+            if (!quiet) {
+                logger.debug("ping output: {}", result);
+                if (eresult != null && eresult.trim().length() > 0) {
+                    logger.debug("ping error output: {}", eresult);
+                }
+            }
+
+            int rc = proc.waitFor();
+            if (rc != 0) {
+                logger.trace("system ping response was not zero: {}", rc);
+            } else {
+                logger.debug("system ping is usable");
+            }
+            return rc == 0;
+        }
+
+        int result = proc.waitFor();
+        if (result != 0) {
+            return false;
+        }
+
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+            String line = r.readLine();
+            if (line == null) {
+                throw new IOException("Received no output from ping process.");
+            }
+            do {
+                if (line.contains("TTL=")) {
+                    return true;
+                }
+                line = r.readLine();
+            } while (line != null);
+
+            return false;
+        }
+    }
+
+    /*
+     * This method returns a new Process that does nothing but fail. It is used to
+     * return a process when the system ping method is unavailable.
+     */
+    static private Process getNoopProcess() {
+        return new Process() {
+
+            @Override
+            public void destroy() {
+            }
+
+            @Override
+            public int exitValue() {
+                return 1;
+            }
+
+            @Override
+            public InputStream getErrorStream() {
+                return getInputStream();
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                // TODO Auto-generated method stub
+                return new ByteArrayInputStream("Noop process always fails".getBytes());
+            }
+
+            @Override
+            public OutputStream getOutputStream() {
+                return new ByteArrayOutputStream();
+            }
+
+            @Override
+            public int waitFor() throws InterruptedException {
+                return 1;
+            }
+        };
+    }
+
+    /**
+     * Use the native ping utility of the operating system to detect device presence.
+     *
+     * @param hostname The DNS name, IPv4 or IPv6 address. Must not be null.
+     * @param timeoutInMS Timeout in milliseconds. Be aware that DNS resolution is not part of this timeout.
+     * @return Returns true if the device responded
+     * @throws IOException The ping command could probably not be found
+     */
+    static public Process getPingProcess(@Nullable IpPingMethodEnum method, String pingPath, String hostname,
+            int timeoutInMS) throws IOException {
+
+        Process proc;
+        if (method == null) {
+            logger.trace("Unable to use system ping, ping method is null");
+            return getNoopProcess();
+        }
+        // Yes, all supported operating systems have their own ping utility with a different command line
+        switch (method) {
+            case IPUTILS_LINUX_PING:
+                proc = new ProcessBuilder(pingPath, "-w", String.valueOf(timeoutInMS / 1000), "-c", "3", hostname)
+                        .redirectErrorStream(true).start();
+                break;
+            case MAC_OS_PING:
+                proc = new ProcessBuilder(pingPath, "-t", String.valueOf(timeoutInMS / 1000), "-c", "1", hostname)
+                        .redirectErrorStream(true).start();
+                break;
+            case WINDOWS_PING:
+                proc = new ProcessBuilder(pingPath, "-w", String.valueOf(timeoutInMS), "-n", "1", hostname)
+                        .redirectErrorStream(true).start();
+                break;
+            case JAVA_PING:
+            default:
+                // We cannot estimate the command line for any other operating system and just return a noop process
+                return getNoopProcess();
+        }
+        return proc;
+    }
+
+    /*
+     * Return a Process that executes the arping command
+     */
+    static public Process getArpProcess(@Nullable ArpPingUtilEnum arpingTool, @Nullable String arpUtilPath,
+            String interfaceName, String ipV4address, int timeoutInMS) throws IOException {
+        if (arpingTool == ArpPingUtilEnum.THOMAS_HABET_ARPING_WITHOUT_TIMEOUT) {
+            return new ProcessBuilder(arpUtilPath, "-c", "1", "-i", interfaceName, ipV4address)
+                    .redirectErrorStream(true).start();
+        } else if (arpingTool == ArpPingUtilEnum.THOMAS_HABET_ARPING) {
+            return new ProcessBuilder(arpUtilPath, "-W", "0.1", "-C", "1", "-c", String.valueOf(timeoutInMS / 100),
+                    "-w", String.valueOf(timeoutInMS / 1000), "-i", interfaceName, ipV4address)
+                            .redirectErrorStream(true).start();
+        } else if (arpingTool == ArpPingUtilEnum.ELI_FULKERSON_ARP_PING_FOR_WINDOWS) {
+            return new ProcessBuilder(arpUtilPath, "-w", String.valueOf(timeoutInMS), "-x", ipV4address)
+                    .redirectErrorStream(true).start();
+        } else {
+            return new ProcessBuilder(arpUtilPath, "-w", String.valueOf(timeoutInMS / 1000), "-f", "-c", "1", "-I",
+                    interfaceName, ipV4address).redirectErrorStream(true).start();
+        }
+    }
+
+    // Return a list of interface names
+    static public List<String> getInterfaceNames() {
+        Set<String> result = new HashSet<>();
+
+        try {
+            // For each interface ...
+            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
+                NetworkInterface networkInterface = en.nextElement();
+                if (!networkInterface.isLoopback()) {
+                    if (networkInterface.getInterfaceAddresses().size() > 0) {
+                        result.add(networkInterface.getName());
+                    }
+                    // if (networkInterface.getInetAddresses().hasMoreElements()) {
+                    // result.add(networkInterface.getName());
+                    // }
+                }
+            }
+        } catch (SocketException ignored) {
+            // If we are not allowed to enumerate, we return an empty result set.
+        }
+
+        return Arrays.asList(result.toArray(new String[0]));
+    }
+
+    /**
+     * Performs a java ping. It is not recommended to use this, as it will not work on windows
+     * systems reliably and will fall back from ICMP pings to
+     * the TCP echo service on port 7 which barely no device or server supports nowadays.
+     * (http://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html#isReachable%28int%29)
+     * This method is safe to use when wrapped within a Future that is cancellable.
+     */
+    static public boolean performJavaPing(String address, int timeoutInMS) {
+        try {
+            logger.trace("Perform java ping presence detection for {}", address);
+            InetAddress ip = InetAddress.getByName(address);
+            if (ip != null && ip.isReachable(timeoutInMS)) {
+                return true;
+            }
+        } catch (IOException e) {
+            logger.trace("Failed to execute a java ping for ip {}", address, e);
+        }
+        return false;
+    }
+
+    /*
+     * A help method to send a wakeup packet to an iOS device by hostname
+     */
+    static public void wakeUpIOS(String address) throws IOException {
+        try {
+            InetAddress ip = InetAddress.getByName(address);
+            wakeUpIOS(ip);
+        } catch (UnknownHostException e) {
+        }
+    }
+
+    /**
+     * iOS devices are in a deep sleep mode, where they only listen to UDP traffic on port 5353 (Bonjour service
+     * discovery). A packet on port 5353 will wake up the network stack to respond to ARP pings at least.
+     *
+     * @throws IOException
+     */
+    static public void wakeUpIOS(InetAddress address) throws IOException {
+        try (DatagramSocket s = new DatagramSocket()) {
+            byte[] buffer = new byte[0];
+            s.send(new DatagramPacket(buffer, buffer.length, address, 5353));
+        } catch (PortUnreachableException ignored) {
+            // We ignore the port unreachable error
+        }
+    }
+}

--- a/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="presence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Presence Binding</name>
+	<description>This is the binding for Presence.</description>
+	<author>Mike Dabbs</author>
+
+	<config-description>
+		<parameter name="allowDHCPListen" type="boolean">
+			<default>true</default>
+			<label>Listen for DHCP Requests</label>
+			<description>Usually a device requests an IP address in an IPv4 network with the help of DHCP as soon as it enters a network. If we listen to those
+			packets, we can detect a device presence even faster. You need elevated access rights (see readme) for this to work.</description>
+		</parameter>
+		<parameter name="arpPingToolPath" type="text">
+			<default>arping</default>
+			<label>ARP Ping Tool Path</label>
+			<description>If your arp ping tool is not called arping and cannot be found in the PATH environment, you can configure the absolute path / tool name here</description>
+		</parameter>
+		<parameter name="pingToolPath" type="text">
+			<default>ping</default>
+			<label>Ping Tool Path</label>
+			<description>If your ping tool is not called ping and cannot be found in the PATH environment, you can configure the absolute path / tool name here</description>
+		</parameter>
+	</config-description>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/i18n/presence_xx_XX.properties
+++ b/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/i18n/presence_xx_XX.properties
@@ -1,0 +1,17 @@
+# FIXME: please substitute the xx_XX with a proper locale, ie. de_DE
+# FIXME: please do not add the file to the repo if you add or change no content
+# binding
+binding.presence.name = <Your localized Binding name>
+binding.presence.description = <Your localized Binding description>
+
+# thing types
+thing-type.presence.sample.label = <Your localized Thing label>
+thing-type.presence.sample.description = <Your localized Thing description>
+
+# thing type config description
+thing-type.config.presence.sample.config1.label = <Your localized config parameter label>
+thing-type.config.presence.sample.config1.description = <Your localized config parameter description>
+
+# channel types
+channel-type.presence.sample-channel.label = <Your localized Channel label>
+channel-type.presence.sample-channel.description = <Your localized Channel description>

--- a/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.presence/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="presence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- PingDevice Thing Type -->
+	<thing-type id="pingdevice">
+		<label>Pingable Device</label>
+		<description>A device that is detectable by ping/arping</description>
+
+		<channels>
+			<channel id="online" typeId="onlineType" />
+			<channel id="lastseen" typeId="lastSeenType" />
+			<channel id="firstseen" typeId="firstSeenType" />
+		</channels>
+
+		<properties>
+			<property name="arp_state">-</property>
+			<property name="dhcp_state">-</property>
+			<property name="icmp_state">-</property>
+			<property name="preferred_method">-</property>
+			<property name="preferred_interface"></property>
+		</properties>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<label>Hostname</label>
+				<description>The hostname of the device being detected</description>
+			</parameter>
+
+			<parameter name="refreshInterval" type="integer">
+				<label>Refresh Interval</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur (in ms)</description>
+				<default>60000</default>
+			</parameter>
+
+			<parameter name="retry" type="integer">
+				<label>Retry</label>
+				<description>How many refresh interval cycles should a presence detection should take place, before the device is stated as offline</description>
+				<default>1</default>
+			</parameter>
+
+			<parameter name="refreshIntervalWhenGone" type="integer">
+				<label>Refresh Interval When Gone</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur when the device is currently not detected (in ms). Defaults to -1 which uses the normal Refresh Interval value</description>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="timeout" type="integer" unit="ms">
+				<label>Timeout</label>
+				<description>States how long to wait for a response (in ms), before if a device is stated as offline</description>
+				<default>5000</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<thing-type id="tcpportdevice">
+		<label>TCP Port Device</label>
+		<description>A device that is detectable by connecting to a TCP port</description>
+
+		<channels>
+			<channel id="online" typeId="onlineType" />
+			<channel id="lastseen" typeId="lastSeenType" />
+			<channel id="firstseen" typeId="firstSeenType" />
+		</channels>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<label>Hostname</label>
+				<description>The hostname of the device being detected</description>
+			</parameter>
+
+			<parameter name="port" type="integer" required="true">
+				<label>Port</label>
+				<description>The port on which the device can be detected</description>
+				<default>443</default>
+			</parameter>
+
+			<parameter name="refreshInterval" type="integer">
+				<label>Refresh Interval</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur (in ms)</description>
+				<default>60000</default>
+			</parameter>
+
+			<parameter name="retry" type="integer">
+				<label>Retry</label>
+				<description>How many refresh interval cycles should a presence detection should take place, before the device is stated as offline</description>
+				<default>1</default>
+			</parameter>
+
+			<parameter name="refreshIntervalWhenGone" type="integer">
+				<label>Refresh Interval When Gone</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur when the device is currently not detected (in ms). Defaults to -1 which uses the normal Refresh Interval value</description>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="timeout" type="integer" unit="ms">
+				<label>Timeout</label>
+				<description>States how long to wait for a response (in ms), before if a device is stated as offline</description>
+				<default>5000</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<thing-type id="smtpdevice">
+		<label>SMTP Device</label>
+		<description>A device that is detectable by connecting and receiving a HELO response</description>
+
+		<channels>
+			<channel id="online" typeId="onlineType" />
+			<channel id="lastseen" typeId="lastSeenType" />
+			<channel id="firstseen" typeId="firstSeenType" />
+		</channels>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<label>Hostname</label>
+				<description>The hostname of the device being detected</description>
+			</parameter>
+
+			<parameter name="port" type="integer" required="true">
+				<label>Port</label>
+				<description>The port on which the device can be detected</description>
+				<default>25</default>
+			</parameter>
+
+			<parameter name="refreshInterval" type="integer">
+				<label>Refresh Interval</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur (in ms)</description>
+				<default>60000</default>
+			</parameter>
+
+			<parameter name="retry" type="integer">
+				<label>Retry</label>
+				<description>How many refresh interval cycles should a presence detection should take place, before the device is stated as offline</description>
+				<default>1</default>
+			</parameter>
+
+			<parameter name="refreshIntervalWhenGone" type="integer">
+				<label>Refresh Interval When Gone</label>
+				<description>States how long to wait after a device state update before the next refresh shall occur when the device is currently not detected (in ms). Defaults to -1 which uses the normal Refresh Interval value</description>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+
+			<parameter name="timeout" type="integer" unit="ms">
+				<label>Timeout</label>
+				<description>States how long to wait for a response (in ms), before if a device is stated as offline</description>
+				<default>5000</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<!-- Sample Channel Type -->
+	<channel-type id="onlineType">
+		<item-type>Switch</item-type>
+		<label>Present</label>
+		<description>States whether the device is present on the network or not</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="lastSeenType">
+		<item-type>DateTime</item-type>
+		<label>Last Seen</label>
+		<description>States the last seen date/time of the device</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="firstSeenType">
+		<item-type>DateTime</item-type>
+		<label>First Seen</label>
+		<description>States the first seen date/time of the device after being away</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -173,6 +173,7 @@
     <module>org.openhab.binding.plclogo</module>
     <module>org.openhab.binding.plugwise</module>
     <module>org.openhab.binding.powermax</module>
+    <module>org.openhab.binding.presence</module>
     <module>org.openhab.binding.pulseaudio</module>
     <module>org.openhab.binding.pushbullet</module>
     <module>org.openhab.binding.regoheatpump</module>


### PR DESCRIPTION
New 'Presence' Binding geared more towards the detecting the presence of cell phones on a local network.

This new binding is geared more towards the detection of the presence of cell phones and other network devices. While it is similar to the Network binding, the Presence binding is more specific and has better detection methods that work better with cell phones than the Network binding. It is also more specific to just presence detection rather than generic network utilities.
