### PR TITLE
[icloud] Fix NPE in AccountBridgeHandler

### DIFF
--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudDeviceInformationParser.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudDeviceInformationParser.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.icloud.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.icloud.internal.json.response.ICloudAccountDataResponse;
 
 import com.google.gson.Gson;
@@ -29,7 +30,7 @@ import com.google.gson.JsonSyntaxException;
 public class ICloudDeviceInformationParser {
     private final Gson gson = new GsonBuilder().create();
 
-    public ICloudAccountDataResponse parse(String json) throws JsonSyntaxException {
+    public @Nullable ICloudAccountDataResponse parse(String json) throws JsonSyntaxException {
         return gson.fromJson(json, ICloudAccountDataResponse.class);
     }
 }

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/handler/ICloudAccountBridgeHandler.java
@@ -65,7 +65,7 @@ public class ICloudAccountBridgeHandler extends BaseBridgeHandler {
     @Nullable
     ServiceRegistration<?> service;
 
-    private Object synchronizeRefresh = new Object();
+    private final Object synchronizeRefresh = new Object();
 
     private List<ICloudDeviceInformationListener> deviceInformationListeners = Collections
             .synchronizedList(new ArrayList<ICloudDeviceInformationListener>());
@@ -167,6 +167,9 @@ public class ICloudAccountBridgeHandler extends BaseBridgeHandler {
 
             try {
                 ICloudAccountDataResponse iCloudData = deviceInformationParser.parse(json);
+                if(iCloudData == null) {
+                    return;
+                }
                 int statusCode = Integer.parseUnsignedInt(iCloudData.getICloudAccountStatusCode());
                 if (statusCode == 200) {
                     updateStatus(ThingStatus.ONLINE);


### PR DESCRIPTION
Hope this makes sense.
I got this NPE few days ago:

```
2020-02-29 22:10:53.325 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
java.lang.NullPointerException: null
	at org.openhab.binding.icloud.internal.handler.ICloudAccountBridgeHandler.refreshData(ICloudAccountBridgeHandler.java:170) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_222]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_222]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_222]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_222]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_222]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_222]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_222]
```

So I think only `iCloudData` can be `null` here.
This and every non-catch Exceptions interrupts the refreshData thread, meaning that the binding won't refresh the data automatically. 
Or should we somehow restart the threads again when something causes it to interrupt?
