### PR TITLE
[samsungtv] Update README.md with supported model UE46F6510SS

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -22,6 +22,7 @@ Tested TV models:
 | LE40C650    | PARTIAL | Supported channels: `volume`, `mute`, `channel`, `keyCode`, `brightness`, `contrast`, `colorTemperature`, `power` (only power off, unable to power on) |
 | UE55LS003   | PARTIAL | Supported channels: `volume`, `mute`, `sourceApp`, `url`, `keyCode`, `power`, `artMode`                                                                |
 | UE43MU6199  | PARTIAL | Supported channels: `volume`, `mute`, `power` (at least)                                                                |
+| UE46F6510SS  | PARTIAL | Supported channels: `volume`, `mute`, `channel` (at least)                                                                |
 
 ## Discovery
 


### PR DESCRIPTION
Improvement 
Tested with device that was not listed as supported model:
Model: UE46F6510SS
Type No.: UE46F6510
Added supported channels: Mute, Volume and Channel. Others did not work.
