### PR TITLE
[systeminfo] Make getSwap* methods able to return 0

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
@@ -428,14 +428,14 @@ public class OSHISysteminfo implements SysteminfoInterface {
     }
 
     @Override
-    public DecimalType getSwapTotal() {
+    public @Nullable DecimalType getSwapTotal() {
         long swapTotal = memory.getVirtualMemory().getSwapTotal();
         swapTotal = getSizeInMB(swapTotal);
         return new DecimalType(swapTotal);
     }
 
     @Override
-    public DecimalType getSwapAvailable() {
+    public @Nullable DecimalType getSwapAvailable() {
         long swapTotal = memory.getVirtualMemory().getSwapTotal();
         long swapUsed = memory.getVirtualMemory().getSwapUsed();
         long swapAvailable = swapTotal - swapUsed;
@@ -444,7 +444,7 @@ public class OSHISysteminfo implements SysteminfoInterface {
     }
 
     @Override
-    public DecimalType getSwapUsed() {
+    public @Nullable DecimalType getSwapUsed() {
         long swapUsed = memory.getVirtualMemory().getSwapUsed();
         swapUsed = getSizeInMB(swapUsed);
         return new DecimalType(swapUsed);

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
@@ -428,37 +428,37 @@ public class OSHISysteminfo implements SysteminfoInterface {
     }
 
     @Override
-    public @Nullable DecimalType getSwapTotal() {
+    public DecimalType getSwapTotal() {
         long swapTotal = memory.getVirtualMemory().getSwapTotal();
         swapTotal = getSizeInMB(swapTotal);
-        return swapTotal > 0 ? new DecimalType(swapTotal) : null;
+        return new DecimalType(swapTotal);
     }
 
     @Override
-    public @Nullable DecimalType getSwapAvailable() {
+    public DecimalType getSwapAvailable() {
         long swapTotal = memory.getVirtualMemory().getSwapTotal();
         long swapUsed = memory.getVirtualMemory().getSwapUsed();
-        long swapAvaialble = swapTotal - swapUsed;
-        swapAvaialble = getSizeInMB(swapAvaialble);
-        return swapAvaialble > 0 ? new DecimalType(swapAvaialble) : null;
+        long swapAvailable = swapTotal - swapUsed;
+        swapAvailable = getSizeInMB(swapAvailable);
+        return new DecimalType(swapAvailable);
     }
 
     @Override
-    public @Nullable DecimalType getSwapUsed() {
-        long swapTotal = memory.getVirtualMemory().getSwapUsed();
-        swapTotal = getSizeInMB(swapTotal);
-        return swapTotal > 0 ? new DecimalType(swapTotal) : null;
+    public DecimalType getSwapUsed() {
+        long swapUsed = memory.getVirtualMemory().getSwapUsed();
+        swapUsed = getSizeInMB(swapUsed);
+        return new DecimalType(swapUsed);
     }
 
     @Override
     public @Nullable DecimalType getSwapAvailablePercent() {
-        long usedSwap = memory.getVirtualMemory().getSwapUsed();
-        long totalSwap = memory.getVirtualMemory().getSwapTotal();
-        long freeSwap = totalSwap - usedSwap;
-        if (totalSwap > 0) {
-            double freePercentDecimal = (double) freeSwap / (double) totalSwap;
-            BigDecimal freePercent = getPercentsValue(freePercentDecimal);
-            return new DecimalType(freePercent);
+        long swapTotal = memory.getVirtualMemory().getSwapTotal();
+        long swapUsed = memory.getVirtualMemory().getSwapUsed();
+        long swapAvailable = swapTotal - swapUsed;
+        if (swapTotal > 0) {
+            double swapAvailablePercentDecimal = (double) swapAvailable / (double) swapTotal;
+            BigDecimal swapAvailablePercent = getPercentsValue(swapAvailablePercentDecimal);
+            return new DecimalType(swapAvailablePercent);
         } else {
             return null;
         }
@@ -466,12 +466,12 @@ public class OSHISysteminfo implements SysteminfoInterface {
 
     @Override
     public @Nullable DecimalType getSwapUsedPercent() {
-        long usedSwap = memory.getVirtualMemory().getSwapUsed();
-        long totalSwap = memory.getVirtualMemory().getSwapTotal();
-        if (totalSwap > 0) {
-            double usedPercentDecimal = (double) usedSwap / (double) totalSwap;
-            BigDecimal usedPercent = getPercentsValue(usedPercentDecimal);
-            return new DecimalType(usedPercent);
+        long swapTotal = memory.getVirtualMemory().getSwapTotal();
+        long swapUsed = memory.getVirtualMemory().getSwapUsed();
+        if (swapTotal > 0) {
+            double swapUsedPercentDecimal = (double) swapUsed / (double) swapTotal;
+            BigDecimal swapUsedPercent = getPercentsValue(swapUsedPercentDecimal);
+            return new DecimalType(swapUsedPercent);
         } else {
             return null;
         }


### PR DESCRIPTION
Remove the null returns for getSwapTotal(), getSwapAvailable() and getSwapUsed(). This makes it obey the specifications in the SysteminfoInterface JavaDoc. Also changes getSwapAvailablePercent() and getSwapUsedPercent() to make variable naming more consistent.

Fixes #6983 

When the getSwap* methods return null the channel and connected Item gets set to UNDEF. This fix makes it able to be set to 0 e.g. shortly after a system reboot, when no pages have been swapped yet.

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
