### PR TITLE
Add JythonScriptEngineFactory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 *       @openhab/add-ons-maintainers
 
 # Add-on maintainers:
+/bundles/org.openhab.automation.scriptenginefactory.jython/ @openhab-5iver
 /bundles/org.openhab.binding.adorne/ @theiding
 /bundles/org.openhab.binding.airquality/ @kubawolanin
 /bundles/org.openhab.binding.airvisualnode/ @3cky

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -16,6 +16,11 @@
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.automation.scriptenginefactory.jython</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.adorne</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/.classpath
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/.classpath
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/.project
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.automation.scriptenginefactory.jython</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/NOTICE
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/README.md
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/README.md
@@ -1,7 +1,8 @@
-# Jython ScriptEngineFactory
+# Jython 2.7.2 ScriptEngineFactory
 
-This addon provides a Jython ScriptEngineFactory for use with scripted automation and eliminates the need to download the Jython jar file and create EXTRA_JAVA_OPTS entries for bootclasspath, python.home and python.path.
-The path to the bundle will be set for python.home and will also be appended to any existing python.path.
-Without this addon, Jython would need to be manually installed as documented here...
+This addon provides a Jython ScriptEngineFactory for use with scripted automation and eliminates the need to download Jython and create `EXTRA_JAVA_OPTS` entries for `bootclasspath`, `python.home` and `python.path`.
+The `python.home` System property will be set to the path of the add-on.
+The `python.path` System property will be set to `$OPENHAB_CONF/automation/lib/python`, but any existing `python.path` will be appended to it. 
+As an alternative to this add-on, the manual installation of Jython for use with openHAB is documented here...
 
