### PR TITLE
[mail] Fix protocol selection for SSL in POP3IMAPHandler

### DIFF
--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/POP3IMAPHandler.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/POP3IMAPHandler.java
@@ -71,7 +71,7 @@ public class POP3IMAPHandler extends BaseThingHandler {
         protocol = baseProtocol;
 
         if (config.security == ServerSecurity.SSL) {
-            protocol.concat("s");
+            protocol = protocol.concat("s");
         }
 
         if (config.port == 0) {


### PR DESCRIPTION
See https://community.openhab.org/t/problem-refreshing-imap-pop3/95637

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
