### PR TITLE
[jeelink] Add suport for sensors that are directly connected to a LGW

### DIFF
--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkBindingConstants.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/JeeLinkBindingConstants.java
@@ -44,6 +44,7 @@ public class JeeLinkBindingConstants {
     public static final ThingTypeUID PCA301_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "pca301");
     public static final ThingTypeUID TX22_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "tx22");
     public static final ThingTypeUID REVOLT_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "revolt");
+    public static final ThingTypeUID LGW_SENSOR_THING_TYPE = new ThingTypeUID(BINDING_ID, "lgw");
 
     // List of all channel ids for lacrosse sensor things
     public static final String TEMPERATURE_CHANNEL = "temperature";

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/SensorDefinition.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.openhab.binding.jeelink.internal.ec3k.Ec3kSensorDefinition;
 import org.openhab.binding.jeelink.internal.lacrosse.LaCrosseSensorDefinition;
+import org.openhab.binding.jeelink.internal.lacrosse.LgwSensorDefinition;
 import org.openhab.binding.jeelink.internal.lacrosse.Tx22SensorDefinition;
 import org.openhab.binding.jeelink.internal.pca301.Pca301SensorDefinition;
 import org.openhab.binding.jeelink.internal.revolt.RevoltSensorDefinition;
@@ -37,7 +38,8 @@ public abstract class SensorDefinition<R extends Reading> {
     
     private static final Set<SensorDefinition<?>> SENSOR_DEFS = Stream
             .of(new LaCrosseSensorDefinition(), new Ec3kSensorDefinition(), new Pca301SensorDefinition(),
-                    new Tx22SensorDefinition(), new RevoltSensorDefinition()).collect(Collectors.toSet());
+                    new Tx22SensorDefinition(), new RevoltSensorDefinition(), new LgwSensorDefinition())
+            .collect(Collectors.toSet());
     private static final Set<JeeLinkReadingConverter<?>> CONVERTERS = SENSOR_DEFS.stream()
             .map(SensorDefinition::createConverter).collect(Collectors.toSet());
 

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwReading.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwReading.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import org.openhab.binding.jeelink.internal.Reading;
+
+/**
+ * Reading of sensors directly connected to a LGW.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class LgwReading implements Reading {
+    private String sensorId;
+    private Float temp;
+    private Integer humidity;
+    private Integer pressure;
+
+    public LgwReading(int sensorId, Float temp, Integer humidity, Integer pressure) {
+        this.sensorId = String.valueOf(sensorId);
+        this.temp = temp;
+        this.humidity = humidity;
+        this.pressure = pressure;
+    }
+
+    @Override
+    public String getSensorId() {
+        return sensorId;
+    }
+
+    public Float getTemperature() {
+        return temp;
+    }
+
+    public Integer getHumidity() {
+        return humidity;
+    }
+    
+    public Integer getPressure() {
+        return pressure;
+    }
+
+    public boolean hasPressure() {
+        return pressure != null;
+    }
+
+    public boolean hasHumidity() {
+        return humidity != null;
+    }
+
+    public boolean hasTemperature() {
+        return temp != null;
+    }
+
+    @Override
+    public String toString() {
+        return "sensorId=" + sensorId + ": temp=" + temp + (hasHumidity() ? ", hum=" + humidity : "") 
+                + (hasPressure() ? ", pressure=" + pressure : "");
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwReadingConverter.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwReadingConverter.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converter for converting a line read from a LGW to a LgwReading.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class LgwReadingConverter implements JeeLinkReadingConverter<LgwReading> {
+    private static final Pattern LINE_P = Pattern.compile(
+            "OK\\s+WS\\s+([0-9]+)\\s+4\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)(?:\\s+255){8}?\\s+0\\s+([0-9]+)\\s+([0-9]+)(?:\\s+255){9}?");
+    private final Logger logger = LoggerFactory.getLogger(LgwReadingConverter.class);
+
+    @Override
+    public LgwReading createReading(String inputLine) {
+        // parse lines only if we have registered listeners
+        if (inputLine != null) {
+            Matcher matcher = LINE_P.matcher(inputLine);
+            if (matcher.matches()) {
+                /* Format
+                  OK WS 71  4   4   203 53  255 255 255 255 255 255 255 255 0    3 219  255 255 255 255 255 255 255 255 255
+                  OK WS 75  4   4   195 61  255 255 255 255 255 255 255 255 0  255 255  255 255 255 255 255 255 255 255 255
+                  OK WS 213 4   5   126 40  255 255 255 255 255 255 255 255 0   40  53  0   48  57
+                  OK WS ID  XXX TTT TTT HHH RRR RRR DDD DDD SSS SSS GGG GGG FFF PPP PPP GAS GAS GAS DEB DEB DEB LUX LUX LUX
+                  |  |  |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |-------------------------------------- Pressure LSB
+                  |  |  |   |   |   |   |   |   |   |   |   |   |   |   |   |   |------------------------------------------ Pressure MSB
+                  |  |  |   |   |   |   |   |   |   |   |   |   |   |   |   |-- Fix 0
+                  |  |  |   |   |   |   |-------------------------------------- Humidity (1 ... 99 %rH)                        FF = none
+                  |  |  |   |   |   |------------------------------------------ Temp * 10 + 1000 LSB (-40 ... +60 °C)          FF/FF = none
+                  |  |  |   |   |---------------------------------------------- Temp * 10 + 1000 MSB
+                  |  |  |   |-------------------------------------------------- fix "4"
+                  |  |  |------------------------------------------------------ Sensor ID (1 ... 63)
+                  |  |--------------------------------------------------------- fix "WS"
+                  |------------------------------------------------------------ fix "OK"
+                 */
+                logger.trace("Creating reading from: {}", inputLine);
+
+                int sensorId = Integer.parseInt(matcher.group(1));
+
+                Float temperature = "255".equals(matcher.group(2)) ? null
+                        : (float) (Integer.parseInt(matcher.group(2)) * 256 + Integer.parseInt(matcher.group(3)) - 1000)
+                        / 10;
+
+                Integer humidity = "255".equals(matcher.group(4)) ? null : Integer.parseInt(matcher.group(4));
+
+                Integer pressure = null;
+                if (!"255".equals(matcher.group(5))) {
+                    pressure = Integer.parseInt(matcher.group(5)) * 256 + Integer.parseInt(matcher.group(6));
+                }
+
+                return new LgwReading(sensorId, temperature, humidity, pressure);
+            }
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorDefinition.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorDefinition.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.jeelink.internal.JeeLinkBindingConstants;
+import org.openhab.binding.jeelink.internal.JeeLinkReadingConverter;
+import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
+import org.openhab.binding.jeelink.internal.SensorDefinition;
+
+/**
+ * Sensor definition of a sensor directly connected to a LGW.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class LgwSensorDefinition extends SensorDefinition<LgwReading> {
+
+    public LgwSensorDefinition() {
+        super(JeeLinkBindingConstants.LGW_SENSOR_THING_TYPE, "LGW Sensor", "LGW");
+    }
+
+    @Override
+    public JeeLinkReadingConverter<LgwReading> createConverter() {
+        return new LgwReadingConverter();
+    }
+
+    @Override
+    public Class<LgwReading> getReadingClass() {
+        return LgwReading.class;
+    }
+
+    @Override
+    public JeeLinkSensorHandler<LgwReading> createHandler(Thing thing) {
+        return new LgwSensorHandler(thing, type);
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jeelink.internal.lacrosse;
+
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.*;
+import static org.openhab.binding.jeelink.internal.JeeLinkBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.openhab.binding.jeelink.internal.JeeLinkSensorHandler;
+import org.openhab.binding.jeelink.internal.ReadingPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for a LGW Sensor thing.
+ *
+ * @author Volker Bier - Initial contribution
+ */
+public class LgwSensorHandler extends JeeLinkSensorHandler<LgwReading> {
+    private final Logger logger = LoggerFactory.getLogger(LgwSensorHandler.class);
+    private boolean hasHumidityChannel;
+    private boolean hasPressureChannel;
+
+    public LgwSensorHandler(Thing thing, String sensorType) {
+        super(thing, sensorType);
+
+        hasHumidityChannel = getThing().getChannel(HUMIDITY_CHANNEL) != null;
+        hasPressureChannel = getThing().getChannel(PRESSURE_CHANNEL) != null;
+    }
+
+    @Override
+    public Class<LgwReading> getReadingClass() {
+        return LgwReading.class;
+    }
+
+    @Override
+    public ReadingPublisher<LgwReading> createPublisher() {
+        ReadingPublisher<LgwReading> publisher = new ReadingPublisher<LgwReading>() {
+            @Override
+            public void publish(LgwReading reading) {
+                if (reading != null && getThing().getStatus() == ThingStatus.ONLINE) {
+                    logger.debug("updating states for thing {} ({}): {}", getThing().getLabel(),
+                            getThing().getUID().getId(), reading);
+
+                    if (reading.hasTemperature()) {
+                        BigDecimal temp = new BigDecimal(reading.getTemperature()).setScale(1, RoundingMode.HALF_UP);
+                        updateState(TEMPERATURE_CHANNEL, new QuantityType<>(temp, SIUnits.CELSIUS));
+                    }
+
+
+                    if (reading.hasHumidity()) {
+                        if (!hasHumidityChannel) {
+                            ThingBuilder thingBuilder = editThing();
+                            thingBuilder.withChannel(ChannelBuilder
+                                    .create(new ChannelUID(getThing().getUID(), HUMIDITY_CHANNEL), "Number:Humidity")
+                                    .withType(new ChannelTypeUID(getThing().getThingTypeUID().getBindingId(), HUMIDITY_CHANNEL))
+                                    .withLabel(StringUtils.capitalize(HUMIDITY_CHANNEL)).build());
+                            updateThing(thingBuilder.build());
+
+                            hasHumidityChannel=true;
+                        }
+
+                        updateState(HUMIDITY_CHANNEL,
+                                new QuantityType<>(reading.getHumidity(), SmartHomeUnits.PERCENT));
+                    }
+
+                    if (reading.hasPressure()) {
+                        if (!hasPressureChannel) {
+                            ThingBuilder thingBuilder = editThing();
+                            thingBuilder.withChannel(ChannelBuilder
+                                    .create(new ChannelUID(getThing().getUID(), PRESSURE_CHANNEL), "Number:Pressure")
+                                    .withType(new ChannelTypeUID(getThing().getThingTypeUID().getBindingId(), PRESSURE_CHANNEL))
+                                    .withLabel(StringUtils.capitalize(PRESSURE_CHANNEL)).build());
+                            updateThing(thingBuilder.build());
+
+                            hasPressureChannel=true;
+                        }
+
+                        updateState(PRESSURE_CHANNEL, new QuantityType<>(reading.getPressure(), HECTO(SIUnits.PASCAL)));
+                    }
+                }
+            }
+
+            @Override
+            public void dispose() {
+            }
+        };
+
+        return publisher;
+    }
+}

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/lacrosse/LgwSensorHandler.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Volker Bier - Initial contribution
  */
