### PR TITLE
[valloxmv] additional channels support

### DIFF
--- a/bundles/org.openhab.binding.valloxmv/.classpath
+++ b/bundles/org.openhab.binding.valloxmv/.classpath
@@ -28,5 +28,22 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.valloxmv/README.md
+++ b/bundles/org.openhab.binding.valloxmv/README.md
@@ -53,17 +53,17 @@ Overview of provided channels
 | awayairtemptarget         | A_CYC_AWAY_AIR_TEMP_TARGET  | Target temperature in away state  |rw| Number (°C)          |
 | boostairtemptarget        | A_CYC_BOOST_AIR_TEMP_TARGET | Target temperature in boost state |rw| Number (°C)          |
 | boosttime                 | A_CYC_BOOST_TIME            | Timer value in boost profile      |rw| 1 - 65535 (min)      |
-| boosttimerenabled         | A_CYC_BOOST_TIMER_ENABLED   | Timer enabled setting in boost profile |rw| 1=Enabled, 0=Disabled |
+| boosttimerenabled         | A_CYC_BOOST_TIMER_ENABLED   | Timer enabled setting in boost profile |rw| On/Off               |
 | fireplaceextrfan          | A_CYC_FIREPLACE_EXTR_FAN    | Fireplace profile extract fan speed |rw| 0 - 100 (%)          |
 | fireplacesuppfan          | A_CYC_FIREPLACE_SUPP_FAN    | Fireplace profile supply fan speed |rw| 0 - 100 (%)          |
 | fireplacetime             | A_CYC_FIREPLACE_TIME        | Timer value in fireplace profile  |rw| 1 - 65535 (min)      |
-| fireplacetimerenabled     | A_CYC_FIREPLACE_TIMER_ENABLED | Timer enabled setting in fireplace profile |rw| 1=Enabled, 0=Disabled |
+| fireplacetimerenabled     | A_CYC_FIREPLACE_TIMER_ENABLED | Timer enabled setting in fireplace profile |rw| On/Off               |
 | extraairtemptarget        | A_CYC_EXTRA_AIR_TEMP_TARGET | Target temperature in programmable profile |rw| Number (°C)          |
 | extraextrfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile extract fan speed |rw| 0 - 100 (%)          |
 | extrasuppfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile supply fan speed |rw| 0 - 100 (%)          |
 | extratime                 | A_CYC_EXTRA_TIME            | Timer value in programmable profile |rw| 1 - 65535 (min)      |
-| extratimerenabled         | A_CYC_EXTRA_TIMER_ENABLED   | Timer enabled setting in programmable profile |rw| 1=Enabled, 0=Disabled |
-| weeklytimerenabled        | A_CYC_WEEKLY_TIMER_ENABLED  | Weekly Timer enabled setting      |rw| 1=Enabled, 0=Disabled |
+| extratimerenabled         | A_CYC_EXTRA_TIMER_ENABLED   | Timer enabled setting in programmable profile |rw| On/Off               |
+| weeklytimerenabled        | A_CYC_WEEKLY_TIMER_ENABLED  | Weekly Timer enabled setting      |rw| On/Off               |
 
 ## Example
 

--- a/bundles/org.openhab.binding.valloxmv/README.md
+++ b/bundles/org.openhab.binding.valloxmv/README.md
@@ -52,6 +52,18 @@ Overview of provided channels
 | homeairtemptarget         | A_CYC_HOME_AIR_TEMP_TARGET  | Target temperature in home state  |rw| Number (°C)          |
 | awayairtemptarget         | A_CYC_AWAY_AIR_TEMP_TARGET  | Target temperature in away state  |rw| Number (°C)          |
 | boostairtemptarget        | A_CYC_BOOST_AIR_TEMP_TARGET | Target temperature in boost state |rw| Number (°C)          |
+| boosttime                 | A_CYC_BOOST_TIME            | Timer value in boost profile      |rw| 1 - 65535 (min)      |
+| boosttimerenabled         | A_CYC_BOOST_TIMER_ENABLED   | Timer enabled setting in boost profile |rw| 1=Enabled, 0=Disabled |
+| fireplaceextrfan          | A_CYC_FIREPLACE_EXTR_FAN    | Fireplace profile extract fan speed |rw| 0 - 100 (%)          |
+| fireplacesuppfan          | A_CYC_FIREPLACE_SUPP_FAN    | Fireplace profile supply fan speed |rw| 0 - 100 (%)          |
+| fireplacetime             | A_CYC_FIREPLACE_TIME        | Timer value in fireplace profile  |rw| 1 - 65535 (min)      |
+| fireplacetimerenabled     | A_CYC_FIREPLACE_TIMER_ENABLED | Timer enabled setting in fireplace profile |rw| 1=Enabled, 0=Disabled |
+| extraairtemptarget        | A_CYC_EXTRA_AIR_TEMP_TARGET | Target temperature in programmable profile |rw| Number (°C)          |
+| extraextrfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile extract fan speed |rw| 0 - 100 (%)          |
+| extrasuppfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile supply fan speed |rw| 0 - 100 (%)          |
+| extratime                 | A_CYC_EXTRA_TIME            | Timer value in programmable profile |rw| 1 - 65535 (min)      |
+| extratimerenabled         | A_CYC_EXTRA_TIMER_ENABLED   | Timer enabled setting in programmable profile |rw| 1=Enabled, 0=Disabled |
+| weeklytimerenabled        | A_CYC_WEEKLY_TIMER_ENABLED  | Weekly Timer enabled setting      |rw| 1=Enabled, 0=Disabled |
 
 ## Example
 

