### PR TITLE
[mqtt] Added publish method to MQTTTopicDiscoveryService

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/MQTTTopicDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/MQTTTopicDiscoveryService.java
@@ -38,4 +38,13 @@ public interface MQTTTopicDiscoveryService {
      * @param listener A listener that has subscribed before.
      */
     void unsubscribe(MQTTTopicDiscoveryParticipant listener);
+
+    /**
+     * Publish a message to all connected brokers
+     *
+     * @param topic The topic to publish on
+     * @param payload The message to publish
+     */
+    void publish(String topic, byte[] payload);
+
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
@@ -125,4 +125,13 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
             handlers.forEach(broker -> broker.unregisterDiscoveryListener(listener, topic));
         });
     }
+
+     @Override
+     public void publish(String topic, byte[] payload) {
+         handlers.forEach(handler -> {
+             handler.getConnectionAsync().thenAccept(connection -> {
+                 connection.publish(topic, payload);
+             });
+         });
+     }
 }


### PR DESCRIPTION
[mqtt] Add publish capability to MQTTTopicDiscoveryService

This patch adds publish capability to MQTTTopicDiscoveryService exposed by the org.openhab.binding.mqtt to allow other bindnigs to do an "active" scan.

Certain MQTT devices respond as a result to a certain message published on a discovery topic, and now other bindings can use the infrastructure laid out by the mqtt binding to do this type of discovery.

A discussion regarding this topic was held here:
https://community.openhab.org/t/adding-mqtttopicdiscoveryservice-publish-method/84713