### PR TITLE
[onkyo] Enumerate supported models using OnkyoModel enum

### DIFF
--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBindingConstants.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBindingConstants.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.onkyo.internal;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -26,93 +27,20 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * @author Paul Frank - Initial contribution
  * @author Pauli Anttila - update for openhab 2
  * @author Stewart Cossey - add additional receiver models
+ * @author Wouter Born - Enumerate supported models using OnkyoModel enum
  */
 @NonNullByDefault
 public class OnkyoBindingConstants {
 
     public static final String BINDING_ID = "onkyo";
 
-    // List of all supported Onkyo Models
-    public static final String ONKYO_TYPE_HTRC560 = "HT-RC560";
-    public static final String ONKYO_TYPE_TXNR414 = "TX-NR414";
-    public static final String ONKYO_TYPE_TXNR474 = "TX-NR474";
-    public static final String ONKYO_TYPE_TXNR509 = "TX-NR509";
-    public static final String ONKYO_TYPE_TXNR515 = "TX-NR515";
-    public static final String ONKYO_TYPE_TXNR525 = "TX-NR525";
-    public static final String ONKYO_TYPE_TXNR535 = "TX-NR535";
-    public static final String ONKYO_TYPE_TXNR545 = "TX-NR545";
-    public static final String ONKYO_TYPE_TXNR555 = "TX-NR555";
-    public static final String ONKYO_TYPE_TXNR575 = "TX-NR575";
-    public static final String ONKYO_TYPE_TXNR575E = "TX-NR575E";
-    public static final String ONKYO_TYPE_TXNR616 = "TX-NR616";
-    public static final String ONKYO_TYPE_TXNR626 = "TX-NR626";
-    public static final String ONKYO_TYPE_TXNR636 = "TX-NR636";
-    public static final String ONKYO_TYPE_TXNR646 = "TX-NR646";
-    public static final String ONKYO_TYPE_TXNR656 = "TX-NR656";
-    public static final String ONKYO_TYPE_TXNR676 = "TX-NR676";
-    public static final String ONKYO_TYPE_TXNR686 = "TX-NR686";
-    public static final String ONKYO_TYPE_TXNR708 = "TX-NR708";
-    public static final String ONKYO_TYPE_TXNR717 = "TX-NR717";
-    public static final String ONKYO_TYPE_TXNR727 = "TX-NR727";
-    public static final String ONKYO_TYPE_TXNR737 = "TX-NR737";
-    public static final String ONKYO_TYPE_TXNR747 = "TX-NR747";
-    public static final String ONKYO_TYPE_TXNR757 = "TX-NR757";
-    public static final String ONKYO_TYPE_TXNR809 = "TX-NR809";
-    public static final String ONKYO_TYPE_TXNR818 = "TX-NR818";
-    public static final String ONKYO_TYPE_TXNR828 = "TX-NR828";
-    public static final String ONKYO_TYPE_TXNR838 = "TX-NR838";
-    public static final String ONKYO_TYPE_TXNR3007 = "TX-NR3007";
-
-    // Extend this set with all successfully tested models
-    public static final Set<String> SUPPORTED_DEVICE_MODELS = Stream
-            .of(ONKYO_TYPE_HTRC560, ONKYO_TYPE_TXNR414, ONKYO_TYPE_TXNR474, ONKYO_TYPE_TXNR509, ONKYO_TYPE_TXNR515,
-                    ONKYO_TYPE_TXNR525, ONKYO_TYPE_TXNR535, ONKYO_TYPE_TXNR555, ONKYO_TYPE_TXNR575, ONKYO_TYPE_TXNR575E,
-                    ONKYO_TYPE_TXNR616, ONKYO_TYPE_TXNR626, ONKYO_TYPE_TXNR636, ONKYO_TYPE_TXNR646, ONKYO_TYPE_TXNR656,
-                    ONKYO_TYPE_TXNR676, ONKYO_TYPE_TXNR686, ONKYO_TYPE_TXNR708, ONKYO_TYPE_TXNR717, ONKYO_TYPE_TXNR727,
-                    ONKYO_TYPE_TXNR737, ONKYO_TYPE_TXNR747, ONKYO_TYPE_TXNR757, ONKYO_TYPE_TXNR809, ONKYO_TYPE_TXNR818,
-                    ONKYO_TYPE_TXNR828, ONKYO_TYPE_TXNR838, ONKYO_TYPE_TXNR3007)
-            .collect(Collectors.toSet());
-
-    // List of all Thing Type UIDs
+    // List of Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_ONKYOAV = new ThingTypeUID(BINDING_ID, "onkyoAVR");
     public static final ThingTypeUID THING_TYPE_ONKYO_UNSUPPORTED = new ThingTypeUID(BINDING_ID, "onkyoUnsupported");
-    public static final ThingTypeUID THING_TYPE_TXNR414 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR414);
-    public static final ThingTypeUID THING_TYPE_HTRC560 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_HTRC560);
-    public static final ThingTypeUID THING_TYPE_TXNR474 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR474);
-    public static final ThingTypeUID THING_TYPE_TXNR509 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR509);
-    public static final ThingTypeUID THING_TYPE_TXNR515 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR515);
-    public static final ThingTypeUID THING_TYPE_TXNR525 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR525);
-    public static final ThingTypeUID THING_TYPE_TXNR535 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR535);
-    public static final ThingTypeUID THING_TYPE_TXNR545 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR545);
-    public static final ThingTypeUID THING_TYPE_TXNR555 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR555);
-    public static final ThingTypeUID THING_TYPE_TXNR575 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR575);
-    public static final ThingTypeUID THING_TYPE_TXNR575E = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR575E);
-    public static final ThingTypeUID THING_TYPE_TXNR616 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR616);
-    public static final ThingTypeUID THING_TYPE_TXNR626 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR626);
-    public static final ThingTypeUID THING_TYPE_TXNR636 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR636);
-    public static final ThingTypeUID THING_TYPE_TXNR646 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR646);
-    public static final ThingTypeUID THING_TYPE_TXNR656 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR656);
-    public static final ThingTypeUID THING_TYPE_TXNR676 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR676);
-    public static final ThingTypeUID THING_TYPE_TXNR686 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR686);
-    public static final ThingTypeUID THING_TYPE_TXNR708 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR708);
-    public static final ThingTypeUID THING_TYPE_TXNR717 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR717);
-    public static final ThingTypeUID THING_TYPE_TXNR727 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR727);
-    public static final ThingTypeUID THING_TYPE_TXNR737 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR737);
-    public static final ThingTypeUID THING_TYPE_TXNR747 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR747);
-    public static final ThingTypeUID THING_TYPE_TXNR757 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR757);
-    public static final ThingTypeUID THING_TYPE_TXNR809 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR809);
-    public static final ThingTypeUID THING_TYPE_TXNR818 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR818);
-    public static final ThingTypeUID THING_TYPE_TXNR828 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR828);
-    public static final ThingTypeUID THING_TYPE_TXNR838 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR838);
-    public static final ThingTypeUID THING_TYPE_TXNR3007 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR3007);
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
-            .of(THING_TYPE_ONKYOAV, THING_TYPE_ONKYO_UNSUPPORTED, THING_TYPE_HTRC560, THING_TYPE_TXNR414,
-                    THING_TYPE_TXNR474, THING_TYPE_TXNR515, THING_TYPE_TXNR525, THING_TYPE_TXNR535, THING_TYPE_TXNR555,
-                    THING_TYPE_TXNR575, THING_TYPE_TXNR575E, THING_TYPE_TXNR616, THING_TYPE_TXNR626, THING_TYPE_TXNR636,
-                    THING_TYPE_TXNR646, THING_TYPE_TXNR656, THING_TYPE_TXNR676, THING_TYPE_TXNR686, THING_TYPE_TXNR708,
-                    THING_TYPE_TXNR717, THING_TYPE_TXNR727, THING_TYPE_TXNR737, THING_TYPE_TXNR747, THING_TYPE_TXNR757,
-                    THING_TYPE_TXNR809, THING_TYPE_TXNR818, THING_TYPE_TXNR828, THING_TYPE_TXNR838, THING_TYPE_TXNR3007)
+            .concat(Stream.of(THING_TYPE_ONKYOAV, THING_TYPE_ONKYO_UNSUPPORTED),
+                    Arrays.stream(OnkyoModel.values()).map(model -> new ThingTypeUID(BINDING_ID, model.getId())))
             .collect(Collectors.toSet());
 
     // List of thing parameters names