-[https://openhab-scripters.github.io/openhab-helper-libraries/Getting%20Started/Installation.html](https://openhab-scripters.github.io/openhab-helper-libraries/Getting%20Started/Installation.html)
+[https://openhab-scripters.github.io/openhab-helper-libraries/)

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/README.md
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/README.md
@@ -1,0 +1,7 @@
+# Jython ScriptEngineFactory
+
+This addon provides a Jython ScriptEngineFactory for use with scripted automation and eliminates the need to download the Jython jar file and create EXTRA_JAVA_OPTS entries for bootclasspath, python.home and python.path.
+The path to the bundle will be set for python.home and will also be appended to any existing python.path.
+Without this addon, Jython would need to be manually installed as documented here...
+
+[https://openhab-scripters.github.io/openhab-helper-libraries/Getting%20Started/Installation.html](https://openhab-scripters.github.io/openhab-helper-libraries/Getting%20Started/Installation.html)

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/bnd.bnd
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-SymbolicName: ${project.artifactId}
+DynamicImport-Package: *
+Import-Package: org.openhab.core.automation.module.script
+-includeresource: @jython-standalone-2.7.[0-9a-z]*.jar; lib:=true
+-fixupmessages: "Classes found in the wrong directory",\
+    "The default package '.' is not permitted by the Import-Package syntax"; restrict:=error; is:=warning

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.4-SNAPSHOT</version>
+    <version>2.5.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.automation.scriptenginefactory.jython</artifactId>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.scriptenginefactory.jython</artifactId>
+
+  <name>openHAB Add-ons :: Automation :: Jython ScriptEngineFactory</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.python</groupId>
+      <artifactId>jython-standalone</artifactId>
+      <version>2.7.2</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.6-SNAPSHOT</version>
+    <version>2.5.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.automation.scriptenginefactory.jython</artifactId>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.automation.scriptenginefactory.jython-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+    <feature name="openhab-misc-scriptenginefactory-jython" description="Jython ScriptEngineFactory" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-core-automation</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.scriptenginefactory.jython/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
     <feature name="openhab-misc-scriptenginefactory-jython" description="Jython ScriptEngineFactory" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-core-automation</feature>
+        <feature>openhab-core-automation-module-script</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.scriptenginefactory.jython/${project.version}</bundle>
     </feature>
 </features>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.automation.scriptenginefactory.jython-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-    <feature name="openhab-misc-scriptenginefactory-jython" description="Jython ScriptEngineFactory" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <feature>openhab-core-automation-module-script</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.scriptenginefactory.jython/${project.version}</bundle>
-    </feature>
+	<feature name="openhab-misc-scriptenginefactory-jython" description="Jython ScriptEngineFactory" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-core-automation-module-script</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.scriptenginefactory.jython/${project.version}</bundle>
+	</feature>
 </features>

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
@@ -108,6 +108,8 @@ public class JythonScriptEngineFactory extends AbstractScriptEngineFactory {
             String newPythonPath = String.join(File.pathSeparator, newPythonPathList);
             System.setProperty("python.path", newPythonPath);
         }
+        System.clearProperty("python.home");
+        System.clearProperty("python.cachedir");
         logger.trace("python.home [{}], python.path [{}], python.cachdir [{}]", System.getProperty("python.home"),
                 System.getProperty("python.path"), System.getProperty("python.cachedir"));
     }

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
@@ -41,10 +41,9 @@ import org.osgi.service.component.annotations.Deactivate;
 public class JythonScriptEngineFactory extends AbstractScriptEngineFactory {
 
     private static final String SCRIPT_TYPE = "py";
-    private static javax.script.ScriptEngineManager ENGINE_MANAGER = new javax.script.ScriptEngineManager();
-
     private static final String DEFAULT_PYTHON_PATH = Paths
             .get(ConfigConstants.getConfigFolder(), "automation", "lib", "python").toString();
+    private static javax.script.ScriptEngineManager ENGINE_MANAGER = new javax.script.ScriptEngineManager();
 
     @Activate
     public JythonScriptEngineFactory() {
@@ -64,8 +63,8 @@ public class JythonScriptEngineFactory extends AbstractScriptEngineFactory {
             System.setProperty("python.path", newPythonPath);
         }
 
-        System.setProperty("python.cachedir",
-                Paths.get(ConfigConstants.getUserDataFolder(), "tmp", "cachedir").toString());
+        System.setProperty("python.cachedir", Paths.get(ConfigConstants.getUserDataFolder(), "cache",
+                "org.openhab.automation.scriptenginefactory.jython", "cachedir").toString());
 
         logger.trace("python.home [{}], python.path [{}], python.cachdir [{}]", System.getProperty("python.home"),
                 System.getProperty("python.path"), System.getProperty("python.cachedir"));

--- a/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.scriptenginefactory.jython/src/main/java/org/openhab/automation/scriptenginefactory/jython/JythonScriptEngineFactory.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.scriptenginefactory.jython;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+import javax.script.ScriptEngine;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigConstants;
+import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * This is an implementation of {@link ScriptEngineFactory} for Jython.
+ *
+ * @author Scott Rushworth - Initial contribution
+ */
+@Component(service = org.openhab.core.automation.module.script.ScriptEngineFactory.class)
+@NonNullByDefault
+public class JythonScriptEngineFactory extends AbstractScriptEngineFactory {
+
+    private static final String SCRIPT_TYPE = "py";
+    private static javax.script.ScriptEngineManager ENGINE_MANAGER = new javax.script.ScriptEngineManager();
+    private static final String DEFAULT_PYTHON_PATH = new StringBuilder(ConfigConstants.getConfigFolder())
+            .append(File.separator).append("automation").append(File.separator).append("lib").append(File.separator)
+            .append("python").toString();
+
+    @Activate
+    public JythonScriptEngineFactory() {
+        logger.debug("Loading JythonScriptEngineFactory");
+        String home = JythonScriptEngineFactory.class.getProtectionDomain().getCodeSource().getLocation().toString()
+                .replace("file:", "");
+        System.setProperty("python.home", home);
+
+        String existingPythonPath = System.getProperty("python.path");
+        if (existingPythonPath == null || existingPythonPath.isEmpty()) {
+            System.setProperty("python.path", DEFAULT_PYTHON_PATH);
+        } else if (!existingPythonPath.contains(DEFAULT_PYTHON_PATH)) {
+            TreeSet<String> newPythonPathList = new TreeSet<>(
+                    new ArrayList<String>(Arrays.asList(existingPythonPath.split(File.pathSeparator))));
+            newPythonPathList.add(DEFAULT_PYTHON_PATH);
+            String newPythonPath = String.join(File.pathSeparator, newPythonPathList);
+            System.setProperty("python.path", newPythonPath);
+        }
+
+        StringBuilder newPythonCachedir = new StringBuilder(System.getenv("OPENHAB_USERDATA")).append(File.separator)
+                .append("tmp");
+        System.setProperty("python.cachedir", newPythonCachedir.toString());
+
+        logger.trace("python.home [{}], python.path [{}], python.cachdir [{}]", System.getProperty("python.home"),
+                System.getProperty("python.path"), System.getProperty("python.cachedir"));
+    }
+
+    @Override
+    public List<String> getScriptTypes() {
+        List<String> scriptTypes = new ArrayList<>();
+
+        for (javax.script.ScriptEngineFactory factory : ENGINE_MANAGER.getEngineFactories()) {
+            List<String> extensions = factory.getExtensions();
+
+            if (extensions.contains(SCRIPT_TYPE)) {
+                scriptTypes.addAll(extensions);
+                scriptTypes.addAll(factory.getMimeTypes());
+            }
+        }
+        return Collections.unmodifiableList(scriptTypes);
+    }
+
+    @Override
+    public @Nullable ScriptEngine createScriptEngine(String scriptType) {
+        ScriptEngine scriptEngine = ENGINE_MANAGER.getEngineByExtension(scriptType);
+        if (scriptEngine == null) {
+            scriptEngine = ENGINE_MANAGER.getEngineByMimeType(scriptType);
+        }
+        if (scriptEngine == null) {
+            scriptEngine = ENGINE_MANAGER.getEngineByName(scriptType);
+        }
+        return scriptEngine;
+    }
+
+    @Deactivate
+    public void deactivate() {
+        logger.debug("Unloading JythonScriptEngineFactory");
+        String existingPythonPath = System.getProperty("python.path");
+        if (existingPythonPath.contains(DEFAULT_PYTHON_PATH)) {
+            TreeSet<String> newPythonPathList = new TreeSet<>(
+                    new ArrayList<String>(Arrays.asList(existingPythonPath.split(File.pathSeparator))));
+            newPythonPathList.remove(DEFAULT_PYTHON_PATH);
+            String newPythonPath = String.join(File.pathSeparator, newPythonPathList);
+            System.setProperty("python.path", newPythonPath);
+        }
+        logger.trace("python.home [{}], python.path [{}], python.cachdir [{}]", System.getProperty("python.home"),
+                System.getProperty("python.path"), System.getProperty("python.cachedir"));
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -17,6 +17,8 @@
   <name>openHAB Add-ons :: Bundles</name>
 
   <modules>
+    <!-- automation -->
+    <module>org.openhab.automation.scriptenginefactory.jython</module>
     <!-- io -->
     <module>org.openhab.io.homekit</module>
     <module>org.openhab.io.hueemulation</module>


### PR DESCRIPTION
This pull request adds functionality for a JythonScriptEngineFactory and replaces https://github.com/openhab/openhab-core/pull/1253. This PR only includes Jython 2.7.2 without any helper libraries, which have been submitted as a separate addon (#7210).

Signed-off-by: Scott Rushworth <openhab@5iver.com>