### PR TITLE
[goecharger] fixed access config command and parse command response

### DIFF
--- a/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerHandler.java
+++ b/bundles/org.openhab.binding.goecharger/src/main/java/org/openhab/binding/goecharger/internal/handler/GoEChargerHandler.java
@@ -298,11 +298,9 @@ public class GoEChargerHandler extends BaseThingHandler {
         try {
             ContentResponse contentResponse = httpClient.newRequest(urlStr).method(HttpMethod.POST)
                     .timeout(5, TimeUnit.SECONDS).send();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Response: {}", contentResponse.getContentAsString());
-            }
-            GoEStatusResponseDTO result = gson.fromJson(contentResponse.getContentAsString(),
-                    GoEStatusResponseDTO.class);
+            String response = contentResponse.getContentAsString();
+            logger.debug("POST Response: {}", response);
+            GoEStatusResponseDTO result = gson.fromJson(response, GoEStatusResponseDTO.class);
             updateChannelsAndStatus(result);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
@@ -327,10 +325,9 @@ public class GoEChargerHandler extends BaseThingHandler {
             ContentResponse contentResponse = httpClient.newRequest(urlStr).method(HttpMethod.GET)
                     .timeout(5, TimeUnit.SECONDS).send();
 
-            result = gson.fromJson(contentResponse.getContentAsString(), GoEStatusResponseDTO.class);
-            if (logger.isDebugEnabled()) {
-                logger.debug("Response: {}", contentResponse.getContentAsString());
-            }
+            String response = contentResponse.getContentAsString();
+            logger.debug("GET Response: {}", response);
+            result = gson.fromJson(response, GoEStatusResponseDTO.class);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             result = null;
         }


### PR DESCRIPTION
Followup to https://github.com/openhab/openhab-addons/pull/7068

There was an error in handling the access state command. I just tested it and noticed, that the commands were not translated correctly so i fixed it.

I also added parsing of the response body of the POST request, as it contains the same data in the body, as a normal GET request. So by sending a command we always get the latest values without the need to query them again.

This is useful for example when setting the access config, as it also has side effects on other properties.

For example
`accessConfig` "OPEN" will set `allowCharging` to true
`accessConfig` "RFID" will set `allowCharging` to false

So when we set "OPEN" we will immidiately get the result for `allowCharging`without additional GET.

@wborn, @J-N-K sorry for requesting your review again, but you already know my code, so can you please have a look? its a quite small code change.