--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoModel.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoModel.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.onkyo.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Enumerates all supported Onkyo models.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public enum OnkyoModel {
+
+    // Please also add new supported models to README.md
+
+    HT_RC560("HT-RC560"),
+    TX_NR414("TX-NR414"),
+    TX_NR474("TX-NR474"),
+    TX_NR509("TX-NR509"),
+    TX_NR515("TX-NR515"),
+    TX_NR525("TX-NR525"),
+    TX_NR535("TX-NR535"),
+    TX_NR545("TX-NR545"),
+    TX_NR555("TX-NR555"),
+    TX_NR575("TX-NR575"),
+    TX_NR575E("TX-NR575E"),
+    TX_NR616("TX-NR616"),
+    TX_NR626("TX-NR626"),
+    TX_NR636("TX-NR636"),
+    TX_NR646("TX-NR646"),
+    TX_NR656("TX-NR656"),
+    TX_NR676("TX-NR676"),
+    TX_NR686("TX-NR686"),
+    TX_NR708("TX-NR708"),
+    TX_NR717("TX-NR717"),
+    TX_NR727("TX-NR727"),
+    TX_NR737("TX-NR737"),
+    TX_NR747("TX-NR747"),
+    TX_NR757("TX-NR757"),
+    TX_NR809("TX-NR809"),
+    TX_NR818("TX-NR818"),
+    TX_NR828("TX-NR828"),
+    TX_NR838("TX-NR838"),
+    TX_NR3007("TX-NR3007");
+
+    private final String id;
+
+    private OnkyoModel(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/discovery/OnkyoUpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/discovery/OnkyoUpnpDiscoveryParticipant.java
@@ -14,18 +14,22 @@ package org.openhab.binding.onkyo.internal.discovery;
 
 import static org.openhab.binding.onkyo.internal.OnkyoBindingConstants.*;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.jupnp.model.meta.RemoteDevice;
+import org.openhab.binding.onkyo.internal.OnkyoModel;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -37,6 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Frank - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class OnkyoUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
@@ -72,7 +77,7 @@ public class OnkyoUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     }
 
     @Override
-    public DiscoveryResult createResult(RemoteDevice device) {
+    public @Nullable DiscoveryResult createResult(RemoteDevice device) {
         DiscoveryResult result = null;
         ThingUID thingUid = getThingUID(device);
         if (thingUid != null) {
@@ -89,7 +94,7 @@ public class OnkyoUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
     }
 
     @Override
-    public ThingUID getThingUID(RemoteDevice device) {
+    public @Nullable ThingUID getThingUID(RemoteDevice device) {
         ThingUID result = null;
         if (isAutoDiscoveryEnabled) {
             if (StringUtils.containsIgnoreCase(device.getDetails().getManufacturerDetails().getManufacturer(),
@@ -115,7 +120,7 @@ public class OnkyoUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
         return result;
     }
 
-    private ThingTypeUID findThingType(String deviceModel) {
+    private ThingTypeUID findThingType(@Nullable String deviceModel) {
         ThingTypeUID thingTypeUID = THING_TYPE_ONKYO_UNSUPPORTED;
 
         for (ThingTypeUID thingType : SUPPORTED_THING_TYPES_UIDS) {
@@ -137,9 +142,9 @@ public class OnkyoUpnpDiscoveryParticipant implements UpnpDiscoveryParticipant {
      * @param deviceModel
      * @return
      */
-    private boolean isSupportedDeviceModel(final String deviceModel) {
-        return StringUtils.isNotBlank(deviceModel) && SUPPORTED_DEVICE_MODELS.stream()
-                .filter(device -> StringUtils.startsWithIgnoreCase(deviceModel, device)).count() > 0;
+    private boolean isSupportedDeviceModel(final @Nullable String deviceModel) {
+        return StringUtils.isNotBlank(deviceModel) && Arrays.stream(OnkyoModel.values())
+                .anyMatch(model -> StringUtils.startsWithIgnoreCase(deviceModel, model.getId()));
     }
 
 }


### PR DESCRIPTION
Using an OnkyoModel enum in some streams simplifies the code so there will be less duplication.
This way it will be easier to add new models and review such PRs.