### PR TITLE
[mcp23017] Don't treat the ActiveLow setting as if it's required

### DIFF
--- a/bundles/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/handler/Mcp23017Handler.java
+++ b/bundles/org.openhab.binding.mcp23017/src/main/java/org/openhab/binding/mcp23017/internal/handler/Mcp23017Handler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.mcp23017.internal.handler;
 import static org.openhab.binding.mcp23017.internal.Mcp23017BindingConstants.*;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -113,7 +114,8 @@ public class Mcp23017Handler extends BaseThingHandler implements GpioPinListener
             Configuration configuration = this.getThing().getChannel(channelUID.getId()).getConfiguration();
 
             // invertLogic is null if not configured
-            boolean activeLowFlag = ACTIVE_LOW_ENABLED.equalsIgnoreCase(configuration.get(ACTIVE_LOW).toString());
+            String activeLowStr = Objects.toString(configuration.get(ACTIVE_LOW), null);
+            boolean activeLowFlag = ACTIVE_LOW_ENABLED.equalsIgnoreCase(activeLowStr);
             PinState pinState = command == OnOffType.ON ^ activeLowFlag ? PinState.HIGH : PinState.LOW;
             logger.debug("got output pin {} for channel {} and command {} [active_low={}, new_state={}]", outputPin,
                     channelUID, command, activeLowFlag, pinState);


### PR DESCRIPTION
The ActiveLow configuration setting is optional, but is being treated as if it's required.
This can cause a NullPointerException when the setting is not defined.

Fixes #6111 

Signed-off-by: 9037568 <namraccr@gmail.com>
