### PR TITLE
Use .isEmpty() instead of counting elements with .size()

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/statedescription/AmazonEchoDynamicStateDescriptionProvider.java
@@ -201,7 +201,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return originalStateDescription;
             }
             List<Device> devices = accountHandler.getLastKnownDevices();
-            if (devices.size() == 0) {
+            if (devices.isEmpty()) {
                 return originalStateDescription;
             }
 

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Capabilities.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Capabilities.java
@@ -63,7 +63,7 @@ public class AtlonaPro3Capabilities extends AtlonaCapabilities {
             throw new IllegalArgumentException("hdmiPorts cannot be null");
         }
 
-        if (hdmiPorts.size() == 0) {
+        if (hdmiPorts.isEmpty()) {
             throw new IllegalArgumentException("hdmiPorts cannot be empty");
         }
 

--- a/bundles/org.openhab.binding.bosesoundtouch/src/main/java/org/openhab/binding/bosesoundtouch/internal/PresetContainer.java
+++ b/bundles/org.openhab.binding.bosesoundtouch/src/main/java/org/openhab/binding/bosesoundtouch/internal/PresetContainer.java
@@ -77,9 +77,10 @@ public class PresetContainer {
             throw new ContentItemNotPresetableException();
         }
     }
-    
+
     /**
      * Remove the Preset stored under the specified Id
+     * 
      * @param presetID
      */
     public void remove(int presetID) {
@@ -126,7 +127,7 @@ public class PresetContainer {
             }
         }
 
-        if (listOfPresets.size() > 0) {
+        if (!listOfPresets.isEmpty()) {
             listOfPresets.forEach(item -> storage.put(String.valueOf(item.getPresetID()), item));
         }
     }

--- a/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/ChaserThingHandler.java
+++ b/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/ChaserThingHandler.java
@@ -186,7 +186,7 @@ public class ChaserThingHandler extends DmxThingHandler {
 
     @Override
     public void dispose() {
-        if (channels.size() != 0) {
+        if (!channels.isEmpty()) {
             Bridge bridge = getBridge();
             if (bridge != null) {
                 DmxBridgeHandler bridgeHandler = (DmxBridgeHandler) bridge.getHandler();

--- a/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/ColorThingHandler.java
+++ b/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/ColorThingHandler.java
@@ -284,7 +284,7 @@ public class ColorThingHandler extends DmxThingHandler {
 
     @Override
     public void dispose() {
-        if (channels.size() != 0) {
+        if (!channels.isEmpty()) {
             channels.get(0).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS_R));
             channels.get(1).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS_G));
             channels.get(2).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS_B));

--- a/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/DimmerThingHandler.java
+++ b/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/DimmerThingHandler.java
@@ -220,7 +220,7 @@ public class DimmerThingHandler extends DmxThingHandler {
 
     @Override
     public void dispose() {
-        if (channels.size() != 0) {
+        if (!channels.isEmpty()) {
             channels.get(0).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS));
 
             Bridge bridge = getBridge();

--- a/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/TunableWhiteThingHandler.java
+++ b/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/handler/TunableWhiteThingHandler.java
@@ -274,7 +274,7 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
 
     @Override
     public void dispose() {
-        if (channels.size() != 0) {
+        if (!channels.isEmpty()) {
             channels.get(0).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS_CW));
             channels.get(1).removeListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS_WW));
         }

--- a/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/handler/DoorbellHandler.java
+++ b/bundles/org.openhab.binding.doorbird/src/main/java/org/openhab/binding/doorbird/internal/handler/DoorbellHandler.java
@@ -434,7 +434,7 @@ public class DoorbellHandler extends BaseThingHandler {
     private void updateMontage(String channelId) {
         logger.debug("Update montage for channel '{}'", channelId);
         ArrayList<BufferedImage> images = getImages(channelId);
-        if (images.size() > 0) {
+        if (!images.isEmpty()) {
             State state = createMontage(images);
             if (state != null) {
                 logger.debug("Got a montage. Updating channel '{}' with image montage", channelId);

--- a/bundles/org.openhab.binding.elerotransmitterstick/src/main/java/org/openhab/binding/elerotransmitterstick/internal/stick/TransmitterStick.java
+++ b/bundles/org.openhab.binding.elerotransmitterstick/src/main/java/org/openhab/binding/elerotransmitterstick/internal/stick/TransmitterStick.java
@@ -269,7 +269,7 @@ public class TransmitterStick {
 
                 try {
                     // in case we have no commands that are currently due, wait for a new one
-                    if (dueCommands.size() == 0) {
+                    if (dueCommands.isEmpty()) {
                         logger.debug("No due commands, invoking take on queue...");
                         dueCommands.add(cmdQueue.take());
                         logger.trace("take returned {}", dueCommands.first());

--- a/bundles/org.openhab.binding.enturno/src/main/java/org/openhab/binding/enturno/internal/EnturNoHandler.java
+++ b/bundles/org.openhab.binding.enturno/src/main/java/org/openhab/binding/enturno/internal/EnturNoHandler.java
@@ -270,7 +270,7 @@ public class EnturNoHandler extends BaseThingHandler {
     private void updateStopPlaceChannel(ChannelUID channelUID) {
         String channelId = channelUID.getIdWithoutGroup();
         String channelGroupId = channelUID.getGroupId();
-        if (processedData.size() > 0) {
+        if (!processedData.isEmpty()) {
             State state = UnDefType.UNDEF;
             switch (channelId) {
                 case EnturNoBindingConstants.CHANNEL_STOP_ID:

--- a/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/GatewayStatus.java
+++ b/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/GatewayStatus.java
@@ -38,7 +38,7 @@ public class GatewayStatus {
     }
 
     public boolean hasActiveFaults() {
-        return activeFaults.size() > 0;
+        return !activeFaults.isEmpty();
     }
 
     public ActiveFault getActiveFault(int index) {

--- a/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/ZoneStatus.java
+++ b/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/ZoneStatus.java
@@ -52,7 +52,7 @@ public class ZoneStatus {
     }
 
     public boolean hasActiveFaults() {
-        return activeFaults.size() > 0;
+        return !activeFaults.isEmpty();
     }
 
     public ActiveFault getActiveFault(int index) {

--- a/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/handler/FeedHandler.java
+++ b/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/handler/FeedHandler.java
@@ -271,7 +271,7 @@ public class FeedHandler extends BaseThingHandler {
     private SyndEntry getLatestEntry(SyndFeed feed) {
         List<SyndEntry> allEntries = feed.getEntries();
         SyndEntry lastEntry = null;
-        if (allEntries.size() >= 1) {
+        if (!allEntries.isEmpty()) {
             /*
              * The entries are stored in the SyndFeed object in the following order -
              * the newest entry has index 0. The order is determined from the time the entry was posted, not the

--- a/bundles/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/api/model/FreeboxPhoneStatusResponse.java
+++ b/bundles/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/api/model/FreeboxPhoneStatusResponse.java
@@ -26,7 +26,7 @@ public class FreeboxPhoneStatusResponse extends FreeboxResponse<List<FreeboxPhon
     @Override
     public void evaluate() throws FreeboxException {
         super.evaluate();
-        if (getResult() == null || getResult().size() == 0) {
+        if (getResult() == null || getResult().isEmpty()) {
             throw new FreeboxException("No phone status in response", this);
         }
     }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -117,7 +117,7 @@ public class CcuGateway extends AbstractHomematicGateway {
                     dpNames.add(dp.getName());
                 }
             }
-            if (dpNames.size() > 0) {
+            if (!dpNames.isEmpty()) {
                 HmDevice device = channel.getDevice();
                 String channelName = String.format("%s.%s:%s.", device.getHmInterface().getName(), device.getAddress(),
                         channel.getNumber());

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/SearchForLightsRequest.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/SearchForLightsRequest.java
@@ -25,7 +25,7 @@ class SearchForLightsRequest {
     private List<String> deviceid;
 
     public SearchForLightsRequest(List<String> deviceid) {
-        if (deviceid != null && (deviceid.size() == 0 || deviceid.size() > 16)) {
+        if (deviceid != null && (deviceid.isEmpty() || deviceid.size() > 16)) {
             throw new IllegalArgumentException("Group cannot be empty and cannot have more than 16 lights");
         }
         if (deviceid != null) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/SetAttributesRequest.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/SetAttributesRequest.java
@@ -35,7 +35,7 @@ class SetAttributesRequest {
     public SetAttributesRequest(String name, List<HueObject> lights) {
         if (name != null && Util.stringSize(name) > 32) {
             throw new IllegalArgumentException("Name can be at most 32 characters long");
-        } else if (lights != null && (lights.size() == 0 || lights.size() > 16)) {
+        } else if (lights != null && (lights.isEmpty() || lights.size() > 16)) {
             throw new IllegalArgumentException("Group cannot be empty and cannot have more than 16 lights");
         }
 

--- a/bundles/org.openhab.binding.hydrawise/src/main/java/org/openhab/binding/hydrawise/internal/HydrawiseHandler.java
+++ b/bundles/org.openhab.binding.hydrawise/src/main/java/org/openhab/binding/hydrawise/internal/HydrawiseHandler.java
@@ -235,7 +235,7 @@ public abstract class HydrawiseHandler extends BaseThingHandler {
             }
 
             updateGroupState(CHANNEL_GROUP_ALLZONES, CHANNEL_ZONE_RUN,
-                    status.running.size() > 0 ? OnOffType.ON : OnOffType.OFF);
+                    !status.running.isEmpty() ? OnOffType.ON : OnOffType.OFF);
         });
     }
 

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -937,7 +937,7 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
             resourceIds.addAll(linkedResourceIds);
             resourceIds.addAll(getAllLinkedChannelsResourceIds());
             logger.debug("Enable runtime notfications for {} resources: {}", resourceIds.size(), resourceIds);
-            if (resourceIds.size() > 0) {
+            if (!resourceIds.isEmpty()) {
                 try {
                     ihc.enableRuntimeValueNotifications(resourceIds);
                 } catch (IhcExecption e) {

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -173,7 +173,7 @@ class KeContactTransceiver {
                         handlers.size());
             }
 
-            if (handlers.size() == 0) {
+            if (handlers.isEmpty()) {
                 stop();
             }
         }

--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200ErrorServiceHandler.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200ErrorServiceHandler.java
@@ -121,7 +121,7 @@ public class KM200ErrorServiceHandler {
         String value = "";
         synchronized (errorMap) {
             int actN = getActiveError();
-            if (errorMap.size() < actN || errorMap.size() == 0) {
+            if (errorMap.size() < actN || errorMap.isEmpty()) {
                 return null;
             }
             /* is the time value existing ("t") then use it on the begin */

--- a/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200SwitchProgramServiceHandler.java
+++ b/bundles/org.openhab.binding.km200/src/main/java/org/openhab/binding/km200/internal/handler/KM200SwitchProgramServiceHandler.java
@@ -526,7 +526,7 @@ public class KM200SwitchProgramServiceHandler {
             Map<String, List<Integer>> week = switchMap.get(getPositiveSwitch());
             if (week != null) {
                 List<Integer> daysList = week.get(getActiveDay());
-                if (daysList.size() > 0) {
+                if (!daysList.isEmpty()) {
                     Integer cycl = getActiveCycle();
                     if (cycl <= daysList.size()) {
                         return (daysList.get(getActiveCycle() - 1));
@@ -545,7 +545,7 @@ public class KM200SwitchProgramServiceHandler {
             Map<String, List<Integer>> week = switchMap.get(getNegativeSwitch());
             if (week != null) {
                 List<Integer> daysList = week.get(getActiveDay());
-                if (daysList.size() > 0) {
+                if (!daysList.isEmpty()) {
                     Integer cycl = getActiveCycle();
                     if (cycl <= daysList.size()) {
                         return (daysList.get(getActiveCycle() - 1));

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
@@ -260,7 +260,7 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
     /** KNXIO */
     private void sendGroupValueResponse(Channel channel, GroupAddress destination) {
         Set<GroupAddress> rsa = getKNXChannelType(channel).getWriteAddresses(channel.getConfiguration());
-        if (rsa.size() > 0) {
+        if (!rsa.isEmpty()) {
             logger.trace("onGroupRead size '{}'", rsa.size());
             withKNXType(channel, (selector, configuration) -> {
                 Optional<OutboundSpec> os = groupAddressesRespondingSpec.stream().filter(spec -> {

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
@@ -63,7 +63,7 @@ public class KonnectedHTTPServlet extends HttpServlet {
             String data = inputStreamToString(req);
 
             logger.debug("The raw json data is: {}", data);
-            if (data != null && !(konnectedThingHandlers.size() == 0)) {
+            if (data != null && !konnectedThingHandlers.isEmpty()) {
                 KonnectedModuleGson event = gson.fromJson(data, KonnectedModuleGson.class);
                 String authorizationHeader = req.getHeader("Authorization");
                 String thingHandlerKey = authorizationHeader.substring("Bearer".length()).trim();

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVKeyboardInput.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVKeyboardInput.java
@@ -76,7 +76,7 @@ public class LGWebOSTVKeyboardInput {
     }
 
     public void sendDel() {
-        if (toSend.size() == 0) {
+        if (toSend.isEmpty()) {
             toSend.add(DELETE);
             if (!waiting) {
                 sendData();
@@ -101,7 +101,7 @@ public class LGWebOSTVKeyboardInput {
             uri = "ssap://com.webos.service.ime/deleteCharacters";
 
             int count = 0;
-            while (toSend.size() > 0 && toSend.get(0).equals(DELETE)) {
+            while (!toSend.isEmpty() && toSend.get(0).equals(DELETE)) {
                 toSend.remove(0);
                 count++;
             }
@@ -111,7 +111,7 @@ public class LGWebOSTVKeyboardInput {
             uri = "ssap://com.webos.service.ime/insertText";
             StringBuilder sb = new StringBuilder();
 
-            while (toSend.size() > 0 && !(toSend.get(0).equals(DELETE) || toSend.get(0).equals(ENTER))) {
+            while (!toSend.isEmpty() && !(toSend.get(0).equals(DELETE) || toSend.get(0).equals(ENTER))) {
                 String text = toSend.get(0);
                 sb.append(text);
                 toSend.remove(0);
@@ -126,7 +126,7 @@ public class LGWebOSTVKeyboardInput {
             @Override
             public void onSuccess(JsonObject response) {
                 waiting = false;
-                if (toSend.size() > 0) {
+                if (!toSend.isEmpty()) {
                     sendData();
                 }
             }
@@ -134,7 +134,7 @@ public class LGWebOSTVKeyboardInput {
             @Override
             public void onError(String error) {
                 waiting = false;
-                if (toSend.size() > 0) {
+                if (!toSend.isEmpty()) {
                     sendData();
                 }
             }

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
@@ -214,7 +214,7 @@ public class LxControlLightControllerV2Test extends LxControlTest {
 
     private void testMoodList(List<StateOption> options, Integer offId) {
         assertEquals(options.size(), handler.extraControls.size());
-        if (options.size() == 0) {
+        if (options.isEmpty()) {
             return;
         }
         Integer min = null;

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
@@ -941,7 +941,7 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
      * Updates the room information by sending M command
      */
     public void sendDeviceAndRoomNameUpdate(String comment) {
-        if (devices.size() > 0) {
+        if (!devices.isEmpty()) {
             SendCommand sendCommand = new SendCommand("Cube(" + getThing().getUID().getId() + ")",
                     new MCommand(devices, rooms), comment);
             queueCommand(sendCommand);

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusDiscoveryService.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusDiscoveryService.java
@@ -82,7 +82,7 @@ public class ModbusDiscoveryService extends AbstractDiscoveryService {
     protected void startScan() {
         logger.trace("ModbusDiscoveryService starting scan");
 
-        if (participants.size() == 0) {
+        if (participants.isEmpty()) {
             // There's no point on continuing if there are no participants at the moment
             stopScan();
             return;

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusEndpointDiscoveryService.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusEndpointDiscoveryService.java
@@ -79,7 +79,7 @@ public class ModbusEndpointDiscoveryService implements ModbusThingHandlerDiscove
 
     @Override
     public boolean scanInProgress() {
-        return participants.size() > 0 || waitingForParticipant;
+        return !participants.isEmpty() || waitingForParticipant;
     }
 
     /**
@@ -89,7 +89,7 @@ public class ModbusEndpointDiscoveryService implements ModbusThingHandlerDiscove
      *            discovered items
      */
     private void startNextParticipant(final ModbusEndpointThingHandler handler, final ModbusDiscoveryService service) {
-        if (participants.size() == 0) {
+        if (participants.isEmpty()) {
             logger.trace("All participants has finished");
             service.scanFinished();
             return; // We're finished, this will exit the process

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/AbstractMqttAttributeClass.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/mapping/AbstractMqttAttributeClass.java
@@ -172,7 +172,7 @@ public abstract class AbstractMqttAttributeClass implements SubscribeFieldToMQTT
             int timeout) {
         // We first need to unsubscribe old subscriptions if any
         final CompletableFuture<@Nullable Void> startFuture;
-        if (subscriptions.size() > 0) {
+        if (!subscriptions.isEmpty()) {
             startFuture = unsubscribe();
         } else {
             startFuture = CompletableFuture.completedFuture(null);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
@@ -44,7 +44,7 @@ public class TextValue extends Value {
     public TextValue(String[] states) {
         super(CoreItemFactory.STRING, Collections.singletonList(StringType.class));
         Set<String> s = Stream.of(states).filter(e -> StringUtils.isNotBlank(e)).collect(Collectors.toSet());
-        if (s.size() > 0) {
+        if (!s.isEmpty()) {
             this.states = s;
         } else {
             this.states = null;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryService.java
@@ -142,7 +142,7 @@ public class NetatmoModuleDiscoveryService extends AbstractDiscoveryService impl
     private void discoverWelcomeHome(NAWelcomeHome home) {
         // I observed that Thermostat homes are also reported here by Netatmo API
         // So I ignore homes that have an empty list of cameras
-        if (home.getCameras().size() > 0) {
+        if (!home.getCameras().isEmpty()) {
             onDeviceAddedInternal(home.getId(), null, WELCOME_HOME_THING_TYPE.getId(), home.getName(), null);
             // Discover Cameras
             home.getCameras().forEach(camera -> {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/MeasurableChannels.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/MeasurableChannels.java
@@ -60,9 +60,9 @@ public class MeasurableChannels {
     protected Optional<State> getNAThingProperty(String channelId) {
         int index = measuredChannels.indexOf(channelId);
         if (index != -1 && measures != null) {
-            if (measures.getBody().size() > 0) {
+            if (!measures.getBody().isEmpty()) {
                 List<List<Float>> valueList = measures.getBody().get(0).getValue();
-                if (valueList.size() > 0) {
+                if (!valueList.isEmpty()) {
                     List<Float> values = valueList.get(0);
                     if (values.size() >= index) {
                         Float value = values.get(index);
@@ -75,7 +75,7 @@ public class MeasurableChannels {
     }
 
     public Optional<CSVParams> getAsCsv() {
-        if (measuredChannels.size() > 0) {
+        if (!measuredChannels.isEmpty()) {
             return Optional.of(new CSVParams(measuredChannels));
         }
         return Optional.empty();

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiApiServlet.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiApiServlet.java
@@ -75,7 +75,7 @@ public class NukiApiServlet extends HttpServlet {
                     nukiBridgeHandler.getThing().getUID());
             return;
         }
-        if (nukiBridgeHandlers.size() == 0) {
+        if (nukiBridgeHandlers.isEmpty()) {
             this.activate();
         }
         nukiBridgeHandlers.add(nukiBridgeHandler);
@@ -86,7 +86,7 @@ public class NukiApiServlet extends HttpServlet {
                 nukiBridgeHandler.getThing().getUID(),
                 nukiBridgeHandler.getThing().getConfiguration().get(NukiBindingConstants.CONFIG_IP));
         nukiBridgeHandlers.remove(nukiBridgeHandler);
-        if (nukiBridgeHandlers.size() == 0) {
+        if (nukiBridgeHandlers.isEmpty()) {
             this.deactivate();
         }
     }

--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/PJLinkDeviceHandler.java
@@ -327,7 +327,7 @@ public class PJLinkDeviceHandler extends BaseThingHandler {
             validationMessages.put("autoReconnectInterval", "allowed values are 0 (never) or >30");
         }
 
-        if (validationMessages.size() > 0) {
+        if (!validationMessages.isEmpty()) {
             String message = validationMessages.entrySet().stream()
                     .map((Map.Entry<String, String> a) -> (a.getKey() + ": " + a.getValue()))
                     .collect(Collectors.joining("; "));

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -197,7 +197,7 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
                                 slaves.add(slave);
                             }
                         }
-                        if (slaves.size() > 0) {
+                        if (!slaves.isEmpty()) {
                             bridge.getClient().setCombinedSinkSlaves(((Sink) device), slaves);
                         }
                     }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Sink.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/items/Sink.java
@@ -38,7 +38,7 @@ public class Sink extends AbstractAudioDeviceConfig {
     }
 
     public boolean isCombinedSink() {
-        return combinedSinkNames.size() > 0;
+        return !combinedSinkNames.isEmpty();
     }
 
     public List<String> getCombinedSinkNames() {

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.robonect.internal.RobonectBindingConstants.*;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -300,8 +301,9 @@ public class RobonectHandler extends BaseThingHandler {
     private void refreshLastErrorInfo() {
         ErrorList errorList = robonectClient.errorList();
         if (errorList.isSuccessful()) {
-            if (errorList.getErrors() != null && errorList.getErrors().size() > 0) {
-                ErrorEntry lastErrorEntry = errorList.getErrors().get(0);
+            List<ErrorEntry> errors = errorList.getErrors();
+            if (errors != null && !errors.isEmpty()) {
+                ErrorEntry lastErrorEntry = errors.get(0);
                 updateLastErrorChannels(lastErrorEntry);
             }
         } else {

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandlerTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandlerTest.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.sensibo.internal.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -136,6 +133,6 @@ public class SensiboSkyHandlerTest {
         Mockito.when(thing.getUID()).thenReturn(new ThingUID("sensibo:account:thinguid"));
         SensiboSkyHandler handler = Mockito.spy(new SensiboSkyHandler(thing));
         List<Channel> dynamicChannels = handler.createDynamicChannels(sky);
-        assertTrue(dynamicChannels.size() > 0);
+        assertTrue(!dynamicChannels.isEmpty());
     }
 }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoapHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoapHandler.java
@@ -310,7 +310,7 @@ public class ShellyCoapHandler implements ShellyCoapListener {
     private void handleStatusUpdate(String devId, String payload, int serial) throws IOException {
         // payload = StringUtils.substringBefore(payload, "]]}") + "]]}";
         logger.debug("{}: CoIoT Sensor data {}", thingName, payload);
-        if (blockMap.size() == 0) {
+        if (blockMap.isEmpty()) {
             // send discovery packet
             resetSerial();
             reqDescription = sendRequest(reqDescription, config.deviceIp, COLOIT_URI_DEVDESC, Type.CON);
@@ -497,7 +497,7 @@ public class ShellyCoapHandler implements ShellyCoapListener {
             }
         }
 
-        if (updates.size() > 0) {
+        if (!updates.isEmpty()) {
             logger.debug("{}: Process {} CoIoT channel updates", thingName, updates.size());
             int i = 0;
             for (Map.Entry<String, State> u : updates.entrySet()) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyLightHandler.java
@@ -478,7 +478,7 @@ public class ShellyLightHandler extends ShellyBaseHandler {
             logger.debug("Setting effect to {}", newCol.effect);
             parms.put(SHELLY_COLOR_EFFECT, newCol.effect.toString());
         }
-        if (parms.size() > 0) {
+        if (!parms.isEmpty()) {
             logger.debug("Send collor settings: {}", parms.toString());
             Validate.notNull(api);
             api.setLightParms(lightId, parms);

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
@@ -132,7 +132,7 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
     }
 
     private synchronized void poll() {
-        if (thermostatHandlers.size() > 0) {
+        if (!thermostatHandlers.isEmpty()) {
             logger.debug("Polling for state");
             try {
                 if (connectToBridge()) {

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/discovery/SomfyTahomaItemDiscoveryService.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/discovery/SomfyTahomaItemDiscoveryService.java
@@ -31,7 +31,11 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.somfytahoma.internal.handler.SomfyTahomaBridgeHandler;
-import org.openhab.binding.somfytahoma.internal.model.*;
+import org.openhab.binding.somfytahoma.internal.model.SomfyTahomaActionGroup;
+import org.openhab.binding.somfytahoma.internal.model.SomfyTahomaDevice;
+import org.openhab.binding.somfytahoma.internal.model.SomfyTahomaGateway;
+import org.openhab.binding.somfytahoma.internal.model.SomfyTahomaSetup;
+import org.openhab.binding.somfytahoma.internal.model.SomfyTahomaState;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
@@ -135,7 +139,7 @@ public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService im
                 String oid = group.getOid();
                 String label = group.getLabel();
 
-                //actiongroups use oid as deviceURL
+                // actiongroups use oid as deviceURL
                 actionGroupDiscovered(label, oid, oid);
             }
         } else {
@@ -297,12 +301,13 @@ public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService im
     }
 
     private boolean isStateLess(SomfyTahomaDevice device) {
-        return device.getStates().size() == 0 || (device.getStates().size() == 1 && hasState(device, STATUS_STATE));
+        return device.getStates().isEmpty() || (device.getStates().size() == 1 && hasState(device, STATUS_STATE));
     }
 
     private void logUnsupportedDevice(SomfyTahomaDevice device) {
         if (!isStateLess(device)) {
-            logger.info("Detected a new unsupported device: {} with widgetName: {}", device.getUiClass(), device.getWidget());
+            logger.info("Detected a new unsupported device: {} with widgetName: {}", device.getUiClass(),
+                    device.getWidget());
             logger.info("If you want to add the support, please create a new issue and attach the information below");
             logger.info("Device definition:\n{}", device.getDefinition());
 
@@ -343,7 +348,8 @@ public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService im
     }
 
     private void deviceDiscovered(SomfyTahomaDevice device, ThingTypeUID thingTypeUID) {
-        deviceDiscovered(device.getLabel(), device.getDeviceURL(), device.getOid(), thingTypeUID, hasState(device, RSSI_LEVEL_STATE));
+        deviceDiscovered(device.getLabel(), device.getDeviceURL(), device.getOid(), thingTypeUID,
+                hasState(device, RSSI_LEVEL_STATE));
     }
 
     private void deviceDiscovered(String label, String deviceURL, String oid, ThingTypeUID thingTypeUID, boolean rssi) {
@@ -357,9 +363,8 @@ public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService im
         ThingUID thingUID = new ThingUID(thingTypeUID, bridge.getThing().getUID(), oid);
 
         logger.debug("Detected a/an {} - label: {} oid: {}", thingTypeUID.getId(), label, oid);
-        thingDiscovered(DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
-                .withProperties(properties).withRepresentationProperty("url").withLabel(label)
-                .withBridge(bridge.getThing().getUID()).build());
+        thingDiscovered(DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID).withProperties(properties)
+                .withRepresentationProperty("url").withLabel(label).withBridge(bridge.getThing().getUID()).build());
     }
 
     private void actionGroupDiscovered(String label, String deviceURL, String oid) {

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -1040,7 +1040,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                         if (response != null) {
                             List<String> fields = SonosXMLParser.getRadioTimeFromXML(response);
 
-                            if (fields != null && fields.size() > 0) {
+                            if (fields != null && !fields.isEmpty()) {
                                 opmlUrlSucceeded = true;
 
                                 resultString = new String();

--- a/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/protocol/SonyAudioMethod.java
+++ b/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/protocol/SonyAudioMethod.java
@@ -432,7 +432,7 @@ class SwitchNotifications extends SonyAudioMethod {
 
     SwitchNotifications(List<Notification> enabled, List<Notification> disabled) {
         super("switchNotifications", "1.0");
-        params = new Param[] { new Param(enabled.size() > 0 ? enabled : null, disabled.size() > 0 ? disabled : null) };
+        params = new Param[] { new Param(!enabled.isEmpty() ? enabled : null, !disabled.isEmpty() ? disabled : null) };
     }
 }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelBridgeCheck.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/ChannelBridgeCheck.java
@@ -101,7 +101,7 @@ final class ChannelBridgeCheck extends ChannelHandlerTemplate {
                 }
             }
             String result;
-            if (unusedScenes.size() > 0) {
+            if (!unusedScenes.isEmpty()) {
                 result = thisBridgeHandler.localization.getText("channelValue.check-integrity-failed")
                         .concat(unusedScenes.toString());
             } else {

--- a/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/handler/VehicleHandler.java
@@ -184,7 +184,7 @@ public class VehicleHandler extends BaseThingHandler {
 
             logger.debug("Trips discovered : {}", newTrips.size());
 
-            if (newTrips.size() > 0) {
+            if (!newTrips.isEmpty()) {
                 Integer newTripId = newTrips.get(newTrips.size() - 1).id;
                 if (newTripId > lastTripId) {
                     updateProperty(LAST_TRIP_ID, newTripId.toString());

--- a/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/handler/ChannelHandler.java
+++ b/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/handler/ChannelHandler.java
@@ -82,7 +82,7 @@ public class ChannelHandler extends BaseThingHandler {
                 if (programmes.size() < 2) {
                     refreshProgramList();
                 }
-                if (programmes.size() == 0) {
+                if (programmes.isEmpty()) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "No programmes to come in the current XML file for this channel");
                 } else if (Instant.now().isAfter(programmes.get(0).getProgrammeStop())) {
@@ -171,7 +171,7 @@ public class ChannelHandler extends BaseThingHandler {
                         break;
                     case CHANNEL_CHANNEL_URL:
                         updateState(channelUID,
-                                mediaChannel != null ? mediaChannel.getIcons().size() > 0
+                                mediaChannel != null ? !mediaChannel.getIcons().isEmpty()
                                         ? new StringType(mediaChannel.getIcons().get(0).getSrc())
                                         : UnDefType.UNDEF : UnDefType.UNDEF);
                         break;
@@ -188,19 +188,19 @@ public class ChannelHandler extends BaseThingHandler {
                     case CHANNEL_PROGRAMME_TITLE:
                         List<WithLangType> titles = programme.getTitles();
                         updateState(channelUID,
-                                titles.size() > 0 ? new StringType(programme.getTitles().get(0).getValue())
+                                !titles.isEmpty() ? new StringType(programme.getTitles().get(0).getValue())
                                         : UnDefType.UNDEF);
                         break;
                     case CHANNEL_PROGRAMME_CATEGORY:
                         List<WithLangType> categories = programme.getCategories();
                         updateState(channelUID,
-                                categories.size() > 0 ? new StringType(programme.getCategories().get(0).getValue())
+                                !categories.isEmpty() ? new StringType(programme.getCategories().get(0).getValue())
                                         : UnDefType.UNDEF);
                         break;
                     case CHANNEL_PROGRAMME_ICON:
                         List<Icon> icons = programme.getIcons();
                         updateState(channelUID,
-                                icons.size() > 0 ? new StringType(icons.get(0).getSrc()) : UnDefType.UNDEF);
+                                !icons.isEmpty() ? new StringType(icons.get(0).getSrc()) : UnDefType.UNDEF);
                         break;
                     case CHANNEL_PROGRAMME_ELAPSED:
                         updateState(channelUID, getDurationInSeconds(programme.getProgrammeStart(), Instant.now()));
@@ -240,7 +240,7 @@ public class ChannelHandler extends BaseThingHandler {
     }
 
     private @Nullable RawType downloadIcon(List<Icon> icons) {
-        if (icons.size() > 0) {
+        if (!icons.isEmpty()) {
             String url = icons.get(0).getSrc();
             return HttpUtil.downloadImage(url);
         }

--- a/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/handler/XmlTVHandler.java
+++ b/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/handler/XmlTVHandler.java
@@ -81,7 +81,7 @@ public class XmlTVHandler extends BaseBridgeHandler {
                     // Remove all finished programmes
                     xmlFile.getProgrammes().removeIf(programme -> Instant.now().isAfter(programme.getProgrammeStop()));
 
-                    if (xmlFile.getProgrammes().size() > 0) {
+                    if (!xmlFile.getProgrammes().isEmpty()) {
                         // Sort programmes by starting instant
                         Collections.sort(xmlFile.getProgrammes(), Comparator.comparing(Programme::getProgrammeStart));
                         // Ready to deliver data to ChannelHandlers

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
@@ -392,18 +392,18 @@ public class StateUtils {
         if (t == null) {
             switch (type) {
                 case CoreItemFactory.COLOR:
-                    if (cs.colorFilter.size() == 0) {
+                    if (cs.colorFilter.isEmpty()) {
                         t = DeviceType.ColorType;
                     }
                     break;
                 case CoreItemFactory.DIMMER:
                 case CoreItemFactory.ROLLERSHUTTER:
-                    if (cs.whiteFilter.size() == 0) {
+                    if (cs.whiteFilter.isEmpty()) {
                         t = DeviceType.WhiteTemperatureType;
                     }
                     break;
                 case CoreItemFactory.SWITCH:
-                    if (cs.switchFilter.size() == 0) {
+                    if (cs.switchFilter.isEmpty()) {
                         t = DeviceType.SwitchType;
                     }
                     break;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Scenes.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/Scenes.java
@@ -144,7 +144,7 @@ public class Scenes implements RegistryChangeListener<Rule> {
             }
         }
 
-        if (items.size() > 0) {
+        if (!items.isEmpty()) {
             entry.lights = items;
         }
 

--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/OpenHabToDeviceConverter.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/OpenHabToDeviceConverter.java
@@ -122,7 +122,7 @@ class OpenHabToDeviceConverter {
 
         }
 
-        if (channels.size() == 0) {
+        if (channels.isEmpty()) {
             logger.debug("No linked channels found for thing {} - ignoring", thing.getLabel());
             return null;
         }

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
@@ -265,7 +265,7 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
         } catch (IOException ioe) {
             // no exception handling - we just return the empty String
         }
-        return lines != null && lines.size() > 0 ? lines.get(0) : "";
+        return lines != null && !lines.isEmpty() ? lines.get(0) : "";
     }
 
     /**


### PR DESCRIPTION
`.isEmpty()` and `!.isEmpty()` express the intent more clearly and are therefore preferred.
Counting the number of elements can also be an expensive operation e.g. when using certain linked list implementations ([ConcurrentSkipListSet](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListSet.html#size--)).

`.isEmpty()` can be used instead of `.size() == 0` and `.size() < 1`
`!.isEmpty()` can be used instead of `.size() != 0`, `.size() > 0` and `.size() >= 1`