### PR TITLE
[lutron] Ignore Connect Bridge mDNS discovery

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMdnsBridgeDiscoveryService.java
@@ -56,6 +56,7 @@ public class LutronMdnsBridgeDiscoveryService implements MDNSDiscoveryParticipan
     private static final String PRODFAM_RA2_SELECT = "RA2 Select";
     private static final String PRODTYP_RA2_SELECT = "Main Repeater";
     private static final String DEVCLASS_RA2_SELECT = "080E0401";
+    private static final String DEVCLASS_CONNECT_BRIDGE = "08090301";
     private static final String DEFAULT_LABEL = "Unknown Lutron bridge";
 
     private static final Pattern HOSTNAME_REGEX = Pattern.compile("lutron-([0-9a-f]+)\\."); // ex: lutron-01f1529a.local
@@ -107,14 +108,17 @@ public class LutronMdnsBridgeDiscoveryService implements MDNSDiscoveryParticipan
         String bridgeHostName = ipAddresses[0].getHostName();
         logger.debug("Lutron mDNS bridge hostname: {}", bridgeHostName);
 
-        if (devclass != null && devclass.equals(DEVCLASS_CASETA_SBP2)) {
+        if (DEVCLASS_CASETA_SBP2.equals(devclass)) {
             properties.put(PROPERTY_PRODFAM, PRODFAM_CASETA);
             properties.put(PROPERTY_PRODTYP, PRODTYP_CASETA_SBP2);
             label = PRODFAM_CASETA + " " + PRODTYP_CASETA_SBP2;
-        } else if (devclass != null && devclass.equals(DEVCLASS_RA2_SELECT)) {
+        } else if (DEVCLASS_RA2_SELECT.equals(devclass)) {
             properties.put(PROPERTY_PRODFAM, PRODFAM_RA2_SELECT);
             properties.put(PROPERTY_PRODTYP, PRODTYP_RA2_SELECT);
             label = PRODFAM_RA2_SELECT + " " + PRODTYP_RA2_SELECT;
+        } else if (DEVCLASS_CONNECT_BRIDGE.equals(devclass)) {
+            logger.debug("Lutron Connect Bridge discovered. Ignoring.");
+            return null;
         } else {
             logger.info("Lutron device with unknown DEVCLASS discovered via mDNS: {}. Configure device manually.",
                     devclass);


### PR DESCRIPTION
A small update to ignore mDNS discovery result from Lutron Connect Bridge devices, as they are not currently supported by the binding.
