### PR TITLE
[innogysmarthome] Fix isr2stop

### DIFF
--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
@@ -301,6 +301,7 @@ public class InnogyClient {
      * @param rollerShutterLevel
      * @throws IOException
      * @throws ApiException
+     * @throws AuthenticationException
      */
     public void setRollerShutterActuatorState(final String capabilityId, final int rollerShutterLevel)
             throws IOException, ApiException, AuthenticationException {
@@ -308,12 +309,20 @@ public class InnogyClient {
                 new StateActionSetter(capabilityId, Capability.TYPE_ROLLERSHUTTERACTUATOR, rollerShutterLevel));
     }
 
+    /**
+     * Starts or stops moving a RollerShutterActuator
+     *
+     * @param capabilityId
+     * @param rollerShutterAction
+     * @throws IOException
+     * @throws ApiException
+     * @throws AuthenticationException
+     */
     public void setRollerShutterAction(final String capabilityId, final ShutterAction.ShutterActions rollerShutterAction)
             throws IOException, ApiException, AuthenticationException {
         executePost(API_URL_ACTION,
                 new ShutterAction(capabilityId, rollerShutterAction));
     }
-
 
     /**
      * Sets a new state of a VariableActuator.

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
@@ -41,6 +41,7 @@ import org.eclipse.smarthome.core.auth.client.oauth2.OAuthException;
 import org.eclipse.smarthome.core.auth.client.oauth2.OAuthResponseException;
 import org.openhab.binding.innogysmarthome.internal.client.entity.StatusResponse;
 import org.openhab.binding.innogysmarthome.internal.client.entity.action.Action;
+import org.openhab.binding.innogysmarthome.internal.client.entity.action.ShutterAction;
 import org.openhab.binding.innogysmarthome.internal.client.entity.action.StateActionSetter;
 import org.openhab.binding.innogysmarthome.internal.client.entity.capability.Capability;
 import org.openhab.binding.innogysmarthome.internal.client.entity.capability.CapabilityState;
@@ -306,6 +307,13 @@ public class InnogyClient {
         executePost(API_URL_ACTION,
                 new StateActionSetter(capabilityId, Capability.TYPE_ROLLERSHUTTERACTUATOR, rollerShutterLevel));
     }
+
+    public void setRollerShutterAction(final String capabilityId, final ShutterAction.ShutterActions rollerShutterAction)
+            throws IOException, ApiException, AuthenticationException {
+        executePost(API_URL_ACTION,
+                new ShutterAction(capabilityId, rollerShutterAction));
+    }
+
 
     /**
      * Sets a new state of a VariableActuator.

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ActionParams.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ActionParams.java
@@ -32,6 +32,8 @@ public class ActionParams {
 
     private StringActionParam operationMode;
 
+    private StringActionParam rampDirection;
+
     /**
      * @return the onState
      */
@@ -116,4 +118,17 @@ public class ActionParams {
         this.operationMode = operationMode;
     }
 
+    /**
+     * @return the rampDirection
+     */
+    public StringActionParam getRampDirection() {
+        return rampDirection;
+    }
+
+    /**
+     * @param rampDirection the rampDirection to set
+     */
+    public void setRampDirection(StringActionParam rampDirection) {
+        this.rampDirection = rampDirection;
+    }
 }

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
@@ -1,5 +1,10 @@
 package org.openhab.binding.innogysmarthome.internal.client.entity.action;
 
