### PR TITLE
[bluetooth] Introduced manufacturer data to BluetoothDevice

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -279,6 +279,7 @@ public class BlueGigaBluetoothDevice extends BluetoothDevice implements BlueGiga
             }
 
             if (manufacturerData != null) {
+                setManufacturerData(manufacturerData);
                 scanNotification.setManufacturerData(manufacturerData);
             }
 

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -130,6 +130,7 @@ public class BlueZBluetoothDevice extends BluetoothDevice {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Received manufacturer data for '{}': {}", address, HexUtils.bytesToHex(data, " "));
                 }
+                setManufacturerData(data);
                 notification.setManufacturerData(data);
                 notifyListeners(BluetoothEventType.SCAN_RECORD, notification);
             }

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -96,6 +96,11 @@ public abstract class BluetoothDevice {
     protected Integer manufacturer = null;
 
     /**
+     * The manufacturer specific data
+     */
+    protected byte[] manufacturerData = null;
+
+    /**
      * Device name.
      * <p>
      * Uses the devices long name if known, otherwise the short name if known
@@ -176,6 +181,24 @@ public abstract class BluetoothDevice {
      */
     public Integer getManufacturerId() {
         return manufacturer;
+    }
+
+    /**
+     * Sets the manufacturer data for the device
+     *
+     * @param manufacturerData the manufacturer data
+     */
+    public void setManufacturerData(byte[] manufacturerData) {
+        this.manufacturerData = manufacturerData.clone();
+    }
+
+    /**
+     * Returns the manufacturer data of the device
+     *
+     * @return an byte array with manufacturer data of the device, or null if not known
+     */
+    public byte[] getManufacturerData() {
+        return (manufacturerData == null) ? null : manufacturerData.clone();
     }
 
     /**
@@ -491,7 +514,7 @@ public abstract class BluetoothDevice {
 
     /**
      * Checks if this device has any listeners
-     * 
+     *
      * @return true if this device has listeners
      */
     public boolean hasListeners() {


### PR DESCRIPTION
Discovery participants can access manufacturer data from scan result if necessary.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
