### PR TITLE
[velux] fix: avoid warnings during non-existent properties.

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/utils/ThingConfiguration.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/utils/ThingConfiguration.java
@@ -68,7 +68,7 @@ public class ThingConfiguration {
         Thing thingOfChannel = bridge.getThingByUID(channelTUID);
         boolean exists = false;
         if (thingOfChannel == null) {
-            LOGGER.warn("exists(): Channel {} does not belong to a thing.", channelUID);
+            LOGGER.debug("exists(): Channel {} does not belong to a thing.", channelUID);
         } else {
             if (thingOfChannel.getConfiguration().get(configName) != null) {
                 exists = true;


### PR DESCRIPTION
When the channel `check` is activated, a warning appears during refresh for any other channel items which do aren't equipped with a property.


