### PR TITLE
[insteon] Improve hub message processing

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/msg_definitions.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/msg_definitions.xml
@@ -120,6 +120,17 @@
 		</header>
 		<byte name = "statusByte"/>
 	</msg>
+	<msg name = "UnknownMessage5C" length = "11" direction = "FROM_MODEM">
+		<header length="9">
+			<byte>0x02</byte>
+			<byte name = "Cmd">0x5c</byte>
+			<address name = "fromAddress"/>
+			<address name = "toAddress"/>
+			<byte name = "messageFlags"/>
+		</header>
+		<byte name = "command1"/>
+		<byte name = "command2"/>
+	</msg>
 
 	<msg name = "GetIMInfo" length="2" direction = "TO_MODEM">
 		<header length="2">
@@ -281,7 +292,7 @@
 		</header>
 		<byte name = "DeviceCategory"/>
 		<byte name = "DeviceSubcategory"/>
-		<byte name = "FirmwareVersion"/>		
+		<byte name = "FirmwareVersion"/>
 	</msg>
 	<msg name = "SetHostDeviceCategoryReply" length="6" direction = "FROM_MODEM">
 		<header length="2">


### PR DESCRIPTION
* Improved message processing in draining the current buffer fully when a bad error message exception is triggered. Currently, when multiple messages are received at the same time and, in the event the first one has corrupted data, the subsequent messages aren't processed until new data is available in the modem buffer. This can lead to a few seconds up to a minute delay in processing these messages.

* Improved hub cleared and wrap around buffer messages parsing, reducing further the amount of potential bad data received errors, based on the [python module](https://github.com/nugget/python-insteonplm) implementation.

* Removed the unnecessary buffer clear request on each write calls, since sending a command to the hub implies the buffer will be cleared at that time.

* Added an [undocumented message code](https://forum.insteon.com/forum/main-category/main-forum/101796-new-commands-with-hub-plm-firmware-a3) that my hub sent out every once in a while, generating some unnecessary unknown command code errors.