### PR TITLE
[infrastructure] exclude feature-templates from spotless formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,8 @@ Import-Package: \\
                 </excludes>
                 <excludes>
                   <exclude>**/feature.xml</exclude>
+                  <exclude>features/openhab-addons/src/main/resources/header.xml</exclude>
+                  <exclude>features/openhab-addons/src/main/resources/footer.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>


### PR DESCRIPTION
see #6874 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>