--- a/bundles/org.openhab.binding.valloxmv/README.md
+++ b/bundles/org.openhab.binding.valloxmv/README.md
@@ -58,12 +58,12 @@ Overview of provided channels
 | fireplacesuppfan          | A_CYC_FIREPLACE_SUPP_FAN    | Fireplace profile supply fan speed |rw| 0 - 100 (%)          |
 | fireplacetime             | A_CYC_FIREPLACE_TIME        | Timer value in fireplace profile  |rw| 1 - 65535 (min)      |
 | fireplacetimerenabled     | A_CYC_FIREPLACE_TIMER_ENABLED | Timer enabled setting in fireplace profile |rw| On/Off               |
-| extraairtemptarget        | A_CYC_EXTRA_AIR_TEMP_TARGET | Target temperature in programmable profile |rw| Number (°C)          |
-| extraextrfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile extract fan speed |rw| 0 - 100 (%)          |
-| extrasuppfan              | A_CYC_EXTRA_EXTR_FAN        | Programmable profile supply fan speed |rw| 0 - 100 (%)          |
-| extratime                 | A_CYC_EXTRA_TIME            | Timer value in programmable profile |rw| 1 - 65535 (min)      |
-| extratimerenabled         | A_CYC_EXTRA_TIMER_ENABLED   | Timer enabled setting in programmable profile |rw| On/Off               |
-| weeklytimerenabled        | A_CYC_WEEKLY_TIMER_ENABLED  | Weekly Timer enabled setting      |rw| On/Off               |
+| extraairtemptarget        | A_CYC_EXTRA_AIR_TEMP_TARGET | Target temperature in extra profile |rw| Number (°C)          |
+| extraextrfan              | A_CYC_EXTRA_EXTR_FAN        | Extra profile extract fan speed   |rw| 0 - 100 (%)          |
+| extrasuppfan              | A_CYC_EXTRA_EXTR_FAN        | Extra profile supply fan speed    |rw| 0 - 100 (%)          |
+| extratime                 | A_CYC_EXTRA_TIME            | Timer value in extra profile      |rw| 1 - 65535 (min)      |
+| extratimerenabled         | A_CYC_EXTRA_TIMER_ENABLED   | Timer enabled setting in extra profile |rw| On/Off               |
+| weeklytimerenabled        | A_CYC_WEEKLY_TIMER_ENABLED  | Weekly timer enabled setting      |rw| On/Off               |
 
 ## Example
 

--- a/bundles/org.openhab.binding.valloxmv/README_DEV.md
+++ b/bundles/org.openhab.binding.valloxmv/README_DEV.md
@@ -96,8 +96,8 @@ There are even more values supported by the interface but the extraction for mos
 * A\_CYC\_DEFROSTING    0
 * **A_CYC_BOOST_TIMER   0**
 * **A_CYC_FIREPLACE_TIMER   0**
-* A\_CYC\_EXTRA\_TIMER   0
-* A\_CYC\_WEEKLY\_TIMER\_ENABLED  0
+* **A_CYC_EXTRA_TIMER**   0
+* **A_CYC_WEEKLY_TIMER_ENABLED**  0
 * **A\_CYC\_CELL\_STATE**    0
 * **A\_CYC\_TOTAL\_UP\_TIME\_YEARS**   0
 * **A\_CYC\_TOTAL\_UP\_TIME\_HOURS**   1913
@@ -176,15 +176,15 @@ There are even more values supported by the interface but the extraction for mos
 * A\_CYC\_MODBUS\_FRAME  257
 * **A\_CYC\_EXTR\_FAN\_BALANCE\_BASE**     100
 * **A\_CYC\_SUPP\_FAN\_BALANCE\_BASE**     100
-* A\_CYC\_FIREPLACE\_EXTR\_FAN    50
-* A\_CYC\_FIREPLACE\_SUPP\_FAN    50
+* **A_CYC_FIREPLACE_EXTR_FAN**    50
+* **A_CYC_FIREPLACE_SUPP_FAN**    50
 * A\_CYC\_RH\_BASIC\_LEVEL    58
 * A\_CYC\_CO2\_THRESHOLD     900
 * A\_CYC\_EXTRA\_ENABLED     0
-* A\_CYC\_EXTRA\_AIR\_TEMP\_TARGET     28815
-* A\_CYC\_EXTRA\_EXTR\_FAN    50
-* A\_CYC\_EXTRA\_SUPP\_FAN    50
-* A\_CYC\_EXTRA\_TIME    10
+* **A_CYC_EXTRA_AIR_TEMP_TARGET**     28815
+* **A_CYC_EXTRA_EXTR_FAN**    50
+* **A_CYC_EXTRA_SUPP_FAN**    50
+* **A_CYC_EXTRA_TIME**    10
 * A\_CYC\_AWAY\_RH\_CTRL\_ENABLED  0
 * A\_CYC\_AWAY\_CO2\_CTRL\_ENABLED     0
 * **A\_CYC\_AWAY\_SPEED\_SETTING**    35
