### PR TITLE
[squeezebox] Change mute/unmute to use mixer muting command

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -97,11 +97,6 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     private String mac;
 
     /**
-     * Before we mute or recieve a mute event, store our current volume
-     */
-    private int unmuteVolume = 0;
-
-    /**
      * The server sends us the current time on play/pause/stop events, we
      * increment it locally from there on
      */
@@ -199,9 +194,9 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 break;
             case CHANNEL_MUTE:
                 if (command.equals(OnOffType.ON)) {
-                    mute();
+                    squeezeBoxServerHandler.mute(mac);
                 } else {
-                    squeezeBoxServerHandler.unMute(mac, unmuteVolume);
+                    squeezeBoxServerHandler.unMute(mac);
                 }
                 break;
             case CHANNEL_STOP:
@@ -236,9 +231,9 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 } else if (command.equals(IncreaseDecreaseType.DECREASE)) {
                     squeezeBoxServerHandler.volumeDown(mac, currentVolume());
                 } else if (command.equals(OnOffType.OFF)) {
-                    mute();
+                    squeezeBoxServerHandler.mute(mac);
                 } else if (command.equals(OnOffType.ON)) {
-                    squeezeBoxServerHandler.unMute(mac, unmuteVolume);
+                    squeezeBoxServerHandler.unMute(mac);
                 }
                 break;
             case CHANNEL_CONTROL:
@@ -349,7 +344,6 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
 
     @Override
     public void muteChangeEvent(String mac, boolean mute) {
-        unmuteVolume = currentVolume();
         updateChannel(mac, CHANNEL_MUTE, mute ? OnOffType.ON : OnOffType.OFF);
     }
 
@@ -523,14 +517,6 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 updateState(channelID, state);
             }
         }
-    }
-
-    /**
-     * Helper method to mute a player
-     */
-    private void mute() {
-        unmuteVolume = currentVolume();
-        squeezeBoxServerHandler.mute(mac);
     }
 
     /**

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -145,11 +145,11 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     }
 
     public void mute(String mac) {
-        setVolume(mac, 0);
+        sendCommand(mac + " mixer muting 1");
     }
 
-    public void unMute(String mac, int unmuteVolume) {
-        setVolume(mac, unmuteVolume);
+    public void unMute(String mac) {
+        sendCommand(mac + " mixer muting 0");
     }
 
     public void powerOn(String mac) {


### PR DESCRIPTION
Fixes #7217 

The binding currently does not use the `<playerid> mixer muting <0|1|toggle|?|>` command to mute/unmute the player. Instead, on mute, it saves the current volume, then sets the volume to 0. On unmute, it restores the saved volume. Muting the player twice in a row causes the initial volume level to be lost.

This PR replaces the call to `setVolume` with the mixer muting command.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
