### PR TITLE
[weathercompany] Increase decimal precision for PWS Observations

### DIFF
--- a/bundles/org.openhab.binding.weathercompany/README.md
+++ b/bundles/org.openhab.binding.weathercompany/README.md
@@ -173,11 +173,11 @@ Number:Length WC_PWS_PrecipitationTotal "Precipitation Total [%.1f %unit%]" <rai
 Number:Intensity WC_PWS_SolarRadiation "Solar Radiation [%.1f %unit%]" <sun> { channel="weathercompany:weather-observations:observations:currentSolarRadiation" }
 Number WC_PWS_UV "UV Index [%.0f]" <sun> { channel="weathercompany:weather-observations:observations:currentUv" }
 Number:Angle WC_PWS_WindDirection "Wind Direction [%.0f %unit%]" <wind> { channel="weathercompany:weather-observations:observations:currentWindDirection" }
-Number:Speed WC_PWS_WindSpeed "Wind Speed [%.0f %unit%]" <wind> { channel="weathercompany:weather-observations:observations:currentWindSpeed" }
-Number:Speed WC_PWS_WindSpeedGust "Wind Speed Gust [%.0f %unit%]" <wind> { channel="weathercompany:weather-observations:observations:currentWindSpeedGust" }
+Number:Speed WC_PWS_WindSpeed "Wind Speed [%.1f %unit%]" <wind> { channel="weathercompany:weather-observations:observations:currentWindSpeed" }
+Number:Speed WC_PWS_WindSpeedGust "Wind Speed Gust [%.1f %unit%]" <wind> { channel="weathercompany:weather-observations:observations:currentWindSpeedGust" }
 String WC_PWS_Country "Country [%s]" <none> { channel="weathercompany:weather-observations:observations:country" }
 Location WC_PWS_Location "Lat/Lon [%2$s°N, %3$s°W]" <none> { channel="weathercompany:weather-observations:observations:location" }
-Number:Length WC_PWS_Elevation "Elevation [%.0f %unit%]" <none> { channel="weathercompany:weather-observations:observations:elevation" }
+Number:Length WC_PWS_Elevation "Elevation [%.1f %unit%]" <none> { channel="weathercompany:weather-observations:observations:elevation" }
 String WC_PWS_Neighborhood "Neighborhood [%s]" <none> { channel="weathercompany:weather-observations:observations:neighborhood" }
 DateTime WC_PWS_ObservationTimeLocal "Observation Time [%1$tA, %1$tm/%1$td/%1$tY %1$tl:%1$tM %1$tp]" <time> { channel="weathercompany:weather-observations:observations:observationTimeLocal" }
 Number WC_PWS_QcStatus "QC Status [%.0f %unit%]" <none> { channel="weathercompany:weather-observations:observations:qcStatus" }

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyForecastHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyForecastHandler.java
@@ -43,8 +43,8 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.weathercompany.internal.config.WeatherCompanyForecastConfig;
-import org.openhab.binding.weathercompany.internal.model.DayPart;
-import org.openhab.binding.weathercompany.internal.model.Forecast;
+import org.openhab.binding.weathercompany.internal.model.DayPartDTO;
+import org.openhab.binding.weathercompany.internal.model.ForecastDTO;
 import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -207,7 +207,7 @@ public class WeatherCompanyForecastHandler extends WeatherCompanyAbstractHandler
         }
         try {
             logger.trace("Handler: Parsing forecast response: {}", response);
-            Forecast forecast = gson.fromJson(response, Forecast.class);
+            ForecastDTO forecast = gson.fromJson(response, ForecastDTO.class);
             logger.debug("Handler: Successfully parsed daily forecast response object");
             updateStatus(ThingStatus.ONLINE);
             updateDailyForecast(forecast);
@@ -219,7 +219,7 @@ public class WeatherCompanyForecastHandler extends WeatherCompanyAbstractHandler
         }
     }
 
