### PR TITLE
[chromecast] bring jackson version in  line with ohc

### DIFF
--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <dep.noembedding>jackson-core,jackson-annotations,jackson-databind</dep.noembedding>
+    <jackson.version>2.9.10</jackson.version>
   </properties>
 
   <dependencies>
@@ -32,19 +33,19 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.9</version>
+      <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.9</version>
+      <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
supersedes #6387 

fixes security issues

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>