@@ -216,8 +216,8 @@ There are even more values supported by the interface but the extraction for mos
 * A\_CYC\_BRANDING  0
 * A\_CYC\_SIDEDNESS     0
 * A\_CYC\_RH\_LEVEL\_MODE     0
-* A\_CYC\_BOOST\_TIME    30
-* A\_CYC\_FIREPLACE\_TIME    15
+* **A_CYC_BOOST_TIME**    30
+* **A_CYC_FIREPLACE_TIME**    15
 * **A\_CYC\_FILTER\_CHANGED\_DAY**    1
 * **A\_CYC\_FILTER\_CHANGED\_MONTH**  1
 * **A\_CYC\_FILTER\_CHANGED\_YEAR**   0
@@ -231,13 +231,13 @@ There are even more values supported by the interface but the extraction for mos
 * A\_CYC\_USER\_PASSWORD     0
 * A\_CYC\_ACCESS\_LEVEL  0
 * A\_CYC\_PARENTAL\_CTRL\_ENABLED     0
-* A\_CYC\_BOOST\_TIMER\_ENABLED   0
-* A\_CYC\_FIREPLACE\_TIMER\_ENABLED   1
+* **A_CYC_BOOST_TIMER_ENABLED**   0
+* **A_CYC_FIREPLACE_TIMER_ENABLED**   1
 * A\_CYC\_SUMMER\_TIME\_AUTO\_ENAB     1
 * A\_CYC\_12\_HOUR\_CLOCK\_ENABLED     0
 * A\_CYC\_SLEEP\_DELAY   10
 * A\_CYC\_BG\_LIGHT\_LEVEL    50
-* A\_CYC\_EXTRA\_TIMER\_ENABLED   1
+* **A_CYC_EXTRA_TIMER_ENABLED**   1
     
     
 * A\_CYC\_SUPP\_FAN\_TEST     0

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVBindingConstants.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVBindingConstants.java
@@ -167,17 +167,89 @@ public class ValloxMVBindingConstants {
     public static final String CHANNEL_BOOST_AIR_TEMP_TARGET = "boostairtemptarget";
 
     /**
+     * Timer value setting in minutes of boost profile (1-65535).
+     */
+    public static final String CHANNEL_BOOST_TIME = "boosttime";
+
+    /**
+     * Timer enabled setting in boost profile (Enabled = 1, Disabled = 0).
+     */
+    public static final String CHANNEL_BOOST_TIMER_ENABLED = "boosttimerenabled";
+
+    /**
+     * Fireplace profile extract fan speed setting in % (0-100).
+     */
+    public static final String CHANNEL_FIREPLACE_EXTR_FAN = "fireplaceextrfan";
+
+    /**
+     * Fireplace profile supply fan speed setting in % (0-100).
+     */
+    public static final String CHANNEL_FIREPLACE_SUPP_FAN = "fireplacesuppfan";
+
+    /**
+     * Timer value setting in minutes of fireplace profile (1-65535).
+     */
+    public static final String CHANNEL_FIREPLACE_TIME = "fireplacetime";
+
+    /**
+     * Timer enabled setting in fireplace profile (Enabled = 1, Disabled = 0).
+     */
+    public static final String CHANNEL_FIREPLACE_TIMER_ENABLED = "fireplacetimerenabled";
+
+    /**
+     * Programmable profile enabled
+     * Not sure if this is needed at all, Vallox modbus document does not list this.
+     */
+    //public static final String CHANNEL_EXTRA_ENABLED = "extraenabled";
+
+    /**
+     * Target temperature in programmable profile.
+     */
+    public static final String CHANNEL_EXTRA_AIR_TEMP_TARGET = "extraairtemptarget";
+
+    /**
+     * Programmable profile extract fan speed setting in % (0-100).
+     */
+    public static final String CHANNEL_EXTRA_EXTR_FAN = "extraextrfan";
+
+    /**
+     * Programmable profile supply fan speed setting in % (0-100).
+     */
+    public static final String CHANNEL_EXTRA_SUPP_FAN = "extrasuppfan";
+
+    /**
+     * Timer value setting in minutes of programmable profile (1-65535).
+     */
+    public static final String CHANNEL_EXTRA_TIME = "extratime";
+
+    /**
+     * Timer enabled setting in programmable profile (Enabled = 1, Disabled = 0).
+     */
+    public static final String CHANNEL_EXTRA_TIMER_ENABLED = "extratimerenabled";
+
+    /**
+     * Weekly Timer enabled setting (Enabled = 1, Disabled = 0).
+     */
+    public static final String CHANNEL_WEEKLY_TIMER_ENABLED = "weeklytimerenabled";
+
+
+    /**
      * Set of writable channels that are dimensionless
      */
     public final static Set<String> WRITABLE_CHANNELS_DIMENSIONLESS = Collections.unmodifiableSet(
             new HashSet<String>(Arrays.asList(CHANNEL_EXTR_FAN_BALANCE_BASE, CHANNEL_SUPP_FAN_BALANCE_BASE,
-                    CHANNEL_HOME_SPEED_SETTING, CHANNEL_AWAY_SPEED_SETTING, CHANNEL_BOOST_SPEED_SETTING)));
+                    CHANNEL_HOME_SPEED_SETTING, CHANNEL_AWAY_SPEED_SETTING, CHANNEL_BOOST_SPEED_SETTING,
+                    CHANNEL_BOOST_TIME, CHANNEL_BOOST_TIMER_ENABLED, CHANNEL_FIREPLACE_EXTR_FAN,
+                    CHANNEL_FIREPLACE_SUPP_FAN, CHANNEL_FIREPLACE_TIME, CHANNEL_FIREPLACE_TIMER_ENABLED,
+                    CHANNEL_EXTRA_EXTR_FAN, CHANNEL_EXTRA_SUPP_FAN, CHANNEL_EXTRA_TIME, CHANNEL_EXTRA_TIMER_ENABLED,
+                    CHANNEL_WEEKLY_TIMER_ENABLED)));
 
     /**
      * Set of writable channels that are temperatures
      */
     public final static Set<String> WRITABLE_CHANNELS_TEMPERATURE = Collections.unmodifiableSet(new HashSet<String>(
-            Arrays.asList(CHANNEL_HOME_AIR_TEMP_TARGET, CHANNEL_AWAY_AIR_TEMP_TARGET, CHANNEL_BOOST_AIR_TEMP_TARGET)));
+            Arrays.asList(CHANNEL_HOME_AIR_TEMP_TARGET, CHANNEL_AWAY_AIR_TEMP_TARGET, CHANNEL_BOOST_AIR_TEMP_TARGET,
+                CHANNEL_EXTRA_AIR_TEMP_TARGET)));
 
     // Thing configuration
     /**

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVBindingConstants.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVBindingConstants.java
@@ -234,7 +234,15 @@ public class ValloxMVBindingConstants {
 
 
     /**
-     * Set of writable channels that are dimensionless
+     * Set of writable channels that are Switches
+     */
+    public final static Set<String> WRITABLE_CHANNELS_SWITCHES = Collections.unmodifiableSet(
+            new HashSet<String>(Arrays.asList(CHANNEL_ONOFF, CHANNEL_BOOST_TIMER_ENABLED,
+                    CHANNEL_FIREPLACE_TIMER_ENABLED, CHANNEL_EXTRA_TIMER_ENABLED, CHANNEL_WEEKLY_TIMER_ENABLED)));
+
+    /**
+
+    * Set of writable channels that are dimensionless
      */
     public final static Set<String> WRITABLE_CHANNELS_DIMENSIONLESS = Collections.unmodifiableSet(
             new HashSet<String>(Arrays.asList(CHANNEL_EXTR_FAN_BALANCE_BASE, CHANNEL_SUPP_FAN_BALANCE_BASE,

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVHandler.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVHandler.java
@@ -107,14 +107,14 @@ public class ValloxMVHandler extends BaseThingHandler {
                 }
             } else if (ValloxMVBindingConstants.WRITABLE_CHANNELS_TEMPERATURE.contains(channelUID.getId())) {
                 if (command instanceof QuantityType) {
-                    // Convert temperature to centKelvin (= (Celsius * 100) + 27315 )
+                    // Convert temperature to centiKelvin (= (Celsius * 100) + 27315 )
                     QuantityType<Temperature> quantity = ((QuantityType<Temperature>) command)
                             .toUnit(SmartHomeUnits.KELVIN);
                     if (quantity == null) {
                         return;
                     }
-                    int centKelvin = quantity.multiply(new BigDecimal(100)).intValue();
-                    valloxSendSocket.request(channelUID, Integer.toString(centKelvin));
+                    int centiKelvin = quantity.multiply(new BigDecimal(100)).intValue();
+                    valloxSendSocket.request(channelUID, Integer.toString(centiKelvin));
                     valloxSendSocket.request(null, null);
                 }
             }

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVHandler.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVHandler.java
@@ -107,14 +107,14 @@ public class ValloxMVHandler extends BaseThingHandler {
                 }
             } else if (ValloxMVBindingConstants.WRITABLE_CHANNELS_TEMPERATURE.contains(channelUID.getId())) {
                 if (command instanceof QuantityType) {
-                    // Convert temperature to millidegree Kelvin
+                    // Convert temperature to centKelvin (= (Celsius * 100) + 27315 )
                     QuantityType<Temperature> quantity = ((QuantityType<Temperature>) command)
                             .toUnit(SmartHomeUnits.KELVIN);
                     if (quantity == null) {
                         return;
                     }
-                    int milliKelvin = quantity.multiply(new BigDecimal(100)).intValue();
-                    valloxSendSocket.request(channelUID, Integer.toString(milliKelvin));
+                    int centKelvin = quantity.multiply(new BigDecimal(100)).intValue();
+                    valloxSendSocket.request(channelUID, Integer.toString(centKelvin));
                     valloxSendSocket.request(null, null);
                 }
             }

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
@@ -477,7 +477,7 @@ public class ValloxMVWebSocket {
                     bdState = new BigDecimal(ValloxMVBindingConstants.STATE_ATHOME);
                 }
 
-                OnOffType ooOnOff = (bytes[217] == 5) ? OnOffType.OFF : OnOffType.ON;
+                OnOffType ooOnOff = OnOffType.from(bytes[217] != 5);
 
                 // Update channels with read values
                 updateChannel(ValloxMVBindingConstants.CHANNEL_ONOFF, ooOnOff);

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
@@ -177,9 +177,11 @@ public class ValloxMVWebSocket {
                 // requestData (Length 3, Command to get data 246, empty set, checksum [sum of everything before])
                 return generateCustomRequest(246, new HashMap<Integer, Integer>());
             }
+            String strChannelUIDid = channelUID.getId();
+            Integer intUpdateState = Integer.parseInt(updateState);
             Map<Integer, Integer> request = new HashMap<>();
-            if (ValloxMVBindingConstants.CHANNEL_STATE.equals(channelUID.getId())) {
-                if (Integer.parseInt(updateState) == ValloxMVBindingConstants.STATE_FIREPLACE) {
+            if (ValloxMVBindingConstants.CHANNEL_STATE == strChannelUIDid) {
+                if (intUpdateState == ValloxMVBindingConstants.STATE_FIREPLACE) {
                     // 15 Min fireplace (Length 6, Command to set data 249, CYC_BOOST_TIMER (4612) = 0,
                     // CYC_FIREPLACE_TIMER (4613) = 15, checksum)
                     // To do: we should check this case already in 'request' function and first request Vallox
@@ -190,19 +192,19 @@ public class ValloxMVWebSocket {
                     // Note: we should be able to request 2 values at a time, same if clause could be used for both
                     request.put(4612, 0);
                     request.put(4613, 15);
-                } else if (Integer.parseInt(updateState) == ValloxMVBindingConstants.STATE_ATHOME) {
+                } else if (intUpdateState == ValloxMVBindingConstants.STATE_ATHOME) {
                     // At Home (Length 8, Command to set data 249, CYC_STATE (4609) = 0, CYC_BOOST_TIMER (4612) = 0,
                     // CYC_FIREPLACE_TIMER (4613) = 0, checksum)
                     request.put(4609, 0);
                     request.put(4612, 0);
                     request.put(4613, 0);
-                } else if (Integer.parseInt(updateState) == ValloxMVBindingConstants.STATE_AWAY) {
+                } else if (intUpdateState == ValloxMVBindingConstants.STATE_AWAY) {
                     // Away (Length 8, Command to set data 249, CYC_STATE (4609) = 1, CYC_BOOST_TIMER (4612) = 0,
                     // CYC_FIREPLACE_TIMER (4613) = 0, checksum)
                     request.put(4609, 1);
                     request.put(4612, 0);
                     request.put(4613, 0);
-                } else if (Integer.parseInt(updateState) == ValloxMVBindingConstants.STATE_BOOST) {
+                } else if (intUpdateState == ValloxMVBindingConstants.STATE_BOOST) {
                     // 30 Min boost (Length 6, Command to set data 249, CYC_BOOST_TIMER (4612) = 30, CYC_FIREPLACE_TIMER
                     // (4613) = 0, checksum)
                     // To do: we should check this case already in 'request' function and first request Vallox
@@ -214,48 +216,48 @@ public class ValloxMVWebSocket {
                     request.put(4612, 30);
                     request.put(4613, 0);
                 }
-            } else if (ValloxMVBindingConstants.CHANNEL_ONOFF.equals(channelUID.getId())) {
-                request.put(4610, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTR_FAN_BALANCE_BASE.equals(channelUID.getId())) {
-                request.put(20485, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_SUPP_FAN_BALANCE_BASE.equals(channelUID.getId())) {
-                request.put(20486, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_HOME_SPEED_SETTING.equals(channelUID.getId())) {
-                request.put(20507, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_AWAY_SPEED_SETTING.equals(channelUID.getId())) {
-                request.put(20501, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_SPEED_SETTING.equals(channelUID.getId())) {
-                request.put(20513, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_HOME_AIR_TEMP_TARGET.equals(channelUID.getId())) {
-                request.put(20508, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_AWAY_AIR_TEMP_TARGET.equals(channelUID.getId())) {
-                request.put(20502, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_AIR_TEMP_TARGET.equals(channelUID.getId())) {
-                request.put(20514, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_TIME.equals(channelUID.getId())) {
-                request.put(20544, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_TIMER_ENABLED.equals(channelUID.getId())) {
-                request.put(21766, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_EXTR_FAN.equals(channelUID.getId())) {
-                request.put(20487, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_SUPP_FAN.equals(channelUID.getId())) {
-                request.put(20488, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_TIME.equals(channelUID.getId())) {
-                request.put(20545, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_TIMER_ENABLED.equals(channelUID.getId())) {
-                request.put(21767, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_AIR_TEMP_TARGET.equals(channelUID.getId())) {
-                request.put(20493, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_EXTR_FAN.equals(channelUID.getId())) {
-                request.put(20494, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_SUPP_FAN.equals(channelUID.getId())) {
-                request.put(20495, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_TIME.equals(channelUID.getId())) {
-                request.put(20496, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_TIMER_ENABLED.equals(channelUID.getId())) {
-                request.put(21772, Integer.parseInt(updateState));
-            } else if (ValloxMVBindingConstants.CHANNEL_WEEKLY_TIMER_ENABLED.equals(channelUID.getId())) {
-                request.put(4615, Integer.parseInt(updateState));
+            } else if (ValloxMVBindingConstants.CHANNEL_ONOFF == strChannelUIDid) {
+                request.put(4610, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTR_FAN_BALANCE_BASE == strChannelUIDid) {
+                request.put(20485, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_SUPP_FAN_BALANCE_BASE == strChannelUIDid) {
+                request.put(20486, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_HOME_SPEED_SETTING == strChannelUIDid) {
+                request.put(20507, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_AWAY_SPEED_SETTING == strChannelUIDid) {
+                request.put(20501, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_SPEED_SETTING == strChannelUIDid) {
+                request.put(20513, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_HOME_AIR_TEMP_TARGET == strChannelUIDid) {
+                request.put(20508, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_AWAY_AIR_TEMP_TARGET == strChannelUIDid) {
+                request.put(20502, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_AIR_TEMP_TARGET == strChannelUIDid) {
+                request.put(20514, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_TIME == strChannelUIDid) {
+                request.put(20544, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_BOOST_TIMER_ENABLED == strChannelUIDid) {
+                request.put(21766, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_EXTR_FAN == strChannelUIDid) {
+                request.put(20487, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_SUPP_FAN == strChannelUIDid) {
+                request.put(20488, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_TIME == strChannelUIDid) {
+                request.put(20545, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_FIREPLACE_TIMER_ENABLED == strChannelUIDid) {
+                request.put(21767, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_AIR_TEMP_TARGET == strChannelUIDid) {
+                request.put(20493, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_EXTR_FAN == strChannelUIDid) {
+                request.put(20494, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_SUPP_FAN == strChannelUIDid) {
+                request.put(20495, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_TIME == strChannelUIDid) {
+                request.put(20496, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_EXTRA_TIMER_ENABLED == strChannelUIDid) {
+                request.put(21772, intUpdateState);
+            } else if (ValloxMVBindingConstants.CHANNEL_WEEKLY_TIMER_ENABLED == strChannelUIDid) {
+                request.put(4615, intUpdateState);
             } else {
                 return null;
             }
@@ -456,10 +458,10 @@ public class ValloxMVWebSocket {
 
         @SuppressWarnings("null")
         private BigDecimal getTemperature(byte[] bytes, int pos) {
-            // Fetch 2 byte number out of bytearray representing the temperature in centKelvin
-            BigDecimal bdTemperatureCentKelvin = new BigDecimal(getNumber(bytes, pos));
-            // Return number converted to degree celsius (= (centKelvin - 27315) / 100 )
-            return (new QuantityType<>(bdTemperatureCentKelvin, MetricPrefix.CENTI(SmartHomeUnits.KELVIN))
+            // Fetch 2 byte number out of bytearray representing the temperature in centiKelvin
+            BigDecimal bdTemperatureCentiKelvin = new BigDecimal(getNumber(bytes, pos));
+            // Return number converted to degree celsius (= (centiKelvin - 27315) / 100 )
+            return (new QuantityType<>(bdTemperatureCentiKelvin, MetricPrefix.CENTI(SmartHomeUnits.KELVIN))
                     .toUnit(SIUnits.CELSIUS)).toBigDecimal();
         }
 

--- a/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
+++ b/bundles/org.openhab.binding.valloxmv/src/main/java/org/openhab/binding/valloxmv/internal/ValloxMVWebSocket.java
@@ -118,7 +118,7 @@ public class ValloxMVWebSocket {
         @OnWebSocketConnect
         public void onConnect(Session session) {
             try {
-                logger.debug("Connect: {}", session.getRemoteAddress().getAddress());
+                logger.debug("Connected to: {}", session.getRemoteAddress().getAddress());
                 ByteBuffer buf = generateRequest();
                 session.getRemote().sendBytes(buf);
             } catch (IOException e) {
@@ -243,6 +243,7 @@ public class ValloxMVWebSocket {
                         default:
                             // This should never happen. Let's get back to basic profile.
                             // Clearing boost and fireplace timers.
+                            logger.debug("Incorrect profile requested, changing back to basic profile");
                             request.put(4612, 0);
                             request.put(4613, 0);
                     }
@@ -410,7 +411,6 @@ public class ValloxMVWebSocket {
                 // COMMAND_READ_TABLES (246)
                 // Read values from received tables
                 int iFanspeed = getNumberBE(bytes, 128);
-                logger.debug("Fan Speed: {}", iFanspeed);
                 int iFanspeedExtract = getNumberBE(bytes, 144);
                 int iFanspeedSupply = getNumberBE(bytes, 146);
                 BigDecimal bdTempInside = getTemperature(bytes, 130);
@@ -574,6 +574,7 @@ public class ValloxMVWebSocket {
         @OnWebSocketClose
         public void onClose(int statusCode, String reason) {
             logger.debug("WebSocket Closed. Code: {}; Reason: {}", statusCode, reason);
+            this.closeLatch.countDown();
         }
 
         public boolean awaitClose(int duration, TimeUnit unit) throws InterruptedException {

--- a/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -261,83 +261,83 @@
 
 	<channel-type id="boosttime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Boost profile timer value</label>
+		<label>Boost Timer</label>
 		<description>Boost profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
 	<channel-type id="boosttimerenabled" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Boost profile timer enabled</label>
+		<label>Boost Timer Enabled</label>
 		<description>Timer enabled setting in boost profile</description>
 	</channel-type>
 
 	<channel-type id="fireplaceextrfan" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Fireplace extract fan speed</label>
+		<label>Fireplace Extract Fan Speed</label>
 		<description>Fireplace profile extract fan speed in % (0-100)</description>
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
 	<channel-type id="fireplacesuppfan" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Fireplace supply fan speed</label>
+		<label>Fireplace Supply Fan Speed</label>
 		<description>Fireplace profile supply fan speed in % (0-100)</description>
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
 	<channel-type id="fireplacetime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Fireplace profile timer value</label>
+		<label>Fireplace Timer</label>
 		<description>Fireplace profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
 	<channel-type id="fireplacetimerenabled" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Fireplace profile timer enabled</label>
+		<label>Fireplace Timer Enabled</label>
 		<description>Timer enabled setting in fireplace profile</description>
 	</channel-type>
 
 	<channel-type id="extraairtemptarget" advanced="true">
 		<item-type>Number:Temperature</item-type>
-		<label>Programmable profile Target Temperature</label>
-		<description>Target temperature in programmable profile</description>
+		<label>Extra Target Temperature</label>
+		<description>Target temperature in extra profile</description>
 		<category>Temperature</category>
 		<state readOnly="false" min="5" max="25" pattern="%.2f %unit%" />
 	</channel-type>
 
 	<channel-type id="extraextrfan" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Programmable profile extract fan speed</label>
-		<description>Programmable profile extract fan speed in % (0-100)</description>
+		<label>Extra Extract Fan Speed</label>
+		<description>Extra profile extract fan speed in % (0-100)</description>
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
 	<channel-type id="extrasuppfan" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Programmable profile supply fan speed</label>
-		<description>Programmable profile supply fan speed in % (0-100)</description>
+		<label>Extra Supply Fan Speed</label>
+		<description>Extra profile supply fan speed in % (0-100)</description>
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
 	<channel-type id="extratime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Programmable profile timer value</label>
-		<description>Programmable profile timer value in minutes</description>
+		<label>Extra Timer</label>
+		<description>Extra profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
 	<channel-type id="extratimerenabled" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Programmable profile timer enabled</label>
-		<description>Timer enabled setting in programmable profile</description>
+		<label>Extra Timer Enabled</label>
+		<description>Timer enabled setting in extra profile</description>
 	</channel-type>
 
 	<channel-type id="weeklytimerenabled" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Weekly timer enabled</label>
-		<description>Weekly Timer enabled setting</description>
+		<label>Weekly Timer Enabled</label>
+		<description>Weekly timer enabled setting</description>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -32,6 +32,18 @@
 			<channel id="homeairtemptarget" typeId="homeairtemptarget" />
 			<channel id="awayairtemptarget" typeId="awayairtemptarget" />
 			<channel id="boostairtemptarget" typeId="boostairtemptarget" />
+			<channel id="boosttime" typeId="boosttime" />
+			<channel id="boosttimerenabled" typeId="boosttimerenabled" />
+			<channel id="fireplaceextrfan" typeId="fireplaceextrfan" />
+			<channel id="fireplacesuppfan" typeId="fireplacesuppfan" />
+			<channel id="fireplacetime" typeId="fireplacetime" />
+			<channel id="fireplacetimerenabled" typeId="fireplacetimerenabled" />
+			<channel id="extraairtemptarget" typeId="extraairtemptarget" />
+			<channel id="extraextrfan" typeId="extraextrfan" />
+			<channel id="extrasuppfan" typeId="extrasuppfan" />
+			<channel id="extratime" typeId="extratime" />
+			<channel id="extratimerenabled" typeId="extratimerenabled" />
+			<channel id="weeklytimerenabled" typeId="weeklytimerenabled" />
 		</channels>
 		<config-description>
 			<parameter name="ip" type="text" required="true">
@@ -246,4 +258,110 @@
 		<category>Temperature</category>
 		<state pattern="%.2f %unit%" readOnly="false" />
 	</channel-type>
+
+	<channel-type id="boosttime">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Boost profile timer value</label>
+		<description>Boost profile timer value in minutes</description>
+		<state readOnly="false" min="1" max="65535" pattern="%d min" />
+	</channel-type>
+
+	<channel-type id="boosttimerenabled">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Boost profile timer enabled</label>
+		<description>Timer enabled setting in boost profile</description>
+		<state readOnly="false">
+			<options>
+				<option value="1">Enabled</option>
+				<option value="0">Disabled</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="fireplaceextrfan" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Fireplace extract fan speed</label>
+		<description>Fireplace profile extract fan speed in % (0-100)</description>
+		<state readOnly="false" min="0" max="100" pattern="%d %%" />
+	</channel-type>
+
+	<channel-type id="fireplacesuppfan" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Fireplace supply fan speed</label>
+		<description>Fireplace profile supply fan speed in % (0-100)</description>
+		<state readOnly="false" min="0" max="100" pattern="%d %%" />
+	</channel-type>
+
+	<channel-type id="fireplacetime">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Fireplace profile timer value</label>
+		<description>Fireplace profile timer value in minutes</description>
+		<state readOnly="false" min="1" max="65535" pattern="%d min" />
+	</channel-type>
+
+	<channel-type id="fireplacetimerenabled">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Fireplace profile timer enabled</label>
+		<description>Timer enabled setting in fireplace profile</description>
+		<state readOnly="false">
+			<options>
+				<option value="1">Enabled</option>
+				<option value="0">Disabled</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="extraairtemptarget" advanced="true">
+		<item-type>Number:Temperature</item-type>
+		<label>Programmable profile Target Temperature</label>
+		<description>Target temperature in programmable profile</description>
+		<category>Temperature</category>
+		<state readOnly="false" min="5" max="25" pattern="%.2f %unit%" />
+	</channel-type>
+
+	<channel-type id="extraextrfan" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Programmable profile extract fan speed</label>
+		<description>Programmable profile extract fan speed in % (0-100)</description>
+		<state readOnly="false" min="0" max="100" pattern="%d %%" />
+	</channel-type>
+
+	<channel-type id="extrasuppfan" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Programmable profile supply fan speed</label>
+		<description>Programmable profile supply fan speed in % (0-100)</description>
+		<state readOnly="false" min="0" max="100" pattern="%d %%" />
+	</channel-type>
+
+	<channel-type id="extratime">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Programmable profile timer value</label>
+		<description>Programmable profile timer value in minutes</description>
+		<state readOnly="false" min="1" max="65535" pattern="%d min" />
+	</channel-type>
+
+	<channel-type id="extratimerenabled">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Programmable profile timer enabled</label>
+		<description>Timer enabled setting in programmable profile</description>
+		<state readOnly="false">
+			<options>
+				<option value="1">Enabled</option>
+				<option value="0">Disabled</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="weeklytimerenabled">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Weekly timer enabled</label>
+		<description>Weekly Timer enabled setting</description>
+		<state readOnly="false">
+			<options>
+				<option value="1">Enabled</option>
+				<option value="0">Disabled</option>
+			</options>
+		</state>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.valloxmv/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -259,23 +259,17 @@
 		<state pattern="%.2f %unit%" readOnly="false" />
 	</channel-type>
 
-	<channel-type id="boosttime">
+	<channel-type id="boosttime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Boost profile timer value</label>
 		<description>Boost profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
-	<channel-type id="boosttimerenabled">
-		<item-type>Number:Dimensionless</item-type>
+	<channel-type id="boosttimerenabled" advanced="true">
+		<item-type>Switch</item-type>
 		<label>Boost profile timer enabled</label>
 		<description>Timer enabled setting in boost profile</description>
-		<state readOnly="false">
-			<options>
-				<option value="1">Enabled</option>
-				<option value="0">Disabled</option>
-			</options>
-		</state>
 	</channel-type>
 
 	<channel-type id="fireplaceextrfan" advanced="true">
@@ -292,23 +286,17 @@
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
-	<channel-type id="fireplacetime">
+	<channel-type id="fireplacetime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Fireplace profile timer value</label>
 		<description>Fireplace profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
-	<channel-type id="fireplacetimerenabled">
-		<item-type>Number:Dimensionless</item-type>
+	<channel-type id="fireplacetimerenabled" advanced="true">
+		<item-type>Switch</item-type>
 		<label>Fireplace profile timer enabled</label>
 		<description>Timer enabled setting in fireplace profile</description>
-		<state readOnly="false">
-			<options>
-				<option value="1">Enabled</option>
-				<option value="0">Disabled</option>
-			</options>
-		</state>
 	</channel-type>
 
 	<channel-type id="extraairtemptarget" advanced="true">
@@ -333,35 +321,23 @@
 		<state readOnly="false" min="0" max="100" pattern="%d %%" />
 	</channel-type>
 
-	<channel-type id="extratime">
+	<channel-type id="extratime" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Programmable profile timer value</label>
 		<description>Programmable profile timer value in minutes</description>
 		<state readOnly="false" min="1" max="65535" pattern="%d min" />
 	</channel-type>
 
-	<channel-type id="extratimerenabled">
-		<item-type>Number:Dimensionless</item-type>
+	<channel-type id="extratimerenabled" advanced="true">
+		<item-type>Switch</item-type>
 		<label>Programmable profile timer enabled</label>
 		<description>Timer enabled setting in programmable profile</description>
-		<state readOnly="false">
-			<options>
-				<option value="1">Enabled</option>
-				<option value="0">Disabled</option>
-			</options>
-		</state>
 	</channel-type>
 
-	<channel-type id="weeklytimerenabled">
-		<item-type>Number:Dimensionless</item-type>
+	<channel-type id="weeklytimerenabled" advanced="true">
+		<item-type>Switch</item-type>
 		<label>Weekly timer enabled</label>
 		<description>Weekly Timer enabled setting</description>
-		<state readOnly="false">
-			<options>
-				<option value="1">Enabled</option>
-				<option value="0">Disabled</option>
-			</options>
-		</state>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
Added support for additional channels, as per here:
https://community.openhab.org/t/new-binding-vallox-mv-ventilation-unit-series-beta/36735/102

This is still to do, not sure what is the best way to do it (added comment about this into code):
 - for timer profiles, use timer value from that profile settings instead of “hardcoded” value in binding code
I am thinking that these values should be asked from Vallox device before changing to Fireplace or Boost profile. In general these values have been received from full data update, but not sure if we can save values for later use - if we could, then a separate data request would not be needed.