### PR TITLE
[nanoleaf] fixed powerStateUpdate, ignore statically defined things on discovery

### DIFF
--- a/bundles/org.openhab.binding.nanoleaf/README.md
+++ b/bundles/org.openhab.binding.nanoleaf/README.md
@@ -174,6 +174,11 @@ Bridge nanoleaf:controller:MyLightPanels [ address="192.168.1.100", port=16021, 
 }
 ```
 
+If you define your device statically in the thing file, autodiscovery of the same thing is suppressed by using
+* the [address="..." ]  of the controller 
+* and the [id=123] of the lightpanel
+in the bracket to identify the uniqueness of the discovered device. Therefore it is recommended to the give the controller a fixed ip address.
+
 Note: To generate the `authToken`:
     
 * On the Nanoleaf controller, hold the on-off button for 5-7 seconds until the LED starts flashing.

--- a/bundles/org.openhab.binding.nanoleaf/pom.xml
+++ b/bundles/org.openhab.binding.nanoleaf/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/feature/feature.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.nanoleaf-${project.version}"
-	xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="org.openhab.binding.nanoleaf-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-nanoleaf" description="Nanoleaf Binding" version="${project.version}">

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/OpenAPIUtils.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/OpenAPIUtils.java
@@ -106,8 +106,9 @@ public class OpenAPIUtils {
                 } else if (openAPIResponse.getStatus() == HttpStatus.NOT_FOUND_404) {
                     throw new NanoleafNotFoundException("OpenAPI request did not get any result back");
                 } else if (openAPIResponse.getStatus() == HttpStatus.BAD_REQUEST_400) {
-                    throw new NanoleafBadRequestException(String.format("Nanoleaf did not expect this request. HTTP response code %s",
-                            openAPIResponse.getStatus()));
+                    throw new NanoleafBadRequestException(
+                            String.format("Nanoleaf did not expect this request. HTTP response code %s",
+                                    openAPIResponse.getStatus()));
                 } else {
                     throw new NanoleafException(String.format("OpenAPI request failed. HTTP response code %s",
                             openAPIResponse.getStatus()));

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/discovery/NanoleafMDNSDiscoveryParticipant.java
@@ -38,6 +38,8 @@ import org.slf4j.LoggerFactory;
  * The {@link NanoleafMDNSDiscoveryParticipant} is responsible for discovering new Nanoleaf controllers (bridges).
  *
  * @author Martin Raepple - Initial contribution
+ * @author Stefan Höhn
+ * @see <a href="https://www.eclipse.org/smarthome/documentation/development/bindings/discovery-services.html">MSDN Discovery</a>
  */
 @Component(immediate = true, configurationPid = "discovery.nanoleaf")
 @NonNullByDefault
@@ -71,10 +73,12 @@ public class NanoleafMDNSDiscoveryParticipant implements MDNSDiscoveryParticipan
         String modelId = service.getPropertyString("md");
         properties.put(Thing.PROPERTY_MODEL_ID, modelId);
         properties.put(Thing.PROPERTY_VENDOR, "Nanoleaf");
+        String qualifiedName = service.getQualifiedName();
+        logger.debug("AVR found: {}", qualifiedName);
 
-        logger.trace("Discovered nanoleaf host: {} port: {} firmWare: {} modelId: {}", host, port, firmwareVersion,
-                modelId);
-        logger.debug("Adding Nanoleaf controller with FW version {} found at {} {} to inbox", firmwareVersion, host,
+        logger.trace("Discovered nanoleaf host: {} port: {} firmWare: {} modelId: {} qualifiedName: {}", host, port, firmwareVersion,
+                modelId, qualifiedName);
+        logger.debug("Adding Nanoleaf controller {} with FW version {} found at {} {} to inbox", qualifiedName, firmwareVersion, host,
                 port);
         if (!OpenAPIUtils.checkRequiredFirmware(service.getPropertyString("md"), firmwareVersion)) {
             logger.warn("Nanoleaf controller firmware is too old. Must be {} or higher",

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandler.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandler.java
@@ -405,7 +405,6 @@ public class NanoleafControllerHandler extends BaseBridgeHandler {
                     Configuration config = editConfiguration();
                     config.put(NanoleafControllerConfig.AUTH_TOKEN, authToken.getAuthToken());
                     updateConfiguration(config);
-                    logger.info("--------device type3 {}", config.getProperties().get(Thing.PROPERTY_MODEL_ID));
 
                     updateStatus(ThingStatus.ONLINE);
                     // Update local field
@@ -564,14 +563,10 @@ public class NanoleafControllerHandler extends BaseBridgeHandler {
         if (controllerInfo == null)
             return;
         final State state = controllerInfo.getState();
-        @Nullable
-        final On on = state.getOn();
-        boolean isOn = false;
-        if (on != null) {
-            on.getValue();
-        }
 
-        updateState(CHANNEL_POWER, isOn ? OnOffType.ON : OnOffType.OFF);
+        OnOffType powerState = state.getOnOff();
+        updateState(CHANNEL_POWER, powerState);
+
         @Nullable
         Ct colorTemperature = state.getColorTemperature();
 
@@ -604,8 +599,8 @@ public class NanoleafControllerHandler extends BaseBridgeHandler {
         Brightness stateBrightness = state.getBrightness();
         int brightness = (stateBrightness != null) ? stateBrightness.getValue() : 0;
 
-        updateState(CHANNEL_COLOR,
-                new HSBType(new DecimalType(hue), new PercentType(saturation), new PercentType(isOn ? brightness : 0)));
+        updateState(CHANNEL_COLOR, new HSBType(new DecimalType(hue), new PercentType(saturation),
+                new PercentType(powerState == OnOffType.ON ? brightness : 0)));
         updateState(CHANNEL_COLOR_MODE, new StringType(state.getColorMode()));
         updateState(CHANNEL_RHYTHM_ACTIVE, controllerInfo.getRhythm().getRhythmActive() ? OnOffType.ON : OnOffType.OFF);
         updateState(CHANNEL_RHYTHM_MODE, new DecimalType(controllerInfo.getRhythm().getRhythmMode()));

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafPanelHandler.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafPanelHandler.java
@@ -179,11 +179,11 @@ public class NanoleafPanelHandler extends BaseThingHandler {
                 newPanelColor = new HSBType(currentPanelColor.getHue(), currentPanelColor.getSaturation(),
                         MIN_PANEL_BRIGHTNESS);
             }
-        } else if (command instanceof PercentType  && (currentPanelColor != null)) {
+        } else if (command instanceof PercentType && (currentPanelColor != null)) {
             PercentType brightness = new PercentType(
                     Math.max(MIN_PANEL_BRIGHTNESS.intValue(), ((PercentType) command).intValue()));
             newPanelColor = new HSBType(currentPanelColor.getHue(), currentPanelColor.getSaturation(), brightness);
-        } else if (command instanceof IncreaseDecreaseType  && (currentPanelColor != null)) {
+        } else if (command instanceof IncreaseDecreaseType && (currentPanelColor != null)) {
             int brightness = currentPanelColor.getBrightness().intValue();
             if (command.equals(IncreaseDecreaseType.INCREASE)) {
                 brightness = Math.min(MAX_PANEL_BRIGHTNESS.intValue(), brightness + BRIGHTNESS_STEP_SIZE);
@@ -224,7 +224,8 @@ public class NanoleafPanelHandler extends BaseThingHandler {
             if (handler != null) {
                 NanoleafControllerConfig config = ((NanoleafControllerHandler) handler).getControllerConfig();
                 // Light Panels and Canvas use different stream commands
-                if (config.deviceType.equals(CONFIG_DEVICE_TYPE_LIGHTPANELS) || config.deviceType.equals(CONFIG_DEVICE_TYPE_CANVAS)) {
+                if (config.deviceType.equals(CONFIG_DEVICE_TYPE_LIGHTPANELS)
+                        || config.deviceType.equals(CONFIG_DEVICE_TYPE_CANVAS)) {
                     logger.trace("Anim Data rgb {} {} {} {}", panelID, red, green, blue);
                     write.setAnimData(String.format("1 %s 1 %d %d %d 0 10", panelID, red, green, blue));
                 } else {
@@ -248,11 +249,10 @@ public class NanoleafPanelHandler extends BaseThingHandler {
         }
     }
 
-
     public void updatePanelColorChannel() {
         @Nullable
         HSBType panelColor = getPanelColor();
-        logger.trace("updatePanelColorChannel: panelColor: {}",panelColor);
+        logger.trace("updatePanelColorChannel: panelColor: {}", panelColor);
         if (panelColor != null)
             updateState(CHANNEL_PANEL_COLOR, panelColor);
     }
@@ -321,7 +321,8 @@ public class NanoleafPanelHandler extends BaseThingHandler {
             logger.warn("Panel data could not be retrieved as no data was returned (static type missing?) : {}",
                     nfe.getMessage());
         } catch (NanoleafBadRequestException nfe) {
-            logger.debug("Panel data could not be retrieved as request not expected(static type missing / dynamic type on) : {}",
+            logger.debug(
+                    "Panel data could not be retrieved as request not expected(static type missing / dynamic type on) : {}",
                     nfe.getMessage());
         } catch (NanoleafException nue) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,

--- a/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/model/State.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/java/org/openhab/binding/nanoleaf/internal/model/State.java
@@ -14,6 +14,7 @@ package org.openhab.binding.nanoleaf.internal.model;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -37,6 +38,10 @@ public class State {
 
     public @Nullable On getOn() {
         return on;
+    }
+
+    public OnOffType getOnOff() {
+        return (on != null && on.getValue() == true) ? OnOffType.ON : OnOffType.OFF;
     }
 
     public void setOn(On on) {

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 
 	<name>@text/binding.nanoleaf.name</name>
 	<description>@text/binding.nanoleaf.description</description>
-	<author>Martin Raepple, (Stefan Höhn)</author>
+	<author>Martin Raepple, Stefan Höhn</author>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/i18n/nanoleaf.properties
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/i18n/nanoleaf.properties
@@ -1,5 +1,5 @@
 binding.nanoleaf.name = Nanoleaf Binding
-binding.nanoleaf.description = Integrates the Nanoleaf Light Panels
+binding.nanoleaf.description = Integrates the Nanoleaf Light Panels (v100320)
 
 # thing types
 thing-type.nanoleaf.controller.name = Nanoleaf Controller

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/i18n/nanoleaf_de.properties
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/i18n/nanoleaf_de.properties
@@ -1,5 +1,5 @@
 binding.nanoleaf.name = Nanoleaf Binding
-binding.nanoleaf.description = Binding für die Integration des Nanoleaf Light Panels
+binding.nanoleaf.description = Binding für die Integration des Nanoleaf Light Panels (v100320)
 
 # thing types
 thing-type.nanoleaf.controller.name = Nanoleaf Controller

--- a/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/thing/lightpanels.xml
+++ b/bundles/org.openhab.binding.nanoleaf/src/main/resources/ESH-INF/thing/lightpanels.xml
@@ -27,6 +27,8 @@
 			<property name="modelId" />
 		</properties>
 
+		<representation-property>address</representation-property>
+
 		<config-description-ref uri="thing-type:nanoleaf:controller" />
 	</bridge-type>
 
@@ -41,6 +43,8 @@
 			<channel id="singleTap" typeId="singleTap" />
 			<channel id="doubleTap" typeId="doubleTap" />
 		</channels>
+
+		<representation-property>id</representation-property>
 
 		<config-description-ref uri="thing-type:nanoleaf:lightpanel" />
 	</thing-type>

--- a/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandlerTest.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandlerTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nanoleaf.internal.handler;
+
+import static java.nio.file.Files.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.nanoleaf.internal.model.ControllerInfo;
+import org.openhab.binding.nanoleaf.internal.model.State;
+
+import com.google.gson.Gson;
+
+/**
+ * Test for the Layout
+ *
+ * @author Stefan Höhn - Initial contribution
+ */
+
+@NonNullByDefault
+public class NanoleafControllerHandlerTest {
+
+    private final Gson gson = new Gson();
+
+    private String controllerInfoJSON = "";
+
+    @Before
+    public void setup() {
+    }
+
+    @Test
+    public void testStateOn() {
+        controllerInfoJSON = "{\r\n  \"name\":\"Nanoleaf Light Panels 12:34:56\",\r\n  \"serialNo\":\"S19082ABCDE\",\r\n  \"manufacturer\":\"Nanoleaf\",\r\n  \"firmwareVersion\":\"3.3.3\",\r\n  \"hardwareVersion\":\"1.6-2\",\r\n  \"model\":\"NL22\",\r\n  \"cloudHash\":{\r\n\r\n  },\r\n  \"discovery\":{\r\n\r\n  },\r\n  \"effects\":{\r\n    \"effectsList\":[\r\n      \"Color Burst\",\r\n      \"Fireworks\",\r\n      \"Flames\",\r\n      \"Forest\",\r\n      \"Inner Peace\",\r\n      \"Lightning\",\r\n      \"Northern Lights\",\r\n      \"Pulse Pop Beats\",\r\n      \"Vibrant Sunrise\"\r\n    ],\r\n    \"select\":\"Flames\"\r\n  },\r\n  \"firmwareUpgrade\":{\r\n\r\n  },\r\n  \"panelLayout\":{\r\n    \"globalOrientation\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n    \"layout\":{\r\n      \"numPanels\":9,\r\n      \"sideLength\":150,\r\n      \"positionData\":[\r\n        {\r\n          \"panelId\":1,\r\n          \"x\":299,\r\n          \"y\":0,\r\n          \"o\":300,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":2,\r\n          \"x\":299,\r\n          \"y\":86,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":3,\r\n          \"x\":224,\r\n          \"y\":129,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":4,\r\n          \"x\":224,\r\n          \"y\":216,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":5,\r\n          \"x\":149,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":6,\r\n          \"x\":74,\r\n          \"y\":216,\r\n          \"o\":240,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":7,\r\n          \"x\":0,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":8,\r\n          \"x\":149,\r\n          \"y\":346,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":9,\r\n          \"x\":374,\r\n          \"y\":129,\r\n          \"o\":180,\r\n          \"shapeType\":0\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"rhythm\":{\r\n    \"auxAvailable\":false,\r\n    \"firmwareVersion\":\"2.4.3\",\r\n    \"hardwareVersion\":\"2.0\",\r\n    \"rhythmActive\":false,\r\n    \"rhythmConnected\":true,\r\n    \"rhythmId\":10,\r\n    \"rhythmMode\":0,\r\n    \"rhythmPos\":{\r\n      \"x\":449.99521692839559,\r\n      \"y\":86.60030339609753,\r\n      \"o\":0.0\r\n    }\r\n  },\r\n  \"schedules\":{\r\n\r\n  },\r\n  \"state\":{\r\n    \"brightness\":{\r\n      \"value\":29,\r\n      \"max\":100,\r\n      \"min\":0\r\n    },\r\n    \"colorMode\":\"effect\",\r\n    \"ct\":{\r\n      \"value\":3000,\r\n      \"max\":6500,\r\n      \"min\":1200\r\n    },\r\n    \"hue\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n    \"on\":{\r\n      \"value\":true\r\n    },\r\n    \"sat\":{\r\n      \"value\":0,\r\n      \"max\":100,\r\n      \"min\":0\r\n    }\r\n  }\r\n}";
+
+        ControllerInfo controllerInfo = gson.fromJson(controllerInfoJSON, ControllerInfo.class);
+
+        final State state = controllerInfo.getState();
+        assertThat(state, is(notNullValue()));
+
+        assertThat(state.getOnOff(), is(OnOffType.ON));
+    }
+
+    @Test
+    public void testStateOff() {
+        controllerInfoJSON = "{\r\n  \"name\":\"Nanoleaf Light Panels 12:34:56\",\r\n  \"serialNo\":\"S19082ABCDE\",\r\n  \"manufacturer\":\"Nanoleaf\",\r\n  \"firmwareVersion\":\"3.3.3\",\r\n  \"hardwareVersion\":\"1.6-2\",\r\n  \"model\":\"NL22\",\r\n  \"cloudHash\":{\r\n\r\n  },\r\n  \"discovery\":{\r\n\r\n  },\r\n  \"effects\":{\r\n    \"effectsList\":[\r\n      \"Color Burst\",\r\n      \"Fireworks\",\r\n      \"Flames\",\r\n      \"Forest\",\r\n      \"Inner Peace\",\r\n      \"Lightning\",\r\n      \"Northern Lights\",\r\n      \"Pulse Pop Beats\",\r\n      \"Vibrant Sunrise\"\r\n    ],\r\n    \"select\":\"Flames\"\r\n  },\r\n  \"firmwareUpgrade\":{\r\n\r\n  },\r\n  \"panelLayout\":{\r\n    \"globalOrientation\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n    \"layout\":{\r\n      \"numPanels\":9,\r\n      \"sideLength\":150,\r\n      \"positionData\":[\r\n        {\r\n          \"panelId\":1,\r\n          \"x\":299,\r\n          \"y\":0,\r\n          \"o\":300,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":2,\r\n          \"x\":299,\r\n          \"y\":86,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":3,\r\n          \"x\":224,\r\n          \"y\":129,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":4,\r\n          \"x\":224,\r\n          \"y\":216,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":5,\r\n          \"x\":149,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":6,\r\n          \"x\":74,\r\n          \"y\":216,\r\n          \"o\":240,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":7,\r\n          \"x\":0,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":8,\r\n          \"x\":149,\r\n          \"y\":346,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":9,\r\n          \"x\":374,\r\n          \"y\":129,\r\n          \"o\":180,\r\n          \"shapeType\":0\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"rhythm\":{\r\n    \"auxAvailable\":false,\r\n    \"firmwareVersion\":\"2.4.3\",\r\n    \"hardwareVersion\":\"2.0\",\r\n    \"rhythmActive\":false,\r\n    \"rhythmConnected\":true,\r\n    \"rhythmId\":10,\r\n    \"rhythmMode\":0,\r\n    \"rhythmPos\":{\r\n      \"x\":449.99521692839559,\r\n      \"y\":86.60030339609753,\r\n      \"o\":0.0\r\n    }\r\n  },\r\n  \"schedules\":{\r\n\r\n  },\r\n  \"state\":{\r\n    \"brightness\":{\r\n      \"value\":29,\r\n      \"max\":100,\r\n      \"min\":0\r\n    },\r\n    \"colorMode\":\"effect\",\r\n    \"ct\":{\r\n      \"value\":3000,\r\n      \"max\":6500,\r\n      \"min\":1200\r\n    },\r\n    \"hue\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n                                                     \"sat\":{\r\n      \"value\":0,\r\n      \"max\":100,\r\n      \"min\":0\r\n    }\r\n  }\r\n}";
+
+        ControllerInfo controllerInfo = gson.fromJson(controllerInfoJSON, ControllerInfo.class);
+
+        final State state = controllerInfo.getState();
+        assertThat(state, is(notNullValue()));
+
+        assertThat(state.getOnOff(), is(OnOffType.OFF));
+    }
+
+    @Test
+    public void testStateOnMissing() {
+        controllerInfoJSON = "{\r\n  \"name\":\"Nanoleaf Light Panels 12:34:56\",\r\n  \"serialNo\":\"S19082ABCDE\",\r\n  \"manufacturer\":\"Nanoleaf\",\r\n  \"firmwareVersion\":\"3.3.3\",\r\n  \"hardwareVersion\":\"1.6-2\",\r\n  \"model\":\"NL22\",\r\n  \"cloudHash\":{\r\n\r\n  },\r\n  \"discovery\":{\r\n\r\n  },\r\n  \"effects\":{\r\n    \"effectsList\":[\r\n      \"Color Burst\",\r\n      \"Fireworks\",\r\n      \"Flames\",\r\n      \"Forest\",\r\n      \"Inner Peace\",\r\n      \"Lightning\",\r\n      \"Northern Lights\",\r\n      \"Pulse Pop Beats\",\r\n      \"Vibrant Sunrise\"\r\n    ],\r\n    \"select\":\"Flames\"\r\n  },\r\n  \"firmwareUpgrade\":{\r\n\r\n  },\r\n  \"panelLayout\":{\r\n    \"globalOrientation\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n    \"layout\":{\r\n      \"numPanels\":9,\r\n      \"sideLength\":150,\r\n      \"positionData\":[\r\n        {\r\n          \"panelId\":1,\r\n          \"x\":299,\r\n          \"y\":0,\r\n          \"o\":300,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":2,\r\n          \"x\":299,\r\n          \"y\":86,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":3,\r\n          \"x\":224,\r\n          \"y\":129,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":4,\r\n          \"x\":224,\r\n          \"y\":216,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":5,\r\n          \"x\":149,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":6,\r\n          \"x\":74,\r\n          \"y\":216,\r\n          \"o\":240,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":7,\r\n          \"x\":0,\r\n          \"y\":259,\r\n          \"o\":60,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":8,\r\n          \"x\":149,\r\n          \"y\":346,\r\n          \"o\":120,\r\n          \"shapeType\":0\r\n        },\r\n        {\r\n          \"panelId\":9,\r\n          \"x\":374,\r\n          \"y\":129,\r\n          \"o\":180,\r\n          \"shapeType\":0\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"rhythm\":{\r\n    \"auxAvailable\":false,\r\n    \"firmwareVersion\":\"2.4.3\",\r\n    \"hardwareVersion\":\"2.0\",\r\n    \"rhythmActive\":false,\r\n    \"rhythmConnected\":true,\r\n    \"rhythmId\":10,\r\n    \"rhythmMode\":0,\r\n    \"rhythmPos\":{\r\n      \"x\":449.99521692839559,\r\n      \"y\":86.60030339609753,\r\n      \"o\":0.0\r\n    }\r\n  },\r\n  \"schedules\":{\r\n\r\n  },\r\n  \"state\":{\r\n    \"brightness\":{\r\n      \"value\":29,\r\n      \"max\":100,\r\n      \"min\":0\r\n    },\r\n    \"colorMode\":\"effect\",\r\n    \"ct\":{\r\n      \"value\":3000,\r\n      \"max\":6500,\r\n      \"min\":1200\r\n    },\r\n    \"hue\":{\r\n      \"value\":0,\r\n      \"max\":360,\r\n      \"min\":0\r\n    },\r\n    \"on\":{\r\n      \"value\":false\r\n    },\r\n    \"sat\":{\r\n      \"value\":0,\r\n      \"max\":100,\r\n      \"min\":0\r\n    }\r\n  }\r\n}";
+
+        ControllerInfo controllerInfo = gson.fromJson(controllerInfoJSON, ControllerInfo.class);
+
+        final State state = controllerInfo.getState();
+        assertThat(state, is(notNullValue()));
+
+        assertThat(state.getOnOff(), is(OnOffType.OFF));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

- fixed the fact that the power state was not resolved anymore correctly
- added test for power state resolving
- added correct autodiscovery suppression based on representation property.