### PR TITLE
[modbus] gracefully handle unexpected slave responses

### DIFF
--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusReadRequestBlueprint.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusReadRequestBlueprint.java
@@ -35,11 +35,8 @@ public interface ModbusReadRequestBlueprint extends ModbusRequestBlueprint {
     public int getReference();
 
     /**
-     * Returns the length of the data appended
-     * after the protocol header.
-     * <p>
+     * Returns the number of registers/coils/discrete inputs
      *
-     * @return the data length as <tt>int</tt>.
      */
     public int getDataLength();
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedResponseFunctionCodeException.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedResponseFunctionCodeException.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.transport.modbus;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception representing situation where function code of the response does not match request
+ *
+ * @author Sami Salonen - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class ModbusUnexpectedResponseFunctionCodeException extends ModbusTransportException {
+
+    private static final long serialVersionUID = 1109165449703638949L;
+    private int requestFunctionCode;
+    private int responseFunctionCode;
+
+    public ModbusUnexpectedResponseFunctionCodeException(int requestFunctionCode, int responseFunctionCode) {
+        this.requestFunctionCode = requestFunctionCode;
+        this.responseFunctionCode = responseFunctionCode;
+
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Function code of request (%d) does not equal response (%d)", requestFunctionCode,
+                responseFunctionCode);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "ModbusUnexpectedResponseFunctionCodeException(requestFunctionCode=%d, responseFunctionCode=%d)",
+                requestFunctionCode, responseFunctionCode);
+    }
+
+}

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedResponseSizeException.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedResponseSizeException.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.transport.modbus;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception representing situation where data length of the response does not match request
+ *
+ * @author Sami Salonen - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class ModbusUnexpectedResponseSizeException extends ModbusTransportException {
+
+    private static final long serialVersionUID = 2460907938819984483L;
+    private int requestSize;
+    private int responseSize;
+
+    public ModbusUnexpectedResponseSizeException(int requestSize, int responseSize) {
+        this.requestSize = requestSize;
+        this.responseSize = responseSize;
+
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Data length of the request (%d) does not equal response (%d). Slave response is invalid.",
+                requestSize, responseSize);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ModbusUnexpectedResponseSizeException(requestFunctionCode=%d, responseFunctionCode=%d)",
+                requestSize, responseSize);
+    }
+
+}

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedTransactionIdException.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusUnexpectedTransactionIdException.java
@@ -35,7 +35,8 @@ public class ModbusUnexpectedTransactionIdException extends ModbusTransportExcep
 
     @Override
     public String getMessage() {
-        return String.format("Transaction id of response (%d) does not equal request (%d)", requestId, responseId);
+        return String.format("Transaction id of request (%d) does not equal response (%d). Slave response is invalid.",
+                requestId, responseId);
     }
 
     @Override

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusLibraryWrapper.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusLibraryWrapper.java
@@ -256,41 +256,71 @@ public class ModbusLibraryWrapper {
     }
 
     /**
+     * Get number of bits/registers/discrete inputs in the request.
+     *
+     *
+     * @param response
+     * @param request
+     * @return
+     */
+    public static int getNumberOfItemsInResponse(ModbusResponse response, ModbusReadRequestBlueprint request) {
+        // jamod library seems to be a bit buggy when it comes number of coils/discrete inputs in the response. Some
+        // of the methods such as ReadCoilsResponse.getBitCount() are returning wrong values.
+        //
+        // This is the reason we use a bit more verbose way to get the number of items in the response.
+        final int responseCount;
+        if (request.getFunctionCode() == ModbusReadFunctionCode.READ_COILS) {
+            responseCount = ((ReadCoilsResponse) response).getCoils().size();
+        } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_DISCRETES) {
+            responseCount = ((ReadInputDiscretesResponse) response).getDiscretes().size();
+        } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS) {
+            responseCount = ((ReadMultipleRegistersResponse) response).getRegisters().length;
+        } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_REGISTERS) {
+            responseCount = ((ReadInputRegistersResponse) response).getRegisters().length;
+        } else {
+            throw new IllegalArgumentException(String.format("Unexpected function code %s", request.getFunctionCode()));
+        }
+        return responseCount;
+    }
+
+    /**
      * Invoke callback with the data received
      *
      * @param message original request
      * @param callback callback for read
      * @param response Modbus library response object
      */
