### PR TITLE
[shelly] Don't auto-initialize when thing is removing

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpApi.java
@@ -427,23 +427,21 @@ public class ShellyHttpApi {
             throws ShellyApiException {
         for (String eventType : eventTypes) {
             if (profile.containsEventUrl(eventType)) {
-                if (profile.containsEventUrl(eventType)) {
-                    String callBackUrl = "http://" + config.localIp + ":" + config.localPort + SHELLY_CALLBACK_URI + "/"
-                            + profile.thingName + "/" + deviceClass + "/" + index + "?type=" + eventType;
-                    String newUrl = enabled ? callBackUrl : SHELLY_NULL_URL;
-                    String test = "\"" + mkEventUrl(eventType) + "\":\"" + callBackUrl + "\"";
-                    if (!enabled && !profile.settingsJson.contains(test)) {
-                        // Don't set URL to null when the current one doesn't point to this OH
-                        // Don't interfere with a 3rd party App
-                        continue;
-                    }
-                    test = "\"" + mkEventUrl(eventType) + "\":\"" + newUrl + "\"";
-                    if (!profile.settingsJson.contains(test)) {
-                        // Current Action URL is != new URL
-                        logger.debug("{}: Set URL for type {} to {}", thingName, eventType, newUrl);
-                        request(SHELLY_URL_SETTINGS + "/" + deviceClass + "/" + index + "?" + mkEventUrl(eventType)
-                                + "=" + urlEncode(newUrl));
-                    }
+                String callBackUrl = "http://" + config.localIp + ":" + config.localPort + SHELLY_CALLBACK_URI + "/"
+                        + profile.thingName + "/" + deviceClass + "/" + index + "?type=" + eventType;
+                String newUrl = enabled ? callBackUrl : SHELLY_NULL_URL;
+                String test = "\"" + mkEventUrl(eventType) + "\":\"" + callBackUrl + "\"";
+                if (!enabled && !profile.settingsJson.contains(test)) {
+                    // Don't set URL to null when the current one doesn't point to this OH
+                    // Don't interfere with a 3rd party App
+                    continue;
+                }
+                test = "\"" + mkEventUrl(eventType) + "\":\"" + newUrl + "\"";
+                if (!profile.settingsJson.contains(test)) {
+                    // Current Action URL is != new URL
+                    logger.debug("{}: Set URL for type {} to {}", thingName, eventType, newUrl);
+                    request(SHELLY_URL_SETTINGS + "/" + deviceClass + "/" + index + "?" + mkEventUrl(eventType) + "="
+                            + urlEncode(newUrl));
                 }
             }
         }

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyBaseHandler.java
@@ -347,8 +347,8 @@ public class ShellyBaseHandler extends BaseThingHandler implements ShellyDeviceL
             }
 
             if (refreshSettings || (scheduledUpdates > 0) || (skipUpdate % skipCount == 0)) {
-                if (thingStatus != ThingStatus.UNINITIALIZED && !profile.isInitialized()
-                        || ((thingStatus == ThingStatus.OFFLINE)) || (thingStatus == ThingStatus.UNKNOWN)) {
+                if (!profile.isInitialized() || ((thingStatus == ThingStatus.OFFLINE))
+                        || (thingStatus == ThingStatus.UNKNOWN)) {
                     logger.debug("{}: Status update triggered thing initialization", thingName);
                     initializeThing(); // may fire an exception if initialization failed
                 }


### PR DESCRIPTION
Depending on timing it could happen that an incoming CoAP message trigges an auto-initialization while a thing is removing or has status REMOVED.