+/**
+ * Special {@link Action} needed to control shutters.
+ *
+ * @author Marco Mans
+ */
 public class ShutterAction extends Action {
 
     public enum ShutterActions {
@@ -15,16 +20,13 @@ public class ShutterAction extends Action {
     private static final String CONSTANT = "Constant";
     private final String NAMESPACE_COSIP = "CosipDevices.RWE";
 
-    /*
-        RAMP DOWN
-        {"id":"276cec8746a24fca816795fc914d7d90",
-         "type":"StartRamp",
-         "target":"/capability/2bce36dbaeb541c58dc691f2bc9d2ca2",
-         "namespace":"CosipDevices.RWE",
-         "params":{"rampDirection":{"type":"Constant","value":"RampDown"}}}
+
+    /**
+     * Describes a Shutteraction
+     *
+     * @param capabilityId String of the 32 character capability id
+     * @param action Which action to perform (UP, DOWN, STOP)
      */
-
-
     public ShutterAction(String capabilityId, ShutterActions action) {
         setTargetCapabilityById(capabilityId);
         setNamespace(NAMESPACE_COSIP);

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.innogysmarthome.internal.client.entity.action;
 
 /**

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
@@ -25,12 +25,12 @@ public class ShutterAction extends Action {
         STOP
     }
 
-    private final String TYPE_STOP_RAMP = "StopRamp";
-    private final String TYPE_START_RAMP = "StartRamp";
-    private final String DIRECTION_RAMP_UP = "RampUp";
-    private final String DIRECTION_RAMP_DOWN = "RampDown";
+    private static final String TYPE_STOP_RAMP = "StopRamp";
+    private static final String TYPE_START_RAMP = "StartRamp";
+    private static final String DIRECTION_RAMP_UP = "RampUp";
+    private static final String DIRECTION_RAMP_DOWN = "RampDown";
     private static final String CONSTANT = "Constant";
-    private final String NAMESPACE_COSIP = "CosipDevices.RWE";
+    private static final String NAMESPACE_COSIP = "CosipDevices.RWE";
 
 
     /**

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/action/ShutterAction.java
@@ -1,0 +1,44 @@
+package org.openhab.binding.innogysmarthome.internal.client.entity.action;
+
+public class ShutterAction extends Action {
+
+    public enum ShutterActions {
+        UP,
+        DOWN,
+        STOP
+    }
+
+    private final String TYPE_STOP_RAMP = "StopRamp";
+    private final String TYPE_START_RAMP = "StartRamp";
+    private final String DIRECTION_RAMP_UP = "RampUp";
+    private final String DIRECTION_RAMP_DOWN = "RampDown";
+    private static final String CONSTANT = "Constant";
+    private final String NAMESPACE_COSIP = "CosipDevices.RWE";
+
+    /*
+        RAMP DOWN
+        {"id":"276cec8746a24fca816795fc914d7d90",
+         "type":"StartRamp",
+         "target":"/capability/2bce36dbaeb541c58dc691f2bc9d2ca2",
+         "namespace":"CosipDevices.RWE",
+         "params":{"rampDirection":{"type":"Constant","value":"RampDown"}}}
+     */
+
+
+    public ShutterAction(String capabilityId, ShutterActions action) {
+        setTargetCapabilityById(capabilityId);
+        setNamespace(NAMESPACE_COSIP);
+        final ActionParams params = new ActionParams();
+
+        if (ShutterActions.STOP.equals(action)) {
+            setType(TYPE_STOP_RAMP);
+        } else if (ShutterActions.UP.equals(action)) {
+            setType(TYPE_START_RAMP);
+            params.setRampDirection(new StringActionParam(CONSTANT, DIRECTION_RAMP_UP));
+        } else if (ShutterActions.DOWN.equals(action)) {
+            setType(TYPE_START_RAMP);
+            params.setRampDirection(new StringActionParam(CONSTANT, DIRECTION_RAMP_DOWN));
+        }
+        setParams(params);
+    }
+}

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- *
+ * <p>
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.innogysmarthome.internal.handler;
@@ -54,6 +54,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerService;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.innogysmarthome.internal.InnogyWebSocket;
 import org.openhab.binding.innogysmarthome.internal.client.InnogyClient;
+import org.openhab.binding.innogysmarthome.internal.client.entity.action.ShutterAction;
 import org.openhab.binding.innogysmarthome.internal.client.entity.capability.Capability;
 import org.openhab.binding.innogysmarthome.internal.client.entity.device.Device;
 import org.openhab.binding.innogysmarthome.internal.client.entity.device.DeviceConfig;
@@ -110,7 +111,8 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
     private @Nullable DeviceStructureManager deviceStructMan;
     private @Nullable String bridgeId;
     private @Nullable ScheduledFuture<?> reinitJob;
-    private @NonNullByDefault({}) InnogyBridgeConfiguration bridgeConfiguration;
+    private @NonNullByDefault({})
+    InnogyBridgeConfiguration bridgeConfiguration;
     private @Nullable OAuthClientService oAuthService;
 
     /**
@@ -330,7 +332,7 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
     }
 
     private void setPropertyIfPresent(final String key, final @Nullable Object data,
-            final Map<String, String> properties) {
+                                      final Map<String, String> properties) {
         if (data != null) {
             properties.put(key, data instanceof String ? (String) data : data.toString());
         }
@@ -857,6 +859,23 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
                 return;
             }
             client.setRollerShutterActuatorState(capabilityId, rollerSchutterLevel);
+        } catch (IOException | ApiException | AuthenticationException e) {
+            handleClientException(e);
+        }
+    }
+
+    public void commandSetRollerShutterStop(final String deviceId, ShutterAction.ShutterActions action) {
+        final DeviceStructureManager deviceStructMan = this.deviceStructMan;
+        if (deviceStructMan == null) {
+            return;
+        }
+        try {
+            final String capabilityId = deviceStructMan.getCapabilityId(deviceId,
+                    Capability.TYPE_ROLLERSHUTTERACTUATOR);
+            if (capabilityId == null) {
+                return;
+            }
+            client.setRollerShutterAction(capabilityId, action);
         } catch (IOException | ApiException | AuthenticationException e) {
             handleClientException(e);
         }

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -7,7 +7,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.innogysmarthome.internal.handler;

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -111,8 +111,7 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
     private @Nullable DeviceStructureManager deviceStructMan;
     private @Nullable String bridgeId;
     private @Nullable ScheduledFuture<?> reinitJob;
-    private @NonNullByDefault({})
-    InnogyBridgeConfiguration bridgeConfiguration;
+    private @NonNullByDefault({}) InnogyBridgeConfiguration bridgeConfiguration;
     private @Nullable OAuthClientService oAuthService;
 
     /**

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- * <p>
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * <p>
+ * 
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.innogysmarthome.internal.handler;

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -864,6 +864,11 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
         }
     }
 
+    /**
+     * Sends the command to start or stop moving the rollershutter (ISR2) in a specified direction
+     * @param deviceId
+     * @param action
+     */
     public void commandSetRollerShutterStop(final String deviceId, ShutterAction.ShutterActions action) {
         final DeviceStructureManager deviceStructMan = this.deviceStructMan;
         if (deviceStructMan == null) {

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyDeviceHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyDeviceHandler.java
@@ -23,12 +23,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.PercentType;
-import org.eclipse.smarthome.core.library.types.StringType;
-import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.library.types.*;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -42,6 +37,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.innogysmarthome.internal.client.entity.action.ShutterAction;
 import org.openhab.binding.innogysmarthome.internal.client.entity.capability.Capability;
 import org.openhab.binding.innogysmarthome.internal.client.entity.capability.CapabilityState;
 import org.openhab.binding.innogysmarthome.internal.client.entity.device.Device;
@@ -144,19 +140,19 @@ public class InnogyDeviceHandler extends BaseThingHandler implements DeviceStatu
                         invertValueIfConfigured(CHANNEL_ROLLERSHUTTER, rollerShutterLevel.intValue()));
             } else if (command instanceof OnOffType) {
                 if (OnOffType.ON.equals(command)) {
-                    innogyBridgeHandler.commandSetRollerShutterLevel(deviceId,
-                            invertValueIfConfigured(CHANNEL_ROLLERSHUTTER, 100));
+                    innogyBridgeHandler.commandSetRollerShutterStop(deviceId, ShutterAction.ShutterActions.DOWN);
                 } else {
-                    innogyBridgeHandler.commandSetRollerShutterLevel(deviceId,
-                            invertValueIfConfigured(CHANNEL_ROLLERSHUTTER, 0));
+                    innogyBridgeHandler.commandSetRollerShutterStop(deviceId, ShutterAction.ShutterActions.UP);
                 }
             } else if (command instanceof UpDownType) {
                 if (UpDownType.DOWN.equals(command)) {
-                    innogyBridgeHandler.commandSetRollerShutterLevel(deviceId,
-                            invertValueIfConfigured(CHANNEL_ROLLERSHUTTER, 100));
+                    innogyBridgeHandler.commandSetRollerShutterStop(deviceId, ShutterAction.ShutterActions.DOWN);
                 } else {
-                    innogyBridgeHandler.commandSetRollerShutterLevel(deviceId,
-                            invertValueIfConfigured(CHANNEL_ROLLERSHUTTER, 0));
+                    innogyBridgeHandler.commandSetRollerShutterStop(deviceId, ShutterAction.ShutterActions.UP);
+                }
+            } else if (command instanceof StopMoveType){
+                if (StopMoveType.STOP.equals(command)){
+                    innogyBridgeHandler.commandSetRollerShutterStop(deviceId, ShutterAction.ShutterActions.STOP);
                 }
             }
 


### PR DESCRIPTION
[innogysmarthome] Optimizes the control of Shutters (ISR2) by using the correct api-calls. Adding the possibility to use the "STOP" command when the shutters are moving.

In the current release the binding uses the "SetState" command to move the shutters (When user clicks on arrow buttons of the default sitemap-widget). So in fact it sets the position variable to 0% or 100%. The stop button was not working. In this PR I use the same API-call as Innogy uses in their app to start moving the shutters (RampStart). I also added support for the STOP-button by using the "RampStop" API-call. This was a missing feature. 