### PR TITLE
[homekit] Implements support for HomeKit with Lock mechanisms.

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -80,6 +80,7 @@ A full list of supported accessory types can be found in the table below.
 |                       | homekit:CurrentHeatingCoolingMode | String                    | Indicates the current mode of the device: OFF, AUTO, HEAT, COOL. The string's value must match those defined in the thermostat*Mode properties. This is a HomeKit-specific term and therefore the tags needs to be prefixed with "homekit:"   |
 |                       | homekit:TargetTemperature         | Number                    | A target temperature that will engage the thermostat's heating and cooling actions as necessary, depending on the heatingCoolingMode. This is a HomeKit-specific term and therefore the tags needs to be prefixed with "homekit:"             |
 | WindowCovering        |                                   | Rollershutter             | A window covering                                                                                                                                                                                                                             |
+| Lock                  |                                   | Switch                    | A Lock Mechanism                                                                                                                                                                                                                              |
 
 **Please note:** `TargetTemperature` has been renamed to `homekit:TargetTemperature` and `homekit:HeatingCoolingMode` has been renamed to `homekit:TargetHeatingCoolingMode`.
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryType.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryType.java
@@ -44,7 +44,8 @@ public enum HomekitAccessoryType {
     SMOKE_SENSOR("SmokeSensor"),
     CARBON_MONOXIDE_SENSOR("CarbonMonoxideSensor"),
     @Deprecated()
-    BLINDS("Blinds");
+    BLINDS("Blinds"),
+    LOCK("Lock");
 
     private static final Map<String, HomekitAccessoryType> TAG_MAP = new HashMap<>();
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -113,6 +113,8 @@ public class HomekitAccessoryFactory {
                                         "Carbon monoxide accessory group should have a carbon monoxide sensor in it"));
                 return new HomekitSmokeSensorImpl(carbonMonoxideSensorAccessory, itemRegistry, updater,
                         BatteryStatus.getFromCharacteristics(characteristicItems));
+            case LOCK:
+                return new HomekitLockImpl(taggedItem, itemRegistry, updater);
         }
 
         throw new HomekitException("Unknown homekit type: " + taggedItem.getAccessoryType());

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
@@ -25,8 +25,9 @@ import io.github.hapjava.accessories.LockableLockMechanism;
 import io.github.hapjava.accessories.properties.LockMechanismState;
 
 /**
+ * Implements the support of Lock accessories, mapping them to OpenHAB Switch type 
  *
- * @author blafois
+ * @author blafois - Support for additional accessory type.
  *
  */
 public class HomekitLockImpl extends AbstractHomekitAccessoryImpl<SwitchItem> implements LockableLockMechanism {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLockImpl.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.homekit.internal.accessories;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
+import org.openhab.io.homekit.internal.HomekitTaggedItem;
+
+import io.github.hapjava.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.accessories.LockableLockMechanism;
+import io.github.hapjava.accessories.properties.LockMechanismState;
+
+/**
+ *
+ * @author blafois
+ *
+ */
+public class HomekitLockImpl extends AbstractHomekitAccessoryImpl<SwitchItem> implements LockableLockMechanism {
+
+    public HomekitLockImpl(HomekitTaggedItem taggedItem, ItemRegistry itemRegistry, HomekitAccessoryUpdater updater) {
+        super(taggedItem, itemRegistry, updater, SwitchItem.class);
+    }
+
+    @Override
+    public CompletableFuture<LockMechanismState> getCurrentMechanismState() {
+        OnOffType state = getItem().getStateAs(OnOffType.class);
+
+        if (state == OnOffType.OFF) {
+            return CompletableFuture.completedFuture(LockMechanismState.SECURED);
+        } else if (state == OnOffType.ON) {
+            return CompletableFuture.completedFuture(LockMechanismState.UNSECURED);
+        }
+
+        return CompletableFuture.completedFuture(LockMechanismState.UNKNOWN);
+    }
+
+    @Override
+    public void subscribeCurrentMechanismState(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), callback);
+    }
+
+    @Override
+    public void unsubscribeCurrentMechanismState() {
+        getUpdater().unsubscribe(getItem());
+    }
+
+    @Override
+    public void setTargetMechanismState(LockMechanismState state) throws Exception {
+        switch (state) {
+            case SECURED:
+                // Close the door
+                if (getItem() instanceof SwitchItem) {
+                    ((SwitchItem) getItem()).send(OnOffType.OFF);
+                }
+                break;
+            case UNSECURED:
+                // Open the door
+                if (getItem() instanceof SwitchItem) {
+                    ((SwitchItem) getItem()).send(OnOffType.ON);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public CompletableFuture<LockMechanismState> getTargetMechanismState() {
+        OnOffType state = getItem().getStateAs(OnOffType.class);
+
+        if (state == OnOffType.OFF) {
+            return CompletableFuture.completedFuture(LockMechanismState.SECURED);
+        } else if (state == OnOffType.ON) {
+            return CompletableFuture.completedFuture(LockMechanismState.UNSECURED);
+        }
+
+        return CompletableFuture.completedFuture(LockMechanismState.UNKNOWN);
+    }
+
+    @Override
+    public void subscribeTargetMechanismState(HomekitCharacteristicChangeCallback callback) {
+        getUpdater().subscribe(getItem(), callback);
+    }
+
+    @Override
+    public void unsubscribeTargetMechanismState() {
+        getUpdater().unsubscribe(getItem());
+    }
+
+}


### PR DESCRIPTION
This PR contains implementation for Lock mechanism in Homekit such as Door Lock.
Switch items can be tagged with "Lock" tag. Although it could previously work with "Lighting" tags, now allows usage of proper sentences with Siri such as "open the door" instead of "turn on the door", and displays it with proper "lock" icon in Home app.

The documentation (README) is also updated.