-    public static void invokeCallbackWithResponse(ModbusReadRequestBlueprint message, ModbusReadCallback callback,
+    public static void invokeCallbackWithResponse(ModbusReadRequestBlueprint request, ModbusReadCallback callback,
             ModbusResponse response) {
         try {
-            getLogger().trace("Calling read response callback {} for request {}. Response was {}", callback, message,
+            getLogger().trace("Calling read response callback {} for request {}. Response was {}", callback, request,
                     response);
-            // jamod library seems to be a bit buggy when it comes number of coils in the response, so we use
-            // minimum(request, response). The underlying reason is that BitVector.createBitVector initializes the
-            // vector
-            // with too many bits as size
-            if (message.getFunctionCode() == ModbusReadFunctionCode.READ_COILS) {
+            // The number of coils/discrete inputs received in response are always in the multiples of 8
+            // bits.
+            // So even if querying 5 bits, you will actually get 8 bits. Here we wrap the data in
+            // BitArrayWrappingBitVector
+            // with will validate that the consumer is not accessing the "invalid" bits of the response.
+            int dataItemsInResponse = getNumberOfItemsInResponse(response, request);
+            if (request.getFunctionCode() == ModbusReadFunctionCode.READ_COILS) {
                 BitVector bits = ((ReadCoilsResponse) response).getCoils();
-                callback.onBits(message,
-                        new BitArrayWrappingBitVector(bits, Math.min(bits.size(), message.getDataLength())));
-            } else if (message.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_DISCRETES) {
+                callback.onBits(request,
+                        new BitArrayWrappingBitVector(bits, Math.min(dataItemsInResponse, request.getDataLength())));
+            } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_DISCRETES) {
                 BitVector bits = ((ReadInputDiscretesResponse) response).getDiscretes();
-                callback.onBits(message,
-                        new BitArrayWrappingBitVector(bits, Math.min(bits.size(), message.getDataLength())));
-            } else if (message.getFunctionCode() == ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS) {
-                callback.onRegisters(message, new RegisterArrayWrappingInputRegister(
+                callback.onBits(request,
+                        new BitArrayWrappingBitVector(bits, Math.min(dataItemsInResponse, request.getDataLength())));
+            } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS) {
+                callback.onRegisters(request, new RegisterArrayWrappingInputRegister(
                         ((ReadMultipleRegistersResponse) response).getRegisters()));
-            } else if (message.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_REGISTERS) {
-                callback.onRegisters(message,
+            } else if (request.getFunctionCode() == ModbusReadFunctionCode.READ_INPUT_REGISTERS) {
+                callback.onRegisters(request,
                         new RegisterArrayWrappingInputRegister(((ReadInputRegistersResponse) response).getRegisters()));
             } else {
                 throw new IllegalArgumentException(
-                        String.format("Unexpected function code %s", message.getFunctionCode()));
+                        String.format("Unexpected function code %s", request.getFunctionCode()));
             }
         } finally {
-            getLogger().trace("Called read response callback {} for request {}. Response was {}", callback, message,
+            getLogger().trace("Called read response callback {} for request {}. Response was {}", callback, request,
                     response);
         }
     }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -42,6 +42,8 @@ import org.openhab.io.transport.modbus.ModbusManagerListener;
 import org.openhab.io.transport.modbus.ModbusReadCallback;
 import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
 import org.openhab.io.transport.modbus.ModbusRequestBlueprint;
+import org.openhab.io.transport.modbus.ModbusUnexpectedResponseFunctionCodeException;
+import org.openhab.io.transport.modbus.ModbusUnexpectedResponseSizeException;
 import org.openhab.io.transport.modbus.ModbusUnexpectedTransactionIdException;
 import org.openhab.io.transport.modbus.ModbusWriteCallback;
 import org.openhab.io.transport.modbus.ModbusWriteRequestBlueprint;
@@ -102,11 +104,19 @@ public class ModbusManagerImpl implements ModbusManager {
          * @param timer aggregate stop watch for performance profiling
          * @param task task to execute
          * @param connection connection to use
-         * @throws Exception on IO errors, slave exception responses, and when transaction IDs of the request and
+         *
+         * @throws IIOException on generic IO errors
+         * @throws ModbusException on Modbus protocol errors (e.g. ModbusIOException on I/O, ModbusSlaveException on
+         *             slave exception responses)
+         * @throws ModbusUnexpectedTransactionIdException when transaction IDs of the request and
          *             response do not match
+         * @throws ModbusUnexpectedResponseFunctionCodeException when response function code does not match the request
+         *             (ill-behaving slave)
+         * @throws ModbusUnexpectedResponseSizeException when data length of the response and request do not match
          */
         public void accept(AggregateStopWatch timer, T task, ModbusSlaveConnection connection)
-                throws ModbusException, IIOException, ModbusUnexpectedTransactionIdException;
+                throws ModbusException, IIOException, ModbusUnexpectedTransactionIdException,
+                ModbusUnexpectedResponseFunctionCodeException, ModbusUnexpectedResponseSizeException;
 
     }
 
@@ -125,12 +135,50 @@ public class ModbusManagerImpl implements ModbusManager {
         // Compare request and response transaction ID. NOTE: ModbusTransaction.getTransactionID() is static and
         // not safe to use
         if ((response.getTransactionID() != libRequest.getTransactionID()) && !response.isHeadless()) {
-            logger.warn(
-                    "Transaction id of the response ({}) does not match request ({}) {}. Endpoint {}. Ignoring response. [operation ID {}]",
-                    response.getTransactionID(), libRequest.getTransactionID(), task.getRequest(), task.getEndpoint(),
-                    operationId);
             throw new ModbusUnexpectedTransactionIdException(libRequest.getTransactionID(),
                     response.getTransactionID());
+        }
+    }
+
+    /**
+     * Check that function code of the response and request match
+     *
+     * @param response
+     * @param libRequest
+     * @param task
+     * @param operationId
+     * @throws ModbusUnexpectedTransactionIdException
+     */
+    private <R> void checkFunctionCode(ModbusResponse response, ModbusRequest libRequest,
+            TaskWithEndpoint<R, ? extends ModbusCallback> task, String operationId)
+            throws ModbusUnexpectedResponseFunctionCodeException {
+        if ((response.getFunctionCode() != libRequest.getFunctionCode())) {
+            throw new ModbusUnexpectedResponseFunctionCodeException(libRequest.getTransactionID(),
+                    response.getTransactionID());
+        }
+    }
+
+    /**
+     * Check that number of bits/registers/discrete inputs is not less than what was requested.
+     *
+     * According to modbus protocol, we should get always get always equal amount of registers data back as response.
+     * With coils and discrete inputs, we can get more since responses are in 8 bit chunks.
+     *
+     * However, in no case we expect less items in response.
+     *
+     * This is to identify clearly invalid responses which might cause problems downstream when using the data.
+     *
+     * @param response
+     * @param request
+     * @param task
+     * @param operationId
+     * @throws ModbusUnexpectedResponseSizeException
+     */
+    private <R> void checkResponseSize(ModbusResponse response, ModbusReadRequestBlueprint request, PollTask task,
+            String operationId) throws ModbusUnexpectedResponseSizeException {
+        final int responseCount = ModbusLibraryWrapper.getNumberOfItemsInResponse(response, request);
+        if (responseCount < request.getDataLength()) {
+            throw new ModbusUnexpectedResponseSizeException(request.getDataLength(), responseCount);
         }
     }
 
@@ -143,7 +191,8 @@ public class ModbusManagerImpl implements ModbusManager {
     private class PollOperation implements ModbusOperation<PollTask> {
         @Override
         public void accept(AggregateStopWatch timer, PollTask task, ModbusSlaveConnection connection)
-                throws ModbusException, ModbusUnexpectedTransactionIdException {
+                throws ModbusException, ModbusUnexpectedTransactionIdException,
+                ModbusUnexpectedResponseFunctionCodeException, ModbusUnexpectedResponseSizeException {
             ModbusSlaveEndpoint endpoint = task.getEndpoint();
             ModbusReadRequestBlueprint request = task.getRequest();
             ModbusReadCallback callback = task.getCallback();
@@ -157,13 +206,15 @@ public class ModbusManagerImpl implements ModbusManager {
                     request.getFunctionCode(), libRequest.getHexMessage(), operationId);
             // Might throw ModbusIOException (I/O error) or ModbusSlaveException (explicit exception response from
             // slave)
-            timer.transaction.timeRunnableWithModbusException(() -> transaction.execute());
+            timer.transaction.timeRunnableWithException(() -> transaction.execute());
             ModbusResponse response = transaction.getResponse();
             logger.trace("Response for read request (FC={}, transaction ID={}): {} [operation ID {}]",
                     response.getFunctionCode(), response.getTransactionID(), response.getHexMessage(), operationId);
             checkTransactionId(response, libRequest, task, operationId);
+            checkFunctionCode(response, libRequest, task, operationId);
+            checkResponseSize(response, request, task, operationId);
             if (callback != null) {
-                timer.callback.timeRunnable(
+                timer.callback.timeRunnableWithException(
                         () -> ModbusLibraryWrapper.invokeCallbackWithResponse(request, callback, response));
             }
         }
@@ -178,7 +229,8 @@ public class ModbusManagerImpl implements ModbusManager {
     private class WriteOperation implements ModbusOperation<WriteTask> {
         @Override
         public void accept(AggregateStopWatch timer, WriteTask task, ModbusSlaveConnection connection)
-                throws ModbusException, ModbusUnexpectedTransactionIdException {
+                throws ModbusException, ModbusUnexpectedTransactionIdException,
+                ModbusUnexpectedResponseFunctionCodeException {
             ModbusSlaveEndpoint endpoint = task.getEndpoint();
             ModbusWriteRequestBlueprint request = task.getRequest();
             ModbusWriteCallback callback = task.getCallback();
@@ -193,12 +245,12 @@ public class ModbusManagerImpl implements ModbusManager {
 
             // Might throw ModbusIOException (I/O error) or ModbusSlaveException (explicit exception response from
             // slave)
-            timer.transaction.timeRunnableWithModbusException(() -> transaction.execute());
+            timer.transaction.timeRunnableWithException(() -> transaction.execute());
             ModbusResponse response = transaction.getResponse();
             logger.trace("Response for write request (FC={}, transaction ID={}): {} [operation ID {}]",
                     response.getFunctionCode(), response.getTransactionID(), response.getHexMessage(), operationId);
-
             checkTransactionId(response, libRequest, task, operationId);
+            checkFunctionCode(response, libRequest, task, operationId);
             if (callback != null) {
                 timer.callback.timeRunnable(
                         () -> invokeCallbackWithResponse(request, callback, new ModbusResponseImpl(response)));
@@ -623,16 +675,17 @@ public class ModbusManagerImpl implements ModbusManager {
                                 tryIndex, request, e.getClass().getName(), e.getMessage(), operationId);
                     }
                     continue;
-                } catch (ModbusUnexpectedTransactionIdException e) {
+                } catch (ModbusUnexpectedTransactionIdException | ModbusUnexpectedResponseFunctionCodeException
+                        | ModbusUnexpectedResponseSizeException e) {
                     lastError.set(e);
                     // transaction error details already logged
                     if (willRetry) {
                         logger.warn(
-                                "Try {} out of {} failed when executing request ({}). Will try again soon. The response transaction ID did not match the request. Reseting the connection. Error details: {} {} [operation ID {}]",
+                                "Try {} out of {} failed when executing request ({}). Will try again soon. The response did not match the request. Reseting the connection. Error details: {} {} [operation ID {}]",
                                 tryIndex, maxTries, request, e.getClass().getName(), e.getMessage(), operationId);
                     } else {
                         logger.error(
-                                "Last try {} failed when executing request ({}). Aborting. The response transaction ID did not match the request. Reseting the connection. Error details: {} {} [operation ID {}]",
+                                "Last try {} failed when executing request ({}). Aborting. The response did not match the request. Reseting the connection. Error details: {} {} [operation ID {}]",
                                 tryIndex, request, e.getClass().getName(), e.getMessage(), operationId);
                     }
                     // Invalidate connection, and empty (so that new connection is acquired before new retry)
@@ -721,7 +774,16 @@ public class ModbusManagerImpl implements ModbusManager {
                 long started = System.currentTimeMillis();
                 logger.debug("Executing scheduled ({}ms) poll task {}. Current millis: {}", pollPeriodMillis, task,
                         started);
-                executeOperation(task, false, pollOperation);
+                try {
+                    executeOperation(task, false, pollOperation);
+                } catch (Exception e) {
+                    // We want to catch all unexpected exceptions since all unhandled exceptions make
+                    // ScheduledExecutorService halt the polling. It is better to print out the exception, and try again
+                    // (on next poll cycle)
+                    logger.error(
+                            "Execution of scheduled ({}ms) poll task {} failed unexpectedly. Ignoring exception, polling again according to poll interval.",
+                            pollPeriodMillis, task, e);
+                }
                 long finished = System.currentTimeMillis();
                 logger.debug(
                         "Execution of scheduled ({}ms) poll task {} finished at {}. Was started at millis: {} (=duration of {} millis)",

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -211,7 +211,7 @@ public class ModbusManagerImpl implements ModbusManager {
             checkFunctionCode(response, libRequest, operationId);
             checkResponseSize(response, request, operationId);
             if (callback != null) {
-                timer.callback.timeRunnableWithModbusException(
+                timer.callback.timeRunnable(
                         () -> ModbusLibraryWrapper.invokeCallbackWithResponse(request, callback, response));
             }
         }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
@@ -18,6 +18,8 @@ import java.util.function.Supplier;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.io.transport.modbus.internal.ModbusManagerImpl.PollTaskUnregistered;
 
+import net.wimpi.modbus.ModbusException;
+
 /**
  * Implementation of simple stop watch.
  *
@@ -36,8 +38,8 @@ public class SimpleStopWatch {
     }
 
     @FunctionalInterface
-    public abstract interface RunnableWithException<T extends Throwable> {
-        public abstract void run() throws T;
+    public abstract interface RunnableWithModbusException {
+        public abstract void run() throws ModbusException;
     }
 
     /**
@@ -127,7 +129,7 @@ public class SimpleStopWatch {
      * @param action action to time
      * @throws T when original action throws the exception
      */
-    public <T extends Throwable> void timeRunnableWithException(RunnableWithException<T> action) throws T {
+    public void timeRunnableWithModbusException(RunnableWithModbusException action) throws ModbusException {
         try {
             this.resume();
             action.run();

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
@@ -18,8 +18,6 @@ import java.util.function.Supplier;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.io.transport.modbus.internal.ModbusManagerImpl.PollTaskUnregistered;
 
-import net.wimpi.modbus.ModbusException;
-
 /**
  * Implementation of simple stop watch.
  *
@@ -38,8 +36,8 @@ public class SimpleStopWatch {
     }
 
     @FunctionalInterface
-    public abstract interface RunnableWithModbusException {
-        public abstract void run() throws ModbusException;
+    public abstract interface RunnableWithException<T extends Throwable> {
+        public abstract void run() throws T;
     }
 
     /**
@@ -127,9 +125,9 @@ public class SimpleStopWatch {
      * First StopWatch is resumed, then action is applied. Finally the StopWatch is suspended.
      *
      * @param action action to time
-     * @throws ModbusException when original action throws the exception
+     * @throws T when original action throws the exception
      */
-    public void timeRunnableWithModbusException(RunnableWithModbusException action) throws ModbusException {
+    public <T extends Throwable> void timeRunnableWithException(RunnableWithException<T> action) throws T {
         try {
             this.resume();
             action.run();

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/SimpleStopWatch.java
@@ -127,7 +127,7 @@ public class SimpleStopWatch {
      * First StopWatch is resumed, then action is applied. Finally the StopWatch is suspended.
      *
      * @param action action to time
-     * @throws T when original action throws the exception
+     * @throws ModbusException when original action throws the exception
      */
     public void timeRunnableWithModbusException(RunnableWithModbusException action) throws ModbusException {
         try {

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
@@ -250,12 +250,10 @@ public class SmokeTest extends IntegrationTestSupport {
         assertTrue(lastError.toString(), lastError.get() instanceof ModbusSlaveIOException);
     }
 
-    /**
-     *
-     * @throws InterruptedException
-     */
-    @Test
-    public void testOneOffReadWithCoil() throws InterruptedException {
+    public void testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode functionCode, int count)
+            throws InterruptedException {
+        assertThat(functionCode, is(anyOf(equalTo(ModbusReadFunctionCode.READ_INPUT_DISCRETES),
+                equalTo(ModbusReadFunctionCode.READ_COILS))));
         generateData();
         ModbusSlaveEndpoint endpoint = getEndpoint();
 
@@ -263,8 +261,10 @@ public class SmokeTest extends IntegrationTestSupport {
         CountDownLatch callbackCalled = new CountDownLatch(1);
         AtomicReference<Object> lastData = new AtomicReference<>();
 
+        final int offset = 1;
+
         BasicPollTaskImpl task = new BasicPollTaskImpl(endpoint,
-                new BasicModbusReadRequestBlueprint(SLAVE_UNIT_ID, ModbusReadFunctionCode.READ_COILS, 1, 15, 1),
+                new BasicModbusReadRequestBlueprint(SLAVE_UNIT_ID, functionCode, offset, count, 1),
                 new ModbusReadCallback() {
 
                     @Override
@@ -289,50 +289,70 @@ public class SmokeTest extends IntegrationTestSupport {
         callbackCalled.await(5, TimeUnit.SECONDS);
         assertThat(unexpectedCount.get(), is(equalTo(0)));
         BitArray bits = (BitArray) lastData.get();
-        assertThat(bits.size(), is(equalTo(15)));
-        testCoilValues(bits, 1);
+        assertThat(bits.size(), is(equalTo(count)));
+        if (functionCode == ModbusReadFunctionCode.READ_INPUT_DISCRETES) {
+            testDiscreteValues(bits, offset);
+        } else {
+            testCoilValues(bits, offset);
+        }
     }
 
-    /**
-     *
-     * @throws InterruptedException
-     */
     @Test
-    public void testOneOffReadWithDiscrete() throws InterruptedException {
-        generateData();
-        ModbusSlaveEndpoint endpoint = getEndpoint();
+    public void testOneOffReadWithDiscrete1() throws InterruptedException {
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_INPUT_DISCRETES, 1);
+    }
 
-        AtomicInteger unexpectedCount = new AtomicInteger();
-        CountDownLatch callbackCalled = new CountDownLatch(1);
-        AtomicReference<Object> lastData = new AtomicReference<>();
+    @Test
+    public void testOneOffReadWithDiscrete7() throws InterruptedException {
+        // less than byte
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_INPUT_DISCRETES, 7);
+    }
 
-        BasicPollTaskImpl task = new BasicPollTaskImpl(endpoint, new BasicModbusReadRequestBlueprint(SLAVE_UNIT_ID,
-                ModbusReadFunctionCode.READ_INPUT_DISCRETES, 1, 15, 1), new ModbusReadCallback() {
+    @Test
+    public void testOneOffReadWithDiscrete8() throws InterruptedException {
+        // exactly one byte
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_INPUT_DISCRETES, 8);
+    }
 
-                    @Override
-                    public void onRegisters(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
-                        unexpectedCount.incrementAndGet();
-                        callbackCalled.countDown();
-                    }
+    @Test
+    public void testOneOffReadWithDiscrete13() throws InterruptedException {
+        // larger than byte, less than word (16 bit)
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_INPUT_DISCRETES, 13);
+    }
 
-                    @Override
-                    public void onError(ModbusReadRequestBlueprint request, Exception error) {
-                        unexpectedCount.incrementAndGet();
-                        callbackCalled.countDown();
-                    }
+    @Test
+    public void testOneOffReadWithDiscrete18() throws InterruptedException {
+        // larger than word (16 bit)
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_INPUT_DISCRETES, 18);
+    }
 
-                    @Override
-                    public void onBits(ModbusReadRequestBlueprint request, BitArray bits) {
-                        lastData.set(bits);
-                        callbackCalled.countDown();
-                    }
-                });
-        modbusManager.submitOneTimePoll(task);
-        callbackCalled.await(5, TimeUnit.SECONDS);
-        assertThat(unexpectedCount.get(), is(equalTo(0)));
-        BitArray bits = (BitArray) lastData.get();
-        assertThat(bits.size(), is(equalTo(15)));
-        testDiscreteValues(bits, 1);
+    @Test
+    public void testOneOffReadWithCoils1() throws InterruptedException {
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_COILS, 1);
+    }
+
+    @Test
+    public void testOneOffReadWithCoils7() throws InterruptedException {
+        // less than byte
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_COILS, 7);
+    }
+
+    @Test
+    public void testOneOffReadWithCoils8() throws InterruptedException {
+        // exactly one byte
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_COILS, 8);
+    }
+
+    @Test
+    public void testOneOffReadWithCoils13() throws InterruptedException {
+        // larger than byte, less than word (16 bit)
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_COILS, 13);
+    }
+
+    @Test
+    public void testOneOffReadWithCoils18() throws InterruptedException {
+        // larger than word (16 bit)
+        testOneOffReadWithDiscreteOrCoils(ModbusReadFunctionCode.READ_COILS, 18);
     }
 
     /**


### PR DESCRIPTION
Resolves #7159 

In this PR, we handle gracefully the two following errors observed in the wild
- slave responds with too little data (e.g. returning 5 registers even though 7 was requested). Instead of crashing later when
using the data, abort immediately.
- slave responds with function code which does not match the request (e.g. returning input registers even though holding registers were requested).

In addition, we have a catch-all to cover any other unknown corner cases, to prevent silent halting of the polling as discussed in #7159.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
