### PR TITLE
[tellstick] Fix auto-detect handling for Rain and Wind devices

### DIFF
--- a/bundles/org.openhab.binding.tellstick/README.md
+++ b/bundles/org.openhab.binding.tellstick/README.md
@@ -123,11 +123,11 @@ Actuators (dimmer/switch) support the following channels:
 
 Sensors (sensor) support the following channels:
 
-| Channel Type ID | Item Type | Description                                                 |
-|-----------------|-----------|-------------------------------------------------------------|
-| humidity        | Number    | This channel reports the current humidity in percentage.    |
-| temperature     | Number    | This channel reports the current temperature in celsius.    |
-| timestamp       | DateTime  | This channel reports the last time this sensor was updates. |
+| Channel Type ID | Item Type           | Description                                                 |
+|-----------------|---------------------|-------------------------------------------------------------|
+| humidity        | Number              | This channel reports the current humidity in percentage.    |
+| temperature     | Number:Temperature  | This channel reports the current temperature in celsius.    |
+| timestamp       | DateTime            | This channel reports the last time this sensor was updates. |
 
 PowerSensors ([powersensor]) support the following channels:
 
@@ -139,11 +139,11 @@ PowerSensors ([powersensor]) support the following channels:
 
 WindSensors ([windsensor]) support the following channels:
 
-| Channel Type ID | Item Type | Description                  |
-|-----------------|-----------|------------------------------|
-| windgust        | Number    | This current peak wind gust. |
-| winddirection   | Number    | The current wind direction.  |
-| windaverage     | DateTime  | The current wind avarage.    |
+| Channel Type ID | Item Type    | Description                  |
+|-----------------|--------------|------------------------------|
+| windgust        | Number:Speed | The current peak wind gust.  |
+| winddirection   | Number       | The current wind direction.  |
+| windaverage     | Number:Speed | The current wind avarage.    |
 
 RainSensors ([rainsensor]) support the following channels:
 
@@ -155,7 +155,7 @@ RainSensors ([rainsensor]) support the following channels:
 ### Switchbased sensor workaround
 
 All switchbased sensors are binary and the goal is to represent them as a `contact` item in openHAB. Eg. a door is open or closed and can't be altered by sending a radio signal.
-To achive that we will create a proxy item which is updated by a rule.
+To achieve that we will create a proxy item which is updated by a rule.
 
 First create another proxy item for every sensor:
 

--- a/bundles/org.openhab.binding.tellstick/README.md
+++ b/bundles/org.openhab.binding.tellstick/README.md
@@ -125,32 +125,32 @@ Sensors (sensor) support the following channels:
 
 | Channel Type ID | Item Type           | Description                                                 |
 |-----------------|---------------------|-------------------------------------------------------------|
-| humidity        | Number              | This channel reports the current humidity in percentage.    |
-| temperature     | Number:Temperature  | This channel reports the current temperature in celsius.    |
+| humidity        | Number:Dimensionless| This channel reports the current humidity in percentage.    |
+| temperature     | Number:Temperature  | This channel reports the current temperature.               |
 | timestamp       | DateTime            | This channel reports the last time this sensor was updates. |
 
 PowerSensors ([powersensor]) support the following channels:
 
-| Channel Type ID | Item Type | Description                                                 |
-|-----------------|-----------|-------------------------------------------------------------|
-| watt            | Number    | This channel reports the current watt.                      |
-| ampere          | Number    | This channel reports the current ampere.                    |
-| timestamp       | DateTime  | This channel reports the last time this sensor was updates. |
+| Channel Type ID | Item Type              | Description                                                 |
+|-----------------|------------------------|-------------------------------------------------------------|
+| watt            | Number:Power           | This channel reports the current watt.                      |
+| ampere          | Number:ElectricCurrent | This channel reports the current ampere.                    |
+| timestamp       | DateTime               | This channel reports the last time this sensor was updates. |
 
 WindSensors ([windsensor]) support the following channels:
 
 | Channel Type ID | Item Type    | Description                  |
 |-----------------|--------------|------------------------------|
 | windgust        | Number:Speed | The current peak wind gust.  |
