### PR TITLE
Remove deprecated DiscoveryServiceCallback, ExtendedDiscoveryService usages

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -27,8 +28,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.amazonechocontrol.internal.Connection;
@@ -45,22 +44,14 @@ import org.slf4j.LoggerFactory;
  * @author Michael Geramb - Initial contribution
  */
 @NonNullByDefault
-public class AmazonEchoDiscovery extends AbstractDiscoveryService implements ExtendedDiscoveryService {
+public class AmazonEchoDiscovery extends AbstractDiscoveryService {
 
-    AccountHandler accountHandler;
+    private final AccountHandler accountHandler;
     private final Logger logger = LoggerFactory.getLogger(AmazonEchoDiscovery.class);
-    private final HashSet<String> discoverdFlashBriefings = new HashSet<>();
+    private final Set<String> discoverdFlashBriefings = new HashSet<>();
 
-    @Nullable
-    ScheduledFuture<?> startScanStateJob;
-    long activateTimeStamp;
-
-    private @Nullable DiscoveryServiceCallback discoveryServiceCallback;
-
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
-    }
+    private @Nullable ScheduledFuture<?> startScanStateJob;
+    private long activateTimeStamp;
 
     public AmazonEchoDiscovery(AccountHandler accountHandler) {
         super(SUPPORTED_THING_TYPES_UIDS, 10);
@@ -118,7 +109,7 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService implements Ext
         stopScanJob();
     }
 
-    void stopScanJob() {
+    private void stopScanJob() {
         @Nullable
         ScheduledFuture<?> currentStartScanStateJob = startScanStateJob;
         if (currentStartScanStateJob != null) {
@@ -138,10 +129,6 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService implements Ext
     }
 
     synchronized void setDevices(List<Device> deviceList) {
-        DiscoveryServiceCallback discoveryServiceCallback = this.discoveryServiceCallback;
-        if (discoveryServiceCallback == null) {
-            return;
-        }
         for (Device device : deviceList) {
             String serialNumber = device.serialNumber;
             if (serialNumber != null) {
@@ -163,12 +150,7 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService implements Ext
 
                     ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
                     ThingUID thingUID = new ThingUID(thingTypeId, brigdeThingUID, serialNumber);
-                    if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
-                        continue;
-                    }
-                    if (discoveryServiceCallback.getExistingThing(thingUID) != null) {
-                        continue;
-                    }
+
                     DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withLabel(device.accountName)
                             .withProperty(DEVICE_PROPERTY_SERIAL_NUMBER, serialNumber)
                             .withProperty(DEVICE_PROPERTY_FAMILY, deviceFamily)
@@ -188,30 +170,13 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService implements Ext
         if (currentFlashBriefingJson.isEmpty()) {
             return;
         }
-        DiscoveryServiceCallback discoveryServiceCallback = this.discoveryServiceCallback;
-        if (discoveryServiceCallback == null) {
-            return;
-        }
 
         if (!discoverdFlashBriefings.contains(currentFlashBriefingJson)) {
-            ThingUID freeThingUID = null;
-            int freeIndex = 0;
-            for (int i = 1; i < 1000; i++) {
-                String id = Integer.toString(i);
-                ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
-                ThingUID thingUID = new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, brigdeThingUID, id);
-                if (discoveryServiceCallback.getExistingThing(thingUID) == null
-                        && discoveryServiceCallback.getExistingDiscoveryResult(thingUID) == null) {
-                    freeThingUID = thingUID;
-                    freeIndex = i;
-                    break;
-                }
-            }
-            if (freeThingUID == null) {
-                logger.debug("No more free flashbriefing thing ID found");
-                return;
-            }
-            DiscoveryResult result = DiscoveryResultBuilder.create(freeThingUID).withLabel("FlashBriefing " + freeIndex)
+            ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
+            ThingUID thingUID = new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, brigdeThingUID,
+                    Integer.toString(currentFlashBriefingJson.hashCode()));
+
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withLabel("FlashBriefing")
                     .withProperty(DEVICE_PROPERTY_FLASH_BRIEFING_PROFILE, currentFlashBriefingJson)
                     .withBridge(accountHandler.getThing().getUID()).build();
             logger.debug("Flash Briefing {} discovered", currentFlashBriefingJson);

--- a/bundles/org.openhab.binding.lirc/src/main/java/org/openhab/binding/lirc/internal/discovery/LIRCRemoteDiscoveryService.java
+++ b/bundles/org.openhab.binding.lirc/src/main/java/org/openhab/binding/lirc/internal/discovery/LIRCRemoteDiscoveryService.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.lirc.internal.LIRCBindingConstants;
@@ -34,23 +32,16 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrew Nagle - Initial contribution
  */
-public class LIRCRemoteDiscoveryService extends AbstractDiscoveryService
-        implements ExtendedDiscoveryService, LIRCMessageListener {
+public class LIRCRemoteDiscoveryService extends AbstractDiscoveryService implements LIRCMessageListener {
 
     private final Logger logger = LoggerFactory.getLogger(LIRCRemoteDiscoveryService.class);
 
     private LIRCBridgeHandler bridgeHandler;
-    private DiscoveryServiceCallback discoveryServiceCallback;
 
     public LIRCRemoteDiscoveryService(LIRCBridgeHandler lircBridgeHandler) {
         super(LIRCBindingConstants.SUPPORTED_DEVICE_TYPES, LIRCBindingConstants.DISCOVERY_TIMOUT, true);
         this.bridgeHandler = lircBridgeHandler;
         bridgeHandler.registerMessageListener(this);
-    }
-
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
     }
 
     @Override
@@ -78,20 +69,13 @@ public class LIRCRemoteDiscoveryService extends AbstractDiscoveryService
     private void addRemote(ThingUID bridge, String remote) {
         ThingTypeUID uid = LIRCBindingConstants.THING_TYPE_REMOTE;
         ThingUID thingUID = new ThingUID(uid, bridge, remote);
-        if (thingUID != null) {
-            if (discoveryServiceCallback != null
-                    && discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
-                // Ignore this remote as we already know about it
-                logger.debug("Remote {}: Already known.", remote);
-                return;
-            }
-            logger.trace("Remote {}: Discovered new remote.", remote);
-            Map<String, Object> properties = new HashMap<>(1);
-            properties.put(LIRCBindingConstants.PROPERTY_REMOTE, remote);
-            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withLabel(remote)
-                    .withBridge(bridge).withProperties(properties).build();
-            thingDiscovered(discoveryResult);
-        }
+
+        logger.trace("Remote {}: Discovered new remote.", remote);
+        Map<String, Object> properties = new HashMap<>(1);
+        properties.put(LIRCBindingConstants.PROPERTY_REMOTE, remote);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withLabel(remote).withBridge(bridge)
+                .withProperties(properties).build();
+        thingDiscovered(discoveryResult);
     }
 
 }

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/discovery/RFXComDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/discovery/RFXComDeviceDiscoveryService.java
@@ -18,8 +18,6 @@ import java.util.Set;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.rfxcom.internal.DeviceMessageListener;
@@ -36,13 +34,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pauli Anttila - Initial contribution
  */
-public class RFXComDeviceDiscoveryService extends AbstractDiscoveryService
-        implements ExtendedDiscoveryService, DeviceMessageListener {
+public class RFXComDeviceDiscoveryService extends AbstractDiscoveryService implements DeviceMessageListener {
     private final Logger logger = LoggerFactory.getLogger(RFXComDeviceDiscoveryService.class);
     private final int DISCOVERY_TTL = 3600;
 
     private RFXComBridgeHandler bridgeHandler;
-    private DiscoveryServiceCallback callback;
 
     public RFXComDeviceDiscoveryService(RFXComBridgeHandler rfxcomBridgeHandler) {
         super(null, 1, false);
@@ -66,11 +62,6 @@ public class RFXComDeviceDiscoveryService extends AbstractDiscoveryService
     @Override
     protected void startScan() {
         // this can be ignored here as we discover devices from received messages
-    }
-
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback callback) {
-        this.callback = callback;
     }
 
     @Override

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/discovery/SomfyTahomaItemDiscoveryService.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/discovery/SomfyTahomaItemDiscoveryService.java
@@ -25,8 +25,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -48,13 +46,11 @@ import org.slf4j.LoggerFactory;
  * @author Ondrej Pecta - Initial contribution
  */
 @NonNullByDefault
-public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService implements ExtendedDiscoveryService {
+public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(SomfyTahomaItemDiscoveryService.class);
 
     private SomfyTahomaBridgeHandler bridge;
-
-    private @Nullable DiscoveryServiceCallback discoveryServiceCallback;
 
     private @Nullable ScheduledFuture<?> discoveryJob;
 
@@ -80,11 +76,6 @@ public class SomfyTahomaItemDiscoveryService extends AbstractDiscoveryService im
     @Deactivate
     public void deactivate() {
         super.deactivate();
-    }
-
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
     }
 
     @Override

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/discovery/ZoneMinderDiscoveryService.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/discovery/ZoneMinderDiscoveryService.java
@@ -22,8 +22,6 @@ import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
-import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback;
-import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -41,12 +39,11 @@ import name.eskildsen.zoneminder.IZoneMinderMonitorData;
  * @author Martin S. Eskildsen - Initial contribution
  */
 public class ZoneMinderDiscoveryService extends AbstractDiscoveryService
-        implements ExtendedDiscoveryService, DiscoveryService, ThingHandlerService {
+        implements DiscoveryService, ThingHandlerService {
 
     private final Logger logger = LoggerFactory.getLogger(ZoneMinderDiscoveryService.class);
 
     private @NonNullByDefault({}) ZoneMinderServerBridgeHandler serverHandler;
-    private DiscoveryServiceCallback discoveryServiceCallback;
 
     public ZoneMinderDiscoveryService() {
         super(30);
@@ -74,11 +71,6 @@ public class ZoneMinderDiscoveryService extends AbstractDiscoveryService
     public void deactivate() {
         logger.debug("[DISCOVERY]: Deactivating ZoneMinder discovery service for {}",
                 serverHandler.getThing().getUID());
-    }
-
-    @Override
-    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
-        this.discoveryServiceCallback = discoveryServiceCallback;
     }
 
     @Override


### PR DESCRIPTION
Because of the deprecation each `DiscoveryServiceCallback` method will always return null so it's better to remove all usages.

Related to openhab/openhab-core#1408, https://github.com/openhab/openhab-core/pull/1424