### PR TITLE
[checkstyle] Treat packages containing .dto. the same way as java classes ending in DTO

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -3,7 +3,7 @@
 <suppressions>
     <!-- These suppressions define which files to be suppressed for which checks. -->
     <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
-    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
+    <suppress files=".+[\\/]dto[\\/].+|.+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
 
     <!-- Homematic and Tellstick bindings are creating and configuring things dynamically, they will log false positives for unused configuration -->

--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -3,7 +3,8 @@
 <suppressions>
     <!-- These suppressions define which files to be suppressed for which checks. -->
     <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
-    <suppress files=".+[\\/]dto[\\/].+|.+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
+    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
+    <suppress files=".+[\\/]dto[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck|NullAnnotationsCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
 
     <!-- Homematic and Tellstick bindings are creating and configuring things dynamically, they will log false positives for unused configuration -->


### PR DESCRIPTION
Currently there is a checkstyle suppression treating files ending i DTO differently than other files by omitting various rules (the null annotations for instance). This PR also allows packages that contain `.dto.` to be treated the same way. Then we do not have to postfix all DTO classes with `DTO` .

Signed-off-by: Arne Seime <arne.seime@gmail.com>
