### PR TITLE
[modbus][sunspec] full inverter support

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -58,6 +58,7 @@ public class SunSpecConstants {
     // Channel group ids
     public static final String GROUP_DEVICE_INFO = "deviceInformation";
     public static final String GROUP_AC_GENERAL = "acGeneral";
+    public static final String GROUP_DC_GENERAL = "dcGeneral";
 
     // List of all Channel ids in device information group
     public static final String CHANNEL_PHASE_CONFIGURATION = "phase-configuration";
@@ -75,6 +76,11 @@ public class SunSpecConstants {
     public static final String CHANNEL_AC_REACTIVE_POWER = "ac-reactive-power";
     public static final String CHANNEL_AC_POWER_FACTOR = "ac-power-factor";
     public static final String CHANNEL_AC_LIFETIME_ENERGY = "ac-lifetime-energy";
+
+    // List of channel ids in DC group for inverter
+    public static final String CHANNEL_DC_CURRENT = "dc-current";
+    public static final String CHANNEL_DC_VOLTAGE = "dc-voltage";
+    public static final String CHANNEL_DC_POWER = "dc-power";
 
     // Expected SunSpec ID This is a magic constant to distinguish SunSpec compatible
     // devices from other modbus devices

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.modbus.sunspec.internal;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -33,17 +33,27 @@ public class SunSpecConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_INVERTER_SINGLE_PHASE = new ThingTypeUID(BINDING_ID,
             "inverter-single-phase");
+    public static final ThingTypeUID THING_TYPE_INVERTER_SPLIT_PHASE = new ThingTypeUID(BINDING_ID,
+            "inverter-split-phase");
+    public static final ThingTypeUID THING_TYPE_INVERTER_THREE_PHASE = new ThingTypeUID(BINDING_ID,
+            "inverter-three-phase");
 
     // Block types
     public static final int COMMON_BLOCK = 1;
     public static final int INVERTER_SINGLE_PHASE = 101;
+    public static final int INVERTER_SPLIT_PHASE = 102;
+    public static final int INVERTER_THREE_PHASE = 103;
     public static final int FINAL_BLOCK = 0xffff;
 
     /**
      * Map of the supported thing type uids, with their block type id
      */
-    public static final Map<Integer, ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
-            .singletonMap(INVERTER_SINGLE_PHASE, THING_TYPE_INVERTER_SINGLE_PHASE);
+    public static final Map<Integer, ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashMap<>();
+    static {
+        SUPPORTED_THING_TYPES_UIDS.put(INVERTER_SINGLE_PHASE, THING_TYPE_INVERTER_SINGLE_PHASE);
+        SUPPORTED_THING_TYPES_UIDS.put(INVERTER_SPLIT_PHASE, THING_TYPE_INVERTER_SPLIT_PHASE);
+        SUPPORTED_THING_TYPES_UIDS.put(INVERTER_THREE_PHASE, THING_TYPE_INVERTER_THREE_PHASE);
+    }
 
     // properties
     public static final String PROPERTY_VENDOR = "vendor";
@@ -59,6 +69,8 @@ public class SunSpecConstants {
     public static final String GROUP_DEVICE_INFO = "deviceInformation";
     public static final String GROUP_AC_GENERAL = "acGeneral";
     public static final String GROUP_AC_PHASE_A = "acPhaseA";
+    public static final String GROUP_AC_PHASE_B = "acPhaseB";
+    public static final String GROUP_AC_PHASE_C = "acPhaseC";
     public static final String GROUP_DC_GENERAL = "dcGeneral";
 
     // List of all Channel ids in device information group

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecConstants.java
@@ -58,6 +58,7 @@ public class SunSpecConstants {
     // Channel group ids
     public static final String GROUP_DEVICE_INFO = "deviceInformation";
     public static final String GROUP_AC_GENERAL = "acGeneral";
+    public static final String GROUP_AC_PHASE_A = "acPhaseA";
     public static final String GROUP_DC_GENERAL = "dcGeneral";
 
     // List of all Channel ids in device information group
@@ -76,6 +77,11 @@ public class SunSpecConstants {
     public static final String CHANNEL_AC_REACTIVE_POWER = "ac-reactive-power";
     public static final String CHANNEL_AC_POWER_FACTOR = "ac-power-factor";
     public static final String CHANNEL_AC_LIFETIME_ENERGY = "ac-lifetime-energy";
+
+    // List of channel ids in AC phase group for inverter
+    public static final String CHANNEL_AC_PHASE_CURRENT = "ac-phase-current";
+    public static final String CHANNEL_AC_VOLTAGE_TO_NEXT = "ac-voltage-to-next";
+    public static final String CHANNEL_AC_VOLTAGE_TO_N = "ac-voltage-to-n";
 
     // List of channel ids in DC group for inverter
     public static final String CHANNEL_DC_CURRENT = "dc-current";

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/SunSpecHandlerFactory.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.modbus.sunspec.internal;
 
-import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.THING_TYPE_INVERTER_SINGLE_PHASE;
-
-import java.util.Collections;
-import java.util.Set;
+import static org.openhab.binding.modbus.sunspec.internal.SunSpecConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -52,9 +49,6 @@ public class SunSpecHandlerFactory extends BaseThingHandlerFactory {
      */
     private ModbusManager manager;
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
-            .singleton(THING_TYPE_INVERTER_SINGLE_PHASE);
-
     /**
      * This factory needs a reference to the ModbusManager wich is provided
      * by the org.openhab.io.transport.modbus bundle. Please make
@@ -69,14 +63,16 @@ public class SunSpecHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
-        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+        return SUPPORTED_THING_TYPES_UIDS.containsValue(thingTypeUID);
     }
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(THING_TYPE_INVERTER_SINGLE_PHASE)) {
+        if (thingTypeUID.equals(THING_TYPE_INVERTER_SINGLE_PHASE)
+                || thingTypeUID.equals(THING_TYPE_INVERTER_SPLIT_PHASE)
+                || thingTypeUID.equals(THING_TYPE_INVERTER_THREE_PHASE)) {
             logger.debug("New InverterHandler created");
             return new InverterHandler(thing, manager);
         }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -38,9 +38,29 @@ public class InverterModelBlock {
     public Integer acCurrentTotal;
 
     /**
+     * AC Phase A Current value
+     */
+    public Integer acCurrentPhaseA;
+
+    /**
      * AC Current scale factor
      */
     public Short acCurrentSF;
+
+    /**
+     * AC Voltage Phase AB value
+     */
+    public Optional<Integer> acVoltageAB;
+
+    /**
+     * AC Voltage Phase A to N value
+     */
+    public Integer acVoltageAtoN;
+
+    /**
+     * AC Voltage scale factor
+     */
+    public Short acVoltageSF;
 
     /**
      * AC Power value

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -43,6 +43,16 @@ public class InverterModelBlock {
     public Integer acCurrentPhaseA;
 
     /**
+     * AC Phase B Current value
+     */
+    public Optional<Integer> acCurrentPhaseB;
+
+    /**
+     * AC Phase C Current value
+     */
+    public Optional<Integer> acCurrentPhaseC;
+
+    /**
      * AC Current scale factor
      */
     public Short acCurrentSF;
@@ -53,9 +63,29 @@ public class InverterModelBlock {
     public Optional<Integer> acVoltageAB;
 
     /**
+     * AC Voltage Phase BC value
+     */
+    public Optional<Integer> acVoltageBC;
+
+    /**
+     * AC Voltage Phase CA value
+     */
+    public Optional<Integer> acVoltageCA;
+
+    /**
      * AC Voltage Phase A to N value
      */
     public Integer acVoltageAtoN;
+
+    /**
+     * AC Voltage Phase B to N value
+     */
+    public Optional<Integer> acVoltageBtoN;
+
+    /**
+     * AC Voltage Phase C to N value
+     */
+    public Optional<Integer> acVoltageCtoN;
 
     /**
      * AC Voltage scale factor

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/dto/InverterModelBlock.java
@@ -103,6 +103,36 @@ public class InverterModelBlock {
     public Short acEnergyLifetimeSF;
 
     /**
+     * DC Current value
+     */
+    public Optional<Integer> dcCurrent;
+
+    /**
+     * DC Current scale factor
+     */
+    public Optional<Short> dcCurrentSF;
+
+    /**
+     * DC Voltage value
+     */
+    public Optional<Integer> dcVoltage;
+
+    /**
+     * DC Voltage scale factor
+     */
+    public Optional<Short> dcVoltageSF;
+
+    /**
+     * DC Power value
+     */
+    public Optional<Short> dcPower;
+
+    /**
+     * DC Power scale factor
+     */
+    public Optional<Short> dcPowerSF;
+
+    /**
      * Cabinet temperature
      */
     public Short temperatureCabinet;

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -514,6 +514,20 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * @param scaleFactor the scale factor to use (may be negative)
      * @return the scaled value as a DecimalType
      */
+    protected State getScaled(Optional<? extends Number> value, Short scaleFactor, Unit<?> unit) {
+        if (!value.isPresent()) {
+            return UnDefType.UNDEF;
+        }
+        return getScaled(value.get().longValue(), scaleFactor, unit);
+    }
+
+    /**
+     * Returns value multiplied by the 10 on the power of scaleFactory
+     *
+     * @param value the value to alter
+     * @param scaleFactor the scale factor to use (may be negative)
+     * @return the scaled value as a DecimalType
+     */
     protected State getScaled(Number value, Short scaleFactor, Unit<?> unit) {
         if (scaleFactor == 1) {
             return new QuantityType<>(value.longValue(), unit);

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -22,7 +22,6 @@ import javax.measure.Unit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -472,34 +471,6 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * @param scaleFactor the scale factor to use (may be negative)
      * @return the scaled value as a DecimalType
      */
-    protected State getScaled(Optional<? extends Number> value, Optional<Short> scaleFactor) {
-        if (!value.isPresent() || !scaleFactor.isPresent()) {
-            return UnDefType.UNDEF;
-        }
-        return getScaled(value.get().longValue(), scaleFactor.get());
-    }
-
-    /**
-     * Returns value multiplied by the 10 on the power of scaleFactory
-     *
-     * @param value the value to alter
-     * @param scaleFactor the scale factor to use (may be negative)
-     * @return the scaled value as a DecimalType
-     */
-    protected State getScaled(Number value, Short scaleFactor) {
-        if (scaleFactor == 1) {
-            return new DecimalType(value.longValue());
-        }
-        return new DecimalType(BigDecimal.valueOf(value.longValue(), scaleFactor * -1));
-    }
-
-    /**
-     * Returns value multiplied by the 10 on the power of scaleFactory
-     *
-     * @param value the value to alter
-     * @param scaleFactor the scale factor to use (may be negative)
-     * @return the scaled value as a DecimalType
-     */
     protected State getScaled(Optional<? extends Number> value, Optional<Short> scaleFactor, Unit<?> unit) {
         if (!value.isPresent() || !scaleFactor.isPresent()) {
             return UnDefType.UNDEF;
@@ -515,10 +486,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * @return the scaled value as a DecimalType
      */
     protected State getScaled(Optional<? extends Number> value, Short scaleFactor, Unit<?> unit) {
-        if (!value.isPresent()) {
-            return UnDefType.UNDEF;
-        }
-        return getScaled(value.get().longValue(), scaleFactor, unit);
+        return getScaled(value, Optional.of(scaleFactor), unit);
     }
 
     /**

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.StringType;
-import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.modbus.sunspec.internal.InverterStatus;
@@ -81,7 +80,7 @@ public class InverterHandler extends AbstractSunSpecHandler {
                 getScaled(block.temperatureOther, Optional.of(block.temperatureSF), CELSIUS));
 
         InverterStatus status = InverterStatus.getByCode(block.status);
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DEVICE_INFO, CHANNEL_STATUS),
+        updateState(channelUID(GROUP_DEVICE_INFO, CHANNEL_STATUS),
                 status == null ? UnDefType.UNDEF : new StringType(status.name()));
 
         // AC General group
@@ -104,12 +103,11 @@ public class InverterHandler extends AbstractSunSpecHandler {
                                                                                   // https://github.com/openhab/openhab-core/pull/1347
 
         // DC General group
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_CURRENT),
+        updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_CURRENT),
                 getScaled(block.dcCurrent, block.dcCurrentSF, AMPERE));
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_VOLTAGE),
+        updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_VOLTAGE),
                 getScaled(block.dcVoltage, block.dcVoltageSF, VOLT));
-        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_POWER),
-                getScaled(block.dcPower, block.dcPowerSF, VOLT));
+        updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_POWER), getScaled(block.dcPower, block.dcPowerSF, VOLT));
 
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
                 getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));
@@ -119,33 +117,33 @@ public class InverterHandler extends AbstractSunSpecHandler {
 
         // AC Phase specific groups
         // All types of inverters
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_PHASE_CURRENT),
+        updateState(channelUID(GROUP_AC_PHASE_A, CHANNEL_AC_PHASE_CURRENT),
                 getScaled(block.acCurrentPhaseA, block.acCurrentSF, AMPERE));
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_NEXT),
+        updateState(channelUID(GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_NEXT),
                 getScaled(block.acVoltageAB, block.acVoltageSF, VOLT));
-        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_N),
+        updateState(channelUID(GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_N),
                 getScaled(block.acVoltageAtoN, block.acVoltageSF, VOLT));
 
         // Split phase and three phase
         if ((thing.getThingTypeUID().equals(THING_TYPE_INVERTER_SPLIT_PHASE)
                 || thing.getThingTypeUID().equals(THING_TYPE_INVERTER_THREE_PHASE))
                 && block.phaseConfiguration >= INVERTER_SPLIT_PHASE) {
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_PHASE_CURRENT),
+            updateState(channelUID(GROUP_AC_PHASE_B, CHANNEL_AC_PHASE_CURRENT),
                     getScaled(block.acCurrentPhaseB, block.acCurrentSF, AMPERE));
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_NEXT),
+            updateState(channelUID(GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_NEXT),
                     getScaled(block.acVoltageBC, block.acVoltageSF, VOLT));
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_N),
+            updateState(channelUID(GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_N),
                     getScaled(block.acVoltageBtoN, block.acVoltageSF, VOLT));
         }
 
         // Three phase only
         if (thing.getThingTypeUID().equals(THING_TYPE_INVERTER_THREE_PHASE)
                 && block.phaseConfiguration >= INVERTER_THREE_PHASE) {
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_PHASE_CURRENT),
+            updateState(channelUID(GROUP_AC_PHASE_C, CHANNEL_AC_PHASE_CURRENT),
                     getScaled(block.acCurrentPhaseC, block.acCurrentSF, AMPERE));
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_NEXT),
+            updateState(channelUID(GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_NEXT),
                     getScaled(block.acVoltageCA, block.acVoltageSF, VOLT));
-            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_N),
+            updateState(channelUID(GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_N),
                     getScaled(block.acVoltageCtoN, block.acVoltageSF, VOLT));
         }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -113,7 +113,7 @@ public class InverterHandler extends AbstractSunSpecHandler {
                 getScaled(block.dcCurrent, block.dcCurrentSF, AMPERE));
         updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_VOLTAGE),
                 getScaled(block.dcVoltage, block.dcVoltageSF, VOLT));
-        updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_POWER), getScaled(block.dcPower, block.dcPowerSF, VOLT));
+        updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_POWER), getScaled(block.dcPower, block.dcPowerSF, WATT));
 
         // AC Phase specific groups
         // All types of inverters

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -122,9 +122,32 @@ public class InverterHandler extends AbstractSunSpecHandler {
         updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_PHASE_CURRENT),
                 getScaled(block.acCurrentPhaseA, block.acCurrentSF, AMPERE));
         updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_NEXT),
-                getScaled(block.acVoltageAB, Optional.of(block.acVoltageSF), VOLT));
+                getScaled(block.acVoltageAB, block.acVoltageSF, VOLT));
         updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_N),
                 getScaled(block.acVoltageAtoN, block.acVoltageSF, VOLT));
+
+        // Split phase and three phase
+        if ((thing.getThingTypeUID().equals(THING_TYPE_INVERTER_SPLIT_PHASE)
+                || thing.getThingTypeUID().equals(THING_TYPE_INVERTER_THREE_PHASE))
+                && block.phaseConfiguration >= INVERTER_SPLIT_PHASE) {
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_PHASE_CURRENT),
+                    getScaled(block.acCurrentPhaseB, block.acCurrentSF, AMPERE));
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_NEXT),
+                    getScaled(block.acVoltageBC, block.acVoltageSF, VOLT));
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_B, CHANNEL_AC_VOLTAGE_TO_N),
+                    getScaled(block.acVoltageBtoN, block.acVoltageSF, VOLT));
+        }
+
+        // Three phase only
+        if (thing.getThingTypeUID().equals(THING_TYPE_INVERTER_THREE_PHASE)
+                && block.phaseConfiguration >= INVERTER_THREE_PHASE) {
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_PHASE_CURRENT),
+                    getScaled(block.acCurrentPhaseC, block.acCurrentSF, AMPERE));
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_NEXT),
+                    getScaled(block.acVoltageCA, block.acVoltageSF, VOLT));
+            updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_C, CHANNEL_AC_VOLTAGE_TO_N),
+                    getScaled(block.acVoltageCtoN, block.acVoltageSF, VOLT));
+        }
 
         resetCommunicationError();
     }

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -102,18 +102,18 @@ public class InverterHandler extends AbstractSunSpecHandler {
                                                                                   // see:
                                                                                   // https://github.com/openhab/openhab-core/pull/1347
 
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
+                getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));
+
+        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
+                getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF, WATT_HOUR));
+
         // DC General group
         updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_CURRENT),
                 getScaled(block.dcCurrent, block.dcCurrentSF, AMPERE));
         updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_VOLTAGE),
                 getScaled(block.dcVoltage, block.dcVoltageSF, VOLT));
         updateState(channelUID(GROUP_DC_GENERAL, CHANNEL_DC_POWER), getScaled(block.dcPower, block.dcPowerSF, VOLT));
-
-        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
-                getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));
-
-        updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
-                getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF, WATT_HOUR));
 
         // AC Phase specific groups
         // All types of inverters

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -117,6 +117,15 @@ public class InverterHandler extends AbstractSunSpecHandler {
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_LIFETIME_ENERGY),
                 getScaled(block.acEnergyLifetime, block.acEnergyLifetimeSF, WATT_HOUR));
 
+        // AC Phase specific groups
+        // All types of inverters
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_PHASE_CURRENT),
+                getScaled(block.acCurrentPhaseA, block.acCurrentSF, AMPERE));
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_NEXT),
+                getScaled(block.acVoltageAB, Optional.of(block.acVoltageSF), VOLT));
+        updateState(new ChannelUID(getThing().getUID(), GROUP_AC_PHASE_A, CHANNEL_AC_VOLTAGE_TO_N),
+                getScaled(block.acVoltageAtoN, block.acVoltageSF, VOLT));
+
         resetCommunicationError();
     }
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/InverterHandler.java
@@ -103,6 +103,14 @@ public class InverterHandler extends AbstractSunSpecHandler {
                                                                                   // see:
                                                                                   // https://github.com/openhab/openhab-core/pull/1347
 
+        // DC General group
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_CURRENT),
+                getScaled(block.dcCurrent, block.dcCurrentSF, AMPERE));
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_VOLTAGE),
+                getScaled(block.dcVoltage, block.dcVoltageSF, VOLT));
+        updateState(new ChannelUID(getThing().getUID(), GROUP_DC_GENERAL, CHANNEL_DC_POWER),
+                getScaled(block.dcPower, block.dcPowerSF, VOLT));
+
         updateState(channelUID(GROUP_AC_GENERAL, CHANNEL_AC_POWER_FACTOR),
                 getScaled(block.acPowerFactor, block.acPowerFactorSF, PERCENT));
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -33,7 +33,13 @@ public class InverterModelParser extends AbstractBaseParser implements SunspecPa
         block.phaseConfiguration = extractUInt16(raw, 0, SunSpecConstants.INVERTER_SINGLE_PHASE);
         block.length = extractUInt16(raw, 1, raw.size());
         block.acCurrentTotal = extractUInt16(raw, 2, 0);
+        block.acCurrentPhaseA = extractUInt16(raw, 3, 0);
         block.acCurrentSF = extractSunSSF(raw, 6);
+
+        block.acVoltageAB = extractOptionalUInt16(raw, 7);
+        block.acVoltageAtoN = extractUInt16(raw, 10, 0);
+        block.acVoltageSF = extractSunSSF(raw, 13);
+
         block.acPower = extractInt16(raw, 14, (short) 0);
         block.acPowerSF = extractSunSSF(raw, 15);
         block.acFrequency = extractUInt16(raw, 16, 0);

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -34,10 +34,16 @@ public class InverterModelParser extends AbstractBaseParser implements SunspecPa
         block.length = extractUInt16(raw, 1, raw.size());
         block.acCurrentTotal = extractUInt16(raw, 2, 0);
         block.acCurrentPhaseA = extractUInt16(raw, 3, 0);
+        block.acCurrentPhaseB = extractOptionalUInt16(raw, 4);
+        block.acCurrentPhaseC = extractOptionalUInt16(raw, 5);
         block.acCurrentSF = extractSunSSF(raw, 6);
 
         block.acVoltageAB = extractOptionalUInt16(raw, 7);
+        block.acVoltageBC = extractOptionalUInt16(raw, 8);
+        block.acVoltageCA = extractOptionalUInt16(raw, 9);
         block.acVoltageAtoN = extractUInt16(raw, 10, 0);
+        block.acVoltageBtoN = extractOptionalUInt16(raw, 11);
+        block.acVoltageCtoN = extractOptionalUInt16(raw, 12);
         block.acVoltageSF = extractSunSSF(raw, 13);
 
         block.acPower = extractInt16(raw, 14, (short) 0);

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/InverterModelParser.java
@@ -46,6 +46,14 @@ public class InverterModelParser extends AbstractBaseParser implements SunspecPa
         block.acPowerFactorSF = extractOptionalSunSSF(raw, 23);
         block.acEnergyLifetime = extractAcc32(raw, 24, 0);
         block.acEnergyLifetimeSF = extractSunSSF(raw, 26);
+
+        block.dcCurrent = extractOptionalUInt16(raw, 27);
+        block.dcCurrentSF = extractOptionalSunSSF(raw, 28);
+        block.dcVoltage = extractOptionalUInt16(raw, 29);
+        block.dcVoltageSF = extractOptionalSunSSF(raw, 30);
+        block.dcPower = extractOptionalInt16(raw, 31);
+        block.dcPowerSF = extractOptionalSunSSF(raw, 32);
+
         block.temperatureCabinet = extractInt16(raw, 33, (short) 0);
         block.temperatureHeatsink = extractOptionalInt16(raw, 34);
         block.temperatureTransformer = extractOptionalInt16(raw, 35);

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -27,4 +27,13 @@
 		</channels>
 	</channel-group-type>
 
+	<channel-group-type id="dc-general">
+		<label>DS summary</label>
+		<channels>
+			<channel id="dc-current" typeId="dc-current-type" />
+			<channel id="dc-voltage" typeId="dc-voltage-type" />
+			<channel id="dc-power" typeId="dc-power-type" />
+		</channels>
+	</channel-group-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -37,7 +37,7 @@
 	</channel-group-type>
 
 	<channel-group-type id="dc-general">
-		<label>DS summary</label>
+		<label>DC summary</label>
 		<channels>
 			<channel id="dc-current" typeId="dc-current-type" />
 			<channel id="dc-voltage" typeId="dc-voltage-type" />

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-groups.xml
@@ -27,6 +27,15 @@
 		</channels>
 	</channel-group-type>
 
+	<channel-group-type id="ac-phase">
+		<label>AC Phase</label>
+		<channels>
+			<channel id="ac-phase-current" typeId="ac-phase-current-type" />
+			<channel id="ac-voltage-to-next" typeId="ac-voltage-to-next-type" />
+			<channel id="ac-voltage-to-n" typeId="ac-voltage-to-n-type" />
+		</channels>
+	</channel-group-type>
+
 	<channel-group-type id="dc-general">
 		<label>DS summary</label>
 		<channels>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -45,6 +45,26 @@
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 	
+	<channel-type id="dc-current-type">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>DC Current value</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="dc-voltage-type">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>DC Voltage value</label>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
+
+	<channel-type id="dc-power-type">
+		<item-type>Number:Power</item-type>
+		<label>DC Power value</label>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
+
+
+
 	<channel-type id="cabinet-temperature-type">
 		<item-type>Number:Temperature</item-type>
 		<label>Cabinet Temperature</label>
@@ -68,7 +88,6 @@
 		<label>Other Temperature</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
-
 
 	<channel-type id="status-type">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -8,6 +8,26 @@
 		<label>AC Total Current Value</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
+
+	<channel-type id="ac-phase-current-type">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>AC Phase Current value</label>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="ac-voltage-to-next-type">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>AC Voltage</label>
+		<description>This phase's AC voltage relative to the next phase</description>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
+
+	<channel-type id="ac-voltage-to-n-type">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>AC Voltage Phase to N value</label>
+		<description>This phase's AC voltage relative to N line</description>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
 	
 	<channel-type id="ac-power-type">
 		<item-type>Number:Power</item-type>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -11,7 +11,7 @@
 
 	<channel-type id="ac-phase-current-type">
 		<item-type>Number:ElectricCurrent</item-type>
-		<label>AC Phase Current value</label>
+		<label>AC Phase Current Value</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
@@ -24,7 +24,7 @@
 
 	<channel-type id="ac-voltage-to-n-type">
 		<item-type>Number:ElectricPotential</item-type>
-		<label>AC Voltage Phase to N value</label>
+		<label>AC Voltage Phase To N Value</label>
 		<description>This phase's AC voltage relative to N line</description>
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
@@ -67,19 +67,19 @@
 	
 	<channel-type id="dc-current-type">
 		<item-type>Number:ElectricCurrent</item-type>
-		<label>DC Current value</label>
+		<label>DC Current Value</label>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
 	<channel-type id="dc-voltage-type">
 		<item-type>Number:ElectricPotential</item-type>
-		<label>DC Voltage value</label>
+		<label>DC Voltage Value</label>
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 	<channel-type id="dc-power-type">
 		<item-type>Number:Power</item-type>
-		<label>DC Power value</label>
+		<label>DC Power Value</label>
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-channel-types.xml
@@ -83,8 +83,6 @@
 		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
-
-
 	<channel-type id="cabinet-temperature-type">
 		<item-type>Number:Temperature</item-type>
 		<label>Cabinet Temperature</label>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -18,7 +18,7 @@
 			<channel-group id="deviceInformation" typeId="device-information" />
 			<channel-group id="acGeneral" typeId="ac-general" />
 			<channel-group id="acPhaseA" typeId="ac-phase">
-				<label>AC Phase A</label>
+				<label>AC Detail</label>
 			</channel-group>
 			<channel-group id="dcGeneral" typeId="dc-general" />
 		</channel-groups>
@@ -51,10 +51,10 @@
 			<channel-group id="deviceInformation" typeId="device-information" />
 			<channel-group id="acGeneral" typeId="ac-general" />
 			<channel-group id="acPhaseA" typeId="ac-phase">
-				<label>AC Phase A</label>
+				<label>AC Phase A (L1)</label>
 			</channel-group>
 			<channel-group id="acPhaseB" typeId="ac-phase">
-				<label>AC Phase B</label>
+				<label>AC Phase B (L2)</label>
 			</channel-group>
 			<channel-group id="dcGeneral" typeId="dc-general" />
 		</channel-groups>
@@ -87,13 +87,13 @@
 			<channel-group id="deviceInformation" typeId="device-information" />
 			<channel-group id="acGeneral" typeId="ac-general" />
 			<channel-group id="acPhaseA" typeId="ac-phase">
-				<label>AC Phase A</label>
+				<label>AC Phase A (L1)</label>
 			</channel-group>
 			<channel-group id="acPhaseB" typeId="ac-phase">
-				<label>AC Phase B</label>
+				<label>AC Phase B (L2)</label>
 			</channel-group>
 			<channel-group id="acPhaseC" typeId="ac-phase">
-				<label>AC Phase C</label>
+				<label>AC Phase C (L3)</label>
 			</channel-group>
 			<channel-group id="dcGeneral" typeId="dc-general" />
 		</channel-groups>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -37,4 +37,79 @@
 
 	</thing-type>
 
+	<thing-type id="inverter-split-phase">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp" />
+			<bridge-type-ref id="serial" />
+		</supported-bridge-type-refs>
+
+		<label>Split Phase Inverter</label>
+		<description>Split phase (Japanese grid and 240V grid in North America) inverter supporting SunSpec mapping over tcp modbus connection</description>
+		<category>Inverter</category>
+
+		<channel-groups>
+			<channel-group id="deviceInformation" typeId="device-information" />
+			<channel-group id="acGeneral" typeId="ac-general" />
+			<channel-group id="acPhaseA" typeId="ac-phase">
+				<label>AC Phase A</label>
+			</channel-group>
+			<channel-group id="acPhaseB" typeId="ac-phase">
+				<label>AC Phase B</label>
+			</channel-group>
+			<channel-group id="dcGeneral" typeId="dc-general" />
+		</channel-groups>
+
+		<properties>
+			<property name="vendor" />
+			<property name="model" />
+			<property name="version" />
+			<property name="serialNumber" />
+			<property name="uniqueAddress" />
+		</properties>
+
+		<representation-property>uniqueAddress</representation-property>
+
+		<config-description-ref uri="thing-type:sunspec:modbusconfig" />
+
+	</thing-type>
+
+	<thing-type id="inverter-three-phase">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="tcp" />
+			<bridge-type-ref id="serial" />
+		</supported-bridge-type-refs>
+
+		<label>Three Phase Inverter</label>
+		<description>Three phase inverter supporting SunSpec mapping over tcp modbus connection</description>
+		<category>Inverter</category>
+
+		<channel-groups>
+			<channel-group id="deviceInformation" typeId="device-information" />
+			<channel-group id="acGeneral" typeId="ac-general" />
+			<channel-group id="acPhaseA" typeId="ac-phase">
+				<label>AC Phase A</label>
+			</channel-group>
+			<channel-group id="acPhaseB" typeId="ac-phase">
+				<label>AC Phase B</label>
+			</channel-group>
+			<channel-group id="acPhaseC" typeId="ac-phase">
+				<label>AC Phase C</label>
+			</channel-group>
+			<channel-group id="dcGeneral" typeId="dc-general" />
+		</channel-groups>
+
+		<properties>
+			<property name="vendor" />
+			<property name="model" />
+			<property name="version" />
+			<property name="serialNumber" />
+			<property name="uniqueAddress" />
+		</properties>
+
+		<representation-property>uniqueAddress</representation-property>
+
+		<config-description-ref uri="thing-type:sunspec:modbusconfig" />
+
+	</thing-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -17,6 +17,9 @@
 		<channel-groups>
 			<channel-group id="deviceInformation" typeId="device-information" />
 			<channel-group id="acGeneral" typeId="ac-general" />
+			<channel-group id="acPhaseA" typeId="ac-phase">
+				<label>AC Phase A</label>
+			</channel-group>
 			<channel-group id="dcGeneral" typeId="dc-general" />
 		</channel-groups>
 

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/ESH-INF/thing/inverter-types.xml
@@ -17,6 +17,7 @@
 		<channel-groups>
 			<channel-group id="deviceInformation" typeId="device-information" />
 			<channel-group id="acGeneral" typeId="ac-general" />
+			<channel-group id="dcGeneral" typeId="dc-general" />
 		</channel-groups>
 
 		<properties>


### PR DESCRIPTION
This pull request is the follow up of PR #6331, this is the complete support for single phase inverters as well support for two and three phase inverters. This is the 3rd of the 4 PR I've split my original PR into.

While it seems to be large at first, it does not change any of the main logic, just extends the parser and handler with the remaining fields of the incoming data. Also adds support for two and three phase inverters, but they are technically the same as the single phase inverter, only that have more channels than the single phase ones.

