### PR TITLE
[chromecast] Explicitly exclude jackson dependencies to avoid build failure

### DIFF
--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -23,6 +23,25 @@
       <artifactId>api-v2</artifactId>
       <version>0.11.2</version>
       <scope>compile</scope>
+      <exclusions>
+        <!-- To avoid intermittent Failure to find com.fasterxml.jackson:jackson-bom:pom:2.9.0.pr4-SNAPSHOT
+		in https://oss.sonatype.org/content/repositories/snapshots/
+
+		These dependencies are explicitly added below
+		-->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Sometimes the build process fails due to a missing dependency

```[ERROR] Failed to execute goal on project org.openhab.binding.chromecast: Could not resolve dependencies for project org.openhab.addons.bundles:org.openhab.binding.chromecast:jar:2.5.4-SNAPSHOT: Failed to collect dependencies at su.litvak.chromecast:api-v2:jar:0.11.2 -> com.fasterxml.jackson.core:jackson-databind:jar:2.9.0,pr4-SNAPSHOT: Failed to read artifact descriptor for com.fasterxml.jackson.core:jackson-databind:jar:2.9.0,pr4-SNAPSHOT: Failure to find com.fasterxml.jackson:jackson-bom:pom:2.9.0.pr4-SNAPSHOT in https://oss.sonatype.org/content/repositories/snapshots/ was cached in the local repository, resolution will not be reattempted until the update interval of sonatype-snapshots has elapsed or updates are forced -> [Help 1]```

Example  here; https://travis-ci.com/github/openhab/openhab-addons/jobs/309159444 - I've seen it before both in Travis and locally

My theory is:  Since the chromecast library has a range dependency 
`<jackson.version>[2.8.11,2.10.0)</jackson.version>`,  sometimes Maven seems to be looking for version `2.9.0,pr4-SNAPSHOT` - which fails.

Comments?