### PR TITLE
[Hue] Null-proof handling getAlertMode()

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
@@ -149,6 +149,9 @@ public class State {
      * @return last alert mode
      */
     public AlertMode getAlertMode() {
+        if (alert == null) {
+            return null;
+        }
         return AlertMode.valueOf(alert.toUpperCase());
     }
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
@@ -209,42 +209,58 @@ public class State {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         State other = (State) obj;
         if (alert == null) {
-            if (other.alert != null)
+            if (other.alert != null) {
                 return false;
-        } else if (!alert.equals(other.alert))
+            }
+        } else if (!alert.equals(other.alert)) {
             return false;
-        if (bri != other.bri)
+        }
+        if (bri != other.bri) {
             return false;
+        }
         if (colormode == null) {
-            if (other.colormode != null)
+            if (other.colormode != null) {
                 return false;
-        } else if (!colormode.equals(other.colormode))
+            }
+        } else if (!colormode.equals(other.colormode)) {
             return false;
-        if (ct != other.ct)
+        }
+        if (ct != other.ct) {
             return false;
+        }
         if (effect == null) {
-            if (other.effect != null)
+            if (other.effect != null) {
                 return false;
-        } else if (!effect.equals(other.effect))
+            }
+        } else if (!effect.equals(other.effect)) {
             return false;
-        if (hue != other.hue)
+        }
+        if (hue != other.hue) {
             return false;
-        if (on != other.on)
+        }
+        if (on != other.on) {
             return false;
-        if (reachable != other.reachable)
+        }
+        if (reachable != other.reachable) {
             return false;
-        if (sat != other.sat)
+        }
+        if (sat != other.sat) {
             return false;
-        if (!Arrays.equals(xy, other.xy))
+        }
+        if (!Arrays.equals(xy, other.xy)) {
             return false;
+        }
         return true;
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/State.java
@@ -190,11 +190,22 @@ public class State {
         return reachable;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((alert == null) ? 0 : alert.hashCode());
+        result = prime * result + bri;
+        result = prime * result + ((colormode == null) ? 0 : colormode.hashCode());
+        result = prime * result + ct;
+        result = prime * result + ((effect == null) ? 0 : effect.hashCode());
+        result = prime * result + hue;
+        result = prime * result + (on ? 1231 : 1237);
+        result = prime * result + (reachable ? 1231 : 1237);
+        result = prime * result + sat;
+        result = prime * result + Arrays.hashCode(xy);
+        return result;
+    }
 
     @Override
     public boolean equals(Object obj) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -52,6 +52,7 @@ import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.HueConfigStatusMessage;
 import org.openhab.binding.hue.internal.State;
+import org.openhab.binding.hue.internal.State.AlertMode;
 import org.openhab.binding.hue.internal.StateUpdate;
 import org.openhab.binding.hue.internal.config.HueBridgeConfig;
 import org.openhab.binding.hue.internal.exceptions.ApiException;
@@ -774,7 +775,11 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
      * @return {@code true} if the available information of both states are equal.
      */
     private boolean isEqual(State state1, State state2) {
-        return state1.getAlertMode().equals(state2.getAlertMode()) && state1.isOn() == state2.isOn()
+        AlertMode alertMode1 = state1.getAlertMode();
+        AlertMode alertMode2 = state2.getAlertMode();
+
+        return ((alertMode1 == null && alertMode2 == null) || (alertMode1 != null && alertMode1.equals(alertMode2)))
+                && state1.isOn() == state2.isOn()
                 && state1.getBrightness() == state2.getBrightness()
                 && state1.getColorTemperature() == state2.getColorTemperature() && state1.getHue() == state2.getHue()
                 && state1.getSaturation() == state2.getSaturation() && state1.isReachable() == state2.isReachable()

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -489,7 +489,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         }
 
         StringType stringType = LightStateConverter.toAlertStringType(fullLight.getState());
-        if (!stringType.toString().equals("NULL")) {
+        if (!"NULL".equals(stringType.toString())) {
             updateState(CHANNEL_ALERT, stringType);
             scheduleAlertStateRestore(stringType);
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStateConverter.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStateConverter.java
@@ -206,7 +206,12 @@ public class LightStateConverter {
      * @return string type representing the alert mode.
      */
     public static StringType toAlertStringType(State lightState) {
-        return new StringType(lightState.getAlertMode().toString());
+        AlertMode alertMode = lightState.getAlertMode();
+        if (alertMode == null) {
+            return new StringType("NULL");
+        } else {
+            return new StringType(alertMode.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
Fix NullPointerException on missing state attribute alert at deconz version 2.05.75

See Bug report #7218
