### PR TITLE
[ambientweather] Fix ws8482 indoor sensor

### DIFF
--- a/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws8482Processor.java
+++ b/bundles/org.openhab.binding.ambientweather/src/main/java/org/openhab/binding/ambientweather/internal/processor/Ws8482Processor.java
@@ -58,8 +58,8 @@ public class Ws8482Processor extends AbstractProcessor {
         // Update the weather data channels
         handler.updateDate(channelGroupId, CH_OBSERVATION_TIME, data.date);
         handler.updateString(channelGroupId, CH_BATTERY_INDICATOR, data.battout);
-        handler.updateQuantity(channelGroupId, CH_TEMPERATURE, data.tempf, ImperialUnits.FAHRENHEIT);
-        handler.updateQuantity(channelGroupId, CH_HUMIDITY, data.humidity, SmartHomeUnits.PERCENT);
+        handler.updateQuantity(channelGroupId, CH_TEMPERATURE, data.tempinf, ImperialUnits.FAHRENHEIT);
+        handler.updateQuantity(channelGroupId, CH_HUMIDITY, data.humidityin, SmartHomeUnits.PERCENT);
 
         // Update the remote sensor channels
         remoteSensor.updateChannels(handler, jsonData);


### PR DESCRIPTION
The processor for the WS8482 weather station was using the wrong data elements for the indoor temperature and humidity sensors.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
