### PR TITLE
[exec] fix loggers for whitelist-service

### DIFF
--- a/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecWhitelistWatchService.java
+++ b/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecWhitelistWatchService.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.service.AbstractWatchService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +42,8 @@ import static java.nio.file.StandardWatchEventKinds.*;
 public class ExecWhitelistWatchService extends AbstractWatchService {
     private static final String COMMAND_WHITELIST_PATH = ConfigConstants.getConfigFolder() + File.separator + "misc";
     private static final String COMMAND_WHITELIST_FILE = "exec.whitelist";
+
+    private final Logger logger = LoggerFactory.getLogger(ExecWhitelistWatchService.class);
     private final Set<String> commandWhitelist = new HashSet<>();
 
     @Activate

--- a/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationWhitelistWatchService.java
+++ b/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationWhitelistWatchService.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.service.AbstractWatchService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +42,8 @@ import static java.nio.file.StandardWatchEventKinds.*;
 public class ExecTransformationWhitelistWatchService extends AbstractWatchService {
     private static final String COMMAND_WHITELIST_PATH = ConfigConstants.getConfigFolder() + File.separator + "misc";
     private static final String COMMAND_WHITELIST_FILE = "exec.whitelist";
+
+    private final Logger logger = LoggerFactory.getLogger(ExecTransformationWhitelistWatchService.class);
     private final Set<String> commandWhitelist = new HashSet<>();
 
     @Activate


### PR DESCRIPTION
Use own class loggers instead of super-class loggers

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
