### PR TITLE
[bluetooth] Fix for AM43 and Airthings devices not being discovered.

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.am43/README.md
+++ b/bundles/org.openhab.binding.bluetooth.am43/README.md
@@ -1,6 +1,6 @@
 # AM43
 
-This extension adds support for AM43 Blind Drive Motors.
+This extension adds support for [AM43 Blind Drive Motors](https://www.a-okmotors.com/am-43/).
 
 ## Supported Things
 

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -3,6 +3,8 @@
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.blukii/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.ruuvitag/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>


### PR DESCRIPTION
I didn't realize there was another file I needed to update in order for those bindings to be bundled into the bluetooth binding.

Also I'm adding a link to the AM43 product page that I forgot to include in my initial commit.