### PR TITLE
[innogysmarthome] New innogy auth endpoint as livisi will shutdown the old endpoint

### DIFF
--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/Constants.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/Constants.java
@@ -34,9 +34,10 @@ public final class Constants {
 
     // API URLs
     public static final String API_HOST = "api.services-smarthome.de";
+    public static final String AUTH_HOST = "auth.services-smarthome.de";
     public static final String API_VERSION = "1.1";
     public static final String API_URL_BASE = "https://" + API_HOST + "/API/" + API_VERSION;
-    public static final String API_URL_TOKEN = "https://" + API_HOST + "/AUTH/token";
+    public static final String API_URL_TOKEN = "https://" + AUTH_HOST + "/AUTH/token";
 
     public static final String API_URL_CHECK_CONNECTION = API_URL_BASE + "/desc/device/SHC.RWE/1.0/event/StateChanged";
     public static final String API_URL_INITIALIZE = API_URL_BASE + "/initialize";


### PR DESCRIPTION
Changes auth endpoint as livisi will shutdown the old endpoint on 31.06.2020

