### PR TITLE
[bluetooth] Removed extra service discovery

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
@@ -229,8 +229,6 @@ public class BluetoothDiscoveryProcess implements Supplier<DiscoveryResult>, Blu
             } finally {
                 serviceDiscoveryLock.unlock();
             }
-            // a failure here would just result in a timeout, which is fine
-            device.discoverServices();
         }
     }
 


### PR DESCRIPTION
Removed extra service discovery from connection event handling. Service
discovery is done when connection based discovery is required.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
