### PR TITLE
[sunspec] Modbus: sunspec bundle auto discovery

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -37,6 +37,7 @@ public class SunSpecConstants {
     // Block types
     public static final int COMMON_BLOCK = 1;
     public static final int INVERTER_SINGLE_PHASE = 101;
+    public static final int FINAL_BLOCK = 0xffff;
 
     /**
      * Map of the supported thing type uids, with their block type id

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryParticipant.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.discovery;
+
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.SUPPORTED_THING_TYPES_UIDS;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.openhab.binding.modbus.discovery.ModbusDiscoveryListener;
+import org.openhab.binding.modbus.discovery.ModbusDiscoveryParticipant;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discovery service for sunspec
+ *
+ * @author Nagy Attila Gabor - initial contribution
+ *
+ */
+@Component(immediate = true)
+@NonNullByDefault
+public class SunspecDiscoveryParticipant implements ModbusDiscoveryParticipant {
+
+    private final Logger logger = LoggerFactory.getLogger(SunspecDiscoveryParticipant.class);
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return new HashSet<ThingTypeUID>(SUPPORTED_THING_TYPES_UIDS.values());
+    }
+
+    @Override
+    public void startDiscovery(ModbusEndpointThingHandler handler, ModbusDiscoveryListener listener) {
+        logger.trace("Starting sunspec discovery");
+        try {
+            new SunspecDiscoveryProcess(handler, listener).detectModel();
+        } catch (EndpointNotInitializedException ex) {
+            logger.debug("Could not start discovery process");
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryParticipant.java
@@ -51,6 +51,7 @@ public class SunspecDiscoveryParticipant implements ModbusDiscoveryParticipant {
             new SunspecDiscoveryProcess(handler, listener).detectModel();
         } catch (EndpointNotInitializedException ex) {
             logger.debug("Could not start discovery process");
+            listener.discoveryFinished();
         }
     }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
@@ -1,0 +1,425 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.discovery;
+
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.modbus.discovery.ModbusDiscoveryListener;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusEndpointThingHandler;
+import org.openhab.binding.modbus.sunspec.internal.dto.CommonModelBlock;
+import org.openhab.binding.modbus.sunspec.internal.dto.ModelBlock;
+import org.openhab.binding.modbus.sunspec.internal.parser.CommonModelParser;
+import org.openhab.io.transport.modbus.BasicModbusReadRequestBlueprint;
+import org.openhab.io.transport.modbus.BasicPollTaskImpl;
+import org.openhab.io.transport.modbus.BitArray;
+import org.openhab.io.transport.modbus.ModbusBitUtilities;
+import org.openhab.io.transport.modbus.ModbusConstants.ValueType;
+import org.openhab.io.transport.modbus.ModbusReadCallback;
+import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
+import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+import org.openhab.io.transport.modbus.ModbusSlaveErrorResponseException;
+import org.openhab.io.transport.modbus.PollTask;
+import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used by the SunspecDiscoveryParticipant to detect
+ * the model blocks defined by the given device.
+ * It scans trough the defined model items and notifies the
+ * discovery service about the discovered devices
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ */
+@NonNullByDefault
+public class SunspecDiscoveryProcess {
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(SunspecDiscoveryProcess.class);
+
+    /**
+     * The handler instance for this device
+     */
+    private final ModbusEndpointThingHandler handler;
+
+    /**
+     * The endpoint where we can reach the device
+     */
+    private final Optional<ModbusSlaveEndpoint> endpoint;
+
+    /**
+     * Listener for the discovered devices. We get this
+     * from the main discovery service, and it is used to
+     * submit any discovered Sunspec devices
+     */
+    private final ModbusDiscoveryListener listener;
+
+    /**
+     * The endpoint's slave id
+     */
+    private Integer slaveId;
+
+    /**
+     * Number of maximum retries
+     */
+    private Integer maxTries = 3;
+
+    /**
+     * List of start addresses to try
+     */
+    private List<Integer> possibleAddresses;
+
+    /**
+     * This is the base address where the next block should be searched for
+     */
+    private int baseAddress = 40000;
+
+    /**
+     * Count of valid Sunspec blocks found
+     */
+    private int blocksFound = 0;
+
+    /**
+     * Parser for commonblock
+     */
+    private final CommonModelParser commonBlockParser;
+
+    /**
+     * The last common block found. This is used
+     * to get the details of any found devices
+     */
+    private Optional<CommonModelBlock> lastCommonBlock = Optional.empty();
+
+    /**
+     * New instances of this class should get a reference to the handler
+     *
+     * @throws EndpointNotInitializedException
+     */
+    public SunspecDiscoveryProcess(ModbusEndpointThingHandler handler, ModbusDiscoveryListener listener)
+            throws EndpointNotInitializedException {
+        this.handler = handler;
+        ModbusSlaveEndpoint endpoint = this.handler.asSlaveEndpoint();
+        if (endpoint != null) {
+            this.endpoint = Optional.of(endpoint);
+        } else {
+            this.endpoint = Optional.empty();
+        }
+        slaveId = handler.getSlaveId();
+        this.listener = listener;
+        commonBlockParser = new CommonModelParser();
+        possibleAddresses = new CopyOnWriteArrayList<>();
+        // Preferred and alternate base registers
+        // @see SunSpec Information Model Overview
+        possibleAddresses.add(40000);
+        possibleAddresses.add(50000);
+        possibleAddresses.add(0);
+    }
+
+    /**
+     * Set the maximum number of retries for operations
+     *
+     * @param num the new value to set
+     * @return
+     */
+    public SunspecDiscoveryProcess setMaxTries(Integer num) {
+        this.maxTries = num;
+        return this;
+    }
+
+    /**
+     * Start model detection
+     *
+     * @param uid the thing type to look for
+     * @throws EndpointNotInitializedException
+     */
+    public void detectModel() throws EndpointNotInitializedException {
+
+        if (!this.endpoint.isPresent()) {
+            logger.debug("Endpoint is null, can not continue with discovery");
+            throw new EndpointNotInitializedException();
+        }
+
+        if (possibleAddresses.size() < 1) {
+            parsingFinished();
+            return;
+        }
+        // Try the next address from the possibles
+        baseAddress = possibleAddresses.get(0);
+        logger.trace("Beginning scan for SunSpec device at address {}", baseAddress);
+
+        BasicModbusReadRequestBlueprint request = new BasicModbusReadRequestBlueprint(slaveId,
+                ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, baseAddress, // Start address
+                SUNSPEC_ID_SIZE, // number or words to return
+                maxTries);
+
+        PollTask task = new BasicPollTaskImpl(endpoint.get(), request, new ModbusReadCallback() {
+
+            @Override
+            public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
+
+                headerReceived(registers);
+
+            }
+
+            @Override
+            public void onError(ModbusReadRequestBlueprint request, Exception error) {
+                handleError(error);
+            }
+
+            @Override
+            public void onBits(@Nullable ModbusReadRequestBlueprint request, @Nullable BitArray bits) {
+                // don't care, we don't expect this result
+            }
+        });
+
+        handler.getManagerRef().get().submitOneTimePoll(task);
+    }
+
+    /**
+     * We received the first two words, that should equal to SunS
+     */
+    private void headerReceived(ModbusRegisterArray registers) {
+        logger.trace("Received response from device {}", registers.toString());
+
+        Optional<DecimalType> id = ModbusBitUtilities.extractStateFromRegisters(registers, 0, ValueType.UINT32);
+
+        if (!id.isPresent() || id.get().longValue() != SUNSPEC_ID) {
+            logger.debug("Could not find SunSpec DID at address {}, received: {}, expected: {}", baseAddress, id,
+                    SUNSPEC_ID);
+            possibleAddresses.remove(0);
+            try {
+                detectModel();
+            } catch (EndpointNotInitializedException ex) {
+                // This should not happen
+                parsingFinished();
+            }
+            return;
+        }
+
+        logger.trace("Header looks correct");
+        baseAddress += SUNSPEC_ID_SIZE;
+
+        lookForModelBlock();
+    }
+
+    /**
+     * Look for a valid model block at the current base address
+     */
+    private void lookForModelBlock() {
+        BasicModbusReadRequestBlueprint request = new BasicModbusReadRequestBlueprint(slaveId,
+                ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, baseAddress, // Start address
+                MODEL_HEADER_SIZE, // number or words to return
+                maxTries);
+
+        PollTask task = new BasicPollTaskImpl(endpoint.get(), request, new ModbusReadCallback() {
+
+            @Override
+            public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
+
+                modelBlockReceived(registers);
+
+            }
+
+            @Override
+            public void onError(ModbusReadRequestBlueprint request, Exception error) {
+                handleError(error);
+            }
+
+            @Override
+            public void onBits(@Nullable ModbusReadRequestBlueprint request, @Nullable BitArray bits) {
+                // don't care, we don't expect this result
+            }
+        });
+
+        handler.getManagerRef().get().submitOneTimePoll(task);
+    }
+
+    /**
+     * We received a model block header
+     */
+    private void modelBlockReceived(ModbusRegisterArray registers) {
+        logger.debug("Received response from device {}", registers.toString());
+
+        Optional<DecimalType> moduleID = ModbusBitUtilities.extractStateFromRegisters(registers, 0, ValueType.UINT16);
+        Optional<DecimalType> blockLength = ModbusBitUtilities.extractStateFromRegisters(registers, 1,
+                ValueType.UINT16);
+
+        if (!moduleID.isPresent() || !blockLength.isPresent()) {
+            logger.info("Could not find valid module id or block length field.");
+            parsingFinished();
+            return;
+        }
+        ModelBlock block = new ModelBlock();
+        block.address = baseAddress;
+        block.moduleID = moduleID.get().intValue();
+        block.length = blockLength.get().intValue() + MODEL_HEADER_SIZE;
+        logger.debug("SunSpec detector found block {}", block);
+
+        blocksFound++;
+
+        if (block.moduleID == FINAL_BLOCK) {
+            parsingFinished();
+        } else {
+            baseAddress += block.length;
+            if (block.moduleID == COMMON_BLOCK) {
+                readCommonBlock(block); // This is an asynchronous task
+                return;
+            } else {
+                createDiscoveryResult(block);
+                lookForModelBlock();
+            }
+
+        }
+    }
+
+    /**
+     * Start reading common block
+     *
+     * @param block
+     */
+    private void readCommonBlock(ModelBlock block) {
+        BasicModbusReadRequestBlueprint request = new BasicModbusReadRequestBlueprint(slaveId,
+                ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, block.address, // Start address
+                block.length, // number or words to return
+                maxTries);
+
+        PollTask task = new BasicPollTaskImpl(endpoint.get(), request, new ModbusReadCallback() {
+
+            @Override
+            public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
+
+                parseCommonBlock(registers);
+
+            }
+
+            @Override
+            public void onError(ModbusReadRequestBlueprint request, Exception error) {
+                handleError(error);
+            }
+
+            @Override
+            public void onBits(@Nullable ModbusReadRequestBlueprint request, @Nullable BitArray bits) {
+                // don't care, we don't expect this result
+            }
+        });
+
+        handler.getManagerRef().get().submitOneTimePoll(task);
+    }
+
+    /**
+     * We've read the details of a common block now parse it, and
+     * store for later use
+     *
+     * @param registers
+     */
+    private void parseCommonBlock(ModbusRegisterArray registers) {
+        logger.trace("Got common block data: {}", registers);
+        lastCommonBlock = Optional.of(commonBlockParser.parse(registers));
+        lookForModelBlock(); // Continue parsing
+    }
+
+    /**
+     * Create a discovery result from a model block
+     *
+     * @param block the block we've found
+     */
+    private void createDiscoveryResult(ModelBlock block) {
+        if (!SUPPORTED_THING_TYPES_UIDS.containsKey(block.moduleID)) {
+            logger.debug("ModuleID {} is not supported, skipping this block", block.moduleID);
+            return;
+        }
+
+        if (!lastCommonBlock.isPresent()) {
+            logger.warn(
+                    "Found model block without a preceding common block. Can't add device because details are unkown");
+            return;
+        }
+
+        ThingUID thingUID = new ThingUID(SUPPORTED_THING_TYPES_UIDS.get(block.moduleID), handler.getUID(),
+                Integer.toString(block.address));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(PROPERTY_VENDOR, lastCommonBlock.get().manufacturer);
+        properties.put(PROPERTY_MODEL, lastCommonBlock.get().model);
+        properties.put(PROPERTY_SERIAL_NUMBER, lastCommonBlock.get().serialNumber);
+        properties.put(PROPERTY_VERSION, lastCommonBlock.get().version);
+        properties.put(PROPERTY_BLOCK_ADDRESS, block.address);
+        properties.put(PROPERTY_BLOCK_LENGTH, block.length);
+        properties.put(PROPERTY_UNIQUE_ADDRESS, handler.getUID().getAsString() + ":" + block.address);
+
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                .withRepresentationProperty(PROPERTY_UNIQUE_ADDRESS).withBridge(handler.getUID())
+                .withLabel(lastCommonBlock.get().manufacturer + " " + lastCommonBlock.get().model).build();
+
+        listener.thingDiscovered(result);
+    }
+
+    /**
+     * Parsing of model blocks finished
+     * Now we have to report back to the handler the common block and the block we were looking for
+     */
+    private void parsingFinished() {
+        listener.discoveryFinished();
+    }
+
+    /**
+     * Handle errors received during communication
+     */
+    private void handleError(Exception error) {
+        String msg = "";
+        String cls = "";
+
+        if (blocksFound > 1 && error instanceof ModbusSlaveErrorResponseException) {
+            int code = ((ModbusSlaveErrorResponseException) error).getExceptionCode();
+            if (code == ModbusSlaveErrorResponseException.ILLEGAL_DATA_ACCESS
+                    || code == ModbusSlaveErrorResponseException.ILLEGAL_DATA_VALUE) {
+                // It is very likely that the slave does not report an end block (0xffff) after the main blocks
+                // so we treat this situation as normal.
+                logger.debug(
+                        "Seems like slave device does not report an end block. Continouing with the dectected blocks");
+                parsingFinished();
+                return;
+            }
+        }
+
+        cls = error.getClass().getName();
+        msg = error.getMessage();
+
+        logger.warn("Error with read at address {}: {} {}", baseAddress, cls, msg);
+
+        possibleAddresses.remove(0); // Drop the current base address, and continue with the next one
+        try {
+            detectModel();
+        } catch (EndpointNotInitializedException ex) {
+            // This should not happen, but if it does then give up the discovery
+            parsingFinished();
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
@@ -83,12 +83,12 @@ public class SunspecDiscoveryProcess {
     /**
      * The endpoint's slave id
      */
-    private Integer slaveId;
+    private int slaveId;
 
     /**
      * Number of maximum retries
      */
-    private Integer maxTries = 3;
+    private static final int maxTries = 3;
 
     /**
      * List of start addresses to try
@@ -142,17 +142,6 @@ public class SunspecDiscoveryProcess {
     }
 
     /**
-     * Set the maximum number of retries for operations
-     *
-     * @param num the new value to set
-     * @return
-     */
-    public SunspecDiscoveryProcess setMaxTries(Integer num) {
-        this.maxTries = num;
-        return this;
-    }
-
-    /**
      * Start model detection
      *
      * @param uid the thing type to look for
@@ -182,9 +171,7 @@ public class SunspecDiscoveryProcess {
 
             @Override
             public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
-
                 headerReceived(registers);
-
             }
 
             @Override
@@ -241,9 +228,7 @@ public class SunspecDiscoveryProcess {
 
             @Override
             public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
-
                 modelBlockReceived(registers);
-
             }
 
             @Override
@@ -313,9 +298,7 @@ public class SunspecDiscoveryProcess {
 
             @Override
             public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
-
                 parseCommonBlock(registers);
-
             }
 
             @Override

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/CommonModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/CommonModelBlock.java
@@ -26,17 +26,17 @@ public class CommonModelBlock {
     /**
      * Value = 0x0001. Uniquely identifies this as a SunSpec Common Model Block
      */
-    public Integer sunSpecDID = 0x0001;
+    public int sunSpecDID = 0x0001;
 
     /**
      * Length of block in 16-bit registers
      */
-    public Integer length = 0;
+    public int length = 0;
 
     /**
      * Modbus unit ID - this is a unique identifier of the device
      */
-    public Integer deviceAddress = 0;
+    public int deviceAddress = 0;
 
     // Manufacturer specific values
     public String manufacturer = "";

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/CommonModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/CommonModelBlock.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This class contains information parsed from the Common Model block
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class CommonModelBlock {
+
+    /**
+     * Value = 0x0001. Uniquely identifies this as a SunSpec Common Model Block
+     */
+    public Integer sunSpecDID = 0x0001;
+
+    /**
+     * Length of block in 16-bit registers
+     */
+    public Integer length = 0;
+
+    /**
+     * Modbus unit ID - this is a unique identifier of the device
+     */
+    public Integer deviceAddress = 0;
+
+    // Manufacturer specific values
+    public String manufacturer = "";
+    public String model = "";
+    public String version = "";
+    public String serialNumber = "";
+
+}

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -153,16 +153,17 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         }
 
         // Try properties first
-        Optional<ModelBlock> mainBlock = getAddressFromProperties();
+        @Nullable
+        ModelBlock mainBlock = getAddressFromProperties();
 
-        if (!mainBlock.isPresent()) {
+        if (mainBlock == null) {
             mainBlock = getAddressFromConfig();
         }
 
-        if (mainBlock.isPresent()) {
-            publishUniqueAddress(mainBlock.get());
+        if (mainBlock != null) {
+            publishUniqueAddress(mainBlock);
             updateStatus(ThingStatus.UNKNOWN);
-            registerPollTask(mainBlock.get());
+            registerPollTask(mainBlock);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "SunSpec item should either have the address and length configuration set or should been created by auto discovery");
@@ -174,35 +175,35 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * Load and parse configuration from the properties
      * These will be set by the auto discovery process
      */
-    private Optional<ModelBlock> getAddressFromProperties() {
+    private @Nullable ModelBlock getAddressFromProperties() {
         Map<String, String> properties = thing.getProperties();
         if (!properties.containsKey(PROPERTY_BLOCK_ADDRESS) || !properties.containsKey(PROPERTY_BLOCK_LENGTH)) {
-            return Optional.empty();
+            return null;
         }
         try {
             ModelBlock block = new ModelBlock();
             block.address = (int) Double.parseDouble(thing.getProperties().get(PROPERTY_BLOCK_ADDRESS));
             block.length = (int) Double.parseDouble(thing.getProperties().get(PROPERTY_BLOCK_LENGTH));
-            return Optional.of(block);
+            return block;
         } catch (NumberFormatException ex) {
             logger.debug("Could not parse address and length properties, error: {}", ex.getMessage());
-            return Optional.empty();
+            return null;
         }
     }
 
     /**
      * Load configuration from main configuration
      */
-    private Optional<ModelBlock> getAddressFromConfig() {
+    private @Nullable ModelBlock getAddressFromConfig() {
         @Nullable
         SunSpecConfiguration myconfig = config;
         if (myconfig == null) {
-            return Optional.empty();
+            return null;
         }
         ModelBlock block = new ModelBlock();
         block.address = myconfig.address;
         block.length = myconfig.length;
-        return Optional.of(block);
+        return block;
     }
 
     /**

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -182,8 +182,8 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
         }
         try {
             ModelBlock block = new ModelBlock();
-            block.address = (int) Double.parseDouble(thing.getProperties().get(PROPERTY_BLOCK_ADDRESS));
-            block.length = (int) Double.parseDouble(thing.getProperties().get(PROPERTY_BLOCK_LENGTH));
+            block.address = Integer.parseInt(thing.getProperties().get(PROPERTY_BLOCK_ADDRESS));
+            block.length = Integer.parseInt(thing.getProperties().get(PROPERTY_BLOCK_LENGTH));
             return block;
         } catch (NumberFormatException ex) {
             logger.debug("Could not parse address and length properties, error: {}", ex.getMessage());

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/CommonModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/CommonModelParser.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.modbus.sunspec.internal.parser;
+
+import java.nio.charset.Charset;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.modbus.sunspec.internal.SunSpecConstants;
+import org.openhab.binding.modbus.sunspec.internal.dto.CommonModelBlock;
+import org.openhab.io.transport.modbus.ModbusBitUtilities;
+import org.openhab.io.transport.modbus.ModbusRegisterArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parser for the Common Message block
+ *
+ * @author Nagy Attila Gabor - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class CommonModelParser extends AbstractBaseParser implements SunspecParser<CommonModelBlock> {
+
+    /**
+     * Logger instance
+     */
+    private final Logger logger = LoggerFactory.getLogger(CommonModelParser.class);
+
+    @Override
+    public CommonModelBlock parse(ModbusRegisterArray raw) {
+
+        CommonModelBlock block = new CommonModelBlock();
+
+        block.sunSpecDID = extractUInt16(raw, 0, 0);
+
+        block.length = extractUInt16(raw, 1, raw.size() - SunSpecConstants.MODEL_HEADER_SIZE);
+
+        if (block.length + SunSpecConstants.MODEL_HEADER_SIZE != raw.size()) {
+            logger.warn("Short read on common block loding. Expected size: {}, got: {}",
+                    block.length + SunSpecConstants.MODEL_HEADER_SIZE, raw.size());
+            return block;
+        }
+
+        // parse manufacturer, model and version
+        block.manufacturer = ModbusBitUtilities.extractStringFromRegisters(raw, 2, 32, Charset.forName("UTF-8"))
+                .toString();
+        block.model = ModbusBitUtilities.extractStringFromRegisters(raw, 18, 32, Charset.forName("UTF-8")).toString();
+        block.version = ModbusBitUtilities.extractStringFromRegisters(raw, 42, 16, Charset.forName("UTF-8")).toString();
+        block.serialNumber = ModbusBitUtilities.extractStringFromRegisters(raw, 50, 32, Charset.forName("UTF-8"))
+                .toString();
+
+        block.deviceAddress = extractUInt16(raw, 66, 1);
+
+        return block;
+
+    }
+
+}


### PR DESCRIPTION
This pull request is the follow up of PR #6331 and adds the auto discovery feature to that.

Until PR #6331 is not merged this contains commits from that PR as well, so when reviewing please check the last commit only.

SunSpec splits the data of the devices into blocks that have a type and a length. So what the auto discovery does is that it will iterate over all these blocks and add the supported types as new things.

I didn't add more device types yet to keep the commit clean as much as possible