+@NonNullByDefault
 public class LgwSensorHandler extends JeeLinkSensorHandler<LgwReading> {
     private final Logger logger = LoggerFactory.getLogger(LgwSensorHandler.class);
     private boolean hasHumidityChannel;

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink.properties
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink.properties
@@ -23,6 +23,8 @@ thing-type.tx22.label = TX22 Sensor
 thing-type.tx22.description = Thing for a TX22 Sensor connected to a JeeLink USB Receiver.
 thing-type.revolt.label = Revolt Power Monitor
 thing-type.revolt.description = Thing for a Revolt Power Monitor connected to a JeeLink USB Receiver.
+thing-type.lgw.label = LGW Sensor
+thing-type.lgw.description = Thing for a Sensor directly connected to a LGW.
 
 # parameters
 parameter.serialport.label = Serial Port

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink_de.properties
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/i18n/jeelink_de.properties
@@ -20,9 +20,11 @@ thing-type.ec3k.description = Ein mit dem JeeLink USB Empfänger verbundenes EC30
 thing-type.pca301.label = PCA301
 thing-type.pca301.description = Eine mit dem JeeLink USB Empfänger verbundene PCA301 Steckdose.
 thing-type.tx22.label = TX22 Sensor
-thing-type.tx22.description = Eine mit dem JeeLink USB Empfänger verbundener TX22 Sensor.
+thing-type.tx22.description = Ein mit dem JeeLink USB Empfänger verbundener TX22 Sensor.
 thing-type.revolt.label = Revolt Energie-Messgerät
 thing-type.revolt.description = Ein mit dem JeeLink USB Empfänger verbundenes Revolt Energie-Messgerät.
+thing-type.lgw.label = LGW Sensor
+thing-type.lgw.description = Ein direkt mit dem LGW verbundener Sensor.
 
 # parameters
 parameter.serialport.label = Serielle Schnittstelle

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -363,6 +363,35 @@
 		</config-description>
 	</thing-type>
 
+	<!-- LGW Sensor SensorThing Type -->
+	<thing-type id="lgw">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="jeelinkTcp" />
+			<bridge-type-ref id="jeelinkUsb" />
+			<bridge-type-ref id="lgwTcp" />
+			<bridge-type-ref id="lgwUsb" />
+		</supported-bridge-type-refs>
+
+		<label>@text/thing-type.lgw.label</label>
+		<description>@text/thing-type.lgw.description</description>
+
+		<channels>
+			<channel id="temperature" typeId="temperature" />
+		</channels>
+
+		<config-description>
+			<parameter name="sensorId" type="text" required="true">
+				<label>@text/parameter.sensorid.label</label>
+				<description>@text/parameter.sensorid.description</description>
+			</parameter>
+			<parameter name="sensorTimeout" type="integer" required="false" min="5" max="3600" unit="s" step="5">
+				<label>@text/parameter.sensortimeout.label</label>
+				<description>@text/parameter.sensortimeout.description</description>
+				<default>600</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<channel-type id="wind-angle">
 		<item-type>Number:Angle</item-type>
 		<label>@text/channel-type.wind-angle.label</label>


### PR DESCRIPTION
This adds support for sensors that are directly connected to Lacrosse Gateways.

See https://community.openhab.org/t/new-jeelink-openhab2-binding/15018/370 ff.

Signed-off-by: Volker Bier <volker.bier@web.de>
