### PR TITLE
[tradfri] Do a dispose() and initialize() when loosing contact with GW.

### DIFF
--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriGatewayHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.tradfri.internal.handler;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
@@ -352,10 +351,9 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
     public void setStatus(ThingStatus status, ThingStatusDetail statusDetail) {
         // to fix connection issues after a gateway reboot, a session resume is forced for the next command
         if (status == ThingStatus.OFFLINE && statusDetail == ThingStatusDetail.COMMUNICATION_ERROR) {
-            logger.debug("Gateway communication error. Forcing session resume on next command.");
-            TradfriGatewayConfig configuration = getConfigAs(TradfriGatewayConfig.class);
-            InetSocketAddress peerAddress = new InetSocketAddress(configuration.host, configuration.port);
-            this.dtlsConnector.forceResumeSessionFor(peerAddress);
+            logger.debug("Gateway communication error. Forcing a re-initialization!");
+            dispose();
+            initialize();
         }
 
         // are we still connected at all?


### PR DESCRIPTION
This PR tries to resolve the issue with the TRADFRI binding lossing contact with IKEA GW reported in many community threads. 

The binding had implementation for some reconnect attempt but that was not sufficient. This PR instead perfroms a dispod/initialize of the binding when this communication error occurs.

I have tested in successfully in my production environment, here are logs for when the binding re-initialized during a communication error:

```
2020-03-31 19:30:37.791 [DEBUG] [internal.handler.TradfriLightHandler] - Setting state to OFF
2020-03-31 19:31:00.696 [DEBUG] [g.tradfri.internal.TradfriCoapClient] - CoAP GET request
uri: coaps://192.168.1.134:5684/15011/15012
2020-03-31 19:31:57.045 [DEBUG] [iscovery.TradfriDiscoveryParticipant] - Discovered Tradfri gateway: [ServiceInfoImpl@13643927 name: 'gw-dcefcaba3a07._CC32E753._sub._coap._udp.local.' address: '/192.168.1
.134:5684 /fe80:0:0:0:deef:caff:feba:3a07:5684 ' status: 'NO DNS state: probing 1 task: null' is persistent, has data
        version: 1.10.29]
2020-03-31 19:31:57.085 [DEBUG] [iscovery.TradfriDiscoveryParticipant] - Discovered Tradfri gateway: [ServiceInfoImpl@5785623 name: 'gw-dcefcaba3a07._CC32E753._sub._coap._udp.local.' address: '/192.168.1.
134:5684 /fe80:0:0:0:deef:caff:feba:3a07:5684 ' status: 'NO DNS state: probing 1 task: null' is persistent, has data
        version: 1.10.30]
2020-03-31 19:32:00.707 [DEBUG] [g.tradfri.internal.TradfriCoapClient] - CoAP GET request
uri: coaps://192.168.1.134:5684/15011/15012
2020-03-31 19:32:07.019 [DEBUG] [.tradfri.internal.TradfriCoapHandler] - CoAP onError
2020-03-31 19:32:31.509 [DEBUG] [.tradfri.internal.TradfriCoapHandler] - CoAP onError
2020-03-31 19:32:31.510 [DEBUG] [ternal.handler.TradfriGatewayHandler] - Gateway communication error. Forcing a re-initialization!
2020-03-31 19:32:31.511 [DEBUG] [ternal.handler.TradfriGatewayHandler] - In dispose()
2020-03-31 19:32:32.020 [DEBUG] [ternal.handler.TradfriGatewayHandler] - In initialize()
2020-03-31 19:32:32.109 [DEBUG] [g.tradfri.internal.TradfriCoapClient] - CoAP GET request
uri: coaps://192.168.1.134:5684/15011/15012
2020-03-31 19:32:32.300 [DEBUG] [.tradfri.internal.TradfriCoapHandler] - CoAP response
options: {"Content-Format":"application/json", "Max-Age":604800}
payload: {"9023":"1.tradfri.pool.ntp.org","9092":0,"9066":5,"9059":1585675952,"9201":2,"9060":"2020-03-31T17:32:32.029392Z","9062":0,"9061":0,"9106":0,"9071":1,"9076":10,"9200":"fe120050-7d40-497e-b4b0-f5200c7ff684","9029":"1.10.30","9105":0,"9081":"7e183552044000f1","9082":true,"9083":"276-82-287","9075":0,"9054":0,"9055":100,"9118":0,"9069":1585675761,"9072":3,"9073":29,"9074":1,"9077":25,"9078":1,"9079":0,"9080":60,"9103":"","9093":0,"9107":0,"9202":1580365713}
2020-03-31 19:32:32.302 [DEBUG] [ternal.handler.TradfriGatewayHandler] - requestGatewayInfo response: {"9023":"1.tradfri.pool.ntp.org","9092":0,"9066":5,"9059":1585675952,"9201":2,"9060":"2020-03-31T17:32:32.029392Z","9062":0,"9061":0,"9106":0,"9071":1,"9076":10,"9200":"fe120050-7d40-497e-b4b0-f5200c7ff684","9029":"1.10.30","9105":0,"9081":"7e183552044000f1","9082":true,"9083":"276-82-287","9075":0,"9054":0,"9055":100,"9118":0,"9069":1585675761,"9072":3,"9073":29,"9074":1,"9077":25,"9078":1,"9079":0,"9080":60,"9103":"","9093":0,"9107":0,"9202":1580365713}
2020-03-31 19:32:32.311 [DEBUG] [.tradfri.internal.TradfriCoapHandler] - CoAP response
options: {"Content-Format":"application/json", "Max-Age":604800}
```

Fixes #7152.

Signed-off-by: Jan Gustafsson <jannegpriv@gmail.com>

