### PR TITLE
[tradfri] correct sitemap example

### DIFF
--- a/bundles/org.openhab.binding.tradfri/README.md
+++ b/bundles/org.openhab.binding.tradfri/README.md
@@ -118,7 +118,7 @@ sitemap demo label="Main Menu"
         Text item=RemoteControlBatteryLevel label="Battery Level [%d %%]"
         Switch item=RemoteControlBatteryLow label="Battery Low Warning"
         Switch item=ControlOutlet label="Power Switch"
-        Rollershutter item=BlindPosition label="Blind Position"
+        Switch item=BlindPosition label="Blind Position [%d]"
     }
 }
 ```


### PR DESCRIPTION
bugfix: sitemap does not seem to support "Rollershutter" element types (at least not for me, gives me an error "mismatched input"), suggesting to replace it with "Switch" and displaying the position value
