### PR TITLE
[nikohomecontrol] Fix thermostat setpoint.

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
@@ -56,7 +56,7 @@ public class NhcThermostat2 extends NhcThermostat {
         logger.debug("Niko Home Control: execute thermostat overrule {} during {} min for {}", overrule, overruletime,
                 id);
 
-        nhcComm.executeThermostat(id, overrule / 10, overruletime);
+        nhcComm.executeThermostat(id, overrule, overruletime);
     }
 
     /**

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -683,7 +683,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             device.properties.add(overruleActiveProp);
 
             NhcProperty overruleSetpointProp = new NhcProperty();
-            overruleSetpointProp.overruleSetpoint = String.valueOf(overruleTemp);
+            overruleSetpointProp.overruleSetpoint = String.valueOf(overruleTemp / 10.0);
             device.properties.add(overruleSetpointProp);
 
             NhcProperty overruleTimeProp = new NhcProperty();


### PR DESCRIPTION
Bugfix for thermostat setpoint using wrong rounding on NHC II.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>