### PR TITLE
[fsinternetradio] Auto discovery for Teufel 3sixty

### DIFF
--- a/bundles/org.openhab.binding.fsinternetradio/README.md
+++ b/bundles/org.openhab.binding.fsinternetradio/README.md
@@ -16,7 +16,8 @@ Successfully tested are internet radios:
  * [Revo SuperConnect](https://revo.co.uk/products/)
  * [Sangean WFR-28C](http://sg.sangean.com.tw/products/product_category.asp?cid=2)
  * [Roku SoundBridge M1001](https://soundbridge.roku.com/soundbridge/index.php)
- * [Dual IR 3a](https://www.dual.de/produkte/digitalradio/radio-station-ir-3a/) 
+ * [Dual IR 3a](https://www.dual.de/produkte/digitalradio/radio-station-ir-3a/)
+ * [Teufel 3sixty](https://www.teufel.de/stereo/radio-3sixty-p16568.html)
 
 But in principle, all internet radios based on the [Frontier Silicon chipset](https://www.frontier-silicon.com/) should be supported because they share the same API.
 So It is very likely that other internet radio models of the same manufacturers do also work.

--- a/bundles/org.openhab.binding.fsinternetradio/src/main/java/org/openhab/binding/fsinternetradio/internal/FSInternetRadioDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/main/java/org/openhab/binding/fsinternetradio/internal/FSInternetRadioDiscoveryParticipant.java
@@ -31,6 +31,8 @@ import org.jupnp.model.meta.ModelDetails;
 import org.jupnp.model.meta.RemoteDevice;
 import org.jupnp.model.meta.RemoteDeviceIdentity;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the discovery service for internet radios based on the fontier silicon chipset. Unfortunately, it is not
@@ -40,9 +42,11 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Patrick Koenemann - Initial contribution
  * @author Mihaela Memova - removed the getLabel(RemoteDevice device) method due to its unreachable code lines
+ * @author Markus Michels - support for Teufel 3sixty discovery
  */
 @Component(immediate = true)
 public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryParticipant {
+    private final Logger logger = LoggerFactory.getLogger(FSInternetRadioDiscoveryParticipant.class);
 
     /** Map from UPnP manufacturer to model number for supported radios; filled in static initializer below. */
     private static final Map<String, Set<String>> SUPPORTED_RADIO_MODELS = new HashMap<>();
@@ -95,6 +99,10 @@ public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryPartici
         SUPPORTED_RADIO_MODELS.put("SMRS18A1", radiosWithoutManufacturer);
         SUPPORTED_RADIO_MODELS.put("SMRS30A1", radiosWithoutManufacturer);
         SUPPORTED_RADIO_MODELS.put("SMRS35A1", radiosWithoutManufacturer);
+
+        final Set<String> teufelRadios = new HashSet<>();
+        SUPPORTED_RADIO_MODELS.put("Teufel", teufelRadios);
+        teufelRadios.add("Radio 3sixty");
 
         // as reported in: https://community.openhab.org/t/internet-radio-i-need-your-help/2131/5
         final Set<String> ttmicroRadios = new HashSet<>();
@@ -150,14 +158,14 @@ public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryPartici
                 if (manufacturer != null) {
                     properties.put(PROPERTY_MANUFACTURER, manufacturer);
                 }
-                final String model = getModel(device);
+                final String dm = getModel(device);
+                final String model = dm != null ? dm : getFriendlyName(device);
                 if (model != null) {
                     properties.put(PROPERTY_MODEL, model);
                 }
-
-                final DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withLabel(device.getDisplayString()).build();
-                return result;
+                final String thingName = (manufacturer == null) && (getModel(device) == null) ? getFriendlyName(device)
+                        : device.getDisplayString();
+                return DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(thingName).build();
             }
         }
         return null;
@@ -165,20 +173,27 @@ public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryPartici
 
     private String getManufacturer(RemoteDevice device) {
         final DeviceDetails details = device.getDetails();
-        if (details != null) {
-            if (details.getManufacturerDetails() != null) {
-                return details.getManufacturerDetails().getManufacturer();
-            }
+        if ((details != null) && (details.getManufacturerDetails() != null)) {
+            String manufacturer = details.getManufacturerDetails().getManufacturer().trim();
+            return manufacturer.isEmpty() ? null : manufacturer;
         }
         return null;
     }
 
     private String getModel(RemoteDevice device) {
         final DeviceDetails details = device.getDetails();
-        if (details != null) {
-            if (details.getModelDetails() != null) {
-                return details.getModelDetails().getModelNumber();
-            }
+        if ((details != null) && (details.getModelDetails().getModelNumber() != null)) {
+            String model = details.getModelDetails().getModelNumber().trim();
+            return model.isEmpty() ? null : model;
+        }
+        return null;
+    }
+
+    private String getFriendlyName(RemoteDevice device) {
+        final DeviceDetails details = device.getDetails();
+        if ((details != null) && (details.getFriendlyName() != null)) {
+            String name = details.getFriendlyName().trim();
+            return name.isEmpty() ? null : name;
         }
         return null;
     }
@@ -203,22 +218,28 @@ public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryPartici
      * If <code>device</code> is a supported device, a unique thing ID (e.g. serial number) must be returned. Further
      * supported devices should be added here, based on the available UPnP information.
      */
+    @SuppressWarnings("null")
     @Override
     public ThingUID getThingUID(RemoteDevice device) {
         final DeviceDetails details = device.getDetails();
+        final String friendlyName = details.getFriendlyName();
+        logger.debug("Discovered unit:  {}", friendlyName);
+
         if (details != null) {
             final ManufacturerDetails manufacturerDetails = details.getManufacturerDetails();
-            final String manufacturer = manufacturerDetails == null ? null : manufacturerDetails.getManufacturer();
             final ModelDetails modelDetails = details.getModelDetails();
             if (modelDetails != null) {
                 // check manufacturer and model number
+                final String manufacturer = manufacturerDetails == null ? null : manufacturerDetails.getManufacturer();
                 final String modelNumber = modelDetails.getModelNumber();
+                String serialNumber = details.getSerialNumber();
+                logger.debug("Discovered unit: {} {} - {}", manufacturer, modelNumber, friendlyName);
                 if (modelNumber != null) {
                     if (manufacturer != null) {
                         final Set<String> supportedRadios = SUPPORTED_RADIO_MODELS
                                 .get(manufacturer.trim().toUpperCase());
                         if (supportedRadios != null && supportedRadios.contains(modelNumber.toUpperCase())) {
-                            return new ThingUID(THING_TYPE_RADIO, details.getSerialNumber());
+                            return new ThingUID(THING_TYPE_RADIO, serialNumber);
                         }
                     }
                     // check model name and number
@@ -226,7 +247,36 @@ public class FSInternetRadioDiscoveryParticipant implements UpnpDiscoveryPartici
                     if (modelName != null) {
                         final Set<String> supportedRadios = SUPPORTED_RADIO_MODELS.get(modelName.trim().toUpperCase());
                         if (supportedRadios != null && supportedRadios.contains(modelNumber.toUpperCase())) {
-                            return new ThingUID(THING_TYPE_RADIO, details.getSerialNumber());
+                            return new ThingUID(THING_TYPE_RADIO, serialNumber);
+                        }
+                        // Teufel reports empty manufacturer and model, but friendly name
+                        if (friendlyName.contains("Teufel")) {
+                            logger.debug("haha");
+                        }
+                        if (!friendlyName.isEmpty()) {
+                            for (Set<String> models : SUPPORTED_RADIO_MODELS.values()) {
+                                for (String model : models) {
+                                    if ((model != null) && !model.isEmpty() && friendlyName.contains(model)) {
+                                        return new ThingUID(THING_TYPE_RADIO, serialNumber);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (((manufacturer == null) || manufacturer.trim().isEmpty())
+                        && ((modelNumber == null) || modelNumber.trim().isEmpty())) {
+                    // Some devices report crappy UPnP device description so manufacturer and model are ""
+                    // In this case we try to find the match in friendlyName
+                    final String uname = friendlyName.toUpperCase();
+                    for (Map.Entry<String, Set<String>> entry : SUPPORTED_RADIO_MODELS.entrySet()) {
+                        for (Set<String> set : SUPPORTED_RADIO_MODELS.values()) {
+                            for (String model : set) {
+                                if ((model != null) && !model.isEmpty() && uname.contains(model)) {
+                                    return new ThingUID(THING_TYPE_RADIO, serialNumber);
+                                }
+                            }
                         }
                     }
                 }

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/internal/handler/HandlerUtils.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/internal/handler/HandlerUtils.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.fsinternetradio.internal.handler;
 
-import org.openhab.binding.fsinternetradio.internal.handler.FSInternetRadioHandler;
 import org.openhab.binding.fsinternetradio.internal.radio.FrontierSiliconRadio;
 
 /**
@@ -20,6 +19,7 @@ import org.openhab.binding.fsinternetradio.internal.radio.FrontierSiliconRadio;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+
 public class HandlerUtils {
 
     /**

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioDiscoveryParticipantJavaTest.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioDiscoveryParticipantJavaTest.java
@@ -100,7 +100,6 @@ public class FSInternetRadioDiscoveryParticipantJavaTest {
      *
      * @throws ValidationException
      */
-    @SuppressWarnings("null")
     @Test
     public void validDiscoveryResultWithComplete() throws ValidationException {
         RemoteDevice completeFSInternetRadioDevice = createDefaultFSInternetRadioDevice(DEFAULT_RADIO_BASE_URL);
@@ -111,17 +110,6 @@ public class FSInternetRadioDiscoveryParticipantJavaTest {
                 result.getProperties().get(FSInternetRadioBindingConstants.PROPERTY_MANUFACTURER));
         assertEquals(DEFAULT_RADIO_MODEL_NUMBER,
                 result.getProperties().get(FSInternetRadioBindingConstants.PROPERTY_MODEL));
-    }
-
-    /**
-     * Verify no discovery result for FSInternetRadio device with null details.
-     *
-     * @throws ValidationException
-     */
-    @Test
-    public void noDiscoveryResultIfNullDetails() throws ValidationException {
-        RemoteDevice fsInterntRadioDeviceWithNullDetails = new RemoteDevice(null);
-        assertNull(discoveryParticipant.createResult(fsInterntRadioDeviceWithNullDetails));
     }
 
     /**
@@ -141,7 +129,6 @@ public class FSInternetRadioDiscoveryParticipantJavaTest {
      *
      * @throws ValidationException
      */
-    @SuppressWarnings("null")
     @Test
     public void validDiscoveryResultIfWithoutBaseUrl() throws ValidationException {
         RemoteDevice fsInternetRadioDeviceWithoutUrl = createDefaultFSInternetRadioDevice(null);

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/MockedRadioHandler.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/MockedRadioHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.fsinternetradio.test;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.openhab.binding.fsinternetradio.internal.handler.FSInternetRadioHandler;
@@ -22,6 +23,7 @@ import org.openhab.binding.fsinternetradio.internal.handler.FSInternetRadioHandl
  * @author Velin Yordanov - initial contribution
  *
  */
+@NonNullByDefault
 public class MockedRadioHandler extends FSInternetRadioHandler {
 
     public MockedRadioHandler(Thing thing, HttpClient client) {

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/RadioServiceDummy.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/RadioServiceDummy.java
@@ -31,7 +31,7 @@ import org.openhab.binding.fsinternetradio.internal.radio.FrontierSiliconRadioCo
 /**
  * Radio service mock.
  *
- * @author Markus Rathgeb - Migrated from Groovy to pure Java, made more robust
+ * @author Markus Rathgeb - Initial contribution
  * @author Velin Yordanov - Small adjustments
  */
 public class RadioServiceDummy extends HttpServlet {
@@ -49,7 +49,6 @@ public class RadioServiceDummy extends HttpServlet {
     private static final String REQUEST_GET_VOLUME = "/" + FrontierSiliconRadioConstants.REQUEST_GET_VOLUME;
     private static final String REQUEST_SET_MUTE = "/" + FrontierSiliconRadioConstants.REQUEST_SET_MUTE;
     private static final String REQUEST_GET_MUTE = "/" + FrontierSiliconRadioConstants.REQUEST_GET_MUTE;
-    private static final String REQUEST_SET_PRESET = "/" + FrontierSiliconRadioConstants.REQUEST_SET_PRESET;
     private static final String REQUEST_SET_PRESET_ACTION = "/"
             + FrontierSiliconRadioConstants.REQUEST_SET_PRESET_ACTION;
     private static final String REQUEST_GET_PLAY_INFO_TEXT = "/"
@@ -70,26 +69,26 @@ public class RadioServiceDummy extends HttpServlet {
 
     private final int httpStatus;
 
-    private String tagToReturn;
-    private String responseToReturn;
+    private String tagToReturn = "";
+    private String responseToReturn = "";
 
     private boolean isInvalidResponseExpected;
     private boolean isInvalidValueExpected;
     private boolean isOKAnswerExpected = true;
 
     private String powerValue;
-    private String powerTag;
+    private String powerTag = "";
 
     private String muteValue;
-    private String muteTag;
+    private String muteTag = "";
 
     private String absoluteVolumeValue;
-    private String absoluteVolumeTag;
+    private String absoluteVolumeTag = "";
 
     private String modeValue;
-    private String modeTag;
+    private String modeTag = "";
 
-    private String radioStation;
+    private String radioStation = "";
 
     public RadioServiceDummy() {
         this.httpStatus = HttpStatus.OK_200;


### PR DESCRIPTION
This PR integrates the Teufel 3sixty into the device discovery.

The 3sixty is not confirming the UPnP standard and returns empty manufacturer and model. However the friendly name is field is filled. Another detection has been implemented to identify a model by friendlyName containing manufacturer and/or model ID.