### PR TITLE
[hueemulation] Fixes HueEmulation DiscoveryIp not used

### DIFF
--- a/bundles/org.openhab.io.hueemulation/README.md
+++ b/bundles/org.openhab.io.hueemulation/README.md
@@ -114,7 +114,7 @@ This option allows you to override what addresses are used for the announcement.
 You can have multiple comma separated entries.
 
 ```
-org.openhab.hueemulation:discoveryIps=192.168.1.100,::FFFF:A9DB:0D85
+org.openhab.hueemulation:discoveryIp=192.168.1.100,::FFFF:A9DB:0D85
 ```
 
 The hue emulation service supports three types of emulated bulbs.

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -175,7 +175,8 @@ public class ConfigStore {
 
     @Modified
     public void modified(Map<String, Object> properties) {
-        this.config = new Configuration(properties).as(HueEmulationConfig.class);
+        final Configuration configuration = new Configuration(properties);
+        this.config = configuration.as(HueEmulationConfig.class);
 
         switchFilter = Collections.unmodifiableSet(
                 Stream.of(config.restrictToTagsSwitches.split(",")).map(String::trim).collect(Collectors.toSet()));
@@ -193,8 +194,20 @@ public class ConfigStore {
         InetAddress configuredAddress = null;
         int networkPrefixLength = 24; // Default for most networks: 255.255.255.0
 
-        if (config.discoveryIps != null) {
-            discoveryIps = Collections.unmodifiableSet(Stream.of(config.discoveryIps.split(",")).map(String::trim)
+        /**
+         * This is a fallback since for some time the value was called discoveryIp in the frontend. It should be named
+         * discoveryIps though so this property takes higher priority when this ConfigStore is build.
+         */
+        String discoveryIpsTemp = null;
+        if(config.discoveryIp != null) {
+            discoveryIpsTemp = config.discoveryIp;
+        }
+        if(config.discoveryIps != null) {
+            discoveryIpsTemp = config.discoveryIps;
+        }
+
+        if (discoveryIpsTemp != null) {
+            discoveryIps = Collections.unmodifiableSet(Stream.of(discoveryIpsTemp.split(",")).map(String::trim)
                     .map(this::byName).filter(e -> e != null).collect(Collectors.toSet()));
         } else {
             discoveryIps = new LinkedHashSet<>();

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -175,8 +175,7 @@ public class ConfigStore {
 
     @Modified
     public void modified(Map<String, Object> properties) {
-        final Configuration configuration = new Configuration(properties);
-        this.config = configuration.as(HueEmulationConfig.class);
+        this.config = new Configuration(properties).as(HueEmulationConfig.class);
 
         switchFilter = Collections.unmodifiableSet(
                 Stream.of(config.restrictToTagsSwitches.split(",")).map(String::trim).collect(Collectors.toSet()));
@@ -194,20 +193,8 @@ public class ConfigStore {
         InetAddress configuredAddress = null;
         int networkPrefixLength = 24; // Default for most networks: 255.255.255.0
 
-        /**
-         * This is a fallback since for some time the value was called discoveryIp in the frontend. It should be named
-         * discoveryIps though so this property takes higher priority when this ConfigStore is build.
-         */
-        String discoveryIpsTemp = null;
-        if(config.discoveryIp != null) {
-            discoveryIpsTemp = config.discoveryIp;
-        }
-        if(config.discoveryIps != null) {
-            discoveryIpsTemp = config.discoveryIps;
-        }
-
-        if (discoveryIpsTemp != null) {
-            discoveryIps = Collections.unmodifiableSet(Stream.of(discoveryIpsTemp.split(",")).map(String::trim)
+        if (config.discoveryIp != null) {
+            discoveryIps = Collections.unmodifiableSet(Stream.of(config.discoveryIp.split(",")).map(String::trim)
                     .map(this::byName).filter(e -> e != null).collect(Collectors.toSet()));
         } else {
             discoveryIps = new LinkedHashSet<>();

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationConfig.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationConfig.java
@@ -39,6 +39,12 @@ public class HueEmulationConfig {
     /** Pairing timeout in seconds */
     public int pairingTimeout = 60;
     public @Nullable String discoveryIps;
+    /**
+     * The field discoveryIps was named discoveryIp in the frontend for some time and thus user probably
+     * have it in their local config saved under this name. We need to keep it here as a possible fallback when
+     * selecting the ips.
+     */
+    public @Nullable String discoveryIp;
     public int discoveryHttpPort = 0;
     /** Comma separated list of tags */
     public String restrictToTagsSwitches = "Switchable";

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationConfig.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationConfig.java
@@ -38,11 +38,9 @@ public class HueEmulationConfig {
 
     /** Pairing timeout in seconds */
     public int pairingTimeout = 60;
-    public @Nullable String discoveryIps;
     /**
      * The field discoveryIps was named discoveryIp in the frontend for some time and thus user probably
-     * have it in their local config saved under this name. We need to keep it here as a possible fallback when
-     * selecting the ips.
+     * have it in their local config saved under the non plural version.
      */
     public @Nullable String discoveryIp;
     public int discoveryHttpPort = 0;

--- a/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
@@ -51,7 +51,7 @@
 			<description>All items that are tagged with the given tags are ignore by the Hue Emulation Service. Use commas to separate multiple entries.</description>
 			<default>internal</default>
 		</parameter>
-		<parameter name="discoveryIp" type="text" required="false">
+		<parameter name="discoveryIps" type="text" required="false">
 			<label>Optional Discovery Address</label>
 			<description>If your host has multiple IP addresses you may specify the IP you would like to advertise in the UPNP discovery process. You may safely leave this empty on most systems.</description>
 		</parameter>

--- a/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
@@ -53,7 +53,7 @@
 		</parameter>
 		<parameter name="discoveryIps" type="text" required="false">
 			<label>Optional Discovery Address</label>
-			<description>If your host has multiple IP addresses you may specify the IP you would like to advertise in the UPNP discovery process. You may safely leave this empty on most systems.</description>
+			<description>If your host has multiple IP addresses you may specify the IP(s) you would like to advertise in the UPNP discovery process. You may safely leave this empty on most systems. Use commas to separate multiple entries.</description>
 		</parameter>
 		<parameter name="discoveryHttpPort" type="integer" required="false">
 			<label>Optional Discovery Web Port</label>

--- a/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.io.hueemulation/src/main/resources/ESH-INF/config/config.xml
@@ -51,7 +51,7 @@
 			<description>All items that are tagged with the given tags are ignore by the Hue Emulation Service. Use commas to separate multiple entries.</description>
 			<default>internal</default>
 		</parameter>
-		<parameter name="discoveryIps" type="text" required="false">
+		<parameter name="discoveryIp" type="text" required="false">
 			<label>Optional Discovery Address</label>
 			<description>If your host has multiple IP addresses you may specify the IP(s) you would like to advertise in the UPNP discovery process. You may safely leave this empty on most systems. Use commas to separate multiple entries.</description>
 		</parameter>


### PR DESCRIPTION
Non uniform parameter naming prevented config param from being saved
and used for discovery.

[hueemulation] Fixes discovery IP not saved/used

<!-- DESCRIPTION -->

This is a fix for the issue opened by me: https://github.com/openhab/openhab-addons/issues/7410

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
