### PR TITLE
[daikin] Update doc to include fandir channel previously omitted

### DIFF
--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -72,6 +72,7 @@ Number:Temperature DaikinACUnit_SetPoint { channel="daikin:ac_unit:living_room_a
 String DaikinACUnit_Mode { channel="daikin:ac_unit:living_room_ac:mode" }
 String DaikinACUnit_HomekitMode { channel="daikin:ac_unit:living_room_ac:homekitmode" }
 String DaikinACUnit_Fan { channel="daikin:ac_unit:living_room_ac:fanspeed" }
+String DaikinACUnit_Fan_Movement { channel="daikin:ac_unit:living_room_ac:fandir" }
 Number:Temperature DaikinACUnit_IndoorTemperature { channel="daikin:ac_unit:living_room_ac:indoortemp" }
 Number:Temperature DaikinACUnit_OutdoorTemperature { channel="daikin:ac_unit:living_room_ac:outdoortemp" }
 # Additional items for BRP1B61

--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -31,8 +31,9 @@ For the BRP072A42:
 | outdoortemp  | The outdoor temperature as measured by the external part of the air conditioning system. May not be available when unit is off. |
 | humidity     | The indoor humidity as measured by the unit. This is not available on all units.            |
 | mode         | The mode set for the unit (AUTO, DEHUMIDIFIER, COLD, HEAT, FAN)                             |
-| homekit mode | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)              |
+| homekit mode | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)            |
 | fanspeed     | The fan speed set for the unit (AUTO, SILENCE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5) |
+| fandir       | The fan blade direction (STOPPED, VERTICAL, HORIZONTAL, VERTICAL_AND_HORIZONTAL)            |
 
 For the BRP15B61:
 
@@ -43,7 +44,7 @@ For the BRP15B61:
 | indoortemp      | The indoor temperature as measured by the unit.                                             |
 | outdoortemp     | The outdoor temperature as measured by the external part of the air conditioning system. May not be available when unit is off. |
 | mode            | The mode set for the unit (AUTO, DEHUMIDIFIER, COLD, HEAT, FAN)                             |
-| homekit mode    | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)              | 
+| homekit mode    | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)            | 
 | airbasefanspeed | The fan speed set for the unit (AUTO, AIRSIDE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO_LEVEL_1, AUTO_LEVEL_2, AUTO_LEVEL_3, AUTO_LEVEL_4, AUTO_LEVEL_5)  |
 | zone1           | Turns zone 1 on/off for the air conditioning unit (if a zone controller is installed.)      |
 | zone2           | Turns zone 2 on/off for the air conditioning unit.                                          |


### PR DESCRIPTION
The fandir channel exists in the code but wasn't included in the documentation. This PR remedies that. This solved https://github.com/openhab/openhab-addons/issues/6308 