### PR TITLE
[velux] Avoiding warning about (yet) unrecognized actuators 

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -448,6 +448,10 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
                     logger.trace("syncChannelsWithProducts(): channel {} not found.", channelUID);
                     continue;
                 }
+                if (!channel2VeluxActuator.get(channelUID).isKnown()) {
+                    logger.trace("syncChannelsWithProducts(): channel {} not registered on bridge.", channelUID);
+                    continue;
+                }
                 ProductBridgeIndex channelPbi = channel2VeluxActuator.get(channelUID).getProductBridgeIndex();
                 if (!channelPbi.equals(productPbi)) {
                     continue;
@@ -471,6 +475,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         logger.trace("syncChannelsWithProducts(): resetting dirty flag.");
         bridgeParameters.actuators.getChannel().existingProducts.resetDirtyFlag();
         logger.trace("syncChannelsWithProducts() done.");
+
     }
 
     // Processing of openHAB events

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/utils/Thing2VeluxActuator.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/utils/Thing2VeluxActuator.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  * the methods provide a cache for faster access,
  * <ul>
  * <li>{@link #Thing2VeluxActuator} Constructor,</LI>
+ * <li>{@link #isKnown} returns whether actuator is well-known,</LI>
  * <li>{@link #getProductBridgeIndex} returns the Velux bridge index for access,</LI>
  * <li>{@link #isInverted} returns a flag about value inversion.</LI>
  * </UL>
@@ -51,8 +52,8 @@ public class Thing2VeluxActuator {
     private void mapThing2Velux() {
         if (!ThingConfiguration.exists(bridgeHandler, channelUID,
                 VeluxBindingProperties.CONFIG_ACTUATOR_SERIALNUMBER)) {
-            logger.warn("mapThing2Velux(): aborting processing as {} is not set.",
-                    VeluxBindingProperties.CONFIG_ACTUATOR_SERIALNUMBER);
+            logger.trace("mapThing2Velux(): aborting processing as {} is not set within {}.",
+                    VeluxBindingProperties.CONFIG_ACTUATOR_SERIALNUMBER, channelUID);
             return;
         }
         String actuatorSerial = (String) ThingConfiguration.getValue(bridgeHandler, channelUID,
@@ -111,6 +112,16 @@ public class Thing2VeluxActuator {
             return ProductBridgeIndex.UNKNOWN;
         }
         return thisProduct.getBridgeProductIndex();
+    }
+
+    /**
+     * Returns true, if the actuator is known within the bridge.
+     * <p>
+     *
+     * @return <b>isKnown</B> as boolean.
+     */
+    public boolean isKnown() {
+        return (!(this.getProductBridgeIndex() == ProductBridgeIndex.UNKNOWN));
     }
 
     /**


### PR DESCRIPTION
especially during startup phase of the binding.

