### PR TITLE
[groheondus] First support for blue devices

### DIFF
--- a/bundles/org.openhab.binding.groheondus/pom.xml
+++ b/bundles/org.openhab.binding.groheondus/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.grohe</groupId>
       <artifactId>ondus-api</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/GroheOndusBindingConstants.java
@@ -26,6 +26,7 @@ public class GroheOndusBindingConstants {
     public static final ThingTypeUID THING_TYPE_BRIDGE_ACCOUNT = new ThingTypeUID(BINDING_ID, "account");
     public static final ThingTypeUID THING_TYPE_SENSEGUARD = new ThingTypeUID(BINDING_ID, "senseguard");
     public static final ThingTypeUID THING_TYPE_SENSE = new ThingTypeUID(BINDING_ID, "sense");
+    public static final ThingTypeUID THING_TYPE_BLUE = new ThingTypeUID(BINDING_ID, "blue");
 
     public static final String CHANNEL_NAME = "name";
     public static final String CHANNEL_PRESSURE = "pressure";
@@ -35,6 +36,7 @@ public class GroheOndusBindingConstants {
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_HUMIDITY = "humidity";
     public static final String CHANNEL_BATTERY = "battery";
+    public static final String CHANNEL_TAP = "tap";
 
     public static final String CHANNEL_CONFIG_TIMEFRAME = "timeframe";
 }

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/discovery/GroheOndusDiscoveryService.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/discovery/GroheOndusDiscoveryService.java
@@ -50,8 +50,8 @@ public class GroheOndusDiscoveryService extends AbstractDiscoveryService {
     private final GroheOndusAccountHandler bridgeHandler;
 
     public GroheOndusDiscoveryService(GroheOndusAccountHandler bridgeHandler) {
-        super(Collections
-                .unmodifiableSet(Stream.of(THING_TYPE_SENSE, THING_TYPE_SENSEGUARD).collect(Collectors.toSet())), 30);
+        super(Collections.unmodifiableSet(
+                Stream.of(THING_TYPE_SENSE, THING_TYPE_SENSEGUARD, THING_TYPE_BLUE).collect(Collectors.toSet())), 30);
         logger.debug("initialize discovery service");
         this.bridgeHandler = bridgeHandler;
         this.activate(null);
@@ -83,6 +83,9 @@ public class GroheOndusDiscoveryService extends AbstractDiscoveryService {
                     break;
                 case org.grohe.ondus.api.model.sense.Appliance.TYPE:
                     thingUID = new ThingUID(THING_TYPE_SENSE, appliance.getApplianceId());
+                    break;
+                case org.grohe.ondus.api.model.blue.Appliance.TYPE:
+                    thingUID = new ThingUID(THING_TYPE_BLUE, appliance.getApplianceId());
                     break;
                 default:
                     return;

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBaseHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBaseHandler.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.groheondus.internal.handler;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -141,14 +140,15 @@ public abstract class GroheOndusBaseHandler<T extends BaseAppliance, M> extends 
 
     protected @Nullable T getAppliance(OndusService ondusService) {
         try {
-            BaseAppliance appliance = ondusService.getAppliance(getRoom(), config.applianceId).orElse(null);
+            BaseAppliance appliance = ondusService.getAppliance(getRoom(), config.applianceId)
+                    .orElseThrow(IllegalStateException::new);
             if (appliance.getType() != getType()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Thing is not a GROHE SENSE Guard device.");
                 return null;
             }
             return (T) appliance;
-        } catch (IOException e) {
+        } catch (Exception e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             logger.debug("Could not load appliance", e);
         }

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Florian Schmidt - Initial contribution
  */
 @NonNullByDefault
-public class GroheOndusBlueHandler<T, M> extends GroheOndusBaseHandler<Appliance, ApplianceCommand> {
+public class GroheOndusBlueHandler extends GroheOndusBaseHandler<Appliance, ApplianceCommand> {
 
     private static final int DEFAULT_POLLING_INTERVAL = 900;
 
@@ -122,7 +122,7 @@ public class GroheOndusBlueHandler<T, M> extends GroheOndusBaseHandler<Appliance
             return;
         }
         OnOffType openClosedCommand = (OnOffType) command;
-        if (openClosedCommand == OnOffType.ON) {
+        if (openClosedCommand == OnOffType.OFF) {
             logger.debug("The GROHE Blue channel tap only supports turning on the tap.");
             return;
         }

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.groheondus.internal.handler;
+
+import static org.openhab.binding.groheondus.internal.GroheOndusBindingConstants.*;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.grohe.ondus.api.OndusService;
+import org.grohe.ondus.api.model.BaseApplianceCommand;
+import org.grohe.ondus.api.model.blue.Appliance;
+import org.grohe.ondus.api.model.blue.ApplianceCommand;
+import org.grohe.ondus.api.model.blue.TapType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Florian Schmidt - Initial contribution
+ */
+@NonNullByDefault
+public class GroheOndusBlueHandler<T, M> extends GroheOndusBaseHandler<Appliance, ApplianceCommand> {
+
+    private static final int DEFAULT_POLLING_INTERVAL = 900;
+
+    private final Logger logger = LoggerFactory.getLogger(GroheOndusBlueHandler.class);
+
+    public GroheOndusBlueHandler(Thing thing) {
+        super(thing, Appliance.TYPE);
+    }
+
+    @Override
+    protected int getPollingInterval(Appliance appliance) {
+        if (config.pollingInterval > 0) {
+            return config.pollingInterval;
+        }
+        return DEFAULT_POLLING_INTERVAL;
+    }
+
+    @Override
+    protected void updateChannel(ChannelUID channelUID, Appliance appliance, ApplianceCommand command) {
+        String channelId = channelUID.getIdWithoutGroup();
+        State newState;
+        switch (channelId) {
+            case CHANNEL_NAME:
+                newState = new StringType(appliance.getName());
+                break;
+            case CHANNEL_TAP:
+                if (command.getCommand().getTapType() == 0) {
+                    newState = OnOffType.OFF;
+                } else {
+                    newState = OnOffType.ON;
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Channel " + channelUID + " not supported.");
+        }
+        updateState(channelUID, newState);
+    }
+
+    @Override
+    protected ApplianceCommand getLastDataPoint(Appliance appliance) {
+        ApplianceCommand command = findApplianceCommand(appliance);
+        if (command == null) {
+            return new ApplianceCommand();
+        }
+        return command;
+    }
+
+    private @Nullable ApplianceCommand findApplianceCommand(Appliance appliance) {
+        OndusService service = getOndusService();
+        if (service == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                    "No initialized OndusService available from bridge.");
+            return null;
+        }
+
+        Optional<BaseApplianceCommand> applianceDataOptional;
+        try {
+            applianceDataOptional = service.applianceCommand(appliance);
+            if (!applianceDataOptional.isPresent() || applianceDataOptional.get().getType() != Appliance.TYPE) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Could not load command from API.");
+                return null;
+            }
+            return (ApplianceCommand) applianceDataOptional.get();
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Could not load command from API because of error: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (!CHANNEL_TAP.equals(channelUID.getIdWithoutGroup())) {
+            return;
+        }
+        if (!(command instanceof OnOffType)) {
+            logger.debug("Invalid command received for channel. Expected OnOffType, received {}.",
+                    command.getClass().getName());
+            return;
+        }
+        OnOffType openClosedCommand = (OnOffType) command;
+        if (openClosedCommand == OnOffType.ON) {
+            logger.debug("The GROHE Blue channel tap only supports turning on the tap.");
+            return;
+        }
+
+        OndusService service = getOndusService();
+        if (service == null) {
+            return;
+        }
+        Appliance appliance = getAppliance(service);
+        if (appliance == null) {
+            return;
+        }
+        try {
+            ApplianceCommand applianceCommand = findApplianceCommand(appliance);
+            if (applianceCommand == null) {
+                return;
+            }
+            applianceCommand.turnTapOn(TapType.CARBONATED, 100);
+            service.sendCommand(applianceCommand);
+            updateChannels();
+        } catch (IOException e) {
+            logger.debug("Could not update valve open state", e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusBlueHandler.java
@@ -66,11 +66,8 @@ public class GroheOndusBlueHandler extends GroheOndusBaseHandler<Appliance, Appl
                 newState = new StringType(appliance.getName());
                 break;
             case CHANNEL_TAP:
-                if (command.getCommand().getTapType() == 0) {
-                    newState = OnOffType.OFF;
-                } else {
-                    newState = OnOffType.ON;
-                }
+                // always show the tap as "off", so that one can turn it on by clicking on the button
+                newState = OnOffType.OFF;
                 break;
             default:
                 throw new IllegalArgumentException("Channel " + channelUID + " not supported.");

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusHandlerFactory.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusHandlerFactory.java
@@ -63,7 +63,7 @@ public class GroheOndusHandlerFactory extends BaseThingHandlerFactory {
     }
 
     private static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Arrays.asList(THING_TYPE_SENSEGUARD,
-            THING_TYPE_SENSE, THING_TYPE_BRIDGE_ACCOUNT);
+            THING_TYPE_SENSE, THING_TYPE_BRIDGE_ACCOUNT, THING_TYPE_BLUE);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -84,6 +84,8 @@ public class GroheOndusHandlerFactory extends BaseThingHandlerFactory {
             return new GroheOndusSenseGuardHandler(thing);
         } else if (THING_TYPE_SENSE.equals(thingTypeUID)) {
             return new GroheOndusSenseHandler(thing);
+        } else if (THING_TYPE_BLUE.equals(thingTypeUID)) {
+            return new GroheOndusBlueHandler(thing);
         }
 
         return null;

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseGuardHandler.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Florian Schmidt and Arne Wohlert - Initial contribution
  */
 @NonNullByDefault
-public class GroheOndusSenseGuardHandler<T, M> extends GroheOndusBaseHandler<Appliance, Data> {
+public class GroheOndusSenseGuardHandler extends GroheOndusBaseHandler<Appliance, Data> {
     private static final int MIN_API_TIMEFRAME_DAYS = 1;
     private static final int MAX_API_TIMEFRAME_DAYS = 90;
     private static final int DEFAULT_TIMEFRAME_DAYS = 1;

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseHandler.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusSenseHandler.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * @author Florian Schmidt - Initial contribution
  */
 @NonNullByDefault
-public class GroheOndusSenseHandler<T, M> extends GroheOndusBaseHandler<Appliance, Measurement> {
+public class GroheOndusSenseHandler extends GroheOndusBaseHandler<Appliance, Measurement> {
 
     private static final int DEFAULT_POLLING_INTERVAL = 900;
 

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/i18n/groheondus_de_DE.properties
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/i18n/groheondus_de_DE.properties
@@ -9,5 +9,5 @@ thing-type.groheondus.senseguard.description = Ein GROHE SENSE Guard
 thing-type.groheondus.sense.description = Ein GROHE SENSE
 thing-type.groheondus.account.label = GROHE ONDUS Account
 thing-type.groheondus.account.description = Dies ist die Schnittstelle zum GROHE ONDUS Account wie sie von der App verwendet wird.
-thing-type.groheondus.account.label = GROHE BLUE Gerät
-thing-type.groheondus.account.description = Ein Blue Home/Professional
+thing-type.groheondus.blue.label = GROHE BLUE Gerät
+thing-type.groheondus.blue.description = Ein Blue Home/Professional

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/i18n/groheondus_de_DE.properties
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/i18n/groheondus_de_DE.properties
@@ -9,3 +9,5 @@ thing-type.groheondus.senseguard.description = Ein GROHE SENSE Guard
 thing-type.groheondus.sense.description = Ein GROHE SENSE
 thing-type.groheondus.account.label = GROHE ONDUS Account
 thing-type.groheondus.account.description = Dies ist die Schnittstelle zum GROHE ONDUS Account wie sie von der App verwendet wird.
+thing-type.groheondus.account.label = GROHE BLUE Gerät
+thing-type.groheondus.account.description = Ein Blue Home/Professional

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -97,40 +97,40 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-	
+
 	<thing-type id="blue">
-	    <supported-bridge-type-refs>
-            <bridge-type-ref id="account" />
-        </supported-bridge-type-refs>
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
 
-        <label>GROHE BLUE Appliance</label>
-        <description>A Blue Home or Professional device</description>
+		<label>GROHE BLUE Appliance</label>
+		<description>A Blue Home or Professional device</description>
 
-        <channels>
-            <channel id="name" typeId="name" />
-            <channel id="tap" typeId="tap" />
-        </channels>
+		<channels>
+			<channel id="name" typeId="name" />
+			<channel id="tap" typeId="tap" />
+		</channels>
 
-        <representation-property>applianceId</representation-property>
+		<representation-property>applianceId</representation-property>
 
-        <config-description>
-            <parameter name="applianceId" type="text" required="true">
-                <label>Appliance ID</label>
-                <description>The UUID of the appliance as retrieved from the GROHE ONDUS API.</description>
-            </parameter>
-            <parameter name="roomId" type="integer" required="true">
-                <label>Room ID</label>
-                <description>The ID of the room the appliance is in as retrieved from the GROHE ONDUS API.</description>
-            </parameter>
-            <parameter name="locationId" type="integer" required="true">
-                <label>Location ID</label>
-                <description>The ID of the location the room is in as retrieved from the GROHE ONDUS API.</description>
-            </parameter>
-            <parameter name="pollingInterval" type="integer" required="false">
-                <label>Polling Interval</label>
-                <description>The interval in seconds used to poll the API for new data.</description>
-            </parameter>
-        </config-description>
+		<config-description>
+			<parameter name="applianceId" type="text" required="true">
+				<label>Appliance ID</label>
+				<description>The UUID of the appliance as retrieved from the GROHE ONDUS API.</description>
+			</parameter>
+			<parameter name="roomId" type="integer" required="true">
+				<label>Room ID</label>
+				<description>The ID of the room the appliance is in as retrieved from the GROHE ONDUS API.</description>
+			</parameter>
+			<parameter name="locationId" type="integer" required="true">
+				<label>Location ID</label>
+				<description>The ID of the location the room is in as retrieved from the GROHE ONDUS API.</description>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" required="false">
+				<label>Polling Interval</label>
+				<description>The interval in seconds used to poll the API for new data.</description>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 	<channel-type id="name">

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -97,6 +97,40 @@
 			</parameter>
 		</config-description>
 	</thing-type>
+	
+	<thing-type id="blue">
+	    <supported-bridge-type-refs>
+            <bridge-type-ref id="account" />
+        </supported-bridge-type-refs>
+
+        <label>GROHE BLUE Appliance</label>
+        <description>A Blue Home or Professional device</description>
+
+        <channels>
+            <channel id="name" typeId="name" />
+        </channels>
+
+        <representation-property>applianceId</representation-property>
+
+        <config-description>
+            <parameter name="applianceId" type="text" required="true">
+                <label>Appliance ID</label>
+                <description>The UUID of the appliance as retrieved from the GROHE ONDUS API.</description>
+            </parameter>
+            <parameter name="roomId" type="integer" required="true">
+                <label>Room ID</label>
+                <description>The ID of the room the appliance is in as retrieved from the GROHE ONDUS API.</description>
+            </parameter>
+            <parameter name="locationId" type="integer" required="true">
+                <label>Location ID</label>
+                <description>The ID of the location the room is in as retrieved from the GROHE ONDUS API.</description>
+            </parameter>
+            <parameter name="pollingInterval" type="integer" required="false">
+                <label>Polling Interval</label>
+                <description>The interval in seconds used to poll the API for new data.</description>
+            </parameter>
+        </config-description>
+	</thing-type>
 
 	<channel-type id="name">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -108,6 +108,7 @@
 
         <channels>
             <channel id="name" typeId="name" />
+            <channel id="tap" typeId="tap" />
         </channels>
 
         <representation-property>applianceId</representation-property>
@@ -178,4 +179,9 @@
 			</parameter>
 		</config-description>
 	</channel-type>
+	<channel-type id="tap">
+        <item-type>Switch</item-type>
+        <label>Open tap</label>
+        <description>Open the tap for the configured time</description>
+    </channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -181,7 +181,7 @@
 	</channel-type>
 	<channel-type id="tap">
         <item-type>Switch</item-type>
-        <label>Open tap</label>
+        <label>Open Tap</label>
         <description>Open the tap for the configured time</description>
     </channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.groheondus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -180,8 +180,8 @@
 		</config-description>
 	</channel-type>
 	<channel-type id="tap">
-        <item-type>Switch</item-type>
-        <label>Open Tap</label>
-        <description>Open the tap for the configured time</description>
-    </channel-type>
+		<item-type>Switch</item-type>
+		<label>Open Tap</label>
+		<description>Open the tap for the configured time</description>
+	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
This adds support for turning on the tap with fixed values for
CARBONATED and 100 mililiters. More commits needed to make it usable,
however, this should already work.

This PR is based on #7131. After the other one is merged, I'll rebase this one to remove the first commit, which is just there to pull in the updated GROHE library.