### PR TITLE
[hueemulation] Fix broken fallback address

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -15,7 +15,7 @@ package org.openhab.io.hueemulation.internal;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -197,7 +197,7 @@ public class ConfigStore {
             discoveryIps = Collections.unmodifiableSet(Stream.of(config.discoveryIps.split(",")).map(String::trim)
                     .map(this::byName).filter(e -> e != null).collect(Collectors.toSet()));
         } else {
-            discoveryIps = new HashSet<>();
+            discoveryIps = new LinkedHashSet<>();
             configuredAddress = byName(networkAddressService.getPrimaryIpv4HostAddress());
             if (configuredAddress != null) {
                 discoveryIps.add(configuredAddress);
@@ -211,7 +211,7 @@ public class ConfigStore {
             }
         }
 
-        if (discoveryIps.size() < 1) {
+        if (discoveryIps.isEmpty()) {
             try {
                 logger.info("No discovery ip specified. Trying to determine the host address");
                 configuredAddress = InetAddress.getLocalHost();
@@ -318,7 +318,7 @@ public class ConfigStore {
     }
 
     public boolean isReady() {
-        return discoveryIps.size() > 0;
+        return !discoveryIps.isEmpty();
     }
 
     public HueEmulationConfig getConfig() {


### PR DESCRIPTION
With the changes in #6967 the `HueEmulationServiceOSGiTest` always fails for me.
The reason is that if the `discoveryIps` are not configured, it is no longer guaranteed it will use the primary IPv4 host address as fallback.
In my case the iterator on the `HashSet` would return an IPv6 address as first address.
By using a `LinkedHashSet` the order is preserved and it will again use the primary IPv4 host address as fallback.