### PR TITLE
[innogysmarthome][doc] update documentation for manually configured Bridge

### DIFF
--- a/bundles/org.openhab.binding.innogysmarthome/README.md
+++ b/bundles/org.openhab.binding.innogysmarthome/README.md
@@ -144,16 +144,10 @@ As an alternative to the automatic discovery process and graphical configuration
 The innogy SmartHome Controller (SHC) can be configured using the following syntax:
 
 ```
-Bridge innogysmarthome:bridge:<bridge-id> [ refreshtoken="<refresh-token>" ]
+Bridge innogysmarthome:bridge:<bridge-id> []
 ```
 
-The easiest way is to retrieve the refresh-token using the Paper UI as described above.
-But you can do it manually by:
-
-1. Changing the log level to TRACE, as the refresh-token is not written into the logs in lower log levels*
-2. Retrieving the auth-code (see description above)
-3. Saving it once in the Bridge configuration like shown below
-4. Fishing the refresh-code from the openhab.log file.
+Then the required authcode is retrieved and set **automatically**:
 
 ```
 Bridge innogysmarthome:bridge:<bridge-id> [ authcode="<authcode>" ]


### PR DESCRIPTION
### [innogysmarthome][doc] Update Documentation for manually configured Bridge

Using the new API of innogy the authentication of bridges has been changed. The according section at https://www.openhab.org/addons/bindings/innogysmarthome/#manual-configuration is outdated.

See also https://community.openhab.org/t/innogysmarthome-where-to-find-refresh-token/90347/4

Signed-off-by: Stephan Strittmatter <stephan@st-strittmatter.name>