-    private void updateDailyForecast(Forecast forecast) {
+    private void updateDailyForecast(ForecastDTO forecast) {
         for (int day = 0; day < forecast.dayOfWeek.length; day++) {
             logger.debug("Processing daily forecast for '{}'", forecast.dayOfWeek[day]);
             updateDaily(day, CH_DAY_OF_WEEK, undefOrString(forecast.dayOfWeek[day]));
@@ -234,11 +234,11 @@ public class WeatherCompanyForecastHandler extends WeatherCompanyAbstractHandler
     }
 
     private void updateDaypartForecast(Object daypartObject) {
-        DayPart[] dayparts;
+        DayPartDTO[] dayparts;
         try {
             String innerJson = gson.toJson(daypartObject);
             logger.debug("Parsing daypartsObject: {}", innerJson);
-            dayparts = gson.fromJson(innerJson.toString(), DayPart[].class);
+            dayparts = gson.fromJson(innerJson.toString(), DayPartDTO[].class);
             logger.debug("Handler: Successfully parsed daypart forecast object");
         } catch (JsonSyntaxException e) {
             logger.debug("Handler: Error parsing daypart forecast object: {}", e.getMessage(), e);
@@ -253,7 +253,7 @@ public class WeatherCompanyForecastHandler extends WeatherCompanyAbstractHandler
         logger.debug("There are {} daypartName entries in this forecast", dayparts[0].daypartName.length);
         for (int i = 0; i < dayparts[0].daypartName.length; i++) {
             // Note: All dayparts[0] (i.e. today day) values are null after 3 pm local time
-            DayPart dp = dayparts[0];
+            DayPartDTO dp = dayparts[0];
             // Even daypart indexes are Day (D); odd daypart indexes are Night (N)
             String dOrN = dp.dayOrNight[i] == null ? (i % 2 == 0 ? "D" : "N") : dp.dayOrNight[i];
             logger.debug("Processing daypart forecast for '{}'", dp.daypartName[i]);

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyObservationsHandler.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/handler/WeatherCompanyObservationsHandler.java
@@ -34,8 +34,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.weathercompany.internal.config.WeatherCompanyObservationsConfig;
-import org.openhab.binding.weathercompany.internal.model.PwsObservations;
-import org.openhab.binding.weathercompany.internal.model.PwsObservations.Observations;
+import org.openhab.binding.weathercompany.internal.model.PwsObservationsDTO;
+import org.openhab.binding.weathercompany.internal.model.PwsObservationsDTO.Observations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,6 +110,8 @@ public class WeatherCompanyObservationsHandler extends WeatherCompanyAbstractHan
         StringBuilder sb = new StringBuilder(BASE_PWS_URL);
         // Set to use Imperial units. UoM will convert to the other units
         sb.append("?units=e");
+        // Get temperatures with one decimal point precision
+        sb.append("&numericPrecision=decimal");
         // Set response type as JSON
         sb.append("&format=json");
         // Set PWS station Id from config
@@ -134,7 +136,7 @@ public class WeatherCompanyObservationsHandler extends WeatherCompanyAbstractHan
         }
         try {
             logger.debug("Handler: Parsing PWS observations response: {}", response);
-            PwsObservations pwsObservations = gson.fromJson(response, PwsObservations.class);
+            PwsObservationsDTO pwsObservations = gson.fromJson(response, PwsObservationsDTO.class);
             logger.debug("Handler: Successfully parsed PWS observations response object");
             updateStatus(ThingStatus.ONLINE);
             updatePwsObservations(pwsObservations);
@@ -145,7 +147,7 @@ public class WeatherCompanyObservationsHandler extends WeatherCompanyAbstractHan
         }
     }
 
-    private void updatePwsObservations(PwsObservations pwsObservations) {
+    private void updatePwsObservations(PwsObservationsDTO pwsObservations) {
         if (pwsObservations.observations.length == 0) {
             logger.debug("Handler: PWS observation object contains no observations!");
             return;

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/DayPartDTO.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/DayPartDTO.java
@@ -13,14 +13,14 @@
 package org.openhab.binding.weathercompany.internal.model;
 
 /**
- * The {@link DayPart} is the JSON object that contains the n-day forecast.
+ * The {@link DayPartDTO} is the JSON object that contains the n-day forecast.
  *
  * The daypart object as well as the temperatureMax field will
  * appear as null in the API after 3:00 pm Local Apparent Time.
  *
  * @author Mark Hilbush - Initial contribution
  */
-public class DayPart {
+public class DayPartDTO {
     /*
      * The name of a 12 hour daypart not including day names in the
      * first 48 hours (Today, Tonight)

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/ForecastDTO.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/ForecastDTO.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.weathercompany.internal.model;
 
 /**
- * The {@link Forecast} is the JSON object that contains the n-day forecast.
+ * The {@link ForecastDTO} is the JSON object that contains the n-day forecast.
  *
  * The daypart object as well as the temperatureMax field OUTSIDE of the daypart object will
  * appear as null in the API after 3:00pm Local Apparent Time.
@@ -36,7 +36,7 @@ package org.openhab.binding.weathercompany.internal.model;
  *
  * @author Mark Hilbush - Initial contribution
  */
-public class Forecast {
+public class ForecastDTO {
     /*
      * Day of week
      */

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/PwsObservationsDTO.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/model/PwsObservationsDTO.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.weathercompany.internal.model;
 
 /**
- * The {@link PwsObservations} contains the most recent weather condition
+ * The {@link PwsObservationsDTO} contains the most recent weather condition
  * observations from the Personl Weather Station (PWS).
  *
  * @author Mark Hilbush - Initial contribution
  */
-public class PwsObservations {
+public class PwsObservationsDTO {
     /*
      * An array of length 1 of observations that represent the
      * most recent PWS observations
@@ -123,7 +123,7 @@ public class PwsObservations {
         /*
          * Elevation of the PWS in feet
          */
-        public Integer elev;
+        public Double elev;
 
         /*
          * An apparent temperature. It represents what the air
@@ -162,13 +162,13 @@ public class PwsObservations {
         /*
          * Sudden and temporary variations of the average Wind Speed.
          */
-        public Integer windGust;
+        public Double windGust;
 
         /*
          * The wind is treated as a vector; hence, winds must have direction and magnitude (speed).
          * The wind information reported in the hourly current conditions corresponds to
          * a 10-minute average called the sustained wind speed
          */
-        public Integer windSpeed;
+        public Double windSpeed;
     }
 }

--- a/bundles/org.openhab.binding.weathercompany/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.weathercompany/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -20,7 +20,7 @@
 			<channel id="neighborhood" typeId="neighborhood" />
 			<channel id="observationTimeLocal" typeId="observationTimeLocal" />
 			<channel id="currentTemperature" typeId="temperature">
-				<label>Current Temperature</label>
+				<label>Temperature</label>
 			</channel>
 			<channel id="currentTemperatureDewPoint" typeId="temperature">
 				<label>Dew Point Temperature</label>
@@ -32,31 +32,31 @@
 				<label>Wind Chill Temperature</label>
 			</channel>
 			<channel id="currentHumidity" typeId="relativeHumidity">
-				<label>Current Humidity</label>
+				<label>Humidity</label>
 			</channel>
 			<channel id="currentPressure" typeId="pressure">
-				<label>Current Pressure</label>
+				<label>Pressure</label>
 			</channel>
 			<channel id="currentPrecipitationRate" typeId="precipitationRate">
-				<label>Current Precipitation Rate</label>
+				<label>Precipitation Rate</label>
 			</channel>
 			<channel id="currentPrecipitationTotal" typeId="precipitationTotal">
-				<label>Current Precipitation Total</label>
+				<label>Precipitation Total</label>
 			</channel>
 			<channel id="currentSolarRadiation" typeId="solarRadiation">
-				<label>Current Solar Radiation</label>
+				<label>Solar Radiation</label>
 			</channel>
 			<channel id="currentUv" typeId="uvIndex">
-				<label>Current UV Index</label>
+				<label>UV Index</label>
 			</channel>
 			<channel id="currentWindDirection" typeId="windDirection">
-				<label>Current Wind Direction</label>
+				<label>Wind Direction</label>
 			</channel>
 			<channel id="currentWindSpeed" typeId="windSpeed">
-				<label>Current Wind Speed</label>
+				<label>Wind Speed</label>
 			</channel>
 			<channel id="currentWindSpeedGust" typeId="windSpeed">
-				<label>Current Wind Gust Speed</label>
+				<label>Wind Gust Speed</label>
 			</channel>
 			<channel id="stationId" typeId="stationId" />
 			<channel id="country" typeId="country" />
@@ -428,7 +428,7 @@
 		<label>Temperature</label>
 		<description>Forecasted temperature</description>
 		<category>Temperature</category>
-		<state readOnly="true" pattern="%.0f %unit%" />
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="thunderCategory" advanced="true">
@@ -491,7 +491,7 @@
 		<item-type>Number:Speed</item-type>
 		<label>Wind Speed</label>
 		<description>Wind speed</description>
-		<state readOnly="true" pattern="%.0f %unit%" />
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="wxPhraseLong">


### PR DESCRIPTION
Increase decimal precision for PWS Observations by requesting the observations using the new "numericPrecision" query parameter. This has been a much requested feature from the Weather Company service provider, and is especially useful for those who use Celsius.

Also rename model classes to eliminate @Null warnings.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
