### PR TITLE
[nanoleaf] show bundle version in controller thing properties

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -65,6 +65,7 @@ Don't worry: the binding comes with some helpful support in the background (this
 - look out for something like "Panel layout and ids" in the logs. Below that you will see a panel layout similar to
 
 Compare the following output with the right picture at the beginning of the article
+
 ```                                     
             31413                    9162       13276     
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandler.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandler.java
@@ -12,20 +12,8 @@
  */
 package org.openhab.binding.nanoleaf.internal.handler;
 
-import static org.openhab.binding.nanoleaf.internal.NanoleafBindingConstants.*;
-
-import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -38,17 +26,8 @@ import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.HSBType;
-import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.PercentType;
-import org.eclipse.smarthome.core.library.types.StringType;
-import org.eclipse.smarthome.core.thing.Bridge;
-import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.thing.Thing;
-import org.eclipse.smarthome.core.thing.ThingStatus;
-import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.library.types.*;
+import org.eclipse.smarthome.core.thing.*;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -58,11 +37,20 @@ import org.openhab.binding.nanoleaf.internal.NanoleafUnauthorizedException;
 import org.openhab.binding.nanoleaf.internal.OpenAPIUtils;
 import org.openhab.binding.nanoleaf.internal.config.NanoleafControllerConfig;
 import org.openhab.binding.nanoleaf.internal.model.*;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.*;
+
+import static org.openhab.binding.nanoleaf.internal.NanoleafBindingConstants.*;
 
 /**
  * The {@link NanoleafControllerHandler} is responsible for handling commands to the controller which
@@ -615,6 +603,7 @@ public class NanoleafControllerHandler extends BaseBridgeHandler {
         Map<String, String> properties = editProperties();
         properties.put(Thing.PROPERTY_SERIAL_NUMBER, controllerInfo.getSerialNo());
         properties.put(Thing.PROPERTY_FIRMWARE_VERSION, controllerInfo.getFirmwareVersion());
+        properties.put("Bundle Version", FrameworkUtil.getBundle(getClass()).getVersion().toString());
         updateProperties(properties);
 
         Configuration config = editConfiguration();
@@ -626,6 +615,7 @@ public class NanoleafControllerHandler extends BaseBridgeHandler {
             config.put(NanoleafControllerConfig.DEVICE_TYPE, DEVICE_TYPE_LIGHTPANELS);
             logger.debug("Set to device type {}", DEVICE_TYPE_LIGHTPANELS);
         }
+
         updateConfiguration(config);
 
         getConfig().getProperties().forEach((key, value) -> {

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 
 	<name>@text/binding.nanoleaf.name</name>
 	<description>@text/binding.nanoleaf.description</description>
-	<author>Martin Raepple, (Stefan Höhn)</author>
+	<author>Martin Raepple, Stefan Höhn</author>
 
 </binding:binding>


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

This provides the possibility to show the used bundle version to the end user which in turn allows a much better support on finding issues.

(thx to 5iver and chris for the support of finding the best way of implementing that)