### PR TITLE
[mqtt] Fix outgoing format for NumberValues

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -80,8 +80,8 @@ public class NumberValue extends Value {
         }
 
         String formatPattern = pattern;
-        if (formatPattern == null || "%s".equals(formatPattern)) {
-            formatPattern = "%f";
+        if (formatPattern == null) {
+            formatPattern = "%s";
         }
 
         return state.format(formatPattern);


### PR DESCRIPTION
This is a fix for #7139

There was some remapping of the outgoing format left over from some intermediate state.
`%s` should stay as is and will be handled correctly by `DecimalType`