### PR TITLE
[rfxcom] Added Cherubini blinds support

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
@@ -30,6 +30,7 @@ import org.openhab.binding.rfxcom.internal.handler.DeviceState;
  *
  * @author Peter Janson / Pål Edman - Initial contribution
  * @author Pauli Anttila - Migration to OH2
+ * @author Fabien Le Bars - Added support for Cherubini
  */
 public class RFXComBlinds1Message extends RFXComBatteryDeviceMessage<RFXComBlinds1Message.SubType> {
 
@@ -47,8 +48,9 @@ public class RFXComBlinds1Message extends RFXComBatteryDeviceMessage<RFXComBlind
         T10(10), // Dolat DLM-1, Topstar
         T11(11), // ASP
         T12(12), // Confexx CNF24-2435
-        T13(13); // Screenline
-
+        T13(13), // Screenline
+        T18(18); //Cherubini
+        
         private final int subType;
 
         SubType(int subType) {

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
@@ -30,7 +30,7 @@ import org.openhab.binding.rfxcom.internal.handler.DeviceState;
  *
  * @author Peter Janson / Pål Edman - Initial contribution
  * @author Pauli Anttila - Migration to OH2
- * @author Fabien Le Bars - Added support for Cherubini
+ * @author Fabien Le Bars - Added support for Cherubini blinds
  */
 public class RFXComBlinds1Message extends RFXComBatteryDeviceMessage<RFXComBlinds1Message.SubType> {
 


### PR DESCRIPTION
Added Cherubini blinds for the Blinds1 (support for Cherubini was added in RFXCom in Version 5.68 - 26/02/2020 ).
I have Cherubini blinds and this very simple addon to the enum does the trick.

The deviceId can be found in RFXMgr when sending a command
   id1-3         = 103000 decimal:1060864
it's the decimal part to which you add .0

Thing blinds1 Salon "Volet Salon" [ deviceId="1060864.0", subType="18" ]

Please note that there is also T14, T15, T16, T17, maybe support for them is also as easy as completing the enum ... since I cannot test, I didn't add them.

Fixes #7417 

Signed-off-by: Fabien Le Bars <github@bleizig.net>