### PR TITLE
[satel] Action for reading the event log added

### DIFF
--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/action/SatelEventLogActions.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/action/SatelEventLogActions.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.satel.action;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.binding.ThingActions;
+import org.eclipse.smarthome.core.thing.binding.ThingActionsScope;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.satel.internal.handler.SatelEventLogHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Automation action handler service for reading Satel event log.
+ *
+ * @author Krzysztof Goworek - Initial contribution
+ * @see SatelEventLogHandler
+ */
+@ThingActionsScope(name = "satel")
+@NonNullByDefault
+public class SatelEventLogActions implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private @Nullable SatelEventLogHandler handler;
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof SatelEventLogHandler) {
+            this.handler = (SatelEventLogHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "@text/actionReadEventLabel", description = "@text/actionReadEventDesc")
+    public @ActionOutput(name = "index", type = "java.lang.Integer", label = "@text/actionOutputIndexLabel", description = "@text/actionOutputIndexDesc") @ActionOutput(name = "prev_index", type = "java.lang.Integer", label = "@text/actionOutputPrevIndexLabel", description = "@text/actionOutputPrevIndexDesc") @ActionOutput(name = "timestamp", type = "java.time.ZonedDateTime", label = "@text/actionOutputTimestampLabel", description = "@text/actionOutputTimestampDesc") @ActionOutput(name = "description", type = "java.lang.String", label = "@text/actionOutputDescriptionLabel", description = "@text/actionOutputDescriptionDesc") @ActionOutput(name = "details", type = "java.lang.String", label = "@text/actionOutputDetailsLabel", description = "@text/actionOutputDetailsDesc") Map<String, Object> readEvent(
+            @ActionInput(name = "index", label = "@text/actionInputIndexLabel", description = "@text/actionInputIndexDesc") @Nullable Number index) {
+        logger.debug("satel.readEvent called with input: index={}", index);
+
+        Map<String, Object> result = new HashMap<>();
+        if (handler != null) {
+            handler.readEvent(index == null ? -1 : index.intValue()).ifPresent(event -> {
+                result.put("index", event.getIndex());
+                result.put("prev_index", event.getPrevIndex());
+                result.put("timestamp", event.getTimestamp());
+                result.put("description", event.getDescription());
+                result.put("details", event.getDetails());
+            });
+        }
+        return result;
+    }
+
+    public static Map<String, Object> readEvent(@Nullable ThingActions actions, @Nullable Number index) {
+        if (actions instanceof SatelEventLogActions) {
+            return ((SatelEventLogActions) actions).readEvent(index);
+        } else {
+            throw new IllegalArgumentException("Instance is not a SatelEventLogActions class.");
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelEventLogHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelEventLogHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.satel.internal.handler;
 import static org.openhab.binding.satel.internal.SatelBindingConstants.*;
 
 import java.nio.charset.Charset;
+import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +34,9 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerService;
 import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.satel.action.SatelEventLogActions;
 import org.openhab.binding.satel.internal.command.ReadDeviceInfoCommand;
 import org.openhab.binding.satel.internal.command.ReadDeviceInfoCommand.DeviceType;
 import org.openhab.binding.satel.internal.command.ReadEventCommand;
@@ -62,6 +66,71 @@ public class SatelEventLogHandler extends SatelThingHandler {
     private final Map<String, @Nullable String> deviceNameCache = new ConcurrentHashMap<>();
     private @Nullable ScheduledFuture<?> cacheExpirationJob;
     private Charset encoding = Charset.defaultCharset();
+
+    /**
+     * Represents single record of the event log.
+     *
+     * @author Krzysztof Goworek
+     *
+     */
+    public static class EventLogEntry {
+
+        private final int index;
+        private final int prevIndex;
+        private final ZonedDateTime timestamp;
+        private final String description;
+        private final String details;
+
+        private EventLogEntry(int index, int prevIndex, ZonedDateTime timestamp, String description, String details) {
+            this.index = index;
+            this.prevIndex = prevIndex;
+            this.timestamp = timestamp;
+            this.description = description;
+            this.details = details;
+        }
+
+        /**
+         * @return index of this record entry
+         */
+        public int getIndex() {
+            return index;
+        }
+
+        /**
+         * @return index of the previous record entry in the log
+         */
+        public int getPrevIndex() {
+            return prevIndex;
+        }
+
+        /**
+         * @return date and time when the event occurred
+         */
+        public ZonedDateTime getTimestamp() {
+            return timestamp;
+        }
+
+        /**
+         * @return description of the event
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * @return details about zones, partitions, users, etc
+         */
+        public String getDetails() {
+            return details;
+        }
+
+        @Override
+        public String toString() {
+            return "EventLogEntry [index=" + index + ", prevIndex=" + prevIndex + ", timestamp=" + timestamp
+                    + ", description=" + description + ", details=" + details + "]";
+        }
+
+    }
 
     public SatelEventLogHandler(Thing thing) {
         super(thing);
@@ -101,7 +170,14 @@ public class SatelEventLogHandler extends SatelThingHandler {
 
         if (CHANNEL_INDEX.equals(channelUID.getId()) && command instanceof DecimalType) {
             int eventIndex = ((DecimalType) command).intValue();
-            withBridgeHandlerPresent(bridgeHandler -> readEvent(eventIndex));
+            withBridgeHandlerPresent(bridgeHandler -> readEvent(eventIndex).ifPresent(entry -> {
+                // update items
+                updateState(CHANNEL_INDEX, new DecimalType(entry.getIndex()));
+                updateState(CHANNEL_PREV_INDEX, new DecimalType(entry.getPrevIndex()));
+                updateState(CHANNEL_TIMESTAMP, new DateTimeType(entry.getTimestamp()));
+                updateState(CHANNEL_DESCRIPTION, new StringType(entry.getDescription()));
+                updateState(CHANNEL_DETAILS, new StringType(entry.getDetails()));
+            }));
         }
     }
 
@@ -114,8 +190,19 @@ public class SatelEventLogHandler extends SatelThingHandler {
         }
     }
 
-    private void readEvent(int eventIndex) {
-        getEventDescription(eventIndex).ifPresent(eventDesc -> {
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(SatelEventLogActions.class);
+    }
+
+    /**
+     * Reads one record from the event log.
+     *
+     * @param eventIndex record index
+     * @return record data or {@linkplain Optional#empty()} if there is no record under given index
+     */
+    public Optional<EventLogEntry> readEvent(int eventIndex) {
+        return getEventDescription(eventIndex).flatMap(eventDesc -> {
             ReadEventCommand readEventCmd = eventDesc.readEventCmd;
             int currentIndex = readEventCmd.getCurrentIndex();
             String eventText = eventDesc.getText();
@@ -192,13 +279,13 @@ public class SatelEventLogHandler extends SatelThingHandler {
                             + (readEventCmd.getObject() * 32 + readEventCmd.getUserControlNumber());
                     Optional<EventDescription> eventDescNext = getEventDescription(readEventCmd.getNextIndex());
                     if (!eventDescNext.isPresent()) {
-                        return;
+                        return Optional.empty();
                     }
                     final EventDescription eventDescNextItem = eventDescNext.get();
                     if (eventDescNextItem.getKind() != 30) {
                         logger.info("Unexpected event record kind {} at index {}", eventDescNextItem.getKind(),
                                 readEventCmd.getNextIndex());
-                        return;
+                        return Optional.empty();
                     }
                     readEventCmd = eventDescNextItem.readEventCmd;
                     eventText = eventDescNextItem.getText();
@@ -214,13 +301,8 @@ public class SatelEventLogHandler extends SatelThingHandler {
                             "object=" + readEventCmd.getObject(), "ucn=" + readEventCmd.getUserControlNumber());
             }
 
-            // update items
-            updateState(CHANNEL_INDEX, new DecimalType(currentIndex));
-            updateState(CHANNEL_PREV_INDEX, new DecimalType(readEventCmd.getNextIndex()));
-            updateState(CHANNEL_TIMESTAMP,
-                    new DateTimeType(readEventCmd.getTimestamp().atZone(getBridgeHandler().getZoneId())));
-            updateState(CHANNEL_DESCRIPTION, new StringType(eventText));
-            updateState(CHANNEL_DETAILS, new StringType(eventDetails));
+            return Optional.of(new EventLogEntry(currentIndex, readEventCmd.getNextIndex(),
+                    readEventCmd.getTimestamp().atZone(getBridgeHandler().getZoneId()), eventText, eventDetails));
         });
     }
 

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/i18n/satel.properties
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/i18n/satel.properties
@@ -1,3 +1,19 @@
 # config status
 config-status.hostEmpty = Host name or IP of ETHM-1 must be provided.
 config-status.portEmpty = Serial port of INT-RS must be provided.
+
+# actions
+actionReadEventLabel = Read event
+actionReadEventDesc = Reads a single record from the event log.
+actionInputIndexLabel = Event index
+actionInputIndexDesc = Index of the event to read
+actionOutputIndexLabel = Current Index
+actionOutputIndexDesc = Index of this record in the event log.
+actionOutputPrevIndexLabel = Previous Index
+actionOutputPrevIndexDesc = Index of the previous record in the event log. Use this value to iterate over the log.
+actionOutputTimestampLabel = Date and Time
+actionOutputTimestampDesc = Date and time when the event happened.
+actionOutputDescriptionLabel = Description
+actionOutputDescriptionDesc = Textual description of the event.
+actionOutputDetailsLabel = Details
+actionOutputDetailsDesc = Additional details about the event, like names of partitions, zones, users, etc.


### PR DESCRIPTION
This PR add a rule action for reading records from the event log. It replaces current way of reading the log using items linked to channels of `event-log` thing. This is still available but marked as deprecated.

It also contains minor changes in README file.

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>
