### PR TITLE
Fix missing 2.5.4-SNAPSHOT changes

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -11,7 +11,7 @@ IF %ARGC% NEQ 3 (
 )
 
 SET OpenhabCoreVersion="2.5.0"
-SET OpenhabVersion="2.5.3-SNAPSHOT"
+SET OpenhabVersion="2.5.4-SNAPSHOT"
 
 SET BindingIdInCamelCase=%~1
 SET BindingIdInLowerCase=%BindingIdInCamelCase%

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -3,7 +3,7 @@
 [ $# -lt 3 ] && { echo "Usage: $0 <BindingIdInCamelCase> <Author> <GitHub Username>"; exit 1; }
 
 openHABCoreVersion=2.5.0
-openHABVersion=2.5.3-SNAPSHOT
+openHABVersion=2.5.4-SNAPSHOT
 
 camelcaseId=$1
 id=`echo $camelcaseId | tr '[:upper:]' '[:lower:]'`

--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -37,8 +37,6 @@ Fragment-Host: org.openhab.binding.astro
 	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
 	org.mockito.mockito-core;version='[3.1.0,3.1.1)',\
-	org.openhab.binding.astro;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.astro.tests;version='[2.5.3,2.5.4)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -46,4 +44,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	org.openhab.core.test;version='[2.5.0,2.5.1)'
+	org.openhab.core.test;version='[2.5.0,2.5.1)',\
+	org.openhab.binding.astro;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.astro.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
+++ b/itests/org.openhab.binding.avmfritz.tests/itest.bndrun
@@ -59,6 +59,6 @@ Fragment-Host: org.openhab.binding.avmfritz
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	org.openhab.binding.avmfritz;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.avmfritz.tests;version='[2.5.3,2.5.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.binding.avmfritz;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.avmfritz.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -62,5 +62,5 @@ Fragment-Host: org.openhab.binding.feed
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.11,7.2.12)',\
-	org.openhab.binding.feed;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.feed.tests;version='[2.5.3,2.5.4)'
+	org.openhab.binding.feed;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.feed.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -62,6 +62,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	org.openhab.binding.hue;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.hue.tests;version='[2.5.3,2.5.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.binding.hue;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.hue.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -49,5 +49,5 @@ Fragment-Host: org.openhab.binding.max
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	org.openhab.binding.max;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.max.tests;version='[2.5.3,2.5.4)'
+	org.openhab.binding.max;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.max.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -69,6 +69,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.openhab.binding.modbus;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.modbus.tests;version='[2.5.3,2.5.4)',\
-	org.openhab.io.transport.modbus;version='[2.5.3,2.5.4)'
+	org.openhab.binding.modbus;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.modbus.tests;version='[2.5.4,2.5.5)',\
+	org.openhab.io.transport.modbus;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -65,6 +65,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.eclipse.jetty.websocket.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	org.openhab.binding.nest;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.nest.tests;version='[2.5.3,2.5.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.binding.nest;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.nest.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -53,5 +53,5 @@ Fragment-Host: org.openhab.binding.ntp
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	org.openhab.binding.ntp;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.ntp.tests;version='[2.5.3,2.5.4)'
+	org.openhab.binding.ntp;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.ntp.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -55,5 +55,5 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	org.openhab.binding.systeminfo;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.systeminfo.tests;version='[2.5.3,2.5.4)'
+	org.openhab.binding.systeminfo;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.systeminfo.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -57,6 +57,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	org.eclipse.californium.core;version='[2.0.0,2.0.1)',\
 	org.eclipse.californium.element-connector;version='[2.0.0,2.0.1)',\
 	org.eclipse.californium.scandium;version='[2.0.0,2.0.1)',\
-	org.openhab.binding.tradfri;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.tradfri.tests;version='[2.5.3,2.5.4)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.binding.tradfri;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.tradfri.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -67,6 +67,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	org.openhab.binding.wemo;version='[2.5.3,2.5.4)',\
-	org.openhab.binding.wemo.tests;version='[2.5.3,2.5.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.binding.wemo;version='[2.5.4,2.5.5)',\
+	org.openhab.binding.wemo.tests;version='[2.5.4,2.5.5)'

--- a/itests/org.openhab.io.hueemulation.tests/itest.bndrun
+++ b/itests/org.openhab.io.hueemulation.tests/itest.bndrun
@@ -75,6 +75,6 @@ Fragment-Host: org.openhab.io.hueemulation
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.11,7.2.12)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
-	org.openhab.io.hueemulation;version='[2.5.3,2.5.4)',\
-	org.openhab.io.hueemulation.tests;version='[2.5.3,2.5.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.io.hueemulation;version='[2.5.4,2.5.5)',\
+	org.openhab.io.hueemulation.tests;version='[2.5.4,2.5.5)'


### PR DESCRIPTION
Without it itests fail and the binding skeleton uses the wrong version.