### PR TITLE
[velux] Decreased logging 

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelBridgeCheck.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelBridgeCheck.java
@@ -106,7 +106,7 @@ final class ChannelBridgeCheck extends ChannelHandlerTemplate {
             } else {
                 result = thisBridgeHandler.localization.getText("channelValue.check-integrity-ok");
             }
-            LOGGER.info("{}", result);
+            LOGGER.debug("{}", result);
             newState = StateUtils.createState(result);
         } while (false); // common exit
         return newState;


### PR DESCRIPTION
Mentioning unexpected configurations will only be logged with level debug:

Definitions of the bridge, which aren't used within the binding configuration, had caused an informational log entry. This is now reduced to level debug for convenience.

Signed-off-by: Guenther Schreiner <guenther.schreiner@smile.de>
