### PR TITLE
Workaround PMD ParseException in all add-ons

### DIFF
--- a/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecWhitelistWatchService.java
+++ b/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecWhitelistWatchService.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -58,13 +59,12 @@ public class ExecWhitelistWatchService extends AbstractWatchService {
     }
 
     @Override
-    protected WatchEvent.Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
-        return new WatchEvent.Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+    protected Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
+        return new Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
     }
 
     @Override
-    protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
-            @Nullable Path path) {
+    protected void processWatchEvent(@Nullable WatchEvent<?> event, @Nullable Kind<?> kind, @Nullable Path path) {
         if (path != null && path.endsWith(COMMAND_WHITELIST_FILE)) {
             commandWhitelist.clear();
             try {

--- a/bundles/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/handler/HarmonyHubHandler.java
+++ b/bundles/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/handler/HarmonyHubHandler.java
@@ -314,7 +314,7 @@ public class HarmonyHubHandler extends BaseBridgeHandler implements HarmonyClien
         }
     }
 
-    private void updateActivityStatus(@Nullable Activity activity, Activity.@Nullable Status status) {
+    private void updateActivityStatus(@Nullable Activity activity, @Nullable Status status) {
         if (activity == null) {
             logger.debug("Cannot update activity status of {} with activity that is null", getThing().getUID());
             return;

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/basic/MiIoDatabaseWatchService.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,13 +82,12 @@ public class MiIoDatabaseWatchService extends AbstractWatchService {
     }
 
     @Override
-    protected WatchEvent.Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
-        return new WatchEvent.Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+    protected Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
+        return new Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
     }
 
     @Override
-    protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
-            @Nullable Path path) {
+    protected void processWatchEvent(@Nullable WatchEvent<?> event, @Nullable Kind<?> kind, @Nullable Path path) {
         if (path != null) {
             final Path p = path.getFileName();
             if (p != null && p.toString().endsWith(DATABASE_FILES)) {

--- a/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/config/YamahaZoneConfig.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/main/java/org/openhab/binding/yamahareceiver/internal/config/YamahaZoneConfig.java
@@ -14,7 +14,7 @@ package org.openhab.binding.yamahareceiver.internal.config;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants;
+import org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone;
 
 /**
  * Zone settings.
@@ -24,8 +24,7 @@ import org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstant
 @NonNullByDefault
 public class YamahaZoneConfig {
     /**
-     * Zone name, will be one of
-     * {@link org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone}.
+     * Zone name, will be one of {@link Zone}.
      */
     private String zone = "";
     /**
@@ -42,8 +41,8 @@ public class YamahaZoneConfig {
      */
     private float volumeDbMax = 12f; // 12.0 dB
 
-    public YamahaReceiverBindingConstants.@Nullable Zone getZone() {
-        return YamahaUtils.tryParseEnum(YamahaReceiverBindingConstants.Zone.class, zone);
+    public @Nullable Zone getZone() {
+        return YamahaUtils.tryParseEnum(Zone.class, zone);
     }
 
     public String getZoneValue() {

--- a/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationWhitelistWatchService.java
+++ b/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationWhitelistWatchService.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -58,13 +59,12 @@ public class ExecTransformationWhitelistWatchService extends AbstractWatchServic
     }
 
     @Override
-    protected WatchEvent.Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
-        return new WatchEvent.Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+    protected Kind<?>[] getWatchEventKinds(@Nullable Path directory) {
+        return new Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
     }
 
     @Override
-    protected void processWatchEvent(@Nullable WatchEvent<?> event, WatchEvent.@Nullable Kind<?> kind,
-            @Nullable Path path) {
+    protected void processWatchEvent(@Nullable WatchEvent<?> event, @Nullable Kind<?> kind, @Nullable Path path) {
         if (path != null && path.endsWith(COMMAND_WHITELIST_FILE)) {
             commandWhitelist.clear();
             try {


### PR DESCRIPTION
This change worksaround the PMD ParseException that would occur while analyzing the MiIoDatabaseWatchService.

See also:
* https://github.com/pmd/pmd/issues/1367
* https://github.com/openhab/static-code-analysis/issues/378