-| winddirection   | Number       | The current wind direction.  |
-| windaverage     | Number:Speed | The current wind avarage.    |
+| winddirection   | Number:Angle | The current wind direction.  |
+| windaverage     | Number:Speed | The current wind average.    |
 
 RainSensors ([rainsensor]) support the following channels:
 
-| Channel Type ID | Item Type | Description                |
-|-----------------|-----------|----------------------------|
-| rainrate        | Number    | This current rate of rain. |
-| raintotal       | Number    | The total rain.            |
+| Channel Type ID | Item Type     | Description                |
+|-----------------|---------------|----------------------------|
+| rainrate        | Number:Length | This current rate of rain. |
+| raintotal       | Number:Length | The total rain.            |
 
 ### Switchbased sensor workaround
 

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBindingConstants.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBindingConstants.java
@@ -12,12 +12,22 @@
  */
 package org.openhab.binding.tellstick.internal;
 
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.HECTO;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.measure.Unit;
+import javax.measure.quantity.Angle;
+import javax.measure.quantity.Pressure;
+import javax.measure.quantity.Speed;
+import javax.measure.quantity.Temperature;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -28,6 +38,11 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class TellstickBindingConstants {
+
+    public static final Unit<Temperature> TEMPERATURE_UNIT = SIUnits.CELSIUS;
+    public static final Unit<Pressure> PRESSURE_UNIT = HECTO(SIUnits.PASCAL);
+    public static final Unit<Speed> WIND_SPEED_UNIT_MS = SmartHomeUnits.METRE_PER_SECOND;
+    public static final Unit<Angle> WIND_DIRECTION_UNIT = SmartHomeUnits.DEGREE_ANGLE;
 
     public static final String BINDING_ID = "tellstick";
 

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBindingConstants.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBindingConstants.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tellstick.internal;
 
-import static org.eclipse.smarthome.core.library.unit.MetricPrefix.HECTO;
+import static org.eclipse.smarthome.core.library.unit.MetricPrefix.*;
 
 import java.util.Collections;
 import java.util.Set;
@@ -21,6 +21,11 @@ import java.util.stream.Stream;
 
 import javax.measure.Unit;
 import javax.measure.quantity.Angle;
+import javax.measure.quantity.Dimensionless;
+import javax.measure.quantity.ElectricCurrent;
+import javax.measure.quantity.Illuminance;
+import javax.measure.quantity.Length;
+import javax.measure.quantity.Power;
 import javax.measure.quantity.Pressure;
 import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
@@ -39,12 +44,17 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class TellstickBindingConstants {
 
+    public static final String BINDING_ID = "tellstick";
+
+    public static final Unit<Dimensionless> HUMIDITY_UNIT = SmartHomeUnits.PERCENT;
     public static final Unit<Temperature> TEMPERATURE_UNIT = SIUnits.CELSIUS;
     public static final Unit<Pressure> PRESSURE_UNIT = HECTO(SIUnits.PASCAL);
     public static final Unit<Speed> WIND_SPEED_UNIT_MS = SmartHomeUnits.METRE_PER_SECOND;
     public static final Unit<Angle> WIND_DIRECTION_UNIT = SmartHomeUnits.DEGREE_ANGLE;
-
-    public static final String BINDING_ID = "tellstick";
+    public static final Unit<Length> RAIN_UNIT = MILLI(SIUnits.METRE);
+    public static final Unit<Illuminance> LUX_UNIT = SmartHomeUnits.LUX;
+    public static final Unit<ElectricCurrent> ELECTRIC_UNIT = SmartHomeUnits.AMPERE;
+    public static final Unit<Power> POWER_UNIT = KILO(SmartHomeUnits.WATT);
 
     public static final String CONFIGPATH_ID = "location";
     public static final String DEVICE_ID = "deviceId";

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
@@ -80,9 +80,10 @@ public class TellstickDiscoveryService extends AbstractDiscoveryService implemen
 
     @Override
     public void onDeviceAdded(Bridge bridge, Device device) {
-        logger.debug("Adding new TellstickDevice! {} with id '{}' to smarthome inbox", device.getDeviceType(),
-                device.getId());
+        logger.debug("Adding new TellstickDevice! '{}' with id '{}' and type '{}' to smarthome inbox", device,
+                device.getId(), device.getDeviceType());
         ThingUID thingUID = getThingUID(bridge, device);
+        logger.debug("Detected thingUID: {}", thingUID);
         if (thingUID != null) {
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withTTL(DEFAULT_TTL)
                     .withProperty(TellstickBindingConstants.DEVICE_ID, device.getUUId())
@@ -149,21 +150,25 @@ public class TellstickDiscoveryService extends AbstractDiscoveryService implemen
     }
 
     private ThingTypeUID findSensorType(Device device) {
+        logger.debug("Device: {}", device);
         ThingTypeUID sensorThingId;
         if (device instanceof TellstickSensor) {
             TellstickSensor sensor = (TellstickSensor) device;
-            if (sensor.getData(DataType.WINDAVERAGE) != null) {
+            logger.debug("Sensor: {}", device);
+            if (sensor.getData(DataType.WINDAVERAGE) != null || sensor.getData(DataType.WINDGUST) != null
+                    || sensor.getData(DataType.WINDDIRECTION) != null) {
                 sensorThingId = TellstickBindingConstants.WINDSENSOR_THING_TYPE;
-            } else if (sensor.getData(DataType.RAINTOTAL) != null) {
+            } else if (sensor.getData(DataType.RAINTOTAL) != null || sensor.getData(DataType.RAINRATE) != null) {
                 sensorThingId = TellstickBindingConstants.RAINSENSOR_THING_TYPE;
             } else {
                 sensorThingId = TellstickBindingConstants.SENSOR_THING_TYPE;
             }
         } else {
             TellstickNetSensor sensor = (TellstickNetSensor) device;
-            if (sensor.isSensorOfType(LiveDataType.WINDAVERAGE)) {
+            if (sensor.isSensorOfType(LiveDataType.WINDAVERAGE) || sensor.isSensorOfType(LiveDataType.WINDDIRECTION)
+                    || sensor.isSensorOfType(LiveDataType.WINDGUST)) {
                 sensorThingId = TellstickBindingConstants.WINDSENSOR_THING_TYPE;
-            } else if (sensor.isSensorOfType(LiveDataType.RAINRATE)) {
+            } else if (sensor.isSensorOfType(LiveDataType.RAINRATE) || sensor.isSensorOfType(LiveDataType.RAINTOTAL)) {
                 sensorThingId = TellstickBindingConstants.RAINSENSOR_THING_TYPE;
             } else if (sensor.isSensorOfType(LiveDataType.WATT)) {
                 sensorThingId = TellstickBindingConstants.POWERSENSOR_THING_TYPE;

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/handler/TelldusDevicesHandler.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/handler/TelldusDevicesHandler.java
@@ -17,11 +17,15 @@ import static org.openhab.binding.tellstick.internal.TellstickBindingConstants.*
 import java.math.BigDecimal;
 import java.util.Calendar;
 
+import javax.measure.quantity.Speed;
+import javax.measure.quantity.Temperature;
+
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PercentType;
-import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -205,11 +209,13 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
 
     private Device getDevice(TelldusBridgeHandler tellHandler, String deviceId) {
         Device dev = null;
-        if (deviceId != null && isSensor()) {
-            dev = tellHandler.getSensor(deviceId);
-        } else if (deviceId != null) {
-            dev = tellHandler.getDevice(deviceId);
-            updateDeviceState(dev);
+        if (deviceId != null) {
+            if (isSensor()) {
+                dev = tellHandler.getSensor(deviceId);
+            } else {
+                dev = tellHandler.getDevice(deviceId);
+                updateDeviceState(dev);
+            }
         }
         return dev;
     }
@@ -274,7 +280,7 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateState(humidityChannel, new DecimalType(data));
                 break;
             case TEMPERATURE:
-                updateState(tempChannel, new DecimalType(data));
+                updateState(tempChannel, new QuantityType<Temperature>(new BigDecimal(data), SIUnits.CELSIUS));
                 break;
             case RAINRATE:
                 updateState(rainRateChannel, new DecimalType(data));
@@ -283,13 +289,13 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateState(raintTotChannel, new DecimalType(data));
                 break;
             case WINDAVERAGE:
-                updateState(windAverageChannel, new DecimalType(data));
+                updateState(windAverageChannel, new QuantityType<Speed>(new BigDecimal(data), WIND_SPEED_UNIT_MS));
                 break;
             case WINDDIRECTION:
-                updateState(windDirectionChannel, new StringType(data));
+                updateState(windDirectionChannel, new DecimalType(data));
                 break;
             case WINDGUST:
-                updateState(windGuestChannel, new DecimalType(data));
+                updateState(windGuestChannel, new QuantityType<Speed>(new BigDecimal(data), WIND_SPEED_UNIT_MS));
                 break;
             default:
         }
@@ -301,7 +307,8 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateState(humidityChannel, new DecimalType(dataType.getValue()));
                 break;
             case TEMPERATURE:
-                updateState(tempChannel, new DecimalType(dataType.getValue()));
+                updateState(tempChannel,
+                        new QuantityType<Temperature>(new BigDecimal(dataType.getValue()), SIUnits.CELSIUS));
                 break;
             case RAINRATE:
                 updateState(rainRateChannel, new DecimalType(dataType.getValue()));
@@ -310,13 +317,15 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 updateState(raintTotChannel, new DecimalType(dataType.getValue()));
                 break;
             case WINDAVERAGE:
-                updateState(windAverageChannel, new DecimalType(dataType.getValue()));
+                updateState(windAverageChannel,
+                        new QuantityType<Speed>(new BigDecimal(dataType.getValue()), WIND_SPEED_UNIT_MS));
                 break;
             case WINDDIRECTION:
-                updateState(windDirectionChannel, new StringType(dataType.getValue()));
+                updateState(windDirectionChannel, new DecimalType(dataType.getValue()));
                 break;
             case WINDGUST:
-                updateState(windGuestChannel, new DecimalType(dataType.getValue()));
+                updateState(windGuestChannel,
+                        new QuantityType<Speed>(new BigDecimal(dataType.getValue()), WIND_SPEED_UNIT_MS));
                 break;
             case WATT:
                 if (dataType.getUnit() != null && dataType.getUnit().equals("A")) {

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/handler/TelldusDevicesHandler.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/handler/TelldusDevicesHandler.java
@@ -17,6 +17,12 @@ import static org.openhab.binding.tellstick.internal.TellstickBindingConstants.*
 import java.math.BigDecimal;
 import java.util.Calendar;
 
+import javax.measure.quantity.Angle;
+import javax.measure.quantity.Dimensionless;
+import javax.measure.quantity.ElectricCurrent;
+import javax.measure.quantity.Illuminance;
+import javax.measure.quantity.Length;
+import javax.measure.quantity.Power;
 import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
 
@@ -277,22 +283,22 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
     private void updateSensorDataState(DataType dataType, String data) {
         switch (dataType) {
             case HUMIDITY:
-                updateState(humidityChannel, new DecimalType(data));
+                updateState(humidityChannel, new QuantityType<Dimensionless>(new BigDecimal(data), HUMIDITY_UNIT));
                 break;
             case TEMPERATURE:
                 updateState(tempChannel, new QuantityType<Temperature>(new BigDecimal(data), SIUnits.CELSIUS));
                 break;
             case RAINRATE:
-                updateState(rainRateChannel, new DecimalType(data));
+                updateState(rainRateChannel, new QuantityType<Length>(new BigDecimal(data), RAIN_UNIT));
                 break;
             case RAINTOTAL:
-                updateState(raintTotChannel, new DecimalType(data));
+                updateState(raintTotChannel, new QuantityType<Length>(new BigDecimal(data), RAIN_UNIT));
                 break;
             case WINDAVERAGE:
                 updateState(windAverageChannel, new QuantityType<Speed>(new BigDecimal(data), WIND_SPEED_UNIT_MS));
                 break;
             case WINDDIRECTION:
-                updateState(windDirectionChannel, new DecimalType(data));
+                updateState(windDirectionChannel, new QuantityType<Angle>(new BigDecimal(data), WIND_DIRECTION_UNIT));
                 break;
             case WINDGUST:
                 updateState(windGuestChannel, new QuantityType<Speed>(new BigDecimal(data), WIND_SPEED_UNIT_MS));
@@ -304,24 +310,26 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
     private void updateSensorDataState(DataTypeValue dataType) {
         switch (dataType.getName()) {
             case HUMIDITY:
-                updateState(humidityChannel, new DecimalType(dataType.getValue()));
+                updateState(humidityChannel,
+                        new QuantityType<Dimensionless>(new BigDecimal(dataType.getValue()), HUMIDITY_UNIT));
                 break;
             case TEMPERATURE:
                 updateState(tempChannel,
                         new QuantityType<Temperature>(new BigDecimal(dataType.getValue()), SIUnits.CELSIUS));
                 break;
             case RAINRATE:
-                updateState(rainRateChannel, new DecimalType(dataType.getValue()));
+                updateState(rainRateChannel, new QuantityType<Length>(new BigDecimal(dataType.getValue()), RAIN_UNIT));
                 break;
             case RAINTOTAL:
-                updateState(raintTotChannel, new DecimalType(dataType.getValue()));
+                updateState(raintTotChannel, new QuantityType<Length>(new BigDecimal(dataType.getValue()), RAIN_UNIT));
                 break;
             case WINDAVERAGE:
                 updateState(windAverageChannel,
                         new QuantityType<Speed>(new BigDecimal(dataType.getValue()), WIND_SPEED_UNIT_MS));
                 break;
             case WINDDIRECTION:
-                updateState(windDirectionChannel, new DecimalType(dataType.getValue()));
+                updateState(windDirectionChannel,
+                        new QuantityType<Angle>(new BigDecimal(dataType.getValue()), WIND_DIRECTION_UNIT));
                 break;
             case WINDGUST:
                 updateState(windGuestChannel,
@@ -329,13 +337,14 @@ public class TelldusDevicesHandler extends BaseThingHandler implements DeviceSta
                 break;
             case WATT:
                 if (dataType.getUnit() != null && dataType.getUnit().equals("A")) {
-                    updateState(ampereChannel, new DecimalType(dataType.getValue()));
+                    updateState(ampereChannel,
+                            new QuantityType<ElectricCurrent>(new BigDecimal(dataType.getValue()), ELECTRIC_UNIT));
                 } else {
-                    updateState(wattChannel, new DecimalType(dataType.getValue()));
+                    updateState(wattChannel, new QuantityType<Power>(new BigDecimal(dataType.getValue()), POWER_UNIT));
                 }
                 break;
             case LUMINATION:
-                updateState(luxChannel, new DecimalType(dataType.getValue()));
+                updateState(luxChannel, new QuantityType<Illuminance>(new DecimalType(dataType.getValue()), LUX_UNIT));
                 break;
             default:
         }

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/xml/LiveDataType.java
@@ -22,7 +22,7 @@ public enum LiveDataType {
     TEMPERATURE("temp"),
     WINDAVERAGE("windaverage"),
     WINDDIRECTION("winddirection"),
-    WINDGUST("temp"),
+    WINDGUST("windgust"),
     RAINRATE("rainrate"),
     RAINTOTAL("rainttotal"),
     WATT("watt"),

--- a/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/config/config.xml
@@ -4,19 +4,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
 		https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="thing-type:tellstick:config">
-		<parameter name="interval" type="integer" min="1" max="86400">
-			<label>Interval</label>
-			<description>Refresh interval for positional data calculation in seconds.</description>
-			<default>300</default>
-		</parameter>
-		<parameter name="model" type="text">
-			<label>Model</label>
-			<description>The model used by a specific device.</description>
-			<required>false</required>
-		</parameter>
-	</config-description>
-
 	<config-description uri="thing-type:tellstick:sensor-config">
 		<parameter name="protocol" type="text">
 			<label>Protocol</label>

--- a/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/devices.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/devices.xml
@@ -49,6 +49,7 @@
 			</parameter>
 		</config-description>
 	</thing-type>
+
 	<thing-type id="switch">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="telldus-core" />
@@ -93,6 +94,7 @@
 			</parameter>
 		</config-description>
 	</thing-type>
+
 	<channel-type id="dimmer">
 		<item-type>Dimmer</item-type>
 		<label>Dimmer Value</label>

--- a/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/sensor.xml
@@ -74,31 +74,31 @@
 		<label>Temperature</label>
 		<description>Actual measured room temperature</description>
 		<category>Temperature</category>
-		<state pattern="%f °C" readOnly="true">
+		<state pattern="%.1f %unit%" readOnly="true">
 		</state>
 	</channel-type>
 
 	<channel-type id="humidity">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>Actual measured room Humidity</description>
 		<category>Humidity</category>
-		<state pattern="%d %%" readOnly="true">
+		<state pattern="%d %unit%" readOnly="true">
 		</state>
 	</channel-type>
 
 	<channel-type id="rainrate">
-		<item-type>Number</item-type>
+		<item-type>Number:Length</item-type>
 		<label>Rainrate</label>
 		<description>The current rain rate</description>
-		<state pattern="%d mm" readOnly="true" />
+		<state pattern="%d %unit%" readOnly="true" />
 	</channel-type>
 
 	<channel-type id="raintotal">
-		<item-type>Number</item-type>
+		<item-type>Number:Length</item-type>
 		<label>Total Rain</label>
 		<description>Total rain</description>
-		<state pattern="%d mm" readOnly="true">
+		<state pattern="%d %unit%" readOnly="true">
 		</state>
 	</channel-type>
 
@@ -106,14 +106,14 @@
 		<item-type>Number:Speed</item-type>
 		<label>Wind Gust</label>
 		<description>Current wind gust</description>
-		<state pattern="%d %unit%" readOnly="true"></state>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="windaverage">
 		<item-type>Number:Speed</item-type>
 		<label>Wind Average</label>
 		<description>Current average wind</description>
-		<state pattern="%d %unit%" readOnly="true"></state>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="winddirection">
@@ -121,7 +121,7 @@
 		<label>Wind Direction</label>
 		<description>Current wind direction</description>
 		<category>Wind</category>
-		<state min="0" max="360" step="1" readOnly="true" pattern="%d %unit%" />
+		<state min="0" max="360" step="1" readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="watt">
@@ -143,7 +143,7 @@
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Ampere</label>
 		<description>Current ampere</description>
-		<state pattern="%.1f A" readOnly="true"></state>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="timestamp">

--- a/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.tellstick/src/main/resources/ESH-INF/thing/sensor.xml
@@ -20,6 +20,7 @@
 		</channels>
 		<config-description-ref uri="thing-type:tellstick:sensor-config" />
 	</thing-type>
+
 	<thing-type id="rainsensor">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="telldus-core" />
@@ -35,6 +36,7 @@
 		</channels>
 		<config-description-ref uri="thing-type:tellstick:sensor-config" />
 	</thing-type>
+
 	<thing-type id="powersensor">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="telldus-live" />
@@ -49,14 +51,15 @@
 		</channels>
 		<config-description-ref uri="thing-type:tellstick:sensor-config" />
 	</thing-type>
+
 	<thing-type id="windsensor">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="telldus-core" />
 			<bridge-type-ref id="telldus-live" />
 		</supported-bridge-type-refs>
 
-		<label>RainSensor</label>
-		<description>This Thing defines a Rain Sensor</description>
+		<label>WindSensor</label>
+		<description>This Thing defines a Wind Sensor</description>
 		<channels>
 			<channel id="timestamp" typeId="timestamp" />
 			<channel id="windgust" typeId="windgust" />
@@ -65,18 +68,19 @@
 		</channels>
 		<config-description-ref uri="thing-type:tellstick:sensor-config" />
 	</thing-type>
+
 	<channel-type id="temperature">
-		<item-type>Number</item-type>
-		<label>Actual Temperature</label>
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature</label>
 		<description>Actual measured room temperature</description>
 		<category>Temperature</category>
 		<state pattern="%f °C" readOnly="true">
 		</state>
-
 	</channel-type>
+
 	<channel-type id="humidity">
 		<item-type>Number</item-type>
-		<label>Actual Humidity</label>
+		<label>Humidity</label>
 		<description>Actual measured room Humidity</description>
 		<category>Humidity</category>
 		<state pattern="%d %%" readOnly="true">
@@ -87,59 +91,59 @@
 		<item-type>Number</item-type>
 		<label>Rainrate</label>
 		<description>The current rain rate</description>
-		<state pattern="%d" readOnly="true" />
+		<state pattern="%d mm" readOnly="true" />
 	</channel-type>
 
 	<channel-type id="raintotal">
 		<item-type>Number</item-type>
 		<label>Total Rain</label>
 		<description>Total rain</description>
-		<state pattern="%d" readOnly="true">
+		<state pattern="%d mm" readOnly="true">
 		</state>
 	</channel-type>
 
 	<channel-type id="windgust">
-		<item-type>Number</item-type>
+		<item-type>Number:Speed</item-type>
 		<label>Wind Gust</label>
 		<description>Current wind gust</description>
-		<state pattern="%d" readOnly="true">
-		</state>
+		<state pattern="%d %unit%" readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="watt">
-		<item-type>Number</item-type>
-		<label>Watt</label>
-		<description>Current kWatt</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
-	<channel-type id="lux">
-		<item-type>Number</item-type>
-		<label>Lux</label>
-		<description>Current lumination</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
-	<channel-type id="ampere">
-		<item-type>Number</item-type>
-		<label>Ampere</label>
-		<description>Current ampere</description>
-		<state pattern="%d" readOnly="true">
-		</state>
-	</channel-type>
 	<channel-type id="windaverage">
-		<item-type>Number</item-type>
+		<item-type>Number:Speed</item-type>
 		<label>Wind Average</label>
-		<description>Current wind average</description>
-		<state pattern="%d" readOnly="true">
-		</state>
+		<description>Current average wind</description>
+		<state pattern="%d %unit%" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="winddirection">
-		<item-type>String</item-type>
+		<item-type>Number:Angle</item-type>
 		<label>Wind Direction</label>
-		<description>Current wind directoin</description>
-		<state readOnly="true" />
+		<description>Current wind direction</description>
+		<category>Wind</category>
+		<state min="0" max="360" step="1" readOnly="true" pattern="%d %unit%" />
+	</channel-type>
+
+	<channel-type id="watt">
+		<item-type>Number:Power</item-type>
+		<label>Watt</label>
+		<description>Current kWatt</description>
+		<state readOnly="true" pattern="%f %unit%">
+		</state>
+	</channel-type>
+
+	<channel-type id="lux">
+		<item-type>Number:Illuminance</item-type>
+		<label>Lux</label>
+		<description>Current lumination</description>
+		<state readOnly="true" pattern="%f %unit%" />
+	</channel-type>
+
+	<channel-type id="ampere">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Ampere</label>
+		<description>Current ampere</description>
+		<state pattern="%.1f A" readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="timestamp">


### PR DESCRIPTION
This PR implements a correct auto-detect handling for Rain and Wind devices.
It also uses the correct measurement types for the different channel types.

README has been updated.

Fixes #7171 

I've tested this [jar-file](https://drive.google.com/open?id=1ZxtCDecRDktKebWtl0OSPQGjmq5m7YO7) successfully in my own production environment.

