### PR TITLE
[chromecast] Update API lib to 0.11.3

### DIFF
--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -21,27 +21,8 @@
     <dependency>
       <groupId>su.litvak.chromecast</groupId>
       <artifactId>api-v2</artifactId>
-      <version>0.11.2</version>
+      <version>0.11.3</version>
       <scope>compile</scope>
-      <exclusions>
-        <!-- To avoid intermittent Failure to find com.fasterxml.jackson:jackson-bom:pom:2.9.0.pr4-SNAPSHOT
-		in https://oss.sonatype.org/content/repositories/snapshots/
-
-		These dependencies are explicitly added below
-		-->
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Fixes:
* Jackson version range resolution issues, so https://github.com/openhab/openhab-addons/pull/7258 can be undone (https://github.com/vitalidze/chromecast-java-api-v2/issues/124)
* Logs IOE on debug instead of warning when disconnecting ("Got IOException while reading due to stream being closed (stop=true)")