### PR TITLE
[squeezebox] Implement like/unlike for remote streaming services

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -114,8 +114,7 @@ All devices support some of the following channels:
 | ircode                  | String    | Received IR code                                                                       |
 | numberPlaylistTracks    | Number    | Number of playlist tracks                                                              |
 | playFavorite            | String    | ID of Favorite to play (channel's state options contains available favorites)          |
-| like                    | Switch    | "Like" the currently playing song (if supported by the streaming service)              |
-| unlike                  | Switch    | "Unlike" the currently playing song (if supported by the streaming service)            |
+| rate                    | Switch    | "Like" or "unlike" the currently playing song (if supported by the streaming service)  |
 
 ## Playing Favorites
 
@@ -198,6 +197,14 @@ then
     playSound("squeezebox:squeezeboxplayer:5919BEA2-764B-4590-BC70-D74DCC15491B:20cfbf221510", "doorbell.mp3", new PercentType(45))
 end
 ```
+
+## Rating Songs
+
+Some streaming services, such as Pandora and Slacker, all songs to be rated.
+When playing from these streaming services, sending commands to the `rate` channel can be used to *like* or *unlike* the currently playing song.
+Sending the ON command will *like* the song.
+Sending the OFF command will *unlike* the song.
+If the streaming service doesn't support rating, sending commands to the `rate` channel has no effect.
 
 ### Known Issues
 

--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -114,6 +114,8 @@ All devices support some of the following channels:
 | ircode                  | String    | Received IR code                                                                       |
 | numberPlaylistTracks    | Number    | Number of playlist tracks                                                              |
 | playFavorite            | String    | ID of Favorite to play (channel's state options contains available favorites)          |
+| like                    | Switch    | "Like" the currently playing song (if supported by the streaming service)              |
+| unlike                  | Switch    | "Unlike" the currently playing song (if supported by the streaming service)            |
 
 ## Playing Favorites
 
@@ -199,12 +201,18 @@ end
 
 ### Known Issues
 
--   There are some versions of squeezelite that will not correctly play very short duration mp3 files. Versions of squeezelite after v1.7 and before v1.8.6 will not play very short duration mp3 files reliably. For example, if you're using piCorePlayer (which uses squeezelite), please check your version of squeezelite if you're having trouble playing notifications. This bug has been fixed in squeezelite version 1.8.6-985, which is included in piCorePlayer version 3.20.
+-   There are some versions of squeezelite that will not correctly play very short duration mp3 files.
+Versions of squeezelite after v1.7 and before v1.8.6 will not play very short duration mp3 files reliably.
+For example, if you're using piCorePlayer (which uses squeezelite), please check your version of squeezelite if you're having trouble playing notifications.
+This bug has been fixed in squeezelite version 1.8.6-985, which is included in piCorePlayer version 3.20.
 
 -   When streaming from a remote service (such as Pandora or Spotify), after the notification plays, the Squeezebox Server starts playing a new track, instead of picking up from where it left off on the currently playing track.
 
--   There have been reports that notifications do not play reliably, or do not play at all, when using Logitech Media Server (LMS) version 7.7.5. Therefore, it is recommended that the LMS be on a more current version than 7.7.5.
+-   There have been reports that notifications do not play reliably, or do not play at all, when using Logitech Media Server (LMS) version 7.7.5.
+Therefore, it is recommended that the LMS be on a more current version than 7.7.5.
 
 -   There have been reports that the LMS does not play some WAV files reliably. If you're using a TTS service that produces WAV files, and the notifications are not playing, try using an MP3-formatted TTS notification.
+This issue reportedly was [fixed in the LMS](https://github.com/Logitech/slimserver/issues/307) by accepting additional MIME types for WAV files.
 
--   The LMS treats player MAC addresses as case-sensitive. Therefore, the case of MAC addresses in the Squeeze Player thing configuration must match the case displayed on the *Information* tab in the LMS Settings.
+-   The LMS treats player MAC addresses as case-sensitive.
+Therefore, the case of MAC addresses in the Squeeze Player thing configuration must match the case displayed on the *Information* tab in the LMS Settings.

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
@@ -67,6 +67,5 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_NAME = "name";
     public static final String CHANNEL_MODEL = "model";
     public static final String CHANNEL_FAVORITES_PLAY = "playFavorite";
-    public static final String CHANNEL_LIKE = "like";
-    public static final String CHANNEL_UNLIKE = "unlike";
+    public static final String CHANNEL_RATE = "rate";
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
@@ -67,4 +67,6 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_NAME = "name";
     public static final String CHANNEL_MODEL = "model";
     public static final String CHANNEL_FAVORITES_PLAY = "playFavorite";
+    public static final String CHANNEL_LIKE = "like";
+    public static final String CHANNEL_UNLIKE = "unlike";
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxHandlerFactory.java
@@ -41,6 +41,7 @@ import org.openhab.binding.squeezebox.internal.handler.SqueezeBoxPlayerHandler;
 import org.openhab.binding.squeezebox.internal.handler.SqueezeBoxServerHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -65,15 +66,23 @@ public class SqueezeBoxHandlerFactory extends BaseThingHandlerFactory {
 
     private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
-    private AudioHTTPServer audioHTTPServer;
-    private NetworkAddressService networkAddressService;
+    private final AudioHTTPServer audioHTTPServer;
+    private final NetworkAddressService networkAddressService;
+    private final SqueezeBoxStateDescriptionOptionsProvider stateDescriptionProvider;
 
     private Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
 
-    private SqueezeBoxStateDescriptionOptionsProvider stateDescriptionProvider;
-
     // Callback url (scheme+server+port) to use for playing notification sounds
     private String callbackUrl = null;
+
+    @Activate
+    public SqueezeBoxHandlerFactory(@Reference AudioHTTPServer audioHTTPServer,
+            @Reference NetworkAddressService networkAddressService,
+            @Reference SqueezeBoxStateDescriptionOptionsProvider stateDescriptionProvider) {
+        this.audioHTTPServer = audioHTTPServer;
+        this.networkAddressService = networkAddressService;
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -196,32 +205,5 @@ public class SqueezeBoxHandlerFactory extends BaseThingHandlerFactory {
         }
 
         return "http://" + ipAddress + ":" + port;
-    }
-
-    @Reference
-    protected void setAudioHTTPServer(AudioHTTPServer audioHTTPServer) {
-        this.audioHTTPServer = audioHTTPServer;
-    }
-
-    protected void unsetAudioHTTPServer(AudioHTTPServer audioHTTPServer) {
-        this.audioHTTPServer = null;
-    }
-
-    @Reference
-    protected void setNetworkAddressService(NetworkAddressService networkAddressService) {
-        this.networkAddressService = networkAddressService;
-    }
-
-    protected void unsetNetworkAddressService(NetworkAddressService networkAddressService) {
-        this.networkAddressService = null;
-    }
-
-    @Reference
-    protected void setDynamicStateDescriptionProvider(SqueezeBoxStateDescriptionOptionsProvider provider) {
-        this.stateDescriptionProvider = provider;
-    }
-
-    protected void unsetDynamicStateDescriptionProvider(SqueezeBoxStateDescriptionOptionsProvider provider) {
-        this.stateDescriptionProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxStateDescriptionOptionsProvider.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxStateDescriptionOptionsProvider.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.binding.BaseDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -29,14 +30,9 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class SqueezeBoxStateDescriptionOptionsProvider extends BaseDynamicStateDescriptionProvider {
 
-    @Reference
-    protected void setChannelTypeI18nLocalizationService(
-            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+    @Activate
+    public SqueezeBoxStateDescriptionOptionsProvider(
+            @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
         this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
-    }
-
-    protected void unsetChannelTypeI18nLocalizationService(
-            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = null;
     }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -67,6 +67,7 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
     protected void startScan() {
         logger.debug("startScan invoked in SqueezeBoxPlayerDiscoveryParticipant");
         this.squeezeBoxServerHandler.requestPlayers();
+        this.squeezeBoxServerHandler.requestFavorites();
     }
 
     /*
@@ -205,5 +206,9 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
 
     @Override
     public void sourceChangeEvent(String mac, String source) {
+    }
+
+    @Override
+    public void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand) {
     }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTO.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link ButtonDTO} represents a custom button that overrides existing
+ * button functionality. For example, "like song" replaces the repeat button.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class ButtonDTO {
+
+    /**
+     * Indicates whether button is standard or custom
+     */
+    public Boolean custom;
+
+    /**
+     * Indicates if standard button is enabled or disabled
+     */
+    public Boolean enabled;
+
+    /**
+     * Concatenation of elements of command array
+     */
+    public String command;
+
+    /**
+     * Currently not used
+     */
+    @SerializedName("icon")
+    public String icon;
+
+    /**
+     * Currently not used
+     */
+    @SerializedName("jiveStyle")
+    public String jiveStyle;
+
+    /**
+     * Currently not used
+     */
+    @SerializedName("tooltip")
+    public String toolTip;
+
+    public boolean isCustom() {
+        return custom == null ? Boolean.FALSE : custom;
+    }
+
+    public boolean isEnabled() {
+        return enabled == null ? Boolean.FALSE : enabled;
+    }
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTODeserializer.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTODeserializer.java
@@ -13,11 +13,8 @@
 package org.openhab.binding.squeezebox.internal.dto;
 
 import java.lang.reflect.Type;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import org.apache.commons.lang.StringUtils;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -40,18 +37,17 @@ public class ButtonDTODeserializer implements JsonDeserializer<ButtonDTO> {
         if (jsonElement.isJsonPrimitive() && jsonElement.getAsJsonPrimitive().isNumber()) {
             Integer value = jsonElement.getAsInt();
             button = new ButtonDTO();
-            button.custom = Boolean.FALSE;
-            button.enabled = value == 0 ? Boolean.FALSE : Boolean.TRUE;
+            button.custom = false;
+            button.enabled = value != 0;
         } else if (jsonElement.isJsonObject()) {
             JsonObject jsonObject = jsonElement.getAsJsonObject();
             button = new ButtonDTO();
-            button.custom = Boolean.TRUE;
+            button.custom = true;
             button.icon = jsonObject.get("icon").getAsString();
             button.jiveStyle = jsonObject.get("jiveStyle").getAsString();
             button.toolTip = jsonObject.get("tooltip").getAsString();
-            List<String> commandList = StreamSupport.stream(jsonObject.getAsJsonArray("command").spliterator(), false)
-                    .map(JsonElement::getAsString).collect(Collectors.toList());
-            button.command = StringUtils.join(commandList, " ");
+            button.command = StreamSupport.stream(jsonObject.getAsJsonArray("command").spliterator(), false)
+                    .map(JsonElement::getAsString).collect(Collectors.joining(" "));
         }
         return button;
     }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTODeserializer.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonDTODeserializer.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+/**
+ * The {@link ButtonDTODeserializer} is responsible for deserializing a button object, which
+ * can either be an Integer, or a custom button specification.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class ButtonDTODeserializer implements JsonDeserializer<ButtonDTO> {
+
+    @Override
+    public ButtonDTO deserialize(JsonElement jsonElement, Type tyoeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        ButtonDTO button = null;
+        if (jsonElement.isJsonPrimitive() && jsonElement.getAsJsonPrimitive().isNumber()) {
+            Integer value = jsonElement.getAsInt();
+            button = new ButtonDTO();
+            button.custom = Boolean.FALSE;
+            button.enabled = value == 0 ? Boolean.FALSE : Boolean.TRUE;
+        } else if (jsonElement.isJsonObject()) {
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
+            button = new ButtonDTO();
+            button.custom = Boolean.TRUE;
+            button.icon = jsonObject.get("icon").getAsString();
+            button.jiveStyle = jsonObject.get("jiveStyle").getAsString();
+            button.toolTip = jsonObject.get("tooltip").getAsString();
+            List<String> commandList = StreamSupport.stream(jsonObject.getAsJsonArray("command").spliterator(), false)
+                    .map(JsonElement::getAsString).collect(Collectors.toList());
+            button.command = StringUtils.join(commandList, " ");
+        }
+        return button;
+    }
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonsDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/ButtonsDTO.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link ButtonsDTO} contains information about the forward, rewind, repeat,
+ * and shuffle buttons, including any custom definitions, such as replacing repeat
+ * and shuffle with like and unlike, respectively.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class ButtonsDTO {
+
+    /**
+     * Indicates if forward button is enabled/disabled,
+     * or if there is a custom button definition.
+     */
+    @SerializedName("fwd")
+    public ButtonDTO forward;
+
+    /**
+     * Indicates if rewind button is enabled/disabled,
+     * or if there is a custom button definition.
+     */
+    @SerializedName("rew")
+    public ButtonDTO rewind;
+
+    /**
+     * Indicates if repeat button is enabled/disabled,
+     * or if there is a custom button definition.
+     */
+    @SerializedName("repeat")
+    public ButtonDTO repeat;
+
+    /**
+     * Indicates if shuffle button is enabled/disabled,
+     * or if there is a custom button definition.
+     */
+    @SerializedName("shuffle")
+    public ButtonDTO shuffle;
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/RemoteMetaDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/RemoteMetaDTO.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link RemoteMetaDTO} contains remote metadata information, including button and
+ * button override functionality.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class RemoteMetaDTO {
+
+    /**
+     * Contains button specifications for forward, rewind, repeat, shuffle
+     */
+    public ButtonsDTO buttons;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("id")
+    public String id;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("title")
+    public String title;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("artist")
+    public String artist;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("album")
+    public String album;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("artwork_url")
+    public String artworkUrl;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("coverart")
+    public String coverart;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("coverid")
+    public String coverid;
+
+    /**
+     * Currently unused
+     */
+    @SerializedName("year")
+    public String year;
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResponseDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResponseDTO.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link StatusResponseDTO} is the response received from a player status request.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class StatusResponseDTO {
+
+    /**
+     * Id. Currently unused.
+     */
+    @SerializedName("id")
+    public String id;
+
+    /**
+     * Method name. Normally "slim.request"
+     */
+    @SerializedName("method")
+    public String method;
+
+    /**
+     * Parameters passed in the query. Currently unused.
+     */
+    @SerializedName("params")
+    public Object params;
+
+    /**
+     * Contains the result of the query
+     */
+    @SerializedName("result")
+    public StatusResultDTO result;
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResultDTO.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/dto/StatusResultDTO.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.squeezebox.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link StatusResultDTO} represents the result of a status request.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class StatusResultDTO {
+
+    /**
+     * Remote metadata information, including button definitions/redefinitions.
+     */
+    @SerializedName("remoteMeta")
+    public RemoteMetaDTO remoteMeta;
+
+    /**
+     * These remaining fields are currently unused by the binding,
+     * as they also are returned by the Command Line Interface (CLI).
+     */
+    @SerializedName("current_title")
+    public String currentTitle;
+
+    @SerializedName("digital_volume_control")
+    public Integer digitalVolumeControl;
+
+    @SerializedName("duration")
+    public Double duration;
+
+    @SerializedName("mixer volume")
+    public Integer mixerVolume;
+
+    @SerializedName("player_connected")
+    public Integer playerConnected;
+
+    @SerializedName("player_ip")
+    public String playerIpAddress;
+
+    @SerializedName("player_name")
+    public String playerName;
+
+    @SerializedName("playlist mode")
+    public String playlistMode;
+
+    @SerializedName("playlist repeat")
+    public Integer playlistRepeat;
+
+    @SerializedName("playlist shuffle")
+    public Integer playlistShuffle;
+
+    @SerializedName("playlist_cur_index")
+    public String playListCurrentIndex;
+
+    @SerializedName("playlist_timestamp")
+    public String playlistTimestamp;
+
+    @SerializedName("playlist_tracks")
+    public Integer playlistTracks;
+
+    @SerializedName("power")
+    public String power;
+
+    @SerializedName("rate")
+    public String rate;
+
+    @SerializedName("remote")
+    public String remote;
+
+    @SerializedName("repeating_stream")
+    public Integer repeatingStream;
+
+    @SerializedName("seq_no")
+    public Integer sequenceNumber;
+
+    @SerializedName("signalstrength")
+    public Integer signalStrength;
+
+    @SerializedName("time")
+    public String time;
+}

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
@@ -216,4 +216,8 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
     @Override
     public void sourceChangeEvent(String mac, String source) {
     }
+
+    @Override
+    public void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand) {
+    }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
@@ -80,4 +80,6 @@ public interface SqueezeBoxPlayerEventListener {
     void updateFavoritesListEvent(List<Favorite> favorites);
 
     void sourceChangeEvent(String mac, String source);
+
+    void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand);
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
  * @author Patrik Gfeller - Timeout for TTS messages increased from 30 to 90s.
  * @author Mark Hilbush - Get favorites from server and play favorite
  * @author Mark Hilbush - Convert sound notification volume from channel to config parameter
+ * @author Mark Hilbush - Add like/unlike functionality
  */
 public class SqueezeBoxPlayerHandler extends BaseThingHandler implements SqueezeBoxPlayerEventListener {
     private final Logger logger = LoggerFactory.getLogger(SqueezeBoxPlayerHandler.class);
@@ -84,7 +85,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     /**
      * Keeps current track time
      */
-    ScheduledFuture<?> timeCounterJob;
+    private ScheduledFuture<?> timeCounterJob;
 
     /**
      * Local reference to our bridge
@@ -120,6 +121,9 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     private static final ExpiringCacheMap<String, RawType> IMAGE_CACHE = new ExpiringCacheMap<>(
             TimeUnit.MINUTES.toMillis(15)); // 15min
 
+    private String likeCommand;
+    private String unlikeCommand;
+
     /**
      * Creates SqueezeBox Player Handler
      *
@@ -138,7 +142,7 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         mac = getConfig().as(SqueezeBoxPlayerConfig.class).mac;
         timeCounter();
         updateBridgeStatus();
-        logger.debug("player thing {} initialized.", getThing().getUID());
+        logger.debug("player thing {} initialized with mac {}", getThing().getUID(), mac);
     }
 
     @Override
@@ -147,12 +151,17 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     }
 
     private void updateBridgeStatus() {
-        ThingStatus bridgeStatus = getBridge().getStatus();
-        if (bridgeStatus == ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.ONLINE) {
-            updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
-            squeezeBoxServerHandler = (SqueezeBoxServerHandler) getBridge().getHandler();
-        } else if (bridgeStatus == ThingStatus.OFFLINE) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+        Thing bridge = getBridge();
+        if (bridge != null) {
+            squeezeBoxServerHandler = (SqueezeBoxServerHandler) bridge.getHandler();
+            ThingStatus bridgeStatus = bridge.getStatus();
+            if (bridgeStatus == ThingStatus.ONLINE && getThing().getStatus() != ThingStatus.ONLINE) {
+                updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
+            } else if (bridgeStatus == ThingStatus.OFFLINE) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            }
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Bridge not found");
         }
     }
 
@@ -167,18 +176,16 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
         if (squeezeBoxServerHandler != null) {
             squeezeBoxServerHandler.removePlayerCache(mac);
         }
-        logger.debug("player thing {} disposed.", getThing().getUID());
+        logger.debug("player thing {} disposed for mac {}", getThing().getUID(), mac);
         super.dispose();
     }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (squeezeBoxServerHandler == null) {
-            logger.info("player thing {} has no server configured, ignoring command: {}", getThing().getUID(), command);
+            logger.debug("Player {} has no server configured, ignoring command: {}", getThing().getUID(), command);
             return;
         }
-        String mac = getConfigAs(SqueezeBoxPlayerConfig.class).mac;
-
         // Some of the code below is not designed to handle REFRESH, only reply to channels where cached values exist
         if (command == RefreshType.REFRESH) {
             String channelID = channelUID.getId();
@@ -292,6 +299,16 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 break;
             case CHANNEL_FAVORITES_PLAY:
                 squeezeBoxServerHandler.playFavorite(mac, command.toString());
+                break;
+            case CHANNEL_LIKE:
+                if (likeCommand != null) {
+                    squeezeBoxServerHandler.like(mac, likeCommand);
+                }
+                break;
+            case CHANNEL_UNLIKE:
+                if (unlikeCommand != null) {
+                    squeezeBoxServerHandler.unlike(mac, unlikeCommand);
+                }
                 break;
             default:
                 break;
@@ -494,8 +511,17 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
     }
 
     @Override
+    public void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand) {
+        if (isMe(mac)) {
+            this.likeCommand = likeCommand;
+            this.unlikeCommand = unlikeCommand;
+            logger.trace("Player {} got a button change event: like='{}' unlike='{}'", mac, likeCommand, unlikeCommand);
+        }
+    }
+
+    @Override
     public void updateFavoritesListEvent(List<Favorite> favorites) {
-        logger.debug("Player {} updating favorites list", mac);
+        logger.trace("Player {} updating favorites list with {} favorites", mac, favorites.size());
         List<StateOption> options = new ArrayList<>();
         for (Favorite favorite : favorites) {
             options.add(new StateOption(favorite.shortId, favorite.name));

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -300,14 +300,11 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
             case CHANNEL_FAVORITES_PLAY:
                 squeezeBoxServerHandler.playFavorite(mac, command.toString());
                 break;
-            case CHANNEL_LIKE:
-                if (likeCommand != null && command.equals(OnOffType.ON)) {
-                    squeezeBoxServerHandler.like(mac, likeCommand);
-                }
-                break;
-            case CHANNEL_UNLIKE:
-                if (unlikeCommand != null && command.equals(OnOffType.ON)) {
-                    squeezeBoxServerHandler.unlike(mac, unlikeCommand);
+            case CHANNEL_RATE:
+                if (command.equals(OnOffType.ON)) {
+                    squeezeBoxServerHandler.rate(mac, likeCommand);
+                } else if (command.equals(OnOffType.OFF)) {
+                    squeezeBoxServerHandler.rate(mac, unlikeCommand);
                 }
                 break;
             default:

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -301,12 +301,12 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                 squeezeBoxServerHandler.playFavorite(mac, command.toString());
                 break;
             case CHANNEL_LIKE:
-                if (likeCommand != null) {
+                if (likeCommand != null && command.equals(OnOffType.ON)) {
                     squeezeBoxServerHandler.like(mac, likeCommand);
                 }
                 break;
             case CHANNEL_UNLIKE:
-                if (unlikeCommand != null) {
+                if (unlikeCommand != null && command.equals(OnOffType.ON)) {
                     squeezeBoxServerHandler.unlike(mac, unlikeCommand);
                 }
                 break;

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -294,12 +294,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         sendCommand(mac + " favorites playlist play item_id:" + favorite);
     }
 
-    public void like(String mac, String command) {
-        sendCommand(mac + " " + command);
-    }
-
-    public void unlike(String mac, String command) {
-        sendCommand(mac + " " + command);
+    public void rate(String mac, String rateCommand) {
+        if (rateCommand != null) {
+            sendCommand(mac + " " + rateCommand);
+        }
     }
 
     /**
@@ -1024,9 +1022,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
         private void scheduleRequestFavorites() {
             // Delay the execution to give the player thing handlers a chance to initialize
-            scheduler.schedule(() -> {
-                requestFavorites();
-            }, 3L, TimeUnit.SECONDS);
+            scheduler.schedule(SqueezeBoxServerHandler.this::requestFavorites, 3L, TimeUnit.SECONDS);
         }
 
         private void updateCustomButtons(final String mac) {

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -866,9 +866,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             if (action.equals("newsong")) {
                 mode = "play";
                 // Execute in separate thread to avoid delaying listener
-                scheduler.execute(() -> {
-                    updateCustomButtons(mac);
-                });
+                scheduler.execute(() -> updateCustomButtons(mac));
                 // Set the track duration to 0
                 updatePlayer(new PlayerUpdateEvent() {
                     @Override

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -24,8 +24,10 @@ import java.net.Socket;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,10 +49,19 @@ import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.io.net.http.HttpRequestBuilder;
 import org.openhab.binding.squeezebox.internal.config.SqueezeBoxServerConfig;
+import org.openhab.binding.squeezebox.internal.dto.ButtonDTO;
+import org.openhab.binding.squeezebox.internal.dto.ButtonDTODeserializer;
+import org.openhab.binding.squeezebox.internal.dto.ButtonsDTO;
+import org.openhab.binding.squeezebox.internal.dto.StatusResponseDTO;
 import org.openhab.binding.squeezebox.internal.model.Favorite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * Handles connection and event handling to a SqueezeBox Server.
@@ -66,6 +77,7 @@ import org.slf4j.LoggerFactory;
  * @author Philippe Siem - Improve refresh of cover art url,remote title, artist, album, genre, year.
  * @author Patrik Gfeller - Support for mixer volume message added
  * @author Mark Hilbush - Get favorites from LMS; update channel and send to players
+ * @author Mark Hilbush - Add like/unlike functionality
  */
 public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private final Logger logger = LoggerFactory.getLogger(SqueezeBoxServerHandler.class);
@@ -86,6 +98,8 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
     private static final String CHANNEL_CONFIG_QUOTE_LIST = "quoteList";
 
+    private static final String JSONRPC_STATUS_REQUEST = "{\"id\":1,\"method\":\"slim.request\",\"params\":[\"@@MAC@@\",[\"status\",\"-\",\"tags:yagJlNKjcB\"]]}";
+
     private List<SqueezeBoxPlayerEventListener> squeezeBoxPlayerListeners = Collections
             .synchronizedList(new ArrayList<>());
 
@@ -105,6 +119,11 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
     private String userId;
 
     private String password;
+
+    private final Gson gson = new GsonBuilder().registerTypeAdapter(ButtonDTO.class, new ButtonDTODeserializer())
+            .create();
+    private String jsonRpcUrl;
+    private String basicAuthorization;
 
     public SqueezeBoxServerHandler(Bridge bridge) {
         super(bridge);
@@ -275,6 +294,14 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         sendCommand(mac + " favorites playlist play item_id:" + favorite);
     }
 
+    public void like(String mac, String command) {
+        sendCommand(mac + " " + command);
+    }
+
+    public void unlike(String mac, String command) {
+        sendCommand(mac + " " + command);
+    }
+
     /**
      * Send a generic command to a given player
      *
@@ -306,6 +333,8 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         if (StringUtils.isEmpty(userId)) {
             return;
         }
+        // Create basic auth string for jsonrpc interface
+        basicAuthorization = new String(Base64.getEncoder().encode((userId + ":" + password).getBytes()));
         logger.debug("Logging into Squeeze Server using userId={}", userId);
         sendCommand("login " + userId + " " + password);
     }
@@ -361,6 +390,9 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, "host is not set");
             return;
         }
+        // Create URL for jsonrpc interface
+        jsonRpcUrl = String.format("http://%s:%d/jsonrpc.js", host, webport);
+
         try {
             clientSocket = new Socket(host, cliport);
         } catch (IOException e) {
@@ -377,7 +409,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         } catch (IllegalThreadStateException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         }
-
         // Mark the server ONLINE. bridgeStatusChanged will cause the players to come ONLINE
         updateStatus(ThingStatus.ONLINE);
     }
@@ -426,7 +457,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 login();
                 updateStatus(ThingStatus.ONLINE);
                 requestPlayers();
-                requestFavorites();
+                scheduleRequestFavorites();
                 sendCommand("listen 1");
 
                 String message = null;
@@ -474,7 +505,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                         "end of stream on socket read");
                 scheduleReconnect();
             }
-
             logger.debug("Squeeze Server listener exiting.");
         }
 
@@ -598,7 +628,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             switch (action) {
                 case "volume":
                     String volumeStringValue = decode(messageParts[3]);
-
                     updatePlayer(new PlayerUpdateEvent() {
                         @Override
                         public void updateListener(SqueezeBoxPlayerEventListener listener) {
@@ -836,6 +865,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             String mode;
             if (action.equals("newsong")) {
                 mode = "play";
+                // Execute in separate thread to avoid delaying listener
+                scheduler.execute(() -> {
+                    updateCustomButtons(mac);
+                });
                 // Set the track duration to 0
                 updatePlayer(new PlayerUpdateEvent() {
                     @Override
@@ -862,7 +895,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             }
             final String value = mode;
             updatePlayer(new PlayerUpdateEvent() {
-
                 @Override
                 public void updateListener(SqueezeBoxPlayerEventListener listener) {
                     listener.modeChangeEvent(mac, value);
@@ -872,9 +904,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
 
         private void handleSourceChangeMessage(String mac, String rawSource) {
             String source = URLDecoder.decode(rawSource);
-
             updatePlayer(new PlayerUpdateEvent() {
-
                 @Override
                 public void updateListener(SqueezeBoxPlayerEventListener listener) {
                     listener.sourceChangeEvent(mac, source);
@@ -886,12 +916,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             if (messageParts.length < 5) {
                 return;
             }
-
             // server prefsets
             if (messageParts[2].equals("server")) {
                 String function = messageParts[3];
                 String value = messageParts[4];
-
                 if (function.equals("power")) {
                     final boolean power = value.equals("1");
                     updatePlayer(new PlayerUpdateEvent() {
@@ -903,7 +931,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 } else if (function.equals("volume")) {
                     final int volume = (int) Double.parseDouble(value);
                     updatePlayer(new PlayerUpdateEvent() {
-
                         @Override
                         public void updateListener(SqueezeBoxPlayerEventListener listener) {
                             listener.absoluteVolumeChangeEvent(mac, volume);
@@ -914,8 +941,6 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
 
         private void handleFavorites(String message) {
-            logger.trace("Handle favorites message: {}", message);
-
             String[] messageParts = message.split("\\s");
             if (messageParts.length == 2 && "changed".equals(messageParts[1])) {
                 // LMS informing us that favorites have changed; request an update to the favorites list
@@ -996,6 +1021,64 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                 String favoritesList = sb.toString();
                 logger.trace("Updating favorites channel for {} to state {}", getThing().getUID(), favoritesList);
                 updateState(CHANNEL_FAVORITES_LIST, new StringType(favoritesList));
+            }
+        }
+
+        private void scheduleRequestFavorites() {
+            // Delay the execution to give the player thing handlers a chance to initialize
+            scheduler.schedule(() -> {
+                requestFavorites();
+            }, 3L, TimeUnit.SECONDS);
+        }
+
+        private void updateCustomButtons(final String mac) {
+            String response = executePost(jsonRpcUrl, JSONRPC_STATUS_REQUEST.replace("@@MAC@@", mac));
+            if (response != null) {
+                logger.trace("Status response: {}", response);
+                String likeCommand = null;
+                String unlikeCommand = null;
+                try {
+                    StatusResponseDTO status = gson.fromJson(response, StatusResponseDTO.class);
+                    if (status != null && status.result != null && status.result.remoteMeta != null
+                            && status.result.remoteMeta.buttons != null) {
+                        ButtonsDTO buttons = status.result.remoteMeta.buttons;
+                        if (buttons.repeat != null && buttons.repeat.isCustom()) {
+                            likeCommand = buttons.repeat.command;
+                        }
+                        if (buttons.shuffle != null && buttons.shuffle.isCustom()) {
+                            unlikeCommand = buttons.shuffle.command;
+                        }
+                    }
+                } catch (JsonSyntaxException e) {
+                    logger.debug("JsonSyntaxException parsing status response: {}", response, e);
+                }
+                final String like = likeCommand;
+                final String unlike = unlikeCommand;
+                updatePlayer(new PlayerUpdateEvent() {
+                    @Override
+                    public void updateListener(SqueezeBoxPlayerEventListener listener) {
+                        listener.buttonsChangeEvent(mac, like, unlike);
+                    }
+                });
+            }
+        }
+
+        private String executePost(String url, String content) {
+            // @formatter:off
+            HttpRequestBuilder builder = HttpRequestBuilder.postTo(url)
+                .withTimeout(Duration.ofSeconds(5))
+                .withContent(content)
+                .withHeader("charset", "utf-8")
+                .withHeader("Content-Type", "application/json");
+            // @formatter:on
+            if (basicAuthorization != null) {
+                builder = builder.withHeader("Authorization", "Basic " + basicAuthorization);
+            }
+            try {
+                return builder.getContentAsString();
+            } catch (IOException e) {
+                logger.debug("Bridge: IOException on jsonrpc call: {}", e.getMessage(), e);
+                return null;
             }
         }
     }

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -83,6 +83,8 @@
 			<channel id="ircode" typeId="ircode"/>
 			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks"/>
 			<channel id="playFavorite" typeId="playFavorite"/>
+			<channel id="like" typeId="like" />
+			<channel id="unlike" typeId="unlike" />
 		</channels>
 
 		<properties>
@@ -297,5 +299,15 @@
 		<label>Number of Playlist Tracks</label>
 		<description>Number of playlist tracks</description>
 		<state readOnly="true" pattern="%d"></state>
+	</channel-type>
+	<channel-type id="like" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Like Song</label>
+		<description>Likes the current song (if the service supports it)</description>
+	</channel-type>
+	<channel-type id="unlike" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Unlike Song</label>
+		<description>Unlikes the current song (if the service supports it)</description>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -83,8 +83,7 @@
 			<channel id="ircode" typeId="ircode"/>
 			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks"/>
 			<channel id="playFavorite" typeId="playFavorite"/>
-			<channel id="like" typeId="like"/>
-			<channel id="unlike" typeId="unlike"/>
+			<channel id="rate" typeId="rate"/>
 		</channels>
 
 		<properties>
@@ -300,14 +299,9 @@
 		<description>Number of playlist tracks</description>
 		<state readOnly="true" pattern="%d"></state>
 	</channel-type>
-	<channel-type id="like" advanced="true">
+	<channel-type id="rate" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Like Song</label>
-		<description>Likes the current song (if the service supports it)</description>
-	</channel-type>
-	<channel-type id="unlike" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Unlike Song</label>
-		<description>Unlikes the current song (if the service supports it)</description>
+		<label>Like or Unlike Song</label>
+		<description>Likes or unlikes the current song (if the service supports it)</description>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -83,8 +83,8 @@
 			<channel id="ircode" typeId="ircode"/>
 			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks"/>
 			<channel id="playFavorite" typeId="playFavorite"/>
-			<channel id="like" typeId="like" />
-			<channel id="unlike" typeId="unlike" />
+			<channel id="like" typeId="like"/>
+			<channel id="unlike" typeId="unlike"/>
 		</channels>
 
 		<properties>


### PR DESCRIPTION
Some streaming services, such as Pandora and Slacker, support "liking" or "unliking" the currently playing song. *Liking* a song causes the streaming service to play more songs like the currently playing song. *Unliking* the song skips the currently playing song, and won't play it again. As each streaming service has a different way to accomplish this, the LMS jsonrpc service supplies the specific like/unlike commands based on the service that's streaming the song. It does this by overriding the functionality of the `repeat` and `shuffle` buttons

This change adds two new channels to the player thing - `like` and `unlike`. If a streaming service doesn't support the like/unlike functionality, sending a command to the `like` or `unlike` channel does nothing.

Unfortunately, the current implementation of the squeezebox binding does not use the Logitech Media Server (LMS) jsonrpc service; it uses the older command line interface (CLI). Therefore, I needed to extend the binding to support the jsonrpc service in order to obtain the like/unlike commands.

I considered changing the binding to use only the jsonrpc service; however, that would require very significant modifications to the binding, which I chose to not undertake at this time.

This PR also introduces a slight change to the process to retrieve favorites from the LMS. Currently, there's a slight race condition where it's possible for the bridge to send the favorites to the player handlers before the player handlers have completed initialization. This change simply adds a slight delay to the retrieval of the favorites from the LMS.

This PR also changes the binding to use constructor injection.

I considered adding null annotations, but decided to save that for another PR as the changes looked pretty significant.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
