### PR TITLE
[exec] Fix missing break in switch

### DIFF
--- a/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/handler/ExecHandler.java
+++ b/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/handler/ExecHandler.java
@@ -208,6 +208,7 @@ public class ExecHandler extends BaseThingHandler {
                             shell = SHELL_NIX;
                             logger.debug("OS: *NIX ({})", getOperatingSystemName());
                             cmdArray = createCmdArray(shell, "-c", commandLine);
+                            break;
 
                         default:
                             logger.debug("OS: Unknown ({})", getOperatingSystemName());


### PR DESCRIPTION
This fixes a problem discussed in [this community thread](https://community.openhab.org/t/exec-binding-os-not-supported-please-manually-split-commands/93053).

The issue is that a defect was introduced in PR #6819 because a switch block does not contain a `break` where it ought. This causes the valid OS clause to fall through to the invalid OS clause.

Signed-off-by: 9037568 <namraccr@gmail.com>
