### PR TITLE
[shelly] Fix NPE on discovery and add RSSI - channel

### DIFF
--- a/bundles/org.openhab.binding.shelly/README.md
+++ b/bundles/org.openhab.binding.shelly/README.md
@@ -94,6 +94,7 @@ Every device has a channel group `device` with the following channels:
 |----------|-------------|---------|---------|---------------------------------------------------------------------------------|
 |device    |uptime       |Number   |yes      |Number of seconds since the device was powered up                                |
 |          |wifiSignal   |Number   |yes      |WiFi signal strength (4=excellent, 3=good, 2=not string, 1=unreliable, 0=none)   |
+|          |rssi         |Number   |yes      |WiFi received signal strength indicator                                          |
 |          |alarm        |Trigger  |yes      |Most recent alarm for health check                                               |
 
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyBindingConstants.java
@@ -222,6 +222,7 @@ public class ShellyBindingConstants {
     public static final String CHANNEL_GROUP_DEV_STATUS = "device";
     public static final String CHANNEL_DEVST_UPTIME = "uptime";
     public static final String CHANNEL_DEVST_RSSI = "wifiSignal";
+    public static final String CHANNEL_DEVST_RSSI_RAW = "rssi";
     public static final String CHANNEL_DEVST_ALARM = "alarm";
 
     // General

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyUtils.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/ShellyUtils.java
@@ -72,7 +72,6 @@ public class ShellyUtils {
     }
 
     // as State
-
     public static StringType getStringType(@Nullable String value) {
         return new StringType(value != null ? value : "");
     }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -420,6 +420,7 @@ public class ShellyBaseHandler extends BaseThingHandler implements ShellyDeviceL
         updateChannel(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_UPTIME,
                 toQuantityType(new DecimalType(uptime), SmartHomeUnits.SECOND));
         updateChannel(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_RSSI, mapSignalStrength(rssi));
+        updateChannel(CHANNEL_GROUP_DEV_STATUS, CHANNEL_DEVST_RSSI_RAW, new DecimalType(rssi));
 
         if ((api != null) && (lastTimeoutErros != api.getTimeoutErrors())) {
             propertyUpdates.put(PROPERTY_STATS_TIMEOUTS, new Integer(api.getTimeoutErrors()).toString());

--- a/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/channels.xml
@@ -325,8 +325,13 @@
 		<item-type>Number:Time</item-type>
 		<label>Uptime</label>
 		<description>Number of seconds since the device was powered up</description>
-		<state readOnly="true" pattern="%d %unit%">
-		</state>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
+	<channel-type id="rssi" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>RSSI</label>
+		<description>Received signal strength indicator</description>
+		<state readOnly="true" pattern="%d dBm"/>
 	</channel-type>
 	<channel-type id="lastUpdate" advanced="true">
 		<item-type>DateTime</item-type>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/device.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/device.xml
@@ -10,6 +10,7 @@
 		<channels>
 			<channel id="uptime" typeId="uptime" />
 			<channel id="wifiSignal" typeId="system.signal-strength" />
+			<channel id="rssi" typeId="rssi" />
 			<channel id="alarm" typeId="alarmTrigger" />
 		</channels>
 	</channel-group-type>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/unknown.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/ESH-INF/thing/unknown.xml
@@ -24,7 +24,5 @@
 				<context>network-address</context>
 			</parameter>
 		</config-description>
-
 	</thing-type>
-
 </thing:thing-descriptions>


### PR DESCRIPTION
Hello everybody,

this PR fixes NPE i got during discovery after upgrade to openHAB 2.5.2. Additionally, I've added
a channel to read "raw" rssi values provided by shelly devices.

Signed-off-by: Alexander Falkenstern <alexander.falkenstern@gmail.com>
