### PR TITLE
[tradfri] Add missing representation property 'host' in in gateway definition

### DIFF
--- a/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -8,6 +8,8 @@
 		<label>TRÅDFRI Gateway</label>
 		<description>IKEA TRÅDFRI IP Gateway</description>
 
+		<representation-property>host</representation-property>
+
 		<config-description-ref uri="bridge-type:tradfri:gateway" />
 	</bridge-type>
 


### PR DESCRIPTION
Caused by: Discovery finds `gateway` that already has been defined in a thing file.

