### PR TITLE
[mqtt.homie] Call out homie binding provided by MQTT binding

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/README.md
+++ b/bundles/org.openhab.binding.mqtt.homie/README.md
@@ -1,5 +1,7 @@
 # MQTT Homie Binding
 
+NOTE: This binding is provided by the [MQTT binding](https://www.openhab.org/addons/bindings/mqtt/), and therefore no explicit installation is necessary beyond installing the MQTT binding.
+
 Devices that follow the [Homie convention](https://homieiot.github.io/) 3.x and better
 are auto-discovered and represented by this binding and the Homie Thing.
 


### PR DESCRIPTION
Help other poor souls that arrive at the homie binding documentation page by way of the great Google and then are confused when they attempt to install mqtt.homie via their configuration files.