### PR TITLE
[homekit] Use consistent styling of "HomeKit"

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryUpdater.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 import io.github.hapjava.HomekitCharacteristicChangeCallback;
 
 /**
- * Subscribes and unsubscribes from Item changes to enable notification to Homekit
+ * Subscribes and unsubscribes from Item changes to enable notification to HomeKit
  * clients. Each item/key pair (key is optional) should be unique, as the underlying
- * Homekit library takes care of insuring only a single subscription exists for
+ * HomeKit library takes care of insuring only a single subscription exists for
  * each accessory.
  *
  * @author Andy Lintner - Initial contribution

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
@@ -27,7 +27,7 @@ import io.github.hapjava.HomekitAuthInfo;
 import io.github.hapjava.HomekitServer;
 
 /**
- * Provides a mechanism to store authenticated homekit client details inside the
+ * Provides a mechanism to store authenticated HomeKit client details inside the
  * ESH StorageService, by implementing HomekitAuthInfo.
  *
  * @author Andy Lintner - Initial contribution

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -35,7 +35,7 @@ import io.github.hapjava.HomekitRoot;
 
 /**
  * Listens for changes to the item registry. When changes are detected, check
- * for Homekit tags and, if present, add the items to the HomekitAccessoryRegistry.
+ * for HomeKit tags and, if present, add the items to the HomekitAccessoryRegistry.
  *
  * @author Andy Lintner - Initial contribution
  */
@@ -166,10 +166,10 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
                         taggedItem.getItem().getUID());
                 return;
             }
-            logger.debug("Adding homekit device {}", taggedItem.getItem().getUID());
+            logger.debug("Adding HomeKit device {}", taggedItem.getItem().getUID());
             accessoryRegistry.addRootAccessory(taggedItem.getName(),
                     HomekitAccessoryFactory.create(taggedItem, itemRegistry, updater, settings));
-            logger.debug("Added homekit device {}", taggedItem.getItem().getUID());
+            logger.debug("Added HomeKit device {}", taggedItem.getItem().getUID());
         } catch (HomekitException | IncompleteAccessoryException e) {
             logger.warn("Could not add device {}: {}", taggedItem.getItem().getUID(), e.getMessage());
         }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
@@ -72,7 +72,7 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
     @Override
     public List<String> getUsages() {
         return Arrays.asList(
-                new String[] { buildCommandUsage(SUBCMD_CLEAR_PAIRINGS, "removes all pairings with Homekit clients"),
+                new String[] { buildCommandUsage(SUBCMD_CLEAR_PAIRINGS, "removes all pairings with HomeKit clients"),
                         buildCommandUsage(SUBCMD_ALLOW_UNAUTHENTICATED + " <boolean>",
                                 "enables or disables unauthenticated access to facilitate debugging") });
     }
@@ -99,15 +99,15 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
         try {
             new HomekitAuthInfoImpl(storageService, null).clear();
             homekit.refreshAuthInfo();
-            console.println("Cleared homekit pairings");
+            console.println("Cleared HomeKit pairings");
         } catch (Exception e) {
-            logger.warn("Could not clear homekit pairings", e);
+            logger.warn("Could not clear HomeKit pairings", e);
         }
     }
 
     private void allowUnauthenticatedHomekitRequests(boolean allow, Console console) {
         homekit.allowUnauthenticatedRequests(allow);
-        console.println((allow ? "Enabled " : "Disabled ") + "unauthenticated homekit access");
+        console.println((allow ? "Enabled " : "Disabled ") + "unauthenticated HomeKit access");
     }
 
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -40,7 +40,7 @@ import io.github.hapjava.HomekitRoot;
 import io.github.hapjava.HomekitServer;
 
 /**
- * Provides access to openHAB items via the Homekit API
+ * Provides access to openHAB items via the HomeKit API
  *
  * @author Andy Lintner - Initial contribution
  */
@@ -88,7 +88,7 @@ public class HomekitImpl implements Homekit {
             settings = processConfig(config);
             changeListener.updateSettings(settings);
             if (!oldSettings.networkInterface.equals(settings.networkInterface) || oldSettings.port != settings.port) {
-                // the homekit server settings changed. we do a complete re-init
+                // the HomeKit server settings changed. we do a complete re-init
                 stopHomekitServer();
                 startHomekitServer();
             } else if (!oldSettings.name.equals(settings.name) || !oldSettings.pin.equals(settings.pin)) {
@@ -97,7 +97,7 @@ public class HomekitImpl implements Homekit {
                 startBridge();
             }
         } catch (IOException | InvalidAlgorithmParameterException e) {
-            logger.debug("Could not initialize homekit connector: {}", e.getMessage());
+            logger.debug("Could not initialize HomeKit connector: {}", e.getMessage());
             return;
         }
     }
