### PR TITLE
[daikin] Support AUTO fan mode with Airbase

### DIFF
--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -44,7 +44,7 @@ For the BRP15B61:
 | outdoortemp     | The outdoor temperature as measured by the external part of the air conditioning system. May not be available when unit is off. |
 | mode            | The mode set for the unit (AUTO, DEHUMIDIFIER, COLD, HEAT, FAN)                             |
 | homekit mode    | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)              | 
-| airbasefanspeed | The fan speed set for the unit (AIRSIDE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO_LEVEL_1, AUTO_LEVEL_2, AUTO_LEVEL_3, AUTO_LEVEL_4, AUTO_LEVEL_5)  |
+| airbasefanspeed | The fan speed set for the unit (AUTO, AIRSIDE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO_LEVEL_1, AUTO_LEVEL_2, AUTO_LEVEL_3, AUTO_LEVEL_4, AUTO_LEVEL_5)  |
 | zone1           | Turns zone 1 on/off for the air conditioning unit (if a zone controller is installed.)      |
 | zone2           | Turns zone 2 on/off for the air conditioning unit.                                          |
 | zone3           | Turns zone 3 on/off for the air conditioning unit.                                          |

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/api/airbase/AirbaseEnums.java
@@ -60,6 +60,7 @@ public class AirbaseEnums {
 
     public enum AirbaseFanSpeed {
         // level,f_auto,f_airside
+        AUTO         (0, false, false),
         LEVEL_1      (1, false, false),
         LEVEL_2      (2, false, false),
         LEVEL_3      (3, false, false),
@@ -99,6 +100,9 @@ public class AirbaseEnums {
             if (airside) {
                 return "Airside";
             }
+            if (level == 0) {
+                return "Auto";
+            }
             String label = "";
             if (auto) {
                 label = "Auto ";
@@ -109,6 +113,9 @@ public class AirbaseEnums {
         public static AirbaseFanSpeed fromValue(int rate, boolean auto, boolean airside) { // convert from f_rate, f_auto, f_airside
             if (airside) {
                 return AIRSIDE;
+            }
+            if (rate == 0) {
+                return AirbaseFanSpeed.AUTO;
             }
             for (AirbaseFanSpeed m : AirbaseFanSpeed.values()) {
                 if (m.getLevel() == rate && m.getAuto() == auto && m.getAirside() == airside) {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
@@ -144,7 +144,7 @@ public class DaikinAirbaseUnitHandler extends DaikinBaseHandler {
         AirbaseFanSpeed newFanSpeed = AirbaseFanSpeed.valueOf(speed);
         if (EnumSet.range(AirbaseFanSpeed.AUTO_LEVEL_1, AirbaseFanSpeed.AUTO_LEVEL_5).contains(newFanSpeed)
                 && !airbaseModelInfo.features.contains(AirbaseFeature.FRATE_AUTO)) {
-            logger.warn("Auto fan levels are not supported by your controller");
+            logger.warn("Fan AUTO_LEVEL_X is not supported by your controller");
             return;
         }
         if (newFanSpeed == AirbaseFanSpeed.AIRSIDE && !airbaseModelInfo.features.contains(AirbaseFeature.AIRSIDE)) {
@@ -174,6 +174,7 @@ public class DaikinAirbaseUnitHandler extends DaikinBaseHandler {
 
     protected void updateAirbaseFanSpeedChannelStateDescription() {
         List<StateOption> options = new ArrayList<>();
+        options.add(new StateOption(AirbaseFanSpeed.AUTO.name(), AirbaseFanSpeed.AUTO.getLabel()));
         if (airbaseModelInfo.features.contains(AirbaseFeature.AIRSIDE)) {
             options.add(new StateOption(AirbaseFanSpeed.AIRSIDE.name(), AirbaseFanSpeed.AIRSIDE.getLabel()));
         }


### PR DESCRIPTION
Airbase supports AUTO fan mode as reported in https://community.openhab.org/t/daikin-binding-fan-error/96129

This is done by setting f_rate=0,f_airside=0,f_auto=0

It appears that this is also allowed in other Airbase compatible systems that don't otherwise allow such setting via the wall controller.