### PR TITLE
[pjlink] enhanced logging (show byte array in addition to string)

### DIFF
--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -234,8 +234,10 @@ public class PJLinkDevice {
         if (response == null) {
             throw new ResponseException("Response to request '" + fullCommand.replaceAll("\r", "\\\\r") + "' was null");
         }
-        logger.debug("Got response '{}' ({}) for request '{}' from {}", response, Arrays.toString(response.getBytes()),
-                fullCommand.replaceAll("\r", "\\\\r"), ipAddress.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Got response '{}' ({}) for request '{}' from {}", response,
+                    Arrays.toString(response.getBytes()), fullCommand.replaceAll("\r", "\\\\r"), ipAddress);
+        }
         return response;
     }
 

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -230,11 +231,11 @@ public class PJLinkDevice {
             logger.debug("Got empty string response for request '{}' from {}, waiting for another line", response,
                     fullCommand.replaceAll("\r", "\\\\r"));
         }
-        logger.debug("Got response '{}' for request '{}' from {}", response, fullCommand.replaceAll("\r", "\\\\r"),
-                ipAddress.toString());
         if (response == null) {
             throw new ResponseException("Response to request '" + fullCommand.replaceAll("\r", "\\\\r") + "' was null");
         }
+        logger.debug("Got response '{}' ({}) for request '{}' from {}", response, Arrays.toString(response.getBytes()),
+                fullCommand.replaceAll("\r", "\\\\r"), ipAddress.toString());
         return response;
     }
 

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/AcknowledgeResponseValue.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/AcknowledgeResponseValue.java
@@ -42,7 +42,7 @@ public enum AcknowledgeResponseValue {
             }
         }
 
-        throw new ResponseException("Cannot understand status: " + code);
+        throw new ResponseException("Cannot understand acknowledgement status: " + code);
     }
 
 }

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/PrefixedResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/PrefixedResponse.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.pjlinkdevice.internal.device.command;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -54,7 +55,8 @@ public abstract class PrefixedResponse<ResponseType> implements Response<Respons
         String fullPrefix = "%1" + this.prefix;
         if (!response.toUpperCase().startsWith(fullPrefix)) {
             throw new ResponseException(
-                    MessageFormat.format("Expected prefix ''{0}'', instead got ''{1}''", fullPrefix, response));
+                    MessageFormat.format("Expected prefix ''{0}'' ({1}), instead got ''{2}'' ({3})", fullPrefix,
+                            Arrays.toString(fullPrefix.getBytes()), response, Arrays.toString(response.getBytes())));
         }
         String result = response.substring(fullPrefix.length());
         ErrorCode.checkForErrorStatus(result, this.specifiedErrors);

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/errorstatus/ErrorStatusQueryResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/errorstatus/ErrorStatusQueryResponse.java
@@ -55,7 +55,7 @@ public class ErrorStatusQueryResponse extends
                 }
             }
 
-            throw new ResponseException("Cannot understand status: " + code);
+            throw new ResponseException("Cannot understand error status: " + code);
         }
     }
 

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/mute/MuteQueryResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/mute/MuteQueryResponse.java
@@ -57,7 +57,7 @@ public class MuteQueryResponse extends PrefixedResponse<MuteQueryResponse.MuteQu
                 }
             }
 
-            throw new ResponseException("Cannot understand status: " + code);
+            throw new ResponseException("Cannot understand mute status: " + code);
         }
 
         public boolean isAudioMuted() {

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/power/PowerQueryResponse.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/command/power/PowerQueryResponse.java
@@ -48,7 +48,7 @@ public class PowerQueryResponse extends PrefixedResponse<PowerQueryResponse.Powe
                 }
             }
 
-            throw new ResponseException("Cannot understand status: " + code);
+            throw new ResponseException("Cannot understand power status: " + code);
         }
 
     }


### PR DESCRIPTION
This improvement enables logging of responses from the device as byte arrays. This could help to resolve some remaining issues reported by the [community](https://community.openhab.org/t/new-pjlink-binding-for-controlling-multiple-projector-brands-models/56608/40).