@@ -121,7 +121,7 @@ public class HomekitImpl implements Homekit {
             this.bridge = bridge;
         } else {
             logger.warn(
-                    "trying to start bridge but homekit server is not initialized or bridge is already initialized");
+                    "trying to start bridge but HomeKit server is not initialized or bridge is already initialized");
         }
     }
 
@@ -131,7 +131,7 @@ public class HomekitImpl implements Homekit {
             homekitServer = new HomekitServer(networkInterface, settings.port);
             startBridge();
         } else {
-            logger.warn("trying to start homekit server but it is already initialized");
+            logger.warn("trying to start HomeKit server but it is already initialized");
         }
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -85,7 +85,7 @@ public class HomekitTaggedItem {
                             "Item belongs to multiple Groups which are tagged as Homekit devices.");
             }
         } catch (BadItemConfigurationException e) {
-            logger.warn("Item {} was misconfigured: {}. Excluding item from homekit.", item.getName(), e.getMessage());
+            logger.warn("Item {} was misconfigured: {}. Excluding item from HomeKit.", item.getName(), e.getMessage());
             homekitAccessoryType = null;
             homekitCharacteristicType = null;
             parentGroupItem = null;
@@ -114,7 +114,7 @@ public class HomekitTaggedItem {
     }
 
     /**
-     * Returns whether or not this item refers to an item that fully specifies a Homekit accessory. Mutually
+     * Returns whether or not this item refers to an item that fully specifies a HomeKit accessory. Mutually
      * exclusive
      * to isCharacteristic(). Primary devices must belong to a root accessory group.
      */
@@ -123,7 +123,7 @@ public class HomekitTaggedItem {
     }
 
     /**
-     * Returns whether or not this item is in a group that specifies a Homekit accessory. It is not possible to be a
+     * Returns whether or not this item is in a group that specifies a HomeKit accessory. It is not possible to be a
      * characteristic and an accessory. Further, all characteristics belong to a
      * root deviceGroup.
      */
@@ -152,9 +152,9 @@ public class HomekitTaggedItem {
     }
 
     /**
-     * Returns whether or not this item belongs to a Homekit accessory group.
+     * Returns whether or not this item belongs to a HomeKit accessory group.
      *
-     * Characteristic devices must belong to a Homekit accessory group.
+     * Characteristic devices must belong to a HomeKit accessory group.
      */
     public boolean isMemberOfAccessoryGroup() {
         return parentGroupItem != null;
@@ -171,7 +171,7 @@ public class HomekitTaggedItem {
         if (CREATED_ACCESSORY_IDS.containsKey(id)) {
             if (!CREATED_ACCESSORY_IDS.get(id).equals(item.getName())) {
                 logger.warn(
-                        "Could not create homekit accessory {} because its hash conflicts with {}. This is a 1:1,000,000 chance occurrence. Change one of the names and consider playing the lottery. See https://github.com/openhab/openhab-addons/issues/257#issuecomment-125886562",
+                        "Could not create HomeKit accessory {} because its hash conflicts with {}. This is a 1:1,000,000 chance occurrence. Change one of the names and consider playing the lottery. See https://github.com/openhab/openhab-addons/issues/257#issuecomment-125886562",
                         item.getName(), CREATED_ACCESSORY_IDS.get(id));
                 return 0;
             }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitLightbulbImpl.java
@@ -26,7 +26,7 @@ import io.github.hapjava.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.accessories.Lightbulb;
 
 /**
- * Abstract class implementing a Homekit Lightbulb using a SwitchItem
+ * Abstract class implementing a HomeKit Lightbulb using a SwitchItem
  *
  * @author Andy Lintner - Initial contribution
  */

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -117,7 +117,7 @@ public class HomekitAccessoryFactory {
                 return new HomekitLockImpl(taggedItem, itemRegistry, updater);
         }
 
-        throw new HomekitException("Unknown homekit type: " + taggedItem.getAccessoryType());
+        throw new HomekitException("Unknown HomeKit type: " + taggedItem.getAccessoryType());
     }
 
     /**

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
@@ -25,7 +25,7 @@ import io.github.hapjava.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.accessories.TemperatureSensor;
 
 /**
- * Implements a Homekit TemperatureSensor using a NumberItem
+ * Implements a HomeKit TemperatureSensor using a NumberItem
  *
  * @author Andy Lintner - Initial contribution
  */


### PR DESCRIPTION
In the HomeKit binding there are many different forms of the noun
"HomeKit" used. This changes the instances of "HomeKit" in comments and
logs to use the style of "HomeKit" consistently.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>