### PR TITLE
[bluetooth] Increased discovery timeout from 5 sec to 10 sec

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryProcess.java
@@ -189,7 +189,7 @@ public class BluetoothDiscoveryProcess implements Supplier<DiscoveryResult>, Blu
                     }
                     if (!servicesDiscovered) {
                         device.discoverServices();
-                        if (!awaitServiceDiscovery(5, TimeUnit.SECONDS)) {
+                        if (!awaitServiceDiscovery(10, TimeUnit.SECONDS)) {
                             logger.debug("Service discovery for device {} timed out", device.getAddress());
                             // something failed, so we abandon connection discovery
                             return null;


### PR DESCRIPTION
Airthings service discovery takes around 5 seconds when device is very
close to bluetooth dongle. Timeouts have been seen multiple times.
Increased timeout to increase probability for successful service
discovers during connection oriented device discovery.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
