### PR TITLE
[hive] Hive Home Binding initial contribution (alternative implementation)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,6 +72,7 @@
 /bundles/org.openhab.binding.hdpowerview/ @beowulfe
 /bundles/org.openhab.binding.helios/ @kgoderis
 /bundles/org.openhab.binding.heos/ @Wire82
+/bundles/org.openhab.binding.hive/ @rbrownwsws
 /bundles/org.openhab.binding.homematic/ @FStolte @gerrieg @mdicke2s
 /bundles/org.openhab.binding.hpprinter/ @cossey
 /bundles/org.openhab.binding.hue/ @cweitkamp

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -356,6 +356,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.hive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.homematic</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.hive/.classpath
+++ b/bundles/org.openhab.binding.hive/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.hive/.project
+++ b/bundles/org.openhab.binding.hive/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.hive</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.hive/NOTICE
+++ b/bundles/org.openhab.binding.hive/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.hive/README.md
+++ b/bundles/org.openhab.binding.hive/README.md
@@ -1,0 +1,251 @@
+# Hive Binding
+
+This binding integrates the [Hive smart home system](https://www.hivehome.com) using the Hive REST API.
+
+_N.B. As this binding uses the Hive REST API it can only integrate Hive branded devices connected to a Hive Hub.
+Setups that do not include a Hive Hub or connect to a different brand of Zigbee hub/bridge will not work with this binding._
+
+## Supported Things
+
+| Thing                         | Supported | Tested |
+|-------------------------------|-----------|--------|
+| Hive Thermostat Gen 1 (white) | ✓         | ✗      |
+| Hive Thermostat Gen 2 (black) | ✓         | ✓      |
+| Hive Radiator Valve           | ✓         | ✓      |
+| Hive Boiler Module            | ✓         | ✓      |
+
+_N.B. At the moment I have not kept track of the firmware / hardware revision of devices.  Hopefully the Hive API abstracts away from this so it should not be a problem._
+
+## Discovery
+
+After manually adding a "Hive Account" thing all the things associated with that account will be auto-discovered
+and appear in the UI Inbox.
+
+
+## Thing Configuration
+
+### Hive Account
+
+| Parameter       | Required | Description                                                                             |
+|-----------------|----------|-----------------------------------------------------------------------------------------|
+| username        | YES      | Hive account username (same as in mobile app)                                           |
+| password        | YES      | Hive account password (same as in mobile app)                                           |
+| pollingInterval | YES      | The time in seconds to wait between each poll of the Hive API for updates (default: 10) |
+
+### Other Things
+
+It is recommended that you use auto-discovery and the UI to add things other than `Hive Account`s.
+You should not have to modify these parameters if you use auto-discovery.
+
+`bridge` - The `Hive Account` to use to communicate with this thing.
+
+| Parameter | Required | Description                                                 |
+|-----------|----------|-------------------------------------------------------------|
+| nodeId    | YES      | The Hive API `nodeId` that identifies the thing.            |
+
+_N.B. You can only get the nodeId of things by querying the Hive API.  This is why use of auto-discovery is recommended._
+
+## Channels
+
+### Hive Account
+
+#### Advanced channels
+
+| Channel                    | Type                     | Read/Write   | Description                  |
+|----------------------------|--------------------------|--------------|------------------------------|
+| last_poll_timestamp        | DateTime                 | Read Only    | The last time this Hive Account thing polled the Hive API. (Mainly for debugging) |
+| dump_nodes                 | Switch                   | Read/Write   | Turning this on triggers dumping the nodes reported by the Hive API for this account to a file in the "userdata" directory. (For debugging) |
+
+
+### Hive Boiler Module
+
+#### Advanced Channels
+
+| Channel                  | Type               | Read/Write   | Description                                                                    |
+|--------------------------|--------------------|--------------|--------------------------------------------------------------------------------|
+| radio-lqi-average        | Number             | Read Only    | The average zigbee radio **L**ink **Q**uality **I**ndicator                    |
+| radio-lqi-last_known     | Number             | Read Only    | The last known zigbee radio **L**ink **Q**uality **I**ndicator                 |
+| radio-rssi-average       | Number             | Read Only    | The average zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator    |
+| radio-rssi-last_known    | Number             | Read Only    | The last known zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator |
+
+
+### Hive Heating Zone
+
+#### Basic channels
+
+| Channel                       | Type               | Read/Write   | Description                  |
+|-------------------------------|--------------------|--------------|------------------------------|
+| temperature-current           | Number:Temperature | Read Only    | The current temperature of the zone.  Only in Celsius for now. |
+| temperature-target            | Number:Temperature | Read/Write   | The temperature you want the zone to be heated to.  Only in Celsius for now. |
+| easy-mode-operating           | String             | Read/Write   | The operating mode of heating in this zone as in app (Manual / Schedule/ Off). |
+| easy-mode-boost               | Switch             | Read/Write   | Is the transient override (boost) active for this zone. (Handles API trickiness for you). |
+| easy-state-is_on              | Switch             | Read Only    | Is the heating currently active in this zone? |
+| temperature-target-boost      | Number:Temperature | Read/Write   | The temperature you want the zone to be heated to when the transient override (boost) is active.  Only in Celsius for now. |
+| transient-duration            | Number             | Read/Write   | How long in minutes the transient override (boost) should be active for once started. |
+| transient-remaining           | Number             | Read Only    | If `transient-end_time` is in the future and the transient override (boost) is active: the time between now and `transient-end_time` in minutes, otherwise 0. |
+| auto_boost-temperature-target | Number:Temperature | Read/Write   | The max temperature you want the zone to be heated to when auto boost (heating-on-demand) is active.  Only in Celsius for now. |
+
+#### Advanced Channels
+
+| Channel                  | Type               | Read/Write   | Description                  |
+|--------------------------|--------------------|--------------|------------------------------|
+| mode-operating           | String             | Read/Write   | The operating mode of heating in the zone (Schedule vs. Manual). |
+| mode-on_off              | Switch             | Read/Write   | Is heating for this zone turned on or off. |
+| state-operating          | String             | Read Only    | Is heating for this zone active? (OFF/HEAT). |
+| mode-operating-override  | Switch             | Read/Write   | Is the transient override (boost) active for this zone. |
+| transient-enabled        | Switch             | Read/Write   | Is the transient override (boost) enabled for this zone. |
+| transient-start_time     | DateTime           | Read Only    | The last time the transient override (boost) was started. |
+| transient-end_time       | DateTime           | Read Only    | The last time the transient override (boost) was scheduled to end (even if it was cancelled). |
+| auto_boost-duration      | Number             | Read/Write   | How long in minutes the auto boost (heating-on-demand boost) should be active for once started. |
+
+### Hive Hot Water
+
+#### Basic Channels
+
+| Channel                  | Type               | Read/Write   | Description                  |
+|--------------------------|--------------------|--------------|------------------------------|
+| easy-mode-operating      | String             | Read/Write   | The operating mode of hot water as in app (On / Schedule/ Off). |
+| easy-mode-boost          | Switch             | Read/Write   | Is the transient override (boost) active for this zone. (Handles API trickiness for you). |
+| easy-state-is_on         | Switch             | Read Only    | Is the hot water currently being heated. |
+| transient-duration       | Number             | Read/Write   | How long in minutes the transient override (boost) should be active for once started. |
+| transient-remaining      | Number             | Read Only    | If `transient-end_time` is in the future and the transient override (boost) is active: the time between now and `transient-end_time` in minutes, otherwise 0. |
+
+
+#### Advanced Channels
+
+| Channel                  | Type               | Read/Write   | Description                  |
+|--------------------------|--------------------|--------------|------------------------------|
+| mode-operating           | String             | Read/Write   | The operating mode of the hot water (Schedule vs. On). |
+| mode-on_off              | Switch             | Read/Write   | Is the hot water turned on or off. |
+| transient-enabled        | Switch             | Read/Write   | Is the transient override (boost) enabled for this zone. |
+| transient-start_time     | DateTime           | Read Only    | The last time the transient override (boost) was started. |
+| transient-end_time       | DateTime           | Read Only    | The last time the transient override (boost) was scheduled to end (even if it was cancelled). |
+
+
+### Hive Hub
+
+No channels exposed in current version of binding.
+
+### Hive Thermostat
+
+#### Basic channels
+
+| Channel                    | Type                     | Read/Write   | Description                  |
+|----------------------------|--------------------------|--------------|------------------------------|
+| battery-level              | Number                   | Read Only    | The percentage of charge the device's battery has left. _N.B. This seems to be a very coarse measurement so don't expect to see it change very often._ |
+| battery-low                | Switch                   | Read Only    | Turns "On" when the battery is low. |
+
+#### Advanced channels
+
+| Channel                    | Type                     | Read/Write   | Description                  |
+|----------------------------|--------------------------|--------------|------------------------------|
+| battery-state              | String                   | Read Only    | The battery state (FULL/NORMAL/LOW) |
+| battery-voltage            | Number:ElectricPotential | Read Only    | The battery voltage. |
+| battery-notification_state | String                   | Read Only    | Indicates whether a "low battery" notification has been sent to the Hive app. |
+| radio-lqi-average          | Number                   | Read Only    | The average zigbee radio **L**ink **Q**uality **I**ndicator                    |
+| radio-lqi-last_known       | Number                   | Read Only    | The last known zigbee radio **L**ink **Q**uality **I**ndicator                 |
+| radio-rssi-average         | Number                   | Read Only    | The average zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator    |
+| radio-rssi-last_known      | Number                   | Read Only    | The last known zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator |
+
+### Hive Radiator Valve
+
+#### Basic channels
+
+| Channel                    | Type                     | Read/Write   | Description                  |
+|----------------------------|--------------------------|--------------|------------------------------|
+| temperature-current        | Number:Temperature       | Read Only    | The current temperature of the zone.  Only in Celsius for now. |
+| battery-level              | Number                   | Read Only    | The percentage of charge the device's battery has left. _N.B. This seems to be a very coarse measurement so don't expect to see it change very often._ |
+| battery-low                | Switch                   | Read Only    | Turns "On" when the battery is low. |
+
+#### Advanced channels
+
+| Channel                    | Type                     | Read/Write   | Description                  |
+|----------------------------|--------------------------|--------------|------------------------------|
+| battery-state              | String                   | Read Only    | The battery state (FULL/NORMAL/LOW) |
+| battery-voltage            | Number:ElectricPotential | Read Only    | The battery voltage. |
+| battery-notification_state | String                   | Read Only    | Indicates whether a "low battery" notification has been sent to the Hive app. |
+| radio-lqi-average          | Number                   | Read Only    | The average zigbee radio **L**ink **Q**uality **I**ndicator                    |
+| radio-lqi-last_known       | Number                   | Read Only    | The last known zigbee radio **L**ink **Q**uality **I**ndicator                 |
+| radio-rssi-average         | Number                   | Read Only    | The average zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator    |
+| radio-rssi-last_known      | Number                   | Read Only    | The last known zigbee radio **R**eceived **S**ignal **S**trength **I**ndicator |
+
+
+### Hive Radiator Valve Heating Zone
+
+#### Basic channels
+
+| Channel                  | Type               | Read/Write   | Description                  |
+|--------------------------|--------------------|--------------|------------------------------|
+| temperature-current      | Number:Temperature | Read Only    | The current temperature of the zone.  Only in Celsius for now. |
+| temperature-target       | Number:Temperature | Read/Write   | The temperature you want the zone to be heated to.  Only in Celsius for now. |
+| easy-mode-operating      | String             | Read/Write   | The operating mode of heating in this zone as in app (Manual / Schedule/ Off). |
+| easy-mode-boost          | Switch             | Read/Write   | Is the transient override (boost) active for this zone. (Handles API trickiness for you). |
+| easy-state-is_on         | Switch             | Read Only    | Is the heating currently active in this zone? |
+| temperature-target-boost | Number:Temperature | Read/Write   | The temperature you want the zone to be heated to when the transient override (boost) is active.  Only in Celsius for now. |
+| transient-duration       | Number             | Read/Write   | How long in minutes the transient override (boost) should be active for once started. |
+| transient-remaining      | Number             | Read Only    | If `transient-end_time` is in the future and the transient override (boost) is active: the time between now and `transient-end_time` in minutes, otherwise 0. |
+
+#### Advanced Channels
+
+| Channel                  | Type               | Read/Write   | Description                  |
+|--------------------------|--------------------|--------------|------------------------------|
+| mode-operating           | String             | Read/Write   | The operating mode of heating in the zone (Schedule vs. Manual). |
+| mode-on_off              | Switch             | Read/Write   | Is heating for this zone turned on or off. |
+| state-operating          | String             | Read Only    | Is heating for this zone active? (OFF/HEAT). |
+| mode-operating-override  | Switch             | Read/Write   | Is the transient override (boost) active for this zone. |
+| transient-enabled        | Switch             | Read/Write   | Is the transient override (boost) enabled for this zone. |
+| transient-start_time     | DateTime           | Read Only    | The last time the transient override (boost) was started. |
+| transient-end_time       | DateTime           | Read Only    | The last time the transient override (boost) was scheduled to end (even if it was cancelled). |
+
+
+## Full Example
+
+### Things
+
+Add using the UI and auto-discovery as explained above.
+
+### example.items
+
+```
+// Thermostat / TRV Heating Zone
+Number:Temperature LivingRoom_HeatingZone_Temperature            "Current Temperature"          <temperature> {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:temperature-current"}
+Number:Temperature LivingRoom_HeatingZone_TargetTemperature      "Target Temperature"           <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:temperature-target"}
+Switch             LivingRoom_HeatingZone_IsActive               "Heating On"                   <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-state-is_on"}
+String             LivingRoom_HeatingZone_Mode                   "Heating Mode"                 <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-mode-operating"}
+Switch             LivingRoom_HeatingZone_BoostActive            "Boost Active"                 <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-mode-boost"}
+Number             LivingRoom_HeatingZone_BoostDuration          "Boost Duration [%d minutes]"  <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:transient-duration"}
+Number             LivingRoom_HeatingZone_BoostRemaining         "Boost Remaining [%d minutes]" <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:transient-remaining"}
+Number:Temperature LivingRoom_HeatingZone_BoostTargetTemperature "Boost Target Temperature"     <heating>     {channel="hive:heating:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:temperature-target-boost"}
+
+// Hot Water
+Switch            HotWater_IsActive                              "Hot Water On"                 <water>       {channel="hive:hot_water:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-state-is_on"}
+String            HotWater_Mode                                  "Hot Water Mode"               <water>       {channel="hive:hot_water:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-mode-operating"}
+Switch            HotWater_BoostActive                           "Boost Active"                 <water>       {channel="hive:hot_water:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:easy-mode-boost"}
+Number            HotWater_BoostDuration                         "Boost Duration [%d minutes]"  <water>       {channel="hive:hot_water:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:transient-duration"}
+Number            HotWater_BoostRemaining                        "Boost Remaining [%d minutes]" <water>       {channel="hive:hot_water:my-bridge:deadbeef-dead-beef-dead-beefdeadbeef:transient-remaining"}
+```
+
+### example.sitemap
+
+```
+sitemap home label="Home" {
+    Frame label="Living Room" icon="sofa" {
+        Default  item=LivingRoom_HeatingZone_Temperature
+        Setpoint item=LivingRoom_HeatingZone_TargetTemperature minValue=7 maxValue=25
+        Text     item=LivingRoom_HeatingZone_IsActive label="Heating is currently [%s]"
+        Default  item=LivingRoom_HeatingZone_Mode
+        Default  item=LivingRoom_HeatingZone_BoostActive
+        Setpoint item=LivingRoom_HeatingZone_BoostDuration minValue=10 maxValue=60 step=5
+        Default  item=LivingRoom_HeatingZone_BoostRemaining
+        Setpoint item=LivingRoom_HeatingZone_BoostTargetTemperature minValue=7 maxValue=25 step=0.5
+    }
+
+    Frame label="Hot Water" icon="water" {
+        Text     item=HotWater_IsActive label="Hot Water is currently [%s]"
+        Default  item=HotWater_Mode
+        Default  item=HotWater_BoostActive
+        Setpoint item=HotWater_BoostDuration minValue=10 maxValue=60 step=5
+        Default  item=LivingRoom_HeatingZone_BoostRemaining
+    }
+}
+```

--- a/bundles/org.openhab.binding.hive/pom.xml
+++ b/bundles/org.openhab.binding.hive/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.hive</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Hive Binding</name>
+
+  <dependencies>
+    <!-- Fluent assertions -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.15.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Automated equals() and hashCode() testing -->
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.1.13</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Nicer junit4 parameterized tests -->
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bundles/org.openhab.binding.hive/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hive/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.hive-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-hive" description="Hive Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hive/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveAccountConfig.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveAccountConfig.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link HiveAccountConfig} class contains fields mapping configuration
+ * parameters for Hive Account things.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveAccountConfig {
+    public @Nullable String username;
+    public @Nullable String password;
+    public @Nullable Integer pollingInterval;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveBindingConstants.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveBindingConstants.java
@@ -1,0 +1,300 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link HiveBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveBindingConstants {
+    /**
+     * The ID of this binding.
+     */
+    public static final String BINDING_ID = "hive";
+
+    /* ######## Type UIDs ######## */
+    /**
+     * {@link ThingTypeUID} of a Hive Account.
+     */
+    public static final ThingTypeUID THING_TYPE_ACCOUNT = new ThingTypeUID(BINDING_ID, "account");
+
+    /**
+     * {@link ThingTypeUID} of a Hive Boiler Module.
+     */
+    public static final ThingTypeUID THING_TYPE_BOILER_MODULE = new ThingTypeUID(BINDING_ID, "boiler_module");
+
+    /**
+     * {@link ThingTypeUID} of a (virtual) Hive Thermostat Heating Zone.
+     */
+    public static final ThingTypeUID THING_TYPE_HEATING = new ThingTypeUID(BINDING_ID, "heating");
+
+    /**
+     * {@link ThingTypeUID} of a (virtual) Hive Hot Water.
+     */
+    public static final ThingTypeUID THING_TYPE_HOT_WATER = new ThingTypeUID(BINDING_ID, "hot_water");
+
+    /**
+     * {@link ThingTypeUID} of a Hive Hub.
+     */
+    public static final ThingTypeUID THING_TYPE_HUB = new ThingTypeUID(BINDING_ID, "hub");
+
+    /**
+     * {@link ThingTypeUID} of a Hive Thermostat.
+     */
+    public static final ThingTypeUID THING_TYPE_THERMOSTAT = new ThingTypeUID(BINDING_ID, "thermostat");
+
+    /**
+     * {@link ThingTypeUID} of a Hive Radiator Valve.
+     */
+    public static final ThingTypeUID THING_TYPE_TRV = new ThingTypeUID(BINDING_ID, "trv");
+
+    /**
+     * {@link ThingTypeUID} of a (virtual) Hive Radiator Valve Heating Zone.
+     */
+    public static final ThingTypeUID THING_TYPE_TRV_GROUP = new ThingTypeUID(BINDING_ID, "trv_group");
+
+    /**
+     * The set of {@link ThingTypeUID}s supported by this binding.
+     */
+    // @formatter:off
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream.of(
+            THING_TYPE_ACCOUNT,
+            THING_TYPE_BOILER_MODULE,
+            THING_TYPE_HEATING,
+            THING_TYPE_HOT_WATER,
+            THING_TYPE_HUB,
+            THING_TYPE_THERMOSTAT,
+            THING_TYPE_TRV,
+            THING_TYPE_TRV_GROUP
+    ).collect(Collectors.toSet()));
+    // @formatter:on
+
+    /**
+     * The set of {@link ThingTypeUID}s that can be discovered
+     * (everything but accounts).
+     */
+    public static final Set<ThingTypeUID> DISCOVERABLE_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            SUPPORTED_THING_TYPES_UIDS.stream()
+                    .filter(it -> it != THING_TYPE_ACCOUNT)
+                    .collect(Collectors.toSet())
+    );
+
+    /* ######## Channel ids ######## */
+    /**
+     * Name of the channel that represents how long an auto boost
+     * (heat-on-demand boost) should be in minutes.
+     */
+    public static final String CHANNEL_AUTO_BOOST_DURATION = "auto_boost-duration";
+
+    /**
+     * Name of the channel that represents the target heating temperature for a
+     * Hive heating zone when auto boost (heating-on-demand) is active.
+     */
+    public static final String CHANNEL_AUTO_BOOST_TEMPERATURE_TARGET = "auto_boost-temperature-target";
+
+    /**
+     * Name of the channel that represents a simplified view of the heating/
+     * hot water operating mode that matches the app (e.g. ON / SCHEDULE / OFF)
+     */
+    public static final String CHANNEL_EASY_MODE_OPERATING = "easy-mode-operating";
+
+    /**
+     * Name of the channel that represents a simplified view of if the heating/
+     * hot water is being boosted.
+     */
+    public static final String CHANNEL_EASY_MODE_BOOST = "easy-mode-boost";
+
+    /**
+     * Name of the channel that represents if hot water or heating is currently
+     * turned on (i.e. is heating water).
+     */
+    public static final String CHANNEL_EASY_STATE_IS_ON = "easy-state-is_on";
+
+    /**
+     * Name of the channel that represents battery level (percent full).
+     */
+    public static final String CHANNEL_BATTERY_LEVEL = "battery-level";
+
+    /**
+     * Name of the channel that represents if a battery is low
+     * (ON=low battery).
+     */
+    public static final String CHANNEL_BATTERY_LOW = "battery-low";
+
+    /**
+     * Name of the channel that represents battery state
+     * (e.g. FULL, NORMAL, LOW).
+     */
+    public static final String CHANNEL_BATTERY_STATE = "battery-state";
+
+    /**
+     * Name of the channel that represents battery voltage.
+     */
+    public static final String CHANNEL_BATTERY_VOLTAGE = "battery-voltage";
+
+    /**
+     * Name of the channel that represents if a low battery warning has been
+     * sent to users of the Hive app.
+     */
+    public static final String CHANNEL_BATTERY_NOTIFICATION_STATE = "battery-notification_state";
+
+    /**
+     * Name of the channel that represents if a Hive device is turned on
+     * or off.
+     */
+    public static final String CHANNEL_MODE_ON_OFF = "mode-on_off";
+
+    /**
+     * Name of the channel that represents the operating mode of a Hive device
+     * (e.g. SCHEDULE, MANUAL)
+     */
+    public static final String CHANNEL_MODE_OPERATING = "mode-operating";
+
+    /**
+     * Name of the channel that represents the current operating state of a
+     * Hive heating related device (e.g. OFF, HEAT).
+     */
+    public static final String CHANNEL_STATE_OPERATING = "state-operating";
+
+    /**
+     * Name of the channel that represents the the temperature currently
+     * measured by a Hive device.
+     */
+    public static final String CHANNEL_TEMPERATURE_CURRENT = "temperature-current";
+
+    /**
+     * Name of the channel that represents the target heating temperature for a
+     * Hive heating zone.
+     */
+    public static final String CHANNEL_TEMPERATURE_TARGET = "temperature-target";
+
+    /**
+     * Name of the channel that represents the target heating temperature for a
+     * Hive heating zone when the transient override (boost) is active.
+     */
+    public static final String CHANNEL_TEMPERATURE_TARGET_BOOST = "temperature-target-boost";
+
+    /**
+     * Name of the channel that represents the current override mode of a Hive
+     * device (e.g. NONE, TRANSIENT)
+     */
+    public static final String CHANNEL_MODE_OPERATING_OVERRIDE = "mode-operating-override";
+
+    /**
+     * Name of the channel that represents how long a transient override
+     * (boost) should be in minutes.
+     */
+    public static final String CHANNEL_TRANSIENT_DURATION = "transient-duration";
+
+    /**
+     * Name of the channel that represents how long a transient override
+     * (boost) has left in minutes.
+     */
+    public static final String CHANNEL_TRANSIENT_REMAINING = "transient-remaining";
+
+    /**
+     * Name of the channel that represents if transient override feature is
+     * enabled for a Hive device.
+     *
+     * <p>
+     *     N.B. This is just if the feature is enabled/disabled, not if the
+     *     override is currently active.
+     * </p>
+     */
+    public static final String CHANNEL_TRANSIENT_ENABLED = "transient-enabled";
+
+    /**
+     * Name of the channel that represents the last time a transient override
+     * (boost) was activated.
+     */
+    public static final String CHANNEL_TRANSIENT_START_TIME = "transient-start_time";
+
+    /**
+     * Name of the channel that represents the last time a transient override
+     * (boost) was scheduled to end.
+     */
+    public static final String CHANNEL_TRANSIENT_END_TIME = "transient-end_time";
+
+    /**
+     * Name of the channel that represents the average Link Quality Indicator
+     * for a wireless Hive device (seems to be from 0-100).
+     */
+    public static final String CHANNEL_RADIO_LQI_AVERAGE = "radio-lqi-average";
+
+    /**
+     * Name of the channel that represents the last known Link Quality Indicator
+     * for a wireless Hive device (seems to be from 0-100).
+     */
+    public static final String CHANNEL_RADIO_LQI_LAST_KNOWN = "radio-lqi-last_known";
+
+    /**
+     * Name of the channel that represents the average Received Signal Strength
+     * Indicator for a wireless Hive device.
+     */
+    public static final String CHANNEL_RADIO_RSSI_AVERAGE = "radio-rssi-average";
+
+    /**
+     * Name of the channel that represents the last known Received Signal
+     * Strength Indicator for a wireless Hive device.
+     */
+    public static final String CHANNEL_RADIO_RSSI_LAST_KNOWN = "radio-rssi-last_known";
+
+    /**
+     * Name of the channel that represents the last time a HiveAccount thing
+     * polled the Hive API.
+     */
+    public static final String CHANNEL_LAST_POLL_TIMESTAMP = "last_poll_timestamp";
+
+    /**
+     * Name of the channel used to trigger a dumping all the node information
+     * for the linked Hive Account.
+     */
+    public static final String CHANNEL_DUMP_NODES = "dump_nodes";
+
+
+    /* ######## Config params ######## */
+    /**
+     * The configuration key for storing the
+     * {@link org.openhab.binding.hive.internal.client.NodeId}
+     * of the {@link org.openhab.binding.hive.internal.client.Node} that a
+     * {@linkplain org.eclipse.smarthome.core.thing.Thing} is representing.
+     */
+    public static final String CONFIG_NODE_ID = "nodeId";
+
+
+    /* ######## Other constants ######## */
+    public static final String HEATING_EASY_MODE_OPERATING_MANUAL = "MANUAL";
+    public static final String HEATING_EASY_MODE_OPERATING_SCHEDULE = "SCHEDULE";
+    public static final String HEATING_EASY_MODE_OPERATING_OFF = "OFF";
+
+    public static final String HOT_WATER_EASY_MODE_OPERATING_ON = "ON";
+    public static final String HOT_WATER_EASY_MODE_OPERATING_SCHEDULE = "SCHEDULE";
+    public static final String HOT_WATER_EASY_MODE_OPERATING_OFF = "OFF";
+
+    public static final String PROPERTY_EUI64 = "EUI64";
+
+    private HiveBindingConstants() {
+        throw new AssertionError();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveHandlerFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/HiveHandlerFactory.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientFactory;
+import org.openhab.binding.hive.internal.client.DefaultHiveClientFactory;
+import org.openhab.binding.hive.internal.client.HiveClientFactory;
+import org.openhab.binding.hive.internal.discovery.DefaultHiveDiscoveryService;
+import org.openhab.binding.hive.internal.handler.DefaultHiveAccountHandler;
+import org.openhab.binding.hive.internal.handler.DefaultHiveThingHandler;
+import org.openhab.binding.hive.internal.handler.strategy.*;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link HiveHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.hive", service = ThingHandlerFactory.class)
+public final class HiveHandlerFactory extends BaseThingHandlerFactory {
+    private final Logger logger = LoggerFactory.getLogger(HiveHandlerFactory.class);
+
+    private final Set<ThingHandlerStrategy> strategiesForBoilerModule;
+    private final Set<ThingHandlerStrategy> strategiesForHeating;
+    private final Set<ThingHandlerStrategy> strategiesForHotWater;
+    private final Set<ThingHandlerStrategy> strategiesForHub;
+    private final Set<ThingHandlerStrategy> strategiesForThermostat;
+    private final Set<ThingHandlerStrategy> strategiesForTrvGroup;
+    private final Set<ThingHandlerStrategy> strategiesForTrv;
+
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServices = new HashMap<>();
+
+    private final HttpClient httpClient;
+    private final HiveClientFactory hiveClientFactory;
+
+    @Activate
+    public HiveHandlerFactory(@Reference final HttpClientFactory httpClientFactory) {
+        final HttpClient httpClient = httpClientFactory.createHttpClient("HiveBinding");
+        try {
+            httpClient.start();
+        } catch (Exception ex) {
+            // Wrap up all exceptions and throw a runtime exception as there
+            // is nothing we can do to recover.
+            throw new IllegalStateException("Could not start HttpClient.", ex);
+        }
+
+        // Keep a copy of HttpClient so we can clean up later
+        this.httpClient = httpClient;
+        this.hiveClientFactory = new DefaultHiveClientFactory(httpClient);
+        
+        // Create all the ThingHandlerStrategies we will need.
+        final AutoBoostHandlerStrategy autoBoostHandlerStrategy = new AutoBoostHandlerStrategy();
+        final BatteryDeviceHandlerStrategy batteryDeviceHandlerStrategy = new BatteryDeviceHandlerStrategy();
+        final BoostTimeRemainingHandlerStrategy boostTimeRemainingHandlerStrategy = new BoostTimeRemainingHandlerStrategy();
+        final HeatingThermostatEasyHandlerStrategy heatingThermostatEasyHandlerStrategy = new HeatingThermostatEasyHandlerStrategy();
+        final HeatingThermostatHandlerStrategy heatingThermostatHandlerStrategy = new HeatingThermostatHandlerStrategy();
+        final HeatingTransientModeHandlerStrategy heatingTransientModeHandlerStrategy = new HeatingTransientModeHandlerStrategy();
+        final OnOffDeviceHandlerStrategy onOffDeviceHandlerStrategy = new OnOffDeviceHandlerStrategy();
+        final PhysicalDeviceHandlerStrategy physicalDeviceHandlerStrategy = new PhysicalDeviceHandlerStrategy();
+        final TemperatureSensorHandlerStrategy temperatureSensorHandlerStrategy = new TemperatureSensorHandlerStrategy();
+        final TransientModeHandlerStrategy transientModeHandlerStrategy = new TransientModeHandlerStrategy();
+        final WaterHeaterEasyHandlerStrategy waterHeaterEasyHandlerStrategy = new WaterHeaterEasyHandlerStrategy();
+        final WaterHeaterHandlerStrategy waterHeaterHandlerStrategy = new WaterHeaterHandlerStrategy();
+        final ZigbeeDeviceHandlerStrategy zigbeeDeviceHandlerStrategy = new ZigbeeDeviceHandlerStrategy();
+        
+        // Create the sets of ThingHandlerStrategies needed for each kind of thing.
+        this.strategiesForBoilerModule = Collections.unmodifiableSet(Stream.of(
+                physicalDeviceHandlerStrategy,
+                zigbeeDeviceHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForHeating = Collections.unmodifiableSet(Stream.of(
+                autoBoostHandlerStrategy,
+                boostTimeRemainingHandlerStrategy,
+                heatingThermostatHandlerStrategy,
+                onOffDeviceHandlerStrategy,
+                temperatureSensorHandlerStrategy,
+                transientModeHandlerStrategy,
+                heatingTransientModeHandlerStrategy,
+                heatingThermostatEasyHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForHotWater = Collections.unmodifiableSet(Stream.of(
+                boostTimeRemainingHandlerStrategy,
+                onOffDeviceHandlerStrategy,
+                transientModeHandlerStrategy,
+                waterHeaterHandlerStrategy,
+                waterHeaterEasyHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForHub = Collections.unmodifiableSet(Stream.of(
+                physicalDeviceHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForThermostat = Collections.unmodifiableSet(Stream.of(
+                batteryDeviceHandlerStrategy,
+                physicalDeviceHandlerStrategy,
+                zigbeeDeviceHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForTrvGroup = Collections.unmodifiableSet(Stream.of(
+                boostTimeRemainingHandlerStrategy,
+                heatingThermostatHandlerStrategy,
+                onOffDeviceHandlerStrategy,
+                temperatureSensorHandlerStrategy,
+                transientModeHandlerStrategy,
+                heatingTransientModeHandlerStrategy,
+                heatingThermostatEasyHandlerStrategy
+        ).collect(Collectors.toSet()));
+
+        this.strategiesForTrv = Collections.unmodifiableSet(Stream.of(
+                batteryDeviceHandlerStrategy,
+                physicalDeviceHandlerStrategy,
+                temperatureSensorHandlerStrategy,
+                zigbeeDeviceHandlerStrategy
+        ).collect(Collectors.toSet()));
+    }
+
+    @Override
+    protected void activate(final ComponentContext componentContext) {
+        super.activate(componentContext);
+
+        // Help keep track of when openHAB reloads binding while debugging.
+        this.logger.trace("HandlerFactory has been activated");
+    }
+
+    @Override
+    protected void deactivate(final ComponentContext componentContext) {
+        super.deactivate(componentContext);
+
+        // Help keep track of when openHAB reloads binding while debugging.
+        this.logger.trace("HandlerFactory has been deactivated");
+
+        // Clean up HttpClient
+        try {
+            httpClient.stop();
+        } catch (Exception ignored) {
+            // Don't care, just trying to clean up.
+        }
+    }
+
+    @Override
+    public boolean supportsThingType(final ThingTypeUID thingTypeUID) {
+        return HiveBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(final Thing thing) {
+        final ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (HiveBindingConstants.THING_TYPE_ACCOUNT.equals(thingTypeUID)) {
+            // Create the handler
+            final DefaultHiveAccountHandler handler = new DefaultHiveAccountHandler(
+                    this.hiveClientFactory,
+                    DefaultHiveDiscoveryService::new,
+                    (Bridge) thing
+            );
+
+            // Register the discovery service and keep track of it so we can
+            // unregister it later.
+            final ServiceRegistration<?> serviceReg = bundleContext.registerService(
+                    DiscoveryService.class.getName(),
+                    handler.getDiscoveryService(),
+                    new Hashtable<>()
+            );
+            final ThingUID uid = thing.getUID();
+            this.discoveryServices.put(uid, serviceReg);
+
+            return handler;
+        } else if (HiveBindingConstants.THING_TYPE_BOILER_MODULE.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForBoilerModule);
+        } else if (HiveBindingConstants.THING_TYPE_HEATING.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForHeating);
+        } else if (HiveBindingConstants.THING_TYPE_HOT_WATER.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForHotWater);
+        } else if (HiveBindingConstants.THING_TYPE_HUB.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForHub);
+        } else if (HiveBindingConstants.THING_TYPE_THERMOSTAT.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForThermostat);
+        } else if (HiveBindingConstants.THING_TYPE_TRV.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForTrv);
+        } else if (HiveBindingConstants.THING_TYPE_TRV_GROUP.equals(thingTypeUID)) {
+            return new DefaultHiveThingHandler(thing, this.strategiesForTrvGroup);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected void removeHandler(final ThingHandler thingHandler) {
+        if (thingHandler instanceof DefaultHiveAccountHandler) {
+            this.logger.trace("Removing bridge");
+            // Clean up associated discovery service.
+            final @Nullable ServiceRegistration<?> serviceReg = this.discoveryServices.remove(thingHandler.getThing().getUID());
+
+            if (serviceReg != null) {
+                this.logger.trace("Unregistered discovery service");
+                serviceReg.unregister();
+            }
+        }
+
+        super.removeHandler(thingHandler);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ActionType.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ActionType.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum ActionType {
+    GENERIC,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/AttributeName.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/AttributeName.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum AttributeName {
+    HEATING_THERMOSTAT_TARGET_HEAT_TEMPERATURE,
+    ON_OFF_DEVICE_MODE,
+    WATER_HEATER_HEATING_OPERATING_MODE,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/BatteryLevel.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/BatteryLevel.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BatteryLevel {
+    private final int value;
+
+    public BatteryLevel(int value) {
+        if (value < 0 || value > 100) {
+            throw new IllegalArgumentException("Battery level is must be between 0-100 (inclusive)");
+        }
+
+        this.value = value;
+    }
+
+    public int intValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || this.getClass() != o.getClass()) {
+            return false;
+        }
+
+        final BatteryLevel that = (BatteryLevel) o;
+        return this.value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return this.value + "%";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/BuilderUtil.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/BuilderUtil.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BuilderUtil {
+    public static final String REQUIRED_ATTRIBUTE_NOT_SET_MESSAGE = "Required attributes have not been set";
+
+    private BuilderUtil() {
+        throw new AssertionError();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultFeatureAttribute.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultFeatureAttribute.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultFeatureAttribute<T> implements SettableFeatureAttribute<T> {
+    private final @Nullable T targetValue;
+    private final T displayValue;
+    private final T reportedValue;
+    private final @Nullable Instant reportReceivedTime;
+    private final @Nullable Instant reportChangedTime;
+
+    private DefaultFeatureAttribute(
+            final @Nullable T targetValue,
+            final T displayValue,
+            final T reportedValue,
+            final @Nullable Instant reportChangedTime,
+            final @Nullable Instant reportReceivedTime
+    ) {
+        this.targetValue = targetValue;
+        this.displayValue = Objects.requireNonNull(displayValue);
+        this.reportedValue = Objects.requireNonNull(reportedValue);
+        this.reportChangedTime = reportChangedTime;
+        this.reportReceivedTime = reportReceivedTime;
+    }
+
+    @Override
+    public @Nullable T getTargetValue() {
+        return this.targetValue;
+    }
+
+    @Override
+    public T getDisplayValue() {
+        return this.displayValue;
+    }
+
+    @Override
+    public T getReportedValue() {
+        return this.reportedValue;
+    }
+
+    @Override
+    public @Nullable Instant getReportReceivedTime() {
+        return this.reportReceivedTime;
+    }
+
+    @Override
+    public @Nullable Instant getReportChangedTime() {
+        return this.reportChangedTime;
+    }
+
+    @Override
+    public SettableFeatureAttribute<T> withTargetValue(final @Nullable T targetValue) {
+        return DefaultFeatureAttribute.<T>builder()
+                .from(this)
+                .targetValue(targetValue)
+                .build();
+    }
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public static final class Builder<T> {
+        private @Nullable T targetValue = null;
+        private @Nullable T displayValue;
+        private @Nullable T reportedValue;
+        private @Nullable Instant reportReceivedTime;
+        private @Nullable Instant reportChangedTime;
+
+        public Builder<T> from(final SettableFeatureAttribute<T> featureAttribute) {
+            Objects.requireNonNull(featureAttribute);
+
+            return this.targetValue(featureAttribute.getTargetValue())
+                    .displayValue(featureAttribute.getDisplayValue())
+                    .reportedValue(featureAttribute.getReportedValue())
+                    .reportReceivedTime(featureAttribute.getReportReceivedTime())
+                    .reportChangedTime(featureAttribute.getReportChangedTime());
+        }
+
+        public Builder<T> from(final FeatureAttribute<T> featureAttribute) {
+            Objects.requireNonNull(featureAttribute);
+
+            return this.displayValue(featureAttribute.getDisplayValue())
+                    .reportedValue(featureAttribute.getReportedValue())
+                    .reportReceivedTime(featureAttribute.getReportReceivedTime())
+                    .reportChangedTime(featureAttribute.getReportChangedTime());
+        }
+
+        public Builder<T> targetValue(final @Nullable T targetValue) {
+            this.targetValue = targetValue;
+
+            return this;
+        }
+
+        public Builder<T> displayValue(final T displayValue) {
+            this.displayValue = Objects.requireNonNull(displayValue);
+
+            return this;
+        }
+
+        public Builder<T> reportedValue(final T reportedValue) {
+            this.reportedValue = Objects.requireNonNull(reportedValue);
+
+            return this;
+        }
+
+        public Builder<T> reportReceivedTime(final @Nullable Instant reportReceivedTime) {
+            this.reportReceivedTime = reportReceivedTime;
+
+            return this;
+        }
+
+        public Builder<T> reportChangedTime(final @Nullable Instant reportChangedTime) {
+            this.reportChangedTime = reportChangedTime;
+
+            return this;
+        }
+
+        public DefaultFeatureAttribute<T> build() {
+            final @Nullable T displayValue = this.displayValue;
+            final @Nullable T reportedValue = this.reportedValue;
+
+            if (displayValue == null
+                    || reportedValue == null
+            ) {
+                throw new IllegalStateException(BuilderUtil.REQUIRED_ATTRIBUTE_NOT_SET_MESSAGE);
+            }
+
+            return new DefaultFeatureAttribute<>(
+                    this.targetValue,
+                    displayValue,
+                    reportedValue,
+                    this.reportChangedTime,
+                    this.reportReceivedTime
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultHiveClient.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultHiveClient.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.exception.*;
+import org.openhab.binding.hive.internal.client.repository.NodeRepository;
+import org.openhab.binding.hive.internal.client.repository.SessionRepository;
+
+/**
+ * The default implementation of {@link HiveClient}
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+final class DefaultHiveClient implements HiveClient {
+    private static final int MAX_REAUTHENTICATION_ATTEMPTS = 1;
+
+    private final SessionAuthenticationManager authenticationManager;
+
+    private final String username;
+    private final String password;
+
+    private final SessionRepository sessionRepository;
+    private final NodeRepository nodeRepository;
+
+    private @Nullable Session session;
+
+    /**
+     *
+     *
+     * @throws HiveApiAuthenticationException
+     *      If we failed to authenticate with the provided username and password.
+     *
+     * @throws HiveApiUnknownException
+     *      If something unexpected happens while communicating with the Hive
+     *      API.
+     *
+     * @throws HiveClientResponseException
+     *      If we don't understand the response the Hive API gave us.
+     */
+    public DefaultHiveClient(
+            final SessionAuthenticationManager authenticationManager,
+            final String username,
+            final String password,
+            final SessionRepository sessionRepository,
+            final NodeRepository nodeRepository
+    ) throws HiveException {
+        Objects.requireNonNull(authenticationManager);
+        Objects.requireNonNull(sessionRepository);
+        Objects.requireNonNull(nodeRepository);
+
+        this.authenticationManager = authenticationManager;
+
+        this.username = username;
+        this.password = password;
+
+        this.sessionRepository = sessionRepository;
+        this.nodeRepository = nodeRepository;
+
+        authenticate();
+    }
+
+    @Override
+    public void close() {
+        // No cleanup required.
+    }
+
+    /**
+     * Try to authenticate with the Hive API.
+     *
+     * @throws HiveApiAuthenticationException
+     *      If we failed to authenticate with the stored username and password.
+     *
+     * @throws HiveApiUnknownException
+     *      If something unexpected happens while communicating with the Hive
+     *      API.
+     */
+    private void authenticate() throws HiveException {
+        this.authenticationManager.clearSession();
+
+        final Session session = this.sessionRepository.createSession(
+                this.username,
+                this.password
+        );
+
+        this.session = session;
+        this.authenticationManager.setSession(session);
+    }
+
+    private <T> T makeAuthenticatedApiCall(final ApiCall<T> apiCall) throws HiveException {
+        // If we get a valid result return it.
+        // If we are not authorised check if session has expired, reauthenticate and try again.
+        // Otherwise let other exceptions bubble up.
+        int reauthenticationCount = 0;
+        while (reauthenticationCount <= MAX_REAUTHENTICATION_ATTEMPTS) {
+            try {
+                return apiCall.call();
+            } catch (final HiveApiNotAuthorisedException ex) {
+                if (reauthenticationCount == MAX_REAUTHENTICATION_ATTEMPTS
+                        || this.sessionRepository.isValidSession(this.authenticationManager.getSession())) {
+                    // We are either not authorised for this resource or
+                    // something has gone wrong with the client logic.
+                    // Pass on the exception.
+                    throw ex;
+                } else {
+                    // Session seems to no longer be valid.
+                    // Reauthenticate and try again.
+                    authenticate();
+                    reauthenticationCount++;
+                }
+            }
+        }
+
+        throw new IllegalStateException("Authentication failed and somehow I've escaped my trap.");
+    }
+
+    @Override
+    public UserId getUserId() {
+        final @Nullable Session session = this.session;
+        if (session == null) {
+            throw new IllegalStateException("Session is unexpectedly null.");
+        }
+
+        return session.getUserId();
+    }
+
+    @Override
+    public Set<Node> getAllNodes() throws HiveException {
+        return makeAuthenticatedApiCall(this.nodeRepository::getAllNodes);
+    }
+
+    @Override
+    public String getAllNodesJson() throws HiveException {
+        return makeAuthenticatedApiCall(this.nodeRepository::getAllNodesJson);
+    }
+
+    @Override
+    public @Nullable Node getNode(final NodeId nodeId) throws HiveException {
+        Objects.requireNonNull(nodeId);
+
+        // N.B. Type parameter because Checker Framework needs a little help.
+        return this.<@Nullable Node>makeAuthenticatedApiCall(() -> this.nodeRepository.getNode(nodeId));
+    }
+
+    @Override
+    public @Nullable Node updateNode(final Node node) throws HiveException {
+        Objects.requireNonNull(node);
+
+        // N.B. Type parameter because Checker Framework needs a little help.
+        return this.<@Nullable Node>makeAuthenticatedApiCall(() -> this.nodeRepository.updateNode(node));
+    }
+    
+    @FunctionalInterface
+    private interface ApiCall<T> {
+        T call() throws HiveException;
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultHiveClientFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/DefaultHiveClientFactory.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+import org.openhab.binding.hive.internal.client.repository.DefaultNodeRepository;
+import org.openhab.binding.hive.internal.client.repository.DefaultSessionRepository;
+import org.openhab.binding.hive.internal.client.repository.NodeRepository;
+import org.openhab.binding.hive.internal.client.repository.SessionRepository;
+
+/**
+ * The default implementation of {@link HiveClientFactory}.
+ *
+ * Returns instances of {@link DefaultHiveClient}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultHiveClientFactory implements HiveClientFactory {
+    private static final String CLIENT_ID = "openHAB";
+
+    private final JettyHiveApiRequestFactory requestFactory;
+
+    public DefaultHiveClientFactory(final HttpClient httpClient) {
+        Objects.requireNonNull(httpClient);
+
+        this.requestFactory = new JettyHiveApiRequestFactory(
+                httpClient,
+                HiveApiConstants.DEFAULT_BASE_PATH,
+                new GsonJsonService(),
+                CLIENT_ID
+        );
+    }
+
+    public HiveClient newClient(
+            final String username,
+            final String password
+    ) throws HiveException {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(password);
+
+        final SessionRepository sessionRepository = new DefaultSessionRepository(
+                this.requestFactory
+        );
+
+        final NodeRepository nodeRepository = new DefaultNodeRepository(
+                this.requestFactory
+        );
+
+        return new DefaultHiveClient(
+                this.requestFactory,
+                username,
+                password,
+                sessionRepository,
+                nodeRepository
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Eui64.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Eui64.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class Eui64 {
+    private final String value;
+
+    public Eui64(final String eui64) {
+        Objects.requireNonNull(eui64);
+
+        if (eui64.length() != 16) {
+            throw new IllegalArgumentException("Provided string is the wrong length.");
+        }
+
+        this.value = eui64;
+    }
+
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Eui64 eui64 = (Eui64) o;
+        return this.value.equals(eui64.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureAttribute.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureAttribute.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface FeatureAttribute<T> {
+    T getDisplayValue();
+    T getReportedValue();
+    @Nullable Instant getReportReceivedTime();
+    @Nullable Instant getReportChangedTime();
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureAttributeFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureAttributeFactory.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.dto.FeatureAttributeDto;
+import org.openhab.binding.hive.internal.client.dto.HiveApiInstant;
+import org.openhab.binding.hive.internal.client.exception.HiveClientResponseException;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class FeatureAttributeFactory {
+    private FeatureAttributeFactory() {
+        throw new AssertionError();
+    }
+
+    private static <F> void applyNano1DtoFix(
+            final FeatureAttributeDto<F> dto
+    ) {
+        // Try to fix the weirdness of the NANO1 hub
+        @Nullable F fixupValue = dto.targetValue;
+        if (dto.reportedValue == null && fixupValue != null) {
+            dto.reportedValue = fixupValue;
+        } else if (dto.reportedValue != null) {
+            fixupValue = dto.reportedValue;
+        } else {
+            throw new IllegalStateException("reportedValue is null and I cannot fix it");
+        }
+
+        if (dto.displayValue == null) {
+            if (fixupValue != null) {
+                dto.displayValue = fixupValue;
+            } else {
+                throw new IllegalStateException("displayValue is null and I cannot fix it");
+            }
+        }
+    }
+
+    private static <F, T> void buildFeatureAttribute(
+            final DefaultFeatureAttribute.Builder<T> featureAttributeBuilder,
+            final Adapter<F, T> adapter,
+            final FeatureAttributeDto<F> dto
+    ) throws HiveClientResponseException {
+        Objects.requireNonNull(featureAttributeBuilder);
+        Objects.requireNonNull(adapter);
+        Objects.requireNonNull(dto);
+
+        final @Nullable F displayValue = dto.displayValue;
+        final @Nullable F reportedValue = dto.reportedValue;
+        final @Nullable HiveApiInstant reportChangedTime = dto.reportChangedTime;
+        final @Nullable HiveApiInstant reportReceivedTime = dto.reportReceivedTime;
+
+        if (displayValue == null) {
+            throw new HiveClientResponseException("Display value is unexpectedly null.");
+        }
+        featureAttributeBuilder.displayValue(adapter.apply(displayValue));
+
+        if (reportedValue == null) {
+            throw new HiveClientResponseException("Reported value is unexpectedly null.");
+        }
+        featureAttributeBuilder.reportedValue(adapter.apply(reportedValue));
+
+        if (reportChangedTime != null) {
+            featureAttributeBuilder.reportChangedTime(reportChangedTime.asInstant());
+        }
+
+        if (reportReceivedTime != null) {
+            featureAttributeBuilder.reportReceivedTime(reportReceivedTime.asInstant());
+        }
+    }
+
+    public static <T> @Nullable FeatureAttribute<T> getReadOnlyFromDto(final @Nullable FeatureAttributeDto<T> dto) throws HiveClientResponseException {
+        return getReadOnlyFromDtoWithAdapter(Adapter.identity(), dto);
+    }
+
+    public static <F, T> @Nullable FeatureAttribute<T> getReadOnlyFromDtoWithAdapter(
+            final Adapter<F, T> adapter,
+            final @Nullable FeatureAttributeDto<F> dto
+    ) throws HiveClientResponseException {
+        if (dto == null) {
+            return null;
+        }
+
+        applyNano1DtoFix(dto);
+
+        final DefaultFeatureAttribute.Builder<T> featureAttributeBuilder = DefaultFeatureAttribute.builder();
+
+        buildFeatureAttribute(
+                featureAttributeBuilder,
+                adapter,
+                dto
+        );
+
+        return featureAttributeBuilder.build();
+    }
+
+    public static <T> @Nullable SettableFeatureAttribute<T> getSettableFromDto(final @Nullable FeatureAttributeDto<T> dto) throws HiveClientResponseException {
+        return getSettableFromDtoWithAdapter(Adapter.identity(), dto);
+    }
+
+    public static <F, T> @Nullable SettableFeatureAttribute<T> getSettableFromDtoWithAdapter(
+            final Adapter<F, T> adapter,
+            final @Nullable FeatureAttributeDto<F> dto
+    ) throws HiveClientResponseException {
+        if (dto == null) {
+            return null;
+        }
+
+        applyNano1DtoFix(dto);
+
+        final DefaultFeatureAttribute.Builder<T> featureAttributeBuilder = DefaultFeatureAttribute.builder();
+
+        buildFeatureAttribute(
+                featureAttributeBuilder,
+                adapter,
+                dto
+        );
+
+        final @Nullable F targetValue = dto.targetValue;
+        if (targetValue != null) {
+            featureAttributeBuilder.targetValue(adapter.apply(targetValue));
+        }
+
+        return featureAttributeBuilder.build();
+    }
+
+    @FunctionalInterface
+    public interface Adapter<F, T> {
+        T apply(F from) throws HiveClientResponseException;
+
+        static <T> Adapter<T, T> identity() {
+            return from -> from;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureType.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/FeatureType.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum FeatureType {
+    AUTOBOOST_V1,
+    BATTERY_DEVICE_V1,
+    CHILD_LOCK_V1,
+    DEVICE_MANAGEMENT_V1,
+    DISPLAY_ORIENTATION_V1,
+    ETHERNET_DEVICE_V1,
+    FROST_PROTECT_V1,
+    GROUP_V1,
+    HEATING_TEMPERATURE_CONTROL_DEVICE_V1,
+    HEATING_TEMPERATURE_CONTROL_V1,
+    HEATING_THERMOSTAT_V1,
+    HIVE_HUB_V1,
+    LIFECYCLE_STATE_V1,
+    LINKS_V1,
+    MOUNTING_MODE_V1,
+    ON_OFF_DEVICE_V1,
+    PI_HEATING_DEMAND_V1,
+    PHYSICAL_DEVICE_V1,
+    RADIO_DEVICE_V1,
+    STANDBY_V1,
+    TEMPERATURE_SENSOR_V1,
+    TRANSIENT_MODE_V1,
+    TRV_CALIBRATION_V1,
+    TRV_ERROR_DIAGNOSTICS_V1,
+    WATER_HEATER_V1,
+    ZIGBEE_DEVICE_V1,
+    ZIGBEE_ROUTING_DEVICE_V1,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/GroupId.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/GroupId.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum GroupId {
+    /**
+     * Group that links
+     * Synthetic TRV Heating Zone --> Physical TRV Device
+     */
+    TRVS,
+
+    /**
+     * Group that links
+     * Synthetic TRV Heating Zone --> Parent Synthetic Thermostat Heating Zone
+     */
+    TRVBM,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/GsonJsonService.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/GsonJsonService.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.adapter.*;
+import org.openhab.binding.hive.internal.client.dto.HiveApiInstant;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * An implementation of {@link JsonService} using {@link Gson}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+final class GsonJsonService implements JsonService {
+    private final Gson gson;
+
+    public GsonJsonService() {
+        this.gson = (new GsonBuilder())
+                .registerTypeAdapter(HiveApiInstant.class, new HiveApiInstantGsonAdapter())
+                .registerTypeAdapter(UserId.class, new UserIdGsonAdapter())
+                .registerTypeAdapter(SessionId.class, new SessionIdGsonAdapter())
+                .registerTypeAdapter(NodeId.class, new NodeIdGsonAdapter())
+                .registerTypeAdapter(NodeType.class, new NodeTypeGsonAdapter())
+                .registerTypeAdapter(FeatureType.class, new FeatureTypeGsonAdapter())
+                .registerTypeAdapter(ProductType.class, new ProductTypeGsonAdapter())
+                .registerTypeAdapter(ActionType.class, new ActionTypeGsonAdapter())
+                .registerTypeAdapter(AttributeName.class, new AttributeNameGsonAdapter())
+                .registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeGsonAdapter())
+                .registerTypeAdapter(Eui64.class, new Eui64GsonAdapter())
+                .registerTypeAdapter(GroupId.class, new GroupIdGsonAdapter())
+                .registerTypeAdapter(ScheduleType.class, new ScheduleTypeGsonAdapter())
+                .registerTypeAdapter(Protocol.class, new ProtocolGsonAdapter())
+                .create();
+    }
+
+    @Override
+    public String toJson(final Object object) {
+        Objects.requireNonNull(object);
+
+        return this.gson.toJson(object);
+    }
+
+    @Override
+    public <T> T fromJson(final String json, final Class<T> classOfT) {
+        Objects.requireNonNull(json);
+        Objects.requireNonNull(classOfT);
+
+        final @Nullable T parsedObject;
+        try {
+            parsedObject = this.gson.fromJson(json, classOfT);
+        } catch (final JsonSyntaxException ex) {
+            throw new IllegalArgumentException("The provided json could not be parsed into " + classOfT.getName());
+        }
+
+        if (parsedObject == null) {
+            throw new IllegalArgumentException("The provided json was empty!");
+        }
+
+        return parsedObject;
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HeatingThermostatOperatingMode.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HeatingThermostatOperatingMode.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents the type of mode that a heating_thermostat is operating in.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum HeatingThermostatOperatingMode {
+    /**
+     * Following the schedule.
+     */
+    SCHEDULE,
+
+    /**
+     * Manually controlled.
+     */
+    MANUAL
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HeatingThermostatOperatingState.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HeatingThermostatOperatingState.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum HeatingThermostatOperatingState {
+    HEAT,
+    OFF
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiConstants.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiConstants.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import java.net.URI;
+
+/**
+ * Constants related to the Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiConstants {
+    private HiveApiConstants() {
+        throw new AssertionError();
+    }
+
+    /**
+     * The location of the real Hive API.
+     */
+    public static final URI DEFAULT_BASE_PATH = URI.create("https://api.prod.bgchprod.info/omnia/");
+
+    /* Endpoints */
+    public static final URI ENDPOINT_ACCESS_TOKENS = URI.create("accessTokens");
+    public static final URI ENDPOINT_CALLBACK_TOKENS = URI.create("callbackTokens");
+    public static final URI ENDPOINT_CHANNELS = URI.create("channels");
+    public static final URI ENDPOINT_CONTACTS = URI.create("contacts");
+    public static final URI ENDPOINT_DEVICE_TOKENS = URI.create("deviceTokens");
+    public static final URI ENDPOINT_EVENTS = URI.create("events");
+    public static final URI ENDPOINT_MEDIA = URI.create("media");
+    public static final URI ENDPOINT_MIGRATION = URI.create("migrations");
+    public static final URI ENDPOINT_NODES = URI.create("nodes");
+    public static final URI ENDPOINT_NODE = URI.create("nodes/");
+    public static final URI ENDPOINT_PASSWORDS = URI.create("auth/passwordReset");
+    public static final URI ENDPOINT_RESERVATIONS = URI.create("nodes/reservation");
+    public static final URI ENDPOINT_RULES = URI.create("rules");
+    public static final URI ENDPOINT_SESSIONS = URI.create("auth/sessions");
+    public static final URI ENDPOINT_SESSION = URI.create("auth/sessions/");
+    public static final URI ENDPOINT_TOPOLOGY = URI.create("topology");
+    public static final URI ENDPOINT_USERS = URI.create("users");
+
+    /* Media Types */
+    public static final String MEDIA_TYPE_JSON = "application/json";
+    public static final String MEDIA_TYPE_API_V6_0_0_JSON = "application/vnd.alertme.zoo-6.0.0+json";
+    public static final String MEDIA_TYPE_API_V6_1_0_JSON = "application/vnd.alertme.zoo-6.1.0+json";
+    public static final String MEDIA_TYPE_API_V6_2_0_JSON = "application/vnd.alertme.zoo-6.2.0+json";
+    public static final String MEDIA_TYPE_API_V6_3_0_JSON = "application/vnd.alertme.zoo-6.3.0+json";
+    public static final String MEDIA_TYPE_API_V6_4_0_JSON = "application/vnd.alertme.zoo-6.4.0+json";
+    public static final String MEDIA_TYPE_API_V6_5_0_JSON = "application/vnd.alertme.zoo-6.5.0+json";
+    public static final String MEDIA_TYPE_API_V6_6_0_JSON = "application/vnd.alertme.zoo-6.6.0+json";
+
+    /* Status Codes */
+    public static final int STATUS_CODE_200_OK = 200;
+    public static final int STATUS_CODE_400_BAD_REQUEST = 400;
+    public static final int STATUS_CODE_401_UNAUTHORIZED = 401;
+    public static final int STATUS_CODE_403_FORBIDDEN = 403;
+
+    /* Action Types */
+    public static final String ACTION_TYPE_GENERIC = "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#";
+    
+    /* Attribute Names */
+    public static final String ATTRIBUTE_NAME_AUTO_BOOST_V1_AUTO_BOOST_DURATION = "autoBoostDuration";
+    public static final String ATTRIBUTE_NAME_AUTO_BOOST_V1_AUTO_BOOST_TARGET_HEAT_TEMPERATURE = "autoBoostTargetHeatTemperature";
+    public static final String ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_LEVEL = "batteryLevel";
+    public static final String ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_STATE = "batteryState";
+    public static final String ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_VOLTAGE = "batteryVoltage";
+    public static final String ATTRIBUTE_NAME_BATTERY_DEVICE_V1_NOTIFICATION_STATE = "notificationState";
+    public static final String ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_MODE = "operatingMode";
+    public static final String ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_STATE = "operatingState";
+    public static final String ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TEMPORARY_OPERATING_MODE_OVERRIDE = "temporaryOperatingModeOverride";
+    public static final String ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TARGET_HEAT_TEMPERATURE = "targetHeatTemperature";
+    public static final String ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE = "mode";
+    public static final String ATTRIBUTE_NAME_TEMPERATURE_SENSOR_V1_TEMPERATURE = "temperature";
+    public static final String ATTRIBUTE_NAME_TRANSIENT_MODE_V1_ACTIONS = "actions";
+    public static final String ATTRIBUTE_NAME_TRANSIENT_MODE_V1_DURATION = "duration";
+    public static final String ATTRIBUTE_NAME_TRANSIENT_MODE_V1_IS_ENABLED = "isEnabled";
+    public static final String ATTRIBUTE_NAME_TRANSIENT_MODE_V1_START_DATETIME = "startDatetime";
+    public static final String ATTRIBUTE_NAME_TRANSIENT_MODE_V1_END_DATETIME = "endDatetime";
+    public static final String ATTRIBUTE_NAME_WATER_HEATER_V1_OPERATING_MODE = "operatingMode";
+    public static final String ATTRIBUTE_NAME_WATER_HEATER_V1_IS_ON = "isOn";
+    public static final String ATTRIBUTE_NAME_WATER_HEATER_V1_TEMPORARY_OPERATING_MODE_OVERRIDE = "temporaryOperatingModeOverride";
+    public static final String ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_EUI64 = "eui64";
+    public static final String ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_AVERAGE_LQI = "averageLQI";
+    public static final String ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_LAST_KNOWN_LQI = "lastKnownLQI";
+    public static final String ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_AVERAGE_RSSI = "averageRSSI";
+    public static final String ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_LAST_KNOWN_RSSI = "lastKnownRSSI";
+    
+    /* Group IDs */
+    public static final String GROUP_ID_TRVS = "trvs";
+    public static final String GROUP_ID_TRVBM = "trvbm";
+    
+    /* Feature Types */
+    public static final String FEATURE_TYPE_AUTOBOOST_V1 = "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#";
+    public static final String FEATURE_TYPE_BATTERY_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.battery_device.v1.json#";
+    public static final String FEATURE_TYPE_CHILD_LOCK_V1 = "http://alertme.com/schema/json/feature/node.feature.child_lock.v1.json#";
+    public static final String FEATURE_TYPE_DEVICE_MANAGEMENT_V1 = "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#";
+    public static final String FEATURE_TYPE_DISPLAY_ORIENTATION_V1 = "http://alertme.com/schema/json/feature/node.feature.display_orientation.v1.json#";
+    public static final String FEATURE_TYPE_ETHERNET_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.ethernet_device.v1.json#";
+    public static final String FEATURE_TYPE_FROST_PROTECT_V1 = "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#";
+    public static final String FEATURE_TYPE_GROUP_V1 = "http://alertme.com/schema/json/feature/node.feature.group.v1.json#";
+    public static final String FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control_device.v1.json#";
+    public static final String FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_V1 = "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#";
+    public static final String FEATURE_TYPE_HEATING_THERMOSTAT_V1 = "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#";
+    public static final String FEATURE_TYPE_HIVE_HUB_V1 = "http://alertme.com/schema/json/feature/node.feature.hive_hub.v1.json#";
+    public static final String FEATURE_TYPE_LIFECYCLE_STATE_V1 = "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#";
+    public static final String FEATURE_TYPE_LINKS_V1 = "http://alertme.com/schema/json/feature/node.feature.links.v1.json#";
+    public static final String FEATURE_TYPE_MOUNTING_MODE_V1 = "http://alertme.com/schema/json/feature/node.feature.mounting_mode.v1.json#";
+    public static final String FEATURE_TYPE_ON_OFF_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#";
+    public static final String FEATURE_TYPE_PI_HEATING_DEMAND_V1 = "http://alertme.com/schema/json/feature/node.feature.pi_heating_demand.v1.json#";
+    public static final String FEATURE_TYPE_PHYSICAL_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.physical_device.v1.json#";
+    public static final String FEATURE_TYPE_RADIO_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.radio_device.v1.json#";
+    public static final String FEATURE_TYPE_STANDBY_V1 = "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#";
+    public static final String FEATURE_TYPE_TEMPERATURE_SENSOR_V1 = "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#";
+    public static final String FEATURE_TYPE_TRANSIENT_MODE_V1 = "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#";
+    public static final String FEATURE_TYPE_TRV_CALIBRATION_V1 = "http://alertme.com/schema/json/feature/node.feature.trv_calibration.v1.json#";
+    public static final String FEATURE_TYPE_TRV_ERROR_DIAGNOSTICS_V1 = "http://alertme.com/schema/json/feature/node.feature.trv_error_diagnostics.v1.json#";
+    public static final String FEATURE_TYPE_WATER_HEATER_V1 = "http://alertme.com/schema/json/feature/node.feature.water_heater.v1.json#";
+    public static final String FEATURE_TYPE_ZIGBEE_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.zigbee_device.v1.json#";
+    public static final String FEATURE_TYPE_ZIGBEE_ROUTING_DEVICE_V1 = "http://alertme.com/schema/json/feature/node.feature.zigbee_routing_device.v1.json#";
+    
+    /* Node Types */
+    public static final String NODE_TYPE_HUB = "http://alertme.com/schema/json/node.class.hub.json#";
+    public static final String NODE_TYPE_THERMOSTAT = "http://alertme.com/schema/json/node.class.thermostat.json#";
+    public static final String NODE_TYPE_THERMOSTAT_UI = "http://alertme.com/schema/json/node.class.thermostatui.json#";
+    public static final String NODE_TYPE_RADIATOR_VALVE = "http://alertme.com/schema/json/node.class.trv.json#";
+    public static final String NODE_TYPE_SYNTHETIC_DAYLIGHT = "http://alertme.com/schema/json/node.class.synthetic.daylight.json#";
+    public static final String NODE_TYPE_SYNTHETIC_HOME_STATE = "http://alertme.com/schema/json/node.class.synthetic.home.state.json#";
+    public static final String NODE_TYPE_SYNTHETIC_RULE = "http://alertme.com/schema/json/node.class.synthetic.rule.json#";
+    
+    /* Product Types */
+    public static final String PRODUCT_TYPE_ACTIONS = "ACTIONS";
+    public static final String PRODUCT_TYPE_BOILER_MODULE = "BOILER_MODULE";
+    public static final String PRODUCT_TYPE_DAYLIGHT_SD = "DAYLIGHT_SD";
+    public static final String PRODUCT_TYPE_HEATING = "HEATING";
+    public static final String PRODUCT_TYPE_HOT_WATER = "HOT_WATER";
+    public static final String PRODUCT_TYPE_HUB = "HUB";
+    public static final String PRODUCT_TYPE_THERMOSTAT_UI = "THERMOSTAT_UI";
+    public static final String PRODUCT_TYPE_TRV = "TRV";
+    public static final String PRODUCT_TYPE_TRV_GROUP = "TRV_GROUP";
+    public static final String PRODUCT_TYPE_UNKNOWN = "UNKNOWN";
+
+    /* Protocols */
+    public static final String PROTOCOL_SYNTHETIC = "SYNTHETIC";
+    public static final String PROTOCOL_ZIGBEE = "ZIGBEE";
+    public static final String PROTOCOL_PROXIED = "PROXIED";
+    public static final String PROTOCOL_MQTT = "MQTT";
+    public static final String PROTOCOL_XMPP = "XMPP";
+    public static final String PROTOCOL_VIRTUAL = "VIRTUAL";
+
+    /* Schedule Types */
+    public static final String SCHEDULE_TYPE_WEEKLY = "http://alertme.com/schema/json/configuration/configuration.device.schedule.weekly.v1.json#";
+
+    public static boolean isServerError(final int statusCode) {
+        return statusCode >= 500;
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiRequest.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.exception.HiveClientRequestException;
+
+/**
+ * A facade for HTTP requests to the Hive API
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveApiRequest {
+    /**
+     * Sets the media type this request accepts (expects in response).
+     *
+     * @param mediaType
+     *      The media type this request accepts.
+     *
+     * @return
+     *      This request.
+     */
+    HiveApiRequest accept(String mediaType);
+
+    /**
+     * Make the request to the Hive API using the method GET.
+     *
+     * @return
+     *      The response to this request.
+     *
+     * @throws org.openhab.binding.hive.internal.client.exception.HiveClientRequestException
+     *      If something goes wrong with making the request to the Hive API
+     *      (before the Hive API has a chance to respond)
+     *      e.g. The connection times out.
+     */
+    HiveApiResponse get() throws HiveClientRequestException;
+
+    /**
+     * Make the request to the Hive API using the method POST.
+     *
+     * @return
+     *      The response to this request.
+     *
+     * @throws org.openhab.binding.hive.internal.client.exception.HiveClientRequestException
+     *      If something goes wrong with making the request to the Hive API
+     *      (before the Hive API has a chance to respond)
+     *      e.g. The connection times out.
+     */
+    HiveApiResponse post(Object requestBody) throws HiveClientRequestException;
+
+    /**
+     * Make the request to the Hive API using the method PUT.
+     *
+     * @return
+     *      The response to this request.
+     *
+     * @throws org.openhab.binding.hive.internal.client.exception.HiveClientRequestException
+     *      If something goes wrong with making the request to the Hive API
+     *      (before the Hive API has a chance to respond)
+     *      e.g. The connection times out.
+     */
+    HiveApiResponse put(Object requestBody) throws HiveClientRequestException;
+
+    /**
+     * Make the request to the Hive API using the method DELETE.
+     *
+     * @return
+     *      The response to this request.
+     *
+     * @throws org.openhab.binding.hive.internal.client.exception.HiveClientRequestException
+     *      If something goes wrong with making the request to the Hive API
+     *      (before the Hive API has a chance to respond)
+     *      e.g. The connection times out.
+     */
+    HiveApiResponse delete() throws HiveClientRequestException;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiRequestFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiRequestFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.net.URI;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A factory for creating new requests to the Hive API.
+ *
+ * @see HiveApiRequest
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveApiRequestFactory {
+    /**
+     * Create a new request to the Hive API.
+     *
+     * @param endpointPath
+     *      The relative URI of the endpoint to make the request to.
+     *      (relative to the Hive API base path).
+     *
+     * @return
+     *      The new request.
+     */
+    HiveApiRequest newRequest(URI endpointPath);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiResponse.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveApiResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A facade for HTTP responses from the Hive API
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveApiResponse {
+    /**
+     * The HTTP response code of this response.
+     */
+    int getStatusCode();
+
+    /**
+     * Get the content of the response.
+     *
+     * @param contentType
+     *      The class of the response content.
+     *
+     * @param <T>
+     *      The type of response content.
+     *
+     * @return
+     *
+     * @throws IllegalArgumentException
+     *      If the content of the response does not represent an instance
+     *      of {@code T}.
+     */
+    <T> T getContent(Class<T> contentType);
+
+    /**
+     * Get the raw content of the response.
+     *
+     * @return
+     */
+    String getRawContent();
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveClient.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveClient.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+
+/**
+ * A class for interacting with the Hive API as a specific user.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveClient extends AutoCloseable {
+    /**
+     * Get the {@link UserId} of the user this client is authenticated as.
+     */
+    UserId getUserId();
+
+    /**
+     * Gets all the {@link Node}s associated with the authenticated user.
+     */
+    Set<Node> getAllNodes() throws HiveException;
+
+    /**
+     * Get the raw JSON returned by the Hive API for a get all nodes request.
+     *
+     * <p>This is meant to be used for debugging purposes only</p>
+     *
+     * @return
+     *      The raw JSON string returned by the Hive API.
+     */
+    String getAllNodesJson() throws HiveException;
+
+    /**
+     * Get a node with a given {@link NodeId}.
+     *
+     * @param nodeId
+     *      The ID of the {@linkplain Node} to get.
+     *
+     * @return
+     *      {@code null} if no {@linkplain Node} exists with the id
+     *      {@code nodeId}.
+     */
+    @Nullable Node getNode(NodeId nodeId) throws HiveException;
+
+    /**
+     * Push an updated version of a {@link Node} to the Hive API.
+     *
+     * @param node
+     *      The locally updated {@linkplain Node} that you want to push
+     *      to the Hive API.
+     *
+     * @return
+     *      The updated version of the {@linkplain Node} returned by the
+     *      Hive API.
+     */
+    @Nullable Node updateNode(Node node) throws HiveException;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveClientFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/HiveClientFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+
+/**
+ * A factory for getting new instances of {@link HiveClient}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveClientFactory {
+    /**
+     *
+     * @param username
+     *      The username to authenticate with.
+     *
+     * @param password
+     *      The password to authenticate with.
+     *
+     * @return
+     *      A new {@link HiveClient}.
+     */
+    HiveClient newClient(
+            final String username,
+            final String password
+    ) throws HiveException;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiRequest.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiRequest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.hive.internal.client.exception.HiveClientRequestException;
+
+/**
+ * An implementation of {@link HiveApiRequest} based around jetty's
+ * {@link org.eclipse.jetty.client.HttpClient}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+final class JettyHiveApiRequest implements HiveApiRequest {
+    private final JsonService jsonService;
+    private final Request request;
+
+    public JettyHiveApiRequest(
+            final JsonService jsonService,
+            final Request request
+    ) {
+        Objects.requireNonNull(jsonService);
+        Objects.requireNonNull(request);
+
+        this.jsonService = jsonService;
+        this.request = request;
+    }
+
+    private void setContent(final Object content) {
+        this.request.content(
+                new StringContentProvider(this.jsonService.toJson(content)),
+                HiveApiConstants.MEDIA_TYPE_JSON
+        );
+    }
+
+    @Override
+    public HiveApiRequest accept(final String mediaType) {
+        this.request.accept(mediaType);
+
+        return this;
+    }
+
+    @Override
+    public HiveApiResponse get() throws HiveClientRequestException {
+        this.request.method(HttpMethod.GET);
+
+        return this.sendRequest();
+    }
+
+    @Override
+    public HiveApiResponse post(final Object requestBody) throws HiveClientRequestException {
+        Objects.requireNonNull(requestBody);
+
+        this.request.method(HttpMethod.POST);
+        this.setContent(requestBody);
+
+        return this.sendRequest();
+    }
+
+    @Override
+    public HiveApiResponse put(final Object requestBody) throws HiveClientRequestException {
+        Objects.requireNonNull(requestBody);
+
+        this.request.method(HttpMethod.PUT);
+        this.setContent(requestBody);
+
+        return this.sendRequest();
+    }
+
+    @Override
+    public HiveApiResponse delete() throws HiveClientRequestException {
+        this.request.method(HttpMethod.DELETE);
+
+        return this.sendRequest();
+    }
+
+    private HiveApiResponse sendRequest() throws HiveClientRequestException {
+        try {
+            final ContentResponse response = this.request.send();
+
+            return new JettyHiveApiResponse(this.jsonService, response);
+        } catch (InterruptedException | TimeoutException | ExecutionException ex) {
+            throw new HiveClientRequestException(ex);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiRequestFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiRequestFactory.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.WWWAuthenticationProtocolHandler;
+import org.eclipse.jetty.client.api.Request;
+
+/**
+ * An implementation of {@link HiveApiRequestFactory} that uses Jetty's
+ * {@link HttpClient}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+final class JettyHiveApiRequestFactory implements HiveApiRequestFactory, SessionAuthenticationManager {
+    private static final String ACCESS_TOKEN_HEADER = "X-Omnia-Access-Token";
+    private static final String CLIENT_ID_HEADER = "X-Omnia-Client";
+
+    private static final long TIMEOUT_VALUE = 5;
+    private static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+    private final HttpClient httpClient;
+    private final URI apiBasePath;
+    private final JsonService jsonService;
+    private final String clientId;
+
+    private @Nullable Session session = null;
+
+    /**
+     * Create a new {@link JettyHiveApiRequestFactory}.
+     *
+     * @param httpClient
+     *      The {@link HttpClient} that should be used to make requests to the
+     *      Hive API. N.B. This should not be reused elsewhere.
+     *
+     * @param apiBasePath
+     *      The base path the Hive API.
+     *
+     * @param jsonService
+     *      The {@link JsonService} to use.
+     *
+     * @param clientId
+     *      The Client ID to identify as to the Hive API.
+     */
+    public JettyHiveApiRequestFactory(
+            final HttpClient httpClient,
+            final URI apiBasePath,
+            final JsonService jsonService,
+            final String clientId
+    ) {
+        this.httpClient = Objects.requireNonNull(httpClient);
+        this.apiBasePath = Objects.requireNonNull(apiBasePath);
+        this.jsonService = Objects.requireNonNull(jsonService);
+        this.clientId = Objects.requireNonNull(clientId);
+
+        if (!apiBasePath.isAbsolute()) {
+            throw new IllegalArgumentException("API base path must be absolute");
+        }
+
+        // httpClient needs to be started or modifying the protocol handlers
+        // will not work correctly.
+        if (!httpClient.isStarted()) {
+            throw new IllegalArgumentException("The provided HttpClient is not started!");
+        }
+
+        // Remove jetty's default authentication handler as it will be confused
+        // by the Hive API's lack of "WWW-Authenticate" header and will mess
+        // up manual authentication.
+        this.httpClient.getProtocolHandlers().remove(WWWAuthenticationProtocolHandler.NAME);
+    }
+
+    @Override
+    public void clearSession() {
+        this.session = null;
+    }
+
+    @Override
+    public @Nullable Session getSession() {
+        return this.session;
+    }
+
+    @Override
+    public void setSession(final Session session) {
+        Objects.requireNonNull(session);
+
+        this.session = session;
+    }
+
+    @Override
+    public HiveApiRequest newRequest(final URI endpointPath) {
+        final URI target = this.apiBasePath.resolve(endpointPath);
+
+        final Request request = this.httpClient.newRequest(target);
+
+        // Add X-Omnia-Client header
+        request.header(CLIENT_ID_HEADER, this.clientId);
+
+        // If we have a session ID add X-Omnia-Access-Token header.
+        final @Nullable Session session = this.session;
+        if (session != null) {
+            request.header(ACCESS_TOKEN_HEADER, session.getSessionId().toString());
+        }
+
+        // Set a short timeout as the Hive API should respond very quickly.
+        // If a response is taking a long time something has gone wrong so we
+        // should abort and back off until things are back to normal.
+        request.timeout(TIMEOUT_VALUE, TIMEOUT_UNIT);
+
+        return new JettyHiveApiRequest(
+                this.jsonService,
+                request
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiResponse.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JettyHiveApiResponse.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.api.ContentResponse;
+
+/**
+ * An implementation of {@link HiveApiResponse} based around jetty's
+ * {@link org.eclipse.jetty.client.HttpClient}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+final class JettyHiveApiResponse implements HiveApiResponse {
+    private final JsonService jsonService;
+    private final ContentResponse response;
+
+    public JettyHiveApiResponse(
+            final JsonService jsonService,
+            final ContentResponse response
+    ) {
+        Objects.requireNonNull(jsonService);
+        Objects.requireNonNull(response);
+
+        this.jsonService = jsonService;
+        this.response = response;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return this.response.getStatus();
+    }
+
+    @Override
+    public <T> T getContent(Class<T> contentType) {
+        return this.jsonService.fromJson(this.response.getContentAsString(), contentType);
+    }
+
+    @Override
+    public String getRawContent() {
+        return this.response.getContentAsString();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JsonService.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/JsonService.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A facade for JSON serialisation/deserialisation.
+ *
+ * <p>
+ *     Used to decouple from Gson and make testing easier.
+ *     ({@code Gson} is final and so annoying to replace with a test double)
+ * </p>
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface JsonService {
+    /**
+     * Serialise a given object into json.
+     *
+     * @param object
+     *      The object you want to be serialised into json.
+     *
+     * @return
+     *      A string containing a json representation of {@code object}.
+     */
+    String toJson(Object object);
+
+    /**
+     * Parse a given json string into an object of a given type.
+     *
+     * @param json
+     *      The json to parse.
+     *
+     * @param classOfT
+     *      The class of {@code T}.
+     *
+     * @param <T>
+     *      The type that you want the json to be parsed into.
+     *
+     * @return
+     *      The {@code T} representation of the provided json.
+     *
+     * @throws IllegalArgumentException
+     *      If the provided json is empty or does not represent an instance
+     *      of {@code T}.
+     */
+    <T> T fromJson(String json, Class<T> classOfT);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Link.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Link.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class Link {
+    private final NodeId nodeId;
+    private final GroupId groupId;
+
+    public Link(
+            final NodeId nodeId,
+            final GroupId groupId
+    ) {
+        Objects.requireNonNull(nodeId);
+        Objects.requireNonNull(groupId);
+
+        this.nodeId = nodeId;
+        this.groupId = groupId;
+    }
+
+    public NodeId getNodeId() {
+        return this.nodeId;
+    }
+
+    public GroupId getGroupId() {
+        return this.groupId;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Link link = (Link) o;
+        return this.nodeId.equals(link.nodeId) &&
+                this.groupId.equals(link.groupId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.nodeId, this.groupId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Node.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Node.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class Node {
+    private final NodeId id;
+    private final String name;
+    private final NodeType nodeType;
+    private final ProductType productType;
+    private final Protocol protocol;
+    private final NodeId parentNodeId;
+    private final Map<Class<? extends Feature>, Feature> features;
+
+    private Node(
+            final NodeId id,
+            final String name,
+            final NodeType nodeType,
+            final ProductType productType,
+            final Protocol protocol,
+            final NodeId parentNodeId,
+            final Map<Class<? extends Feature>, Feature> features
+    ) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(nodeType);
+        Objects.requireNonNull(productType);
+        Objects.requireNonNull(protocol);
+        Objects.requireNonNull(parentNodeId);
+        Objects.requireNonNull(features);
+
+        this.id = id;
+        this.name = name;
+        this.nodeType = nodeType;
+        this.productType = productType;
+        this.protocol = protocol;
+        this.parentNodeId = parentNodeId;
+        this.features = features;
+    }
+
+    public NodeId getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public NodeType getNodeType() {
+        return this.nodeType;
+    }
+
+    public ProductType getProductType() {
+        return this.productType;
+    }
+
+    public Protocol getProtocol() {
+        return this.protocol;
+    }
+
+    public NodeId getParentNodeId() {
+        return this.parentNodeId;
+    }
+
+    public Map<Class<? extends Feature>, Feature> getFeatures() {
+        return Collections.unmodifiableMap(this.features);
+    }
+
+    @SuppressWarnings({"unchecked", "cast.unsafe"})
+    public <T extends Feature> @Nullable T getFeature(final Class<T> classOfFeature) {
+        // N.B. "Unchecked cast" warning suppressed because we should be
+        //      ensuring that the class of the value matches the key
+        //      when they are put in the map.
+        return (T) this.features.get(classOfFeature);
+    }
+
+    public <T extends Feature> Node withFeature(final Class<T> featureClass, final T feature) {
+        return Node.builder()
+                .from(this)
+                .putFeature(featureClass, feature)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable NodeId id;
+        private @Nullable String name;
+        private @Nullable NodeType nodeType;
+        private @Nullable ProductType productType;
+        private @Nullable Protocol protocol;
+        private @Nullable NodeId parentNodeId;
+        private Map<Class<? extends Feature>, Feature> features = new HashMap<>();
+
+        public Builder from(final Node node) {
+            Objects.requireNonNull(node);
+
+            return this.id(node.getId())
+                    .name(node.getName())
+                    .nodeType(node.getNodeType())
+                    .productType(node.getProductType())
+                    .protocol(node.getProtocol())
+                    .parentNodeId(node.getParentNodeId())
+                    .features(node.getFeatures());
+        }
+
+        public Builder id(final NodeId id) {
+            this.id = Objects.requireNonNull(id);
+
+            return this;
+        }
+
+        public Builder name(final String name) {
+            this.name = Objects.requireNonNull(name);
+
+            return this;
+        }
+
+        public Builder nodeType(final NodeType nodeType) {
+            this.nodeType = Objects.requireNonNull(nodeType);
+
+            return this;
+        }
+
+        public Builder productType(final ProductType productType) {
+            this.productType = Objects.requireNonNull(productType);
+
+            return this;
+        }
+
+        public Builder protocol(final Protocol protocol) {
+            this.protocol = Objects.requireNonNull(protocol);
+
+            return this;
+        }
+
+        public Builder parentNodeId(final NodeId parentNodeId) {
+            this.parentNodeId = Objects.requireNonNull(parentNodeId);
+
+            return this;
+        }
+
+        public Builder features(final Map<Class<? extends Feature>, Feature> features) {
+            this.features = new HashMap<>(features);
+
+            return this;
+        }
+
+        public <F extends Feature> Builder putFeature(
+                final Class<F> featureClass,
+                final F feature
+        ) {
+            Objects.requireNonNull(featureClass);
+            Objects.requireNonNull(feature);
+
+            this.features.put(featureClass, feature);
+
+            return this;
+        }
+
+        public Node build() {
+            final @Nullable NodeId id = this.id;
+            final @Nullable String name = this.name;
+            final @Nullable NodeType nodeType = this.nodeType;
+            final @Nullable ProductType productType = this.productType;
+            final @Nullable Protocol protocol = this.protocol;
+            final @Nullable NodeId parentNodeId = this.parentNodeId;
+
+            if (id == null
+                    || name == null
+                    || nodeType == null
+                    || productType == null
+                    || protocol == null
+                    || parentNodeId == null
+            ) {
+                throw new IllegalStateException(BuilderUtil.REQUIRED_ATTRIBUTE_NOT_SET_MESSAGE);
+            }
+
+            return new Node(
+                    id,
+                    name,
+                    nodeType,
+                    productType,
+                    protocol,
+                    parentNodeId,
+                    Collections.unmodifiableMap(this.features)
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/NodeId.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/NodeId.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents a Hive API node ID.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class NodeId extends SimpleValueTypeBase<UUID> {
+    public NodeId(final UUID nodeId) {
+        super(nodeId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/NodeType.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/NodeType.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents a Hive API node type.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum NodeType {
+    HUB,
+    THERMOSTAT,
+    THERMOSTAT_UI,
+    RADIATOR_VALVE,
+    SYNTHETIC_DAYLIGHT,
+    SYNTHETIC_HOME_STATE,
+    SYNTHETIC_RULE,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/OnOffMode.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/OnOffMode.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum OnOffMode {
+    ON,
+    OFF
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/OverrideMode.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/OverrideMode.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum OverrideMode {
+    NONE,
+    TRANSIENT
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ProductType.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ProductType.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents a Hive API product type.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum ProductType {
+    ACTIONS,
+    BOILER_MODULE,
+    DAYLIGHT_SD,
+    HEATING,
+    HOT_WATER,
+    HUB,
+    THERMOSTAT_UI,
+    TRV,
+    TRV_GROUP,
+    UNKNOWN,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Protocol.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Protocol.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum Protocol {
+    SYNTHETIC,
+    ZIGBEE,
+    PROXIED,
+    MQTT,
+    XMPP,
+    VIRTUAL,
+
+    NONE,
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ReverseLink.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ReverseLink.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ReverseLink {
+    private final NodeId nodeId;
+    private final Set<GroupId> groupIds;
+
+    public ReverseLink(
+            final NodeId nodeId,
+            final Set<GroupId> groupIds
+    ) {
+        Objects.requireNonNull(nodeId);
+        Objects.requireNonNull(groupIds);
+
+        // Make a defensive copy.
+        final Set<GroupId> groupIdsCopy = Collections.unmodifiableSet(new HashSet<>(groupIds));
+
+        if (groupIdsCopy.isEmpty()) {
+            throw new IllegalArgumentException("A reverse link must have at least one group id");
+        }
+
+        if (groupIdsCopy.contains(null)) {
+            throw new IllegalArgumentException("Null group ids are not allowed.");
+        }
+
+        this.nodeId = nodeId;
+        this.groupIds = groupIdsCopy;
+    }
+
+    public NodeId getNodeId() {
+        return this.nodeId;
+    }
+
+    public Set<GroupId> getGroupIds() {
+        return this.groupIds;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ReverseLink that = (ReverseLink) o;
+        return this.nodeId.equals(that.nodeId) &&
+                this.groupIds.equals(that.groupIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.nodeId, this.groupIds);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ScheduleType.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/ScheduleType.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum ScheduleType {
+    WEEKLY,
+
+    UNEXPECTED
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Session.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/Session.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Represents a session with the Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class Session {
+    private final SessionId sessionId;
+    private final UserId userId;
+
+    public Session(
+            final SessionId sessionId,
+            final UserId userId
+    ) {
+        Objects.requireNonNull(sessionId);
+        Objects.requireNonNull(userId);
+
+        this.sessionId = sessionId;
+        this.userId = userId;
+    }
+
+    public SessionId getSessionId() {
+        return sessionId;
+    }
+
+    public UserId getUserId() {
+        return userId;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final Session session = (Session) o;
+        return sessionId.equals(session.sessionId) &&
+                userId.equals(session.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sessionId, userId);
+    }
+
+    @Override
+    public String toString() {
+        return "Session{" +
+                "sessionId=" + sessionId +
+                ", userId=" + userId +
+                '}';
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SessionAuthenticationManager.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SessionAuthenticationManager.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+interface SessionAuthenticationManager {
+    void clearSession();
+    @Nullable Session getSession();
+    void setSession(Session session);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SessionId.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SessionId.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents a Hive API Session ID.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class SessionId extends SimpleValueTypeBase<String> {
+    public SessionId(final String sessionId) {
+        super(sessionId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SettableFeatureAttribute.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SettableFeatureAttribute.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface SettableFeatureAttribute<T> extends FeatureAttribute<T> {
+    @Nullable T getTargetValue();
+
+    SettableFeatureAttribute<T> withTargetValue(@Nullable T targetValue);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SimpleValueTypeBase.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/SimpleValueTypeBase.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A base class for simple value types.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+abstract class SimpleValueTypeBase<T extends @NonNull Object> {
+    private final T value;
+
+    public SimpleValueTypeBase(final T value) {
+        Objects.requireNonNull(value);
+
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value.toString();
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o)
+            return true;
+        if (o == null || this.getClass() != o.getClass())
+            return false;
+        final SimpleValueTypeBase<?> other = (SimpleValueTypeBase<?>) o;
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.value);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/UserId.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/UserId.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents a Hive API User ID.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class UserId extends SimpleValueTypeBase<UUID> {
+    public UserId(final UUID userId) {
+        super(userId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/WaterHeaterOperatingMode.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/WaterHeaterOperatingMode.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Represents the type of mode that a water_heater is operating in.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public enum WaterHeaterOperatingMode {
+    /**
+     * Following the schedule.
+     */
+    SCHEDULE,
+
+    /**
+     * Manually controlled.
+     */
+    ON
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ActionTypeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ActionTypeGsonAdapter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.ActionType;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link ActionType}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ActionTypeGsonAdapter extends ComplexEnumGsonTypeAdapterBase<ActionType> {
+    public ActionTypeGsonAdapter() {
+        super(EnumMapper.builder(ActionType.class)
+                .setUnexpectedValue(ActionType.UNEXPECTED)
+                .add(ActionType.GENERIC, HiveApiConstants.ACTION_TYPE_GENERIC)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/AttributeNameGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/AttributeNameGsonAdapter.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.AttributeName;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link AttributeName}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class AttributeNameGsonAdapter extends ComplexEnumGsonTypeAdapterBase<AttributeName> {
+    public AttributeNameGsonAdapter() {
+        super(EnumMapper.builder(AttributeName.class)
+                .setUnexpectedValue(AttributeName.UNEXPECTED)
+                .add(
+                        AttributeName.HEATING_THERMOSTAT_TARGET_HEAT_TEMPERATURE,
+                        HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TARGET_HEAT_TEMPERATURE
+                )
+                .add(
+                        AttributeName.ON_OFF_DEVICE_MODE,
+                        HiveApiConstants.ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE
+                )
+                .add(
+                        AttributeName.WATER_HEATER_HEATING_OPERATING_MODE,
+                        HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_OPERATING_MODE
+                )
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ComplexEnumGsonTypeAdapterBase.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ComplexEnumGsonTypeAdapterBase.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+abstract class ComplexEnumGsonTypeAdapterBase<E extends Enum<E>> extends GsonTypeAdapterBase<E> {
+    private final EnumMapper<E> enumMap;
+
+    protected ComplexEnumGsonTypeAdapterBase(final EnumMapper<E> enumMap) {
+        this.enumMap = Objects.requireNonNull(enumMap);
+    }
+
+    @Override
+    public @Nullable E readValue(final JsonReader in) throws IOException {
+        final @Nullable String enumString = in.nextString();
+
+        if (enumString != null) {
+            return this.enumMap.getEnumForString(enumString);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void writeValue(final JsonWriter out, final E value) throws IOException {
+        out.value(this.enumMap.getStringForEnum(value));
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/EnumMapper.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/EnumMapper.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.text.MessageFormat;
+import java.util.*;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+final class EnumMapper<E extends @NonNull Enum<E>> {
+    private final Logger logger = LoggerFactory.getLogger(EnumMapper.class);
+
+    private final Class<E> enumClass;
+    private final Map<E, String> enumToStringMap;
+    private final Map<String, E> stringToEnumMap;
+    private final E unexpectedValue;
+
+    private EnumMapper(
+            final Class<E> enumClass,
+            final Map<E, String> enumToStringMap,
+            final Map<String, E> stringToEnumMap,
+            final E unexpectedValue
+    ) {
+        // Trust the builder has created everything correctly.
+        this.enumClass = enumClass;
+        this.enumToStringMap = enumToStringMap;
+        this.stringToEnumMap = stringToEnumMap;
+        this.unexpectedValue = unexpectedValue;
+    }
+
+    public @Nullable String getStringForEnum(final E enumValue) {
+        Objects.requireNonNull(enumValue);
+
+        return this.enumToStringMap.get(enumValue);
+    }
+
+    public E getEnumForString(final String stringValue) {
+        Objects.requireNonNull(stringValue);
+
+        final @Nullable E enumValue = this.stringToEnumMap.get(stringValue);
+
+        if (enumValue != null) {
+            return enumValue;
+        } else {
+            this.logger.trace(
+                    "Given unexpected string for enum {}: \"{}\"",
+                    this.enumClass.toString(),
+                    stringValue
+            );
+
+            return this.unexpectedValue;
+        }
+    }
+
+    public static <E extends @NonNull Enum<E>> Builder<E> builder(final Class<E> enumClass) {
+        return new Builder<>(enumClass);
+    }
+
+    public static class Builder<E extends @NonNull Enum<E>> {
+        private final Class<E> enumClass;
+
+        private final Map<E, String> enumToStringMap;
+        private final Map<String, E> stringToEnumMap;
+        private final Set<E> ignoredValues;
+
+        private @Nullable E unexpectedValue;
+
+        public Builder(final Class<E> enumClass) {
+            this.enumClass = Objects.requireNonNull(enumClass);
+
+            this.enumToStringMap = new EnumMap<>(enumClass);
+            this.stringToEnumMap = new HashMap<>();
+            this.ignoredValues = EnumSet.noneOf(enumClass);
+        }
+
+        public Builder<E> setUnexpectedValue(final E enumValue) {
+            Objects.requireNonNull(enumValue);
+
+            checkNotUsed(enumValue);
+
+            this.unexpectedValue = enumValue;
+
+            return this;
+        }
+
+        public Builder<E> ignore(final E enumValue) {
+            Objects.requireNonNull(enumValue);
+
+            checkNotUsed(enumValue);
+
+            this.ignoredValues.add(enumValue);
+
+            return this;
+        }
+
+        public Builder<E> add(final E enumValue, final String stringValue) {
+            Objects.requireNonNull(enumValue);
+            Objects.requireNonNull(stringValue);
+
+            checkNotUsed(enumValue);
+
+            if (this.stringToEnumMap.containsKey(stringValue)) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "The string value \"{0}\" has already been added to the map.",
+                        stringValue
+                ));
+            }
+
+            this.enumToStringMap.put(enumValue, stringValue);
+            this.stringToEnumMap.put(stringValue, enumValue);
+
+            return this;
+        }
+
+        public EnumMapper<E> build() {
+            final @Nullable E unknownValue = this.unexpectedValue;
+            if (unknownValue == null) {
+                throw new IllegalStateException("The unknown value has not been set.");
+            }
+
+            final EnumSet<E> missingValues = EnumSet.allOf(this.enumClass);
+            missingValues.removeAll(this.enumToStringMap.keySet());
+            missingValues.removeAll(this.ignoredValues);
+            missingValues.remove(unknownValue);
+
+            if (missingValues.size() > 0) {
+                throw new IllegalStateException("Expected values have not been added: " + missingValues.toString());
+            }
+
+            return new EnumMapper<>(
+                    this.enumClass,
+                    Collections.unmodifiableMap(this.enumToStringMap),
+                    Collections.unmodifiableMap(this.stringToEnumMap),
+                    unknownValue
+            );
+        }
+
+        private void checkNotUsed(final E enumValue) {
+            if (this.unexpectedValue == enumValue) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "The enum value \"{0}\" has already been used as the unexpected value.",
+                        enumValue.toString()
+                ));
+            }
+
+            if (this.ignoredValues.contains(enumValue)) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "The enum value \"{0}\" has already been set as ignored.",
+                        enumValue.toString()
+                ));
+            }
+
+            if (this.enumToStringMap.containsKey(enumValue)) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "The enum value \"{0}\" has already been added to the map.",
+                        enumValue.toString()
+                ));
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/Eui64GsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/Eui64GsonAdapter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.Eui64;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link Eui64}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class Eui64GsonAdapter extends GsonTypeAdapterBase<Eui64> {
+    @Override
+    public @Nullable Eui64 readValue(final JsonReader in) throws IOException {
+        return new Eui64(in.nextString());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/FeatureTypeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/FeatureTypeGsonAdapter.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.FeatureType;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link FeatureType}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class FeatureTypeGsonAdapter extends ComplexEnumGsonTypeAdapterBase<FeatureType> {
+    public FeatureTypeGsonAdapter() {
+        super(EnumMapper.builder(FeatureType.class)
+                .setUnexpectedValue(FeatureType.UNEXPECTED)
+                .add(FeatureType.AUTOBOOST_V1, HiveApiConstants.FEATURE_TYPE_AUTOBOOST_V1)
+                .add(FeatureType.BATTERY_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_BATTERY_DEVICE_V1)
+                .add(FeatureType.CHILD_LOCK_V1, HiveApiConstants.FEATURE_TYPE_CHILD_LOCK_V1)
+                .add(FeatureType.DEVICE_MANAGEMENT_V1, HiveApiConstants.FEATURE_TYPE_DEVICE_MANAGEMENT_V1)
+                .add(FeatureType.DISPLAY_ORIENTATION_V1, HiveApiConstants.FEATURE_TYPE_DISPLAY_ORIENTATION_V1)
+                .add(FeatureType.ETHERNET_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ETHERNET_DEVICE_V1)
+                .add(FeatureType.FROST_PROTECT_V1, HiveApiConstants.FEATURE_TYPE_FROST_PROTECT_V1)
+                .add(FeatureType.GROUP_V1, HiveApiConstants.FEATURE_TYPE_GROUP_V1)
+                .add(FeatureType.HEATING_TEMPERATURE_CONTROL_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_DEVICE_V1)
+                .add(FeatureType.HEATING_TEMPERATURE_CONTROL_V1, HiveApiConstants.FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_V1)
+                .add(FeatureType.HEATING_THERMOSTAT_V1, HiveApiConstants.FEATURE_TYPE_HEATING_THERMOSTAT_V1)
+                .add(FeatureType.HIVE_HUB_V1, HiveApiConstants.FEATURE_TYPE_HIVE_HUB_V1)
+                .add(FeatureType.LIFECYCLE_STATE_V1, HiveApiConstants.FEATURE_TYPE_LIFECYCLE_STATE_V1)
+                .add(FeatureType.LINKS_V1, HiveApiConstants.FEATURE_TYPE_LINKS_V1)
+                .add(FeatureType.MOUNTING_MODE_V1, HiveApiConstants.FEATURE_TYPE_MOUNTING_MODE_V1)
+                .add(FeatureType.ON_OFF_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ON_OFF_DEVICE_V1)
+                .add(FeatureType.PHYSICAL_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_PHYSICAL_DEVICE_V1)
+                .add(FeatureType.PI_HEATING_DEMAND_V1, HiveApiConstants.FEATURE_TYPE_PI_HEATING_DEMAND_V1)
+                .add(FeatureType.RADIO_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_RADIO_DEVICE_V1)
+                .add(FeatureType.STANDBY_V1, HiveApiConstants.FEATURE_TYPE_STANDBY_V1)
+                .add(FeatureType.TEMPERATURE_SENSOR_V1, HiveApiConstants.FEATURE_TYPE_TEMPERATURE_SENSOR_V1)
+                .add(FeatureType.TRANSIENT_MODE_V1, HiveApiConstants.FEATURE_TYPE_TRANSIENT_MODE_V1)
+                .add(FeatureType.TRV_CALIBRATION_V1, HiveApiConstants.FEATURE_TYPE_TRV_CALIBRATION_V1)
+                .add(FeatureType.TRV_ERROR_DIAGNOSTICS_V1, HiveApiConstants.FEATURE_TYPE_TRV_ERROR_DIAGNOSTICS_V1)
+                .add(FeatureType.WATER_HEATER_V1, HiveApiConstants.FEATURE_TYPE_WATER_HEATER_V1)
+                .add(FeatureType.ZIGBEE_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ZIGBEE_DEVICE_V1)
+                .add(FeatureType.ZIGBEE_ROUTING_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ZIGBEE_ROUTING_DEVICE_V1)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/GroupIdGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/GroupIdGsonAdapter.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.GroupId;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link GroupId}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class GroupIdGsonAdapter extends ComplexEnumGsonTypeAdapterBase<GroupId> {
+    public GroupIdGsonAdapter() {
+        super(EnumMapper.builder(GroupId.class)
+                .setUnexpectedValue(GroupId.UNEXPECTED)
+                .add(GroupId.TRVBM, HiveApiConstants.GROUP_ID_TRVBM)
+                .add(GroupId.TRVS, HiveApiConstants.GROUP_ID_TRVS)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/GsonTypeAdapterBase.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/GsonTypeAdapterBase.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * An abstract base class for gson {@link TypeAdapter}s.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+abstract class GsonTypeAdapterBase<T> extends TypeAdapter<T> {
+    @Override
+    public final T read(final @Nullable JsonReader in) throws IOException {
+        if (in == null) {
+            throw new IllegalArgumentException("in must not be null");
+        }
+
+        return readValue(in);
+    }
+
+    @Override
+    public final void write(final @Nullable JsonWriter out, final @Nullable T value) throws IOException {
+        if (out == null) {
+            throw new IllegalArgumentException("out must not be null");
+        }
+
+        if (value == null) {
+            out.nullValue();
+        } else {
+            this.writeValue(out, value);
+        }
+    }
+
+    abstract @Nullable T readValue(final JsonReader in) throws IOException;
+
+    public void writeValue(final JsonWriter out, final T value) throws IOException {
+        // Default for simple types where toString() is good enough.
+        out.value(value.toString());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/HiveApiInstantGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/HiveApiInstantGsonAdapter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.dto.HiveApiInstant;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link HiveApiInstant}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiInstantGsonAdapter extends GsonTypeAdapterBase<HiveApiInstant> {
+    @Override
+    public void writeValue(final JsonWriter out, final @Nullable HiveApiInstant hiveApiInstant) throws IOException {
+        if (hiveApiInstant != null) {
+            out.value(hiveApiInstant.asInstant().toEpochMilli());
+        } else {
+            out.nullValue();
+        }
+    }
+
+    @Override
+    public @Nullable HiveApiInstant readValue(final JsonReader in) throws IOException {
+        return new HiveApiInstant(Instant.ofEpochMilli(in.nextLong()));
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/NodeIdGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/NodeIdGsonAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.NodeId;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link NodeId}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class NodeIdGsonAdapter extends GsonTypeAdapterBase<NodeId> {
+    @Override
+    public @Nullable NodeId readValue(final JsonReader in) throws IOException {
+        return new NodeId(UUID.fromString(in.nextString()));
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/NodeTypeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/NodeTypeGsonAdapter.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.NodeType;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link NodeType}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class NodeTypeGsonAdapter extends ComplexEnumGsonTypeAdapterBase<NodeType> {
+    public NodeTypeGsonAdapter() {
+        super(EnumMapper.builder(NodeType.class)
+                .setUnexpectedValue(NodeType.UNEXPECTED)
+                .add(NodeType.HUB, HiveApiConstants.NODE_TYPE_HUB)
+                .add(NodeType.RADIATOR_VALVE, HiveApiConstants.NODE_TYPE_RADIATOR_VALVE)
+                .add(NodeType.SYNTHETIC_DAYLIGHT, HiveApiConstants.NODE_TYPE_SYNTHETIC_DAYLIGHT)
+                .add(NodeType.SYNTHETIC_HOME_STATE, HiveApiConstants.NODE_TYPE_SYNTHETIC_HOME_STATE)
+                .add(NodeType.SYNTHETIC_RULE, HiveApiConstants.NODE_TYPE_SYNTHETIC_RULE)
+                .add(NodeType.THERMOSTAT, HiveApiConstants.NODE_TYPE_THERMOSTAT)
+                .add(NodeType.THERMOSTAT_UI, HiveApiConstants.NODE_TYPE_THERMOSTAT_UI)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ProductTypeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ProductTypeGsonAdapter.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.ProductType;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link ProductType}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ProductTypeGsonAdapter extends ComplexEnumGsonTypeAdapterBase<ProductType> {
+    public ProductTypeGsonAdapter() {
+        super(EnumMapper.builder(ProductType.class)
+                .setUnexpectedValue(ProductType.UNEXPECTED)
+                .add(ProductType.ACTIONS, HiveApiConstants.PRODUCT_TYPE_ACTIONS)
+                .add(ProductType.BOILER_MODULE, HiveApiConstants.PRODUCT_TYPE_BOILER_MODULE)
+                .add(ProductType.DAYLIGHT_SD, HiveApiConstants.PRODUCT_TYPE_DAYLIGHT_SD)
+                .add(ProductType.HEATING, HiveApiConstants.PRODUCT_TYPE_HEATING)
+                .add(ProductType.HOT_WATER, HiveApiConstants.PRODUCT_TYPE_HOT_WATER)
+                .add(ProductType.HUB, HiveApiConstants.PRODUCT_TYPE_HUB)
+                .add(ProductType.THERMOSTAT_UI, HiveApiConstants.PRODUCT_TYPE_THERMOSTAT_UI)
+                .add(ProductType.TRV, HiveApiConstants.PRODUCT_TYPE_TRV)
+                .add(ProductType.TRV_GROUP, HiveApiConstants.PRODUCT_TYPE_TRV_GROUP)
+                .add(ProductType.UNKNOWN, HiveApiConstants.PRODUCT_TYPE_UNKNOWN)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ProtocolGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ProtocolGsonAdapter.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Protocol;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link Protocol}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ProtocolGsonAdapter extends ComplexEnumGsonTypeAdapterBase<Protocol> {
+    public ProtocolGsonAdapter() {
+        super(EnumMapper.builder(Protocol.class)
+                .setUnexpectedValue(Protocol.UNEXPECTED)
+                .add(Protocol.MQTT, HiveApiConstants.PROTOCOL_MQTT)
+                .add(Protocol.PROXIED, HiveApiConstants.PROTOCOL_PROXIED)
+                .add(Protocol.SYNTHETIC, HiveApiConstants.PROTOCOL_SYNTHETIC)
+                .add(Protocol.VIRTUAL, HiveApiConstants.PROTOCOL_VIRTUAL)
+                .add(Protocol.XMPP, HiveApiConstants.PROTOCOL_XMPP)
+                .add(Protocol.ZIGBEE, HiveApiConstants.PROTOCOL_ZIGBEE)
+                .ignore(Protocol.NONE)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ScheduleTypeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ScheduleTypeGsonAdapter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.ScheduleType;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link ScheduleType}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ScheduleTypeGsonAdapter extends ComplexEnumGsonTypeAdapterBase<ScheduleType> {
+    public ScheduleTypeGsonAdapter() {
+        super(EnumMapper.builder(ScheduleType.class)
+                .setUnexpectedValue(ScheduleType.UNEXPECTED)
+                .add(ScheduleType.WEEKLY, HiveApiConstants.SCHEDULE_TYPE_WEEKLY)
+                .build());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/SessionIdGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/SessionIdGsonAdapter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.SessionId;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link SessionId}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class SessionIdGsonAdapter extends GsonTypeAdapterBase<SessionId> {
+    @Override
+    public @Nullable SessionId readValue(final JsonReader in) throws IOException {
+        return new SessionId(in.nextString());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/UserIdGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/UserIdGsonAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.UserId;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link UserId}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class UserIdGsonAdapter extends GsonTypeAdapterBase<UserId> {
+    @Override
+    public @Nullable UserId readValue(final JsonReader in) throws IOException {
+        return new UserId(UUID.fromString(in.nextString()));
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ZonedDateTimeGsonAdapter.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/adapter/ZonedDateTimeGsonAdapter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A gson {@link com.google.gson.TypeAdapter} for {@link ZonedDateTime} as used by the
+ * Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ZonedDateTimeGsonAdapter extends GsonTypeAdapterBase<ZonedDateTime> {
+    private static final DateTimeFormatter HIVE_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    @Override
+    public void writeValue(final JsonWriter out, final @Nullable ZonedDateTime zonedDateTime) throws IOException {
+        if (zonedDateTime != null) {
+            out.value(zonedDateTime.format(HIVE_DATETIME_FORMAT));
+        } else {
+            out.nullValue();
+        }
+    }
+
+    @Override
+    public @Nullable ZonedDateTime readValue(final JsonReader in) throws IOException {
+        return ZonedDateTime.parse(in.nextString(), HIVE_DATETIME_FORMAT);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ActionDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ActionDto.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.ActionType;
+import org.openhab.binding.hive.internal.client.AttributeName;
+import org.openhab.binding.hive.internal.client.FeatureType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ActionDto {
+    public @Nullable ActionType actionType;
+    public @Nullable FeatureType featureType;
+    public @Nullable AttributeName attribute;
+    public @Nullable String value;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/AutoBoostV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/AutoBoostV1FeatureDto.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class AutoBoostV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<Long> autoBoostDuration;
+    public @Nullable FeatureAttributeDto<BigDecimal> autoBoostTargetHeatTemperature;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/BatteryDeviceV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/BatteryDeviceV1FeatureDto.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BatteryDeviceV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<Integer> batteryLevel;
+    public @Nullable FeatureAttributeDto<String> batteryState;
+    public @Nullable FeatureAttributeDto<BigDecimal> batteryVoltage;
+    public @Nullable FeatureAttributeDto<String> notificationState;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/DeviceManagementV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/DeviceManagementV1FeatureDto.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.ProductType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DeviceManagementV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<ProductType> productType;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeatureAttributeDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeatureAttributeDto.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class FeatureAttributeDto<T> {
+    public @Nullable T reportedValue;
+    public @Nullable T targetValue;
+    public @Nullable T displayValue;
+
+    public @Nullable HiveApiInstant reportReceivedTime;
+    public @Nullable HiveApiInstant reportChangedTime;
+    public @Nullable HiveApiInstant targetSetTime;
+    public @Nullable HiveApiInstant targetExpiryTime;
+
+    public @Nullable String targetSetTXId;
+    public @Nullable String propertyStatus;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeatureDtoBase.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeatureDtoBase.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<FeatureType> featureType;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeaturesDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/FeaturesDto.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class FeaturesDto {
+    public @Nullable AutoBoostV1FeatureDto autoboost_v1;
+    public @Nullable BatteryDeviceV1FeatureDto battery_device_v1;
+    public @Nullable DeviceManagementV1FeatureDto device_management_v1;
+    public @Nullable HeatingThermostatV1FeatureDto heating_thermostat_v1;
+    public @Nullable LinksV1FeatureDto links_v1;
+    public @Nullable OnOffDeviceV1FeatureDto on_off_device_v1;
+    public @Nullable PhysicalDeviceV1FeatureDto physical_device_v1;
+    public @Nullable TemperatureSensorV1FeatureDto temperature_sensor_v1;
+    public @Nullable TransientModeV1FeatureDto transient_mode_v1;
+    public @Nullable WaterHeaterV1FeatureDto water_heater_v1;
+    public @Nullable ZigbeeDeviceV1FeatureDto zigbee_device_v1;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/HeatingThermostatV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/HeatingThermostatV1FeatureDto.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.HeatingThermostatOperatingMode;
+import org.openhab.binding.hive.internal.client.HeatingThermostatOperatingState;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HeatingThermostatV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<HeatingThermostatOperatingMode> operatingMode;
+    public @Nullable FeatureAttributeDto<HeatingThermostatOperatingState> operatingState;
+    public @Nullable FeatureAttributeDto<OverrideMode> temporaryOperatingModeOverride;
+    public @Nullable FeatureAttributeDto<BigDecimal> targetHeatTemperature;
+    public @Nullable FeatureAttributeDto<BigDecimal> maxHeatTargetTemperature;
+    public @Nullable FeatureAttributeDto<BigDecimal> minHeatTargetTemperature;
+    public @Nullable FeatureAttributeDto<ScheduleDto> heatSchedule;
+    public @Nullable FeatureAttributeDto<String> operatingStateReason;
+    public @Nullable FeatureAttributeDto<List<ActionDto>> previousConfiguration;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/HiveApiInstant.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/HiveApiInstant.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A class representing absolute times returned by the Hive API.
+ *
+ * <p>
+ *     N.B. This should only be used by DTOs.
+ * </p>
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiInstant {
+    private final Instant instant;
+
+    public HiveApiInstant(final Instant instant) {
+        Objects.requireNonNull(instant);
+
+        this.instant = instant;
+    }
+
+    public Instant asInstant() {
+        return this.instant;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || this.getClass() != o.getClass()) {
+            return false;
+        }
+
+        final HiveApiInstant that = (HiveApiInstant) o;
+
+        return this.instant.equals(that.instant);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.instant);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/LinkDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/LinkDto.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.GroupId;
+import org.openhab.binding.hive.internal.client.NodeId;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class LinkDto {
+    public @Nullable GroupId bindingGroupId;
+    public @Nullable NodeId boundNode;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/LinksV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/LinksV1FeatureDto.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class LinksV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<Set<LinkDto>> links;
+    public @Nullable FeatureAttributeDto<Set<ReverseLinkDto>> reverseLinks;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/NodeDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/NodeDto.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.NodeId;
+import org.openhab.binding.hive.internal.client.NodeType;
+import org.openhab.binding.hive.internal.client.Protocol;
+import org.openhab.binding.hive.internal.client.UserId;
+
+/**
+ * A model of a "Node"
+ *
+ * Based on the Hive API Swagger model.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class NodeDto {
+    /**
+     * address (string, optional): Internal node ID, read-only.
+     * The first part of node ID can be hub ID or node address.
+     * Hub ID conforms following pattern: ([0-9]{19}).
+     * Node address conforms following pattern: ::([a-f0-9]{1,4}):([a-f0-9]{1,4}):([a-f0-9]{1,4}):([a-f0-9]{1,4}).
+     * Admin access required.
+     */
+    public @Nullable String address;
+
+    /*
+     * brokers (inline_model_26, optional): Brokers address map
+     * e.g.: {"greengrass": {"url": "mqtt://10.0.0.7:8883", "topic": "hub/deviceid/userid"}}
+     */
+
+    /**
+     * createdOn (integer, optional): Timestamp of when the node state was created.
+     * UTC Unix timestamp (in milliseconds)
+     */
+    public @Nullable HiveApiInstant createdOn;
+
+    public @Nullable FeaturesDto features;
+
+    /**
+     * firstInstall (integer, optional): Timestamp of when the device was discovered.
+     * UTC Unix timestamp (in milliseconds)
+     */
+    public @Nullable HiveApiInstant firstInstall;
+
+    /**
+     * homeId (string, optional): Home ID, read-only
+     */
+    public @Nullable String homeId;
+
+    /**
+     * href (string, optional, read only): URL of the API call for retrieving this object
+     */
+    public @Nullable String href;
+
+    /**
+     * id (string, optional): Object identifier
+     */
+    public @Nullable NodeId id;
+
+    /**
+     * lastSeen (integer, optional): Timestamp of when the node was last seen.
+     * UTC Unix timestamp (in milliseconds)
+     */
+    public @Nullable HiveApiInstant lastSeen;
+
+    /**
+     * lastUpgradeSucceeded (boolean, optional): Last upgrade succeeded
+     */
+    public @Nullable Boolean lastUpgradeSucceeded;
+
+    /*
+     * links (inline_model_27, optional): URL Templates for links to other entities
+     * e.g.: "users.nodes": "https://api.example.com/nodes/{users.nodes}"
+     */
+
+    /**
+     * name (string, optional): Node name
+     */
+    public @Nullable String name;
+
+    /**
+     * nodeType (string, optional): Node type
+     */
+    public @Nullable NodeType nodeType;
+
+    /**
+     * ownerId (string, optional): Original owner UUID
+     */
+    public @Nullable UserId ownerId;
+
+    /**
+     * parentNodeId (string, optional): Parent node UUID
+     */
+    public @Nullable NodeId parentNodeId;
+
+    /**
+     * protocol (string, optional): Node protocol, optional, read-only
+     * ['SYNTHETIC', 'ZIGBEE', 'PROXIED', 'MQTT', 'XMPP', 'VIRTUAL', 'any other provided by hub']
+     */
+    public @Nullable Protocol protocol;
+
+    /*
+     * relationships (inline_model_28, optional): Node relationships
+     * e.g.: "boundNodes" : [{ "type" : "node", "id" : "1b3b3c30-740a-11e5-8a3b-f46d042e952c"}] ,
+     */
+
+    /**
+     * upgradeAvailable (boolean, optional): Is upgrade available
+     */
+    public @Nullable Boolean upgradeAvailable;
+
+    /**
+     * upgradeProgress (number, optional): Upgrade progress in percentages
+     */
+    public @Nullable Double upgradeProgress;
+
+    /**
+     * upgradeStatus (string, optional): Upgrade status, read-only
+     * ['PENDING', 'DEFERRED', 'STARTING', 'IN_PROGRESS', 'COMPLETE', 'FAILED', 'UNSUPPORTED', 'INVALID']
+     */
+    public @Nullable String upgradeStatus;
+
+    /**
+     * userId (string, optional): User UUID
+     */
+    public @Nullable UserId userId;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/NodesDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/NodesDto.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A model of a "NodeRequestEntity"/"NodeResponseEntity"
+ *
+ * Based on the Hive API Swagger model.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class NodesDto {
+    /*
+     * linked (object, optional): Linked entities grouped by entity type. Used when side-loading entities
+     */
+
+    /*
+     * links (inline_model_34, optional): URL Templates for links to other entities e.g.: "users.nodes": "https://api.example.com/nodes/{users.nodes}" ,
+     */
+
+    /*
+     * meta (object, optional): Meta information about this entity
+     */
+
+    /**
+     * sessions (Array[Session], optional): List of sessions
+     */
+    public @Nullable List<@Nullable NodeDto> nodes;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/OnOffDeviceV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/OnOffDeviceV1FeatureDto.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.OnOffMode;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class OnOffDeviceV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<OnOffMode> mode;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/PhysicalDeviceV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/PhysicalDeviceV1FeatureDto.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class PhysicalDeviceV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<String> nativeIdentifier;
+    public @Nullable FeatureAttributeDto<String> hardwareIdentifier;
+    public @Nullable FeatureAttributeDto<String> model;
+    public @Nullable FeatureAttributeDto<String> manufacturer;
+    public @Nullable FeatureAttributeDto<String> powerSupply;
+    public @Nullable FeatureAttributeDto<String> softwareVersion;
+    public @Nullable FeatureAttributeDto<String> latestSoftwareVersion;
+    public @Nullable FeatureAttributeDto<Integer> upgradeProgress;
+    public @Nullable FeatureAttributeDto<String> upgradeStatus;
+    public @Nullable FeatureAttributeDto<ZonedDateTime> lastSeen;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ReverseLinkDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ReverseLinkDto.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.GroupId;
+import org.openhab.binding.hive.internal.client.NodeId;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ReverseLinkDto {
+    public @Nullable Set<GroupId> bindingGroupIds;
+    public @Nullable NodeId boundNode;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ScheduleDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ScheduleDto.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.ScheduleType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ScheduleDto {
+    public @Nullable ScheduleType scheduleType;
+    public @Nullable Integer maxNumSetpointsPerDay;
+    public @Nullable List<SetpointDto> setpoints;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SessionDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SessionDto.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.SessionId;
+import org.openhab.binding.hive.internal.client.UserId;
+
+/**
+ * A model of a "Session"
+ *
+ * Based on the Hive API Swagger model.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class SessionDto {
+    /**
+     * extCustomerLevel (integer, optional): The user's account level in a third party's database (default value 1)
+     */
+    public @Nullable Integer extCustomerLevel;
+
+    /**
+     * href (string, optional, read only): URL of the API call for retrieving this object
+     */
+    public @Nullable String href;
+
+    /**
+     * id (string, optional)
+     */
+    public @Nullable SessionId id;
+
+    /**
+     * latestSupportedApiVersion (string, optional): The API version which the user's account and data are compatible with
+     */
+    public @Nullable String latestSupportedApiVersion;
+
+    /*
+     * links (inline_model_33, optional): URL Templates for links to other entities e.g.: "users.nodes": "https://api.example.com/nodes/{users.nodes}" ,
+     */
+
+    /**
+     * password (string, optional): Password
+     */
+    public @Nullable String password;
+
+    /**
+     * sessionDuration (integer, optional): Session duration in minutes
+     */
+    public @Nullable Integer sessionDuration;
+
+    /**
+     * sessionId (string, optional): UUID of this session
+     */
+    public @Nullable SessionId sessionId;
+
+    /**
+     * userId (string, optional): User UUID
+     */
+    public @Nullable UserId userId;
+
+    /**
+     * username (string, optional): Username
+     */
+    public @Nullable String username;
+
+    /**
+     * uuid (string, optional): User UUID
+     */
+    public @Nullable UserId uuid;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SessionsDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SessionsDto.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A model of a "SessionRequestEntity"/"SessionResponseEntity"
+ *
+ * Based on the Hive API Swagger model.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class SessionsDto {
+    /*
+     * linked (object, optional): Linked entities grouped by entity type. Used when side-loading entities
+     */
+
+    /*
+     * links (inline_model_34, optional): URL Templates for links to other entities e.g.: "users.nodes": "https://api.example.com/nodes/{users.nodes}" ,
+     */
+
+    /*
+     * meta (object, optional): Meta information about this entity
+     */
+
+    /**
+     * sessions (Array[Session], optional): List of sessions
+     */
+    public @Nullable List<@Nullable SessionDto> sessions;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SetpointDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/SetpointDto.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class SetpointDto {
+    // TODO: Parse to DayOfWeek
+    public @Nullable Integer dayIndex;
+
+    // TODO: Parse to LocalTime
+    public @Nullable String time;
+
+    public @Nullable List<ActionDto> actions;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/TemperatureSensorV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/TemperatureSensorV1FeatureDto.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TemperatureSensorV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<BigDecimal> temperature;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/TransientModeV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/TransientModeV1FeatureDto.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TransientModeV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<List<ActionDto>> actions;
+    public @Nullable FeatureAttributeDto<Long> duration;
+    public @Nullable FeatureAttributeDto<Boolean> isEnabled;
+    public @Nullable FeatureAttributeDto<List<ActionDto>> previousConfiguration;
+    public @Nullable FeatureAttributeDto<ZonedDateTime> startDatetime;
+    public @Nullable FeatureAttributeDto<ZonedDateTime> endDatetime;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/WaterHeaterV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/WaterHeaterV1FeatureDto.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.WaterHeaterOperatingMode;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class WaterHeaterV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<WaterHeaterOperatingMode> operatingMode;
+    public @Nullable FeatureAttributeDto<Boolean> isOn;
+    public @Nullable FeatureAttributeDto<OverrideMode> temporaryOperatingModeOverride;
+    public @Nullable FeatureAttributeDto<ScheduleDto> schedule;
+    public @Nullable FeatureAttributeDto<List<ActionDto>> previousConfiguration;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ZigbeeDeviceV1FeatureDto.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/dto/ZigbeeDeviceV1FeatureDto.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.Eui64;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ZigbeeDeviceV1FeatureDto extends FeatureDtoBase {
+    public @Nullable FeatureAttributeDto<Eui64> eui64;
+    public @Nullable FeatureAttributeDto<Integer> averageLQI;
+    public @Nullable FeatureAttributeDto<Integer> lastKnownLQI;
+    public @Nullable FeatureAttributeDto<Integer> averageRSSI;
+    public @Nullable FeatureAttributeDto<Integer> lastKnownRSSI;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiAuthenticationException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiAuthenticationException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate something has gone wrong while authenticating with the
+ * Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiAuthenticationException extends HiveApiException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveApiAuthenticationException() {
+        super();
+    }
+
+    public HiveApiAuthenticationException(final String message) {
+        super(message);
+    }
+
+    public HiveApiAuthenticationException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveApiAuthenticationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate that the Hive API has signaled something is wrong.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class HiveApiException extends HiveException {
+    public static final long serialVersionUID = 1L;
+
+    public HiveApiException() {
+        super();
+    }
+
+    public HiveApiException(final String message) {
+        super(message);
+    }
+
+    public HiveApiException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveApiException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiNotAuthorisedException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiNotAuthorisedException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate a call to the Hive API has failed because the client is not authorised.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiNotAuthorisedException extends HiveApiException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveApiNotAuthorisedException() {
+        super();
+    }
+
+    public HiveApiNotAuthorisedException(final String message) {
+        super(message);
+    }
+
+    public HiveApiNotAuthorisedException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveApiNotAuthorisedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiUnknownException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveApiUnknownException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate something of an unknown nature has gone wrong while
+ * making a call to the Hive API (and it is the server's fault).
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveApiUnknownException extends HiveApiException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveApiUnknownException() {
+        super();
+    }
+
+    public HiveApiUnknownException(final String message) {
+        super(message);
+    }
+
+    public HiveApiUnknownException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveApiUnknownException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate that something has gone wrong with the Hive Client
+ * library.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class HiveClientException extends HiveException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveClientException() {
+        super();
+    }
+
+    public HiveClientException(final String message) {
+        super(message);
+    }
+
+    public HiveClientException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveClientException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientRequestException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientRequestException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate a HTTP request to the Hive API has failed before it
+ * could be completed.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveClientRequestException extends HiveClientException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveClientRequestException() {
+        super();
+    }
+
+    public HiveClientRequestException(final String message) {
+        super(message);
+    }
+
+    public HiveClientRequestException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveClientRequestException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientResponseException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientResponseException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate that the Hive client got a "success" response from the
+ * Hive API but either does not understand the response or thinks it is
+ * malformed.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveClientResponseException extends HiveClientException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveClientResponseException() {
+        super();
+    }
+
+    public HiveClientResponseException(final String message) {
+        super(message);
+    }
+
+    public HiveClientResponseException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveClientResponseException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientUnknownException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveClientUnknownException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate that the Hive Client got a non-success response from the
+ * Hive API but does not understand why (and it is the client's fault).
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HiveClientUnknownException extends HiveClientException {
+    private static final long serialVersionUID = 1L;
+
+    public HiveClientUnknownException() {
+        super();
+    }
+
+    public HiveClientUnknownException(final String message) {
+        super(message);
+    }
+
+    public HiveClientUnknownException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveClientUnknownException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveException.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/exception/HiveException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Thrown to indicate something has gone wrong while interacting with the
+ * Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class HiveException extends Exception {
+    public static final long serialVersionUID = 1L;
+
+    public HiveException() {
+        super();
+    }
+
+    public HiveException(final String message) {
+        super(message);
+    }
+
+    public HiveException(final Throwable cause) {
+        super(cause);
+    }
+
+    public HiveException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/AutoBoostFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/AutoBoostFeature.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.SettableFeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class AutoBoostFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<Duration> autoBoostDuration;
+    private final @Nullable SettableFeatureAttribute<Quantity<Temperature>> autoBoostTargetHeatTemperature;
+
+    private AutoBoostFeature(
+            final @Nullable SettableFeatureAttribute<Duration> autoBoostDuration,
+            final @Nullable SettableFeatureAttribute<Quantity<Temperature>> autoBoostTargetHeatTemperature
+    ) {
+        this.autoBoostDuration = autoBoostDuration;
+        this.autoBoostTargetHeatTemperature = autoBoostTargetHeatTemperature;
+    }
+
+    public @Nullable SettableFeatureAttribute<Duration> getAutoBoostDuration() {
+        return this.autoBoostDuration;
+    }
+
+    public AutoBoostFeature withTargetAutoBoostDuration(final Duration targetAutoBoostDuration) {
+        Objects.requireNonNull(targetAutoBoostDuration);
+
+        final @Nullable SettableFeatureAttribute<Duration> autoBoostDuration = this.autoBoostDuration;
+        if (autoBoostDuration == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("autoBoostDuration"));
+        }
+
+        return AutoBoostFeature.builder()
+                .from(this)
+                .autoBoostDuration(
+                        autoBoostDuration.withTargetValue(targetAutoBoostDuration)
+                )
+                .build();
+    }
+
+    public @Nullable SettableFeatureAttribute<Quantity<Temperature>> getAutoBoostTargetHeatTemperature() {
+        return this.autoBoostTargetHeatTemperature;
+    }
+
+    public AutoBoostFeature withTargetAutoBoostTargetHeatTemperature(final Quantity<Temperature> targetAutoBoostTargetHeatTemperature) {
+        Objects.requireNonNull(targetAutoBoostTargetHeatTemperature);
+
+        final @Nullable SettableFeatureAttribute<Quantity<Temperature>> autoBoostTargetHeatTemperature = this.autoBoostTargetHeatTemperature;
+        if (autoBoostTargetHeatTemperature == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("autoBoostTargetHeatTemperature"));
+        }
+
+        return AutoBoostFeature.builder()
+                .from(this)
+                .autoBoostTargetHeatTemperature(
+                        autoBoostTargetHeatTemperature.withTargetValue(targetAutoBoostTargetHeatTemperature)
+                )
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<Duration> autoBoostDuration;
+        private @Nullable SettableFeatureAttribute<Quantity<Temperature>> autoBoostTargetHeatTemperature;
+
+        public Builder from(final AutoBoostFeature autoBoostFeature) {
+            Objects.requireNonNull(autoBoostFeature);
+
+            this.autoBoostDuration(autoBoostFeature.getAutoBoostDuration());
+            this.autoBoostTargetHeatTemperature(autoBoostFeature.getAutoBoostTargetHeatTemperature());
+
+            return this;
+        }
+
+        public Builder autoBoostDuration(final @Nullable SettableFeatureAttribute<Duration> autoBoostDuration) {
+            this.autoBoostDuration = autoBoostDuration;
+
+            return this;
+        }
+
+        public Builder autoBoostTargetHeatTemperature(final @Nullable SettableFeatureAttribute<Quantity<Temperature>> autoBoostTargetHeatTemperature) {
+            this.autoBoostTargetHeatTemperature = autoBoostTargetHeatTemperature;
+
+            return this;
+        }
+
+        public AutoBoostFeature build() {
+            return new AutoBoostFeature(
+                    this.autoBoostDuration,
+                    this.autoBoostTargetHeatTemperature
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/BatteryDeviceFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/BatteryDeviceFeature.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.ElectricPotential;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.BatteryLevel;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BatteryDeviceFeature implements Feature {
+    private final @Nullable FeatureAttribute<BatteryLevel> batteryLevel;
+    private final @Nullable FeatureAttribute<String> batteryState;
+    private final @Nullable FeatureAttribute<Quantity<ElectricPotential>> batteryVoltage;
+    private final @Nullable FeatureAttribute<String> batteryNotificationState;
+
+    private BatteryDeviceFeature(
+            final @Nullable FeatureAttribute<BatteryLevel> batteryLevel,
+            final @Nullable FeatureAttribute<String> batteryState,
+            final @Nullable FeatureAttribute<Quantity<ElectricPotential>> batteryVoltage,
+            final @Nullable FeatureAttribute<String> batteryNotificationState
+    ) {
+        this.batteryLevel = batteryLevel;
+        this.batteryState = batteryState;
+        this.batteryVoltage = batteryVoltage;
+        this.batteryNotificationState = batteryNotificationState;
+    }
+
+    public @Nullable FeatureAttribute<BatteryLevel> getBatteryLevel() {
+        return this.batteryLevel;
+    }
+
+    public @Nullable FeatureAttribute<String> getBatteryState() {
+        return this.batteryState;
+    }
+
+    public @Nullable FeatureAttribute<Quantity<ElectricPotential>> getBatteryVoltage() {
+        return this.batteryVoltage;
+    }
+
+    public @Nullable FeatureAttribute<String> getBatteryNotificationState() {
+        return this.batteryNotificationState;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable FeatureAttribute<BatteryLevel> batteryLevel;
+        private @Nullable FeatureAttribute<String> batteryState;
+        private @Nullable FeatureAttribute<Quantity<ElectricPotential>> batteryVoltage;
+        private @Nullable FeatureAttribute<String> batteryNotificationState;
+
+        public Builder from(final BatteryDeviceFeature batteryDeviceFeature) {
+            Objects.requireNonNull(batteryDeviceFeature);
+
+            return this.batteryLevel(batteryDeviceFeature.getBatteryLevel())
+                    .batteryState(batteryDeviceFeature.getBatteryState())
+                    .batteryVoltage(batteryDeviceFeature.getBatteryVoltage())
+                    .batteryNotificationState(batteryDeviceFeature.getBatteryNotificationState());
+        }
+
+        public Builder batteryLevel(final @Nullable FeatureAttribute<BatteryLevel> batteryLevel) {
+            this.batteryLevel = batteryLevel;
+
+            return this;
+        }
+
+        public Builder batteryState(final @Nullable FeatureAttribute<String> batteryState) {
+            this.batteryState = batteryState;
+
+            return this;
+        }
+
+        public Builder batteryVoltage(final @Nullable FeatureAttribute<Quantity<ElectricPotential>> batteryVoltage) {
+            this.batteryVoltage = batteryVoltage;
+
+            return this;
+        }
+
+        public Builder batteryNotificationState(final @Nullable FeatureAttribute<String> batteryNotificationState) {
+            this.batteryNotificationState = batteryNotificationState;
+
+            return this;
+        }
+
+        public BatteryDeviceFeature build() {
+            return new BatteryDeviceFeature(
+                    this.batteryLevel,
+                    this.batteryState,
+                    this.batteryVoltage,
+                    this.batteryNotificationState
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/Feature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/Feature.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface Feature {}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/FeatureBuilderUtil.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/FeatureBuilderUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.text.MessageFormat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class FeatureBuilderUtil {
+    private static final String CANNOT_SET_TARGET_MESSAGE = "Cannot set target for \"{0}\" because that attribute is not available";
+
+    public static String getCannotSetTargetMessage(final String attributeName) {
+        return MessageFormat.format(CANNOT_SET_TARGET_MESSAGE, attributeName);
+    }
+
+    private FeatureBuilderUtil() {
+        throw new AssertionError();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/HeatingThermostatFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/HeatingThermostatFeature.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.*;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HeatingThermostatFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> operatingMode;
+    private final @Nullable FeatureAttribute<HeatingThermostatOperatingState> operatingState;
+    private final @Nullable SettableFeatureAttribute<Quantity<Temperature>> targetHeatTemperature;
+    private final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride;
+
+    private HeatingThermostatFeature(
+            final @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> operatingMode,
+            final @Nullable FeatureAttribute<HeatingThermostatOperatingState> operatingState,
+            final @Nullable SettableFeatureAttribute<Quantity<Temperature>> targetHeatTemperature,
+            final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride
+    ) {
+        this.operatingMode = operatingMode;
+        this.operatingState = operatingState;
+        this.targetHeatTemperature = targetHeatTemperature;
+        this.temporaryOperatingModeOverride = temporaryOperatingModeOverride;
+    }
+
+    public @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> getOperatingMode() {
+        return this.operatingMode;
+    }
+
+    public HeatingThermostatFeature withTargetOperatingMode(final HeatingThermostatOperatingMode targetOperatingMode) {
+        Objects.requireNonNull(targetOperatingMode);
+
+        final @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> operatingMode = this.operatingMode;
+        if (operatingMode == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("operatingMode"));
+        }
+
+        return HeatingThermostatFeature.builder()
+                .from(this)
+                .operatingMode(
+                        operatingMode.withTargetValue(targetOperatingMode)
+                )
+                .build();
+    }
+
+    public @Nullable FeatureAttribute<HeatingThermostatOperatingState> getOperatingState() {
+        return this.operatingState;
+    }
+
+    public @Nullable SettableFeatureAttribute<Quantity<Temperature>> getTargetHeatTemperature() {
+        return this.targetHeatTemperature;
+    }
+
+    public HeatingThermostatFeature withTargetTargetHeatTemperature(final Quantity<Temperature> targetTargetHeatTemperature) {
+        Objects.requireNonNull(targetTargetHeatTemperature);
+
+        final @Nullable SettableFeatureAttribute<Quantity<Temperature>> targetHeatTemperature = this.targetHeatTemperature;
+        if (targetHeatTemperature == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("targetHeatTemperature"));
+        }
+
+        return HeatingThermostatFeature.builder()
+                .from(this)
+                .targetHeatTemperature(
+                        targetHeatTemperature.withTargetValue(targetTargetHeatTemperature)
+                )
+                .build();
+    }
+
+    public @Nullable SettableFeatureAttribute<OverrideMode> getTemporaryOperatingModeOverride() {
+        return this.temporaryOperatingModeOverride;
+    }
+
+    public HeatingThermostatFeature withTargetTemporaryOperatingModeOverride(final OverrideMode targetOverrideMode) {
+        Objects.requireNonNull(targetOverrideMode);
+
+        final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride = this.temporaryOperatingModeOverride;
+        if (temporaryOperatingModeOverride == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("temporaryOperatingModeOverride"));
+        }
+
+        return HeatingThermostatFeature.builder()
+                .from(this)
+                .temporaryOperatingModeOverride(
+                        temporaryOperatingModeOverride.withTargetValue(targetOverrideMode)
+                )
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> operatingMode;
+        private @Nullable FeatureAttribute<HeatingThermostatOperatingState> operatingState;
+        private @Nullable SettableFeatureAttribute<Quantity<Temperature>> targetHeatTemperature;
+        private @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride;
+
+        public Builder from(final HeatingThermostatFeature heatingThermostatFeature) {
+            Objects.requireNonNull(heatingThermostatFeature);
+
+            return this.operatingMode(heatingThermostatFeature.getOperatingMode())
+                    .operatingState(heatingThermostatFeature.getOperatingState())
+                    .targetHeatTemperature(heatingThermostatFeature.getTargetHeatTemperature())
+                    .temporaryOperatingModeOverride(heatingThermostatFeature.getTemporaryOperatingModeOverride());
+        }
+
+        public Builder operatingMode(final @Nullable SettableFeatureAttribute<HeatingThermostatOperatingMode> operatingMode) {
+            this.operatingMode = operatingMode;
+
+            return this;
+        }
+
+        public Builder operatingState(final @Nullable FeatureAttribute<HeatingThermostatOperatingState> operatingState) {
+            this.operatingState = operatingState;
+
+            return this;
+        }
+
+        public Builder targetHeatTemperature(final @Nullable SettableFeatureAttribute<Quantity<Temperature>> targetHeatTemperature) {
+            this.targetHeatTemperature = targetHeatTemperature;
+
+            return this;
+        }
+
+        public Builder temporaryOperatingModeOverride(final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride) {
+            this.temporaryOperatingModeOverride = temporaryOperatingModeOverride;
+
+            return this;
+        }
+
+        public HeatingThermostatFeature build() {
+            return new HeatingThermostatFeature(
+                    this.operatingMode,
+                    this.operatingState,
+                    this.targetHeatTemperature,
+                    this.temporaryOperatingModeOverride
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/LinksFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/LinksFeature.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+import org.openhab.binding.hive.internal.client.Link;
+import org.openhab.binding.hive.internal.client.ReverseLink;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class LinksFeature implements Feature {
+    private final @Nullable FeatureAttribute<Set<Link>> links;
+    private final @Nullable FeatureAttribute<Set<ReverseLink>> reverseLinks;
+
+    private LinksFeature(
+            final @Nullable FeatureAttribute<Set<Link>> links,
+            final @Nullable FeatureAttribute<Set<ReverseLink>> reverseLinks
+    ) {
+        this.links = links;
+        this.reverseLinks = reverseLinks;
+    }
+
+    public @Nullable FeatureAttribute<Set<Link>> getLinks() {
+        return this.links;
+    }
+
+    public @Nullable FeatureAttribute<Set<ReverseLink>> getReverseLinks() {
+        return this.reverseLinks;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable FeatureAttribute<Set<Link>> links;
+        private @Nullable FeatureAttribute<Set<ReverseLink>> reverseLinks;
+        
+        public Builder from(final LinksFeature linksFeature) {
+            Objects.requireNonNull(linksFeature);
+            
+            return this.links(linksFeature.getLinks())
+                    .reverseLinks(linksFeature.getReverseLinks());
+        }
+        
+        public Builder links(final @Nullable FeatureAttribute<Set<Link>> links) {
+            this.links = links;
+            
+            return this;
+        }
+
+        public Builder reverseLinks(final @Nullable FeatureAttribute<Set<ReverseLink>> reverseLinks) {
+            this.reverseLinks = reverseLinks;
+
+            return this;
+        }
+
+        public LinksFeature build() {
+            return new LinksFeature(links, reverseLinks);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/OnOffDeviceFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/OnOffDeviceFeature.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.OnOffMode;
+import org.openhab.binding.hive.internal.client.SettableFeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class OnOffDeviceFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<OnOffMode> mode;
+
+    private OnOffDeviceFeature(
+            final @Nullable SettableFeatureAttribute<OnOffMode> mode
+    ) {
+        this.mode = mode;
+    }
+
+    public @Nullable SettableFeatureAttribute<OnOffMode> getMode() {
+        return this.mode;
+    }
+
+    public OnOffDeviceFeature withTargetMode(final OnOffMode targetMode) {
+        Objects.requireNonNull(targetMode);
+
+        final @Nullable SettableFeatureAttribute<OnOffMode> mode = this.mode;
+        if (mode == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("mode"));
+        }
+
+        return OnOffDeviceFeature.builder()
+                .from(this)
+                .mode(mode.withTargetValue(targetMode))
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<OnOffMode> mode;
+
+        public Builder from(final OnOffDeviceFeature onOffDeviceFeature) {
+            Objects.requireNonNull(onOffDeviceFeature);
+
+            return this.mode(onOffDeviceFeature.getMode());
+        }
+
+        public Builder mode(final @Nullable SettableFeatureAttribute<OnOffMode> mode) {
+            this.mode = mode;
+
+            return this;
+        }
+
+        public OnOffDeviceFeature build() {
+            return new OnOffDeviceFeature(this.mode);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/PhysicalDeviceFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/PhysicalDeviceFeature.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class PhysicalDeviceFeature implements Feature {
+    private final @Nullable FeatureAttribute<String> hardwareIdentifier;
+    private final @Nullable FeatureAttribute<String> model;
+    private final @Nullable FeatureAttribute<String> manufacturer;
+    private final @Nullable FeatureAttribute<String> softwareVersion;
+
+    private PhysicalDeviceFeature(
+            final @Nullable FeatureAttribute<String> hardwareIdentifier,
+            final @Nullable FeatureAttribute<String> model,
+            final @Nullable FeatureAttribute<String> manufacturer,
+            final @Nullable FeatureAttribute<String> softwareVersion
+    ) {
+        this.hardwareIdentifier = hardwareIdentifier;
+        this.model = model;
+        this.manufacturer = manufacturer;
+        this.softwareVersion = softwareVersion;
+    }
+
+    public @Nullable FeatureAttribute<String> getHardwareIdentifier() {
+        return this.hardwareIdentifier;
+    }
+
+    public @Nullable FeatureAttribute<String> getModel() {
+        return this.model;
+    }
+
+    public @Nullable FeatureAttribute<String> getManufacturer() {
+        return this.manufacturer;
+    }
+
+    public @Nullable FeatureAttribute<String> getSoftwareVersion() {
+        return this.softwareVersion;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private @Nullable FeatureAttribute<String> hardwareIdentifier;
+        private @Nullable FeatureAttribute<String> model;
+        private @Nullable FeatureAttribute<String> manufacturer;
+        private @Nullable FeatureAttribute<String> softwareVersion;
+
+        public Builder from(final PhysicalDeviceFeature physicalDeviceFeature) {
+            Objects.requireNonNull(physicalDeviceFeature);
+
+            return this.hardwareIdentifier(physicalDeviceFeature.getHardwareIdentifier())
+                    .model(physicalDeviceFeature.getModel())
+                    .manufacturer(physicalDeviceFeature.getManufacturer())
+                    .softwareVersion(physicalDeviceFeature.getSoftwareVersion());
+        }
+
+        public Builder hardwareIdentifier(final @Nullable FeatureAttribute<String> hardwareIdentifier) {
+            this.hardwareIdentifier = hardwareIdentifier;
+
+            return this;
+        }
+
+        public Builder model(final @Nullable FeatureAttribute<String> model) {
+            this.model = model;
+
+            return this;
+        }
+
+        public Builder manufacturer(final @Nullable FeatureAttribute<String> manufacturer) {
+            this.manufacturer = manufacturer;
+
+            return this;
+        }
+
+        public Builder softwareVersion(final @Nullable FeatureAttribute<String> softwareVersion) {
+            this.softwareVersion = softwareVersion;
+
+            return this;
+        }
+        
+        public PhysicalDeviceFeature build() {
+            return new PhysicalDeviceFeature(
+                    this.hardwareIdentifier,
+                    this.model,
+                    this.manufacturer,
+                    this.softwareVersion
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TemperatureSensorFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TemperatureSensorFeature.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TemperatureSensorFeature implements Feature {
+    private final @Nullable FeatureAttribute<Quantity<Temperature>> temperature;
+
+    private TemperatureSensorFeature(
+            final @Nullable FeatureAttribute<Quantity<Temperature>> temperature
+    ) {
+        this.temperature = temperature;
+    }
+
+    public @Nullable FeatureAttribute<Quantity<Temperature>> getTemperature() {
+        return this.temperature;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable FeatureAttribute<Quantity<Temperature>> temperature;
+
+        public Builder from(final TemperatureSensorFeature temperatureSensorFeature) {
+            Objects.requireNonNull(temperatureSensorFeature);
+
+            return this.temperature(temperatureSensorFeature.getTemperature());
+        }
+
+        public Builder temperature(final @Nullable FeatureAttribute<Quantity<Temperature>> temperature) {
+            this.temperature = temperature;
+
+            return this;
+        }
+
+        public TemperatureSensorFeature build() {
+            return new TemperatureSensorFeature(this.temperature);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TransientModeFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TransientModeFeature.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+import org.openhab.binding.hive.internal.client.SettableFeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TransientModeFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<Duration> duration;
+    private final @Nullable SettableFeatureAttribute<Boolean> isEnabled;
+    private final @Nullable FeatureAttribute<ZonedDateTime> startDatetime;
+    private final @Nullable FeatureAttribute<ZonedDateTime> endDatetime;
+
+    private TransientModeFeature(
+            final @Nullable SettableFeatureAttribute<Duration> duration,
+            final @Nullable SettableFeatureAttribute<Boolean> isEnabled,
+            final @Nullable FeatureAttribute<ZonedDateTime> startDatetime,
+            final @Nullable FeatureAttribute<ZonedDateTime> endDatetime
+    ) {
+        this.duration = duration;
+        this.isEnabled = isEnabled;
+        this.startDatetime = startDatetime;
+        this.endDatetime = endDatetime;
+    }
+
+    public @Nullable SettableFeatureAttribute<Duration> getDuration() {
+        return this.duration;
+    }
+
+    public TransientModeFeature withTargetDuration(final Duration targetDuration) {
+        Objects.requireNonNull(targetDuration);
+
+        final @Nullable SettableFeatureAttribute<Duration> duration = this.duration;
+        if (duration == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("duration"));
+        }
+
+        return TransientModeFeature.builder()
+                .from(this)
+                .duration(duration.withTargetValue(targetDuration))
+                .build();
+    }
+
+    public @Nullable SettableFeatureAttribute<Boolean> getIsEnabled() {
+        return this.isEnabled;
+    }
+
+    public TransientModeFeature withTargetIsEnabled(final boolean targetIsEnabled) {
+        final @Nullable SettableFeatureAttribute<Boolean> isEnabled = this.isEnabled;
+        if (isEnabled == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("isEnabled"));
+        }
+
+        return TransientModeFeature.builder()
+                .from(this)
+                .isEnabled(isEnabled.withTargetValue(targetIsEnabled))
+                .build();
+    }
+
+    public @Nullable FeatureAttribute<ZonedDateTime> getStartDatetime() {
+        return this.startDatetime;
+    }
+
+    public @Nullable FeatureAttribute<ZonedDateTime> getEndDatetime() {
+        return this.endDatetime;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<Duration> duration;
+        private @Nullable SettableFeatureAttribute<Boolean> isEnabled;
+        private @Nullable FeatureAttribute<ZonedDateTime> startDatetime;
+        private @Nullable FeatureAttribute<ZonedDateTime> endDatetime;
+
+        public Builder from(final TransientModeFeature transientModeFeature) {
+            Objects.requireNonNull(transientModeFeature);
+
+            return this.duration(transientModeFeature.getDuration())
+                    .isEnabled(transientModeFeature.getIsEnabled())
+                    .startDatetime(transientModeFeature.getStartDatetime())
+                    .endDatetime(transientModeFeature.getEndDatetime());
+        }
+
+        public Builder duration(final @Nullable SettableFeatureAttribute<Duration> duration) {
+            this.duration = duration;
+
+            return this;
+        }
+
+        public Builder isEnabled(final @Nullable SettableFeatureAttribute<Boolean> isEnabled) {
+            this.isEnabled = isEnabled;
+
+            return this;
+        }
+
+        public Builder startDatetime(final @Nullable FeatureAttribute<ZonedDateTime> startDatetime) {
+            this.startDatetime = startDatetime;
+
+            return this;
+        }
+
+        public Builder endDatetime(final @Nullable FeatureAttribute<ZonedDateTime> endDatetime) {
+            this.endDatetime = endDatetime;
+
+            return this;
+        }
+
+        public TransientModeFeature build() {
+            return new TransientModeFeature(
+                    this.duration,
+                    this.isEnabled,
+                    this.startDatetime,
+                    this.endDatetime
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TransientModeHeatingActionsFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/TransientModeHeatingActionsFeature.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.SettableFeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TransientModeHeatingActionsFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<Quantity<Temperature>> boostTargetTemperature;
+
+    private TransientModeHeatingActionsFeature(
+            final @Nullable SettableFeatureAttribute<Quantity<Temperature>> boostTargetTemperature
+    ) {
+        this.boostTargetTemperature = boostTargetTemperature;
+    }
+
+    public @Nullable SettableFeatureAttribute<Quantity<Temperature>> getBoostTargetTemperature() {
+        return this.boostTargetTemperature;
+    }
+
+    public TransientModeHeatingActionsFeature withTargetBoostTargetTemperature(final Quantity<Temperature> targetBoostTargetTemperature) {
+        Objects.requireNonNull(targetBoostTargetTemperature);
+
+        final @Nullable SettableFeatureAttribute<Quantity<Temperature>> boostTargetTemperature = this.boostTargetTemperature;
+        if (boostTargetTemperature == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("boostTargetTemperature"));
+        }
+
+        return TransientModeHeatingActionsFeature.builder()
+                .from(this)
+                .boostTargetTemperature(
+                        boostTargetTemperature.withTargetValue(targetBoostTargetTemperature)
+                )
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<Quantity<Temperature>> boostTargetTemperature;
+
+        public Builder from(final TransientModeHeatingActionsFeature transientModeHeatingActionsFeature) {
+            Objects.requireNonNull(transientModeHeatingActionsFeature);
+
+            return this.boostTargetTemperature(transientModeHeatingActionsFeature.getBoostTargetTemperature());
+        }
+
+        public Builder boostTargetTemperature(final @Nullable SettableFeatureAttribute<Quantity<Temperature>> boostTargetTemperature) {
+            this.boostTargetTemperature = boostTargetTemperature;
+
+            return this;
+        }
+
+        public TransientModeHeatingActionsFeature build() {
+            return new TransientModeHeatingActionsFeature(
+                    this.boostTargetTemperature
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/WaterHeaterFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/WaterHeaterFeature.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.SettableFeatureAttribute;
+import org.openhab.binding.hive.internal.client.WaterHeaterOperatingMode;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class WaterHeaterFeature implements Feature {
+    private final @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> operatingMode;
+    private final @Nullable FeatureAttribute<Boolean> isOn;
+    private final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride;
+
+    private WaterHeaterFeature(
+            final @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> operatingMode,
+            final @Nullable FeatureAttribute<Boolean> isOn,
+            final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride
+    ) {
+        this.operatingMode = operatingMode;
+        this.isOn = isOn;
+        this.temporaryOperatingModeOverride = temporaryOperatingModeOverride;
+    }
+
+    public @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> getOperatingMode() {
+        return this.operatingMode;
+    }
+
+    public WaterHeaterFeature withTargetOperatingMode(final WaterHeaterOperatingMode targetOperatingMode) {
+        Objects.requireNonNull(targetOperatingMode);
+
+        final @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> operatingMode = this.operatingMode;
+        if (operatingMode == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("operatingMode"));
+        }
+
+        return WaterHeaterFeature.builder()
+                .from(this)
+                .operatingMode(operatingMode.withTargetValue(targetOperatingMode))
+                .build();
+    }
+
+    public @Nullable FeatureAttribute<Boolean> getIsOn() {
+        return this.isOn;
+    }
+
+    public @Nullable SettableFeatureAttribute<OverrideMode> getTemporaryOperatingModeOverride() {
+        return this.temporaryOperatingModeOverride;
+    }
+
+    public WaterHeaterFeature withTargetTemporaryOperatingModeOverride(final OverrideMode targetOverrideMode) {
+        Objects.requireNonNull(targetOverrideMode);
+
+        final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride = this.temporaryOperatingModeOverride;
+        if (temporaryOperatingModeOverride == null) {
+            throw new IllegalStateException(FeatureBuilderUtil.getCannotSetTargetMessage("temporaryOperatingModeOverride"));
+        }
+
+        return WaterHeaterFeature.builder()
+                .from(this)
+                .temporaryOperatingModeOverride(
+                        temporaryOperatingModeOverride.withTargetValue(targetOverrideMode)
+                )
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> operatingMode;
+        private @Nullable FeatureAttribute<Boolean> isOn;
+        private @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride;
+
+        public Builder from(final WaterHeaterFeature waterHeaterFeature) {
+            Objects.requireNonNull(waterHeaterFeature);
+
+            return this.operatingMode(waterHeaterFeature.getOperatingMode())
+                    .isOn(waterHeaterFeature.getIsOn())
+                    .temporaryOperatingModeOverride(waterHeaterFeature.getTemporaryOperatingModeOverride());
+        }
+
+        public Builder operatingMode(final @Nullable SettableFeatureAttribute<WaterHeaterOperatingMode> operatingMode) {
+            this.operatingMode = operatingMode;
+
+            return this;
+        }
+
+        public Builder isOn(final @Nullable FeatureAttribute<Boolean> isOn) {
+            this.isOn = isOn;
+
+            return this;
+        }
+
+        public Builder temporaryOperatingModeOverride(final @Nullable SettableFeatureAttribute<OverrideMode> temporaryOperatingModeOverride) {
+            this.temporaryOperatingModeOverride = temporaryOperatingModeOverride;
+
+            return this;
+        }
+
+        public WaterHeaterFeature build() {
+            return new WaterHeaterFeature(
+                    this.operatingMode,
+                    this.isOn,
+                    this.temporaryOperatingModeOverride
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/ZigbeeDeviceFeature.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/feature/ZigbeeDeviceFeature.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.feature;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.Eui64;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ZigbeeDeviceFeature implements Feature {
+    private final @Nullable FeatureAttribute<Eui64> eui64;
+    private final @Nullable FeatureAttribute<Integer> averageLQI;
+    private final @Nullable FeatureAttribute<Integer> lastKnownLQI;
+    private final @Nullable FeatureAttribute<Integer> averageRSSI;
+    private final @Nullable FeatureAttribute<Integer> lastKnownRSSI;
+
+    private ZigbeeDeviceFeature(
+            final @Nullable FeatureAttribute<Eui64> eui64,
+            final @Nullable FeatureAttribute<Integer> averageLQI,
+            final @Nullable FeatureAttribute<Integer> lastKnownLQI,
+            final @Nullable FeatureAttribute<Integer> averageRSSI,
+            final @Nullable FeatureAttribute<Integer> lastKnownRSSI
+    ) {
+        this.eui64 = eui64;
+        this.averageLQI = averageLQI;
+        this.lastKnownLQI = lastKnownLQI;
+        this.averageRSSI = averageRSSI;
+        this.lastKnownRSSI = lastKnownRSSI;
+    }
+
+    public @Nullable FeatureAttribute<Eui64> getEui64() {
+        return this.eui64;
+    }
+
+    public @Nullable FeatureAttribute<Integer> getAverageLQI() {
+        return this.averageLQI;
+    }
+
+    public @Nullable FeatureAttribute<Integer> getLastKnownLQI() {
+        return this.lastKnownLQI;
+    }
+
+    public @Nullable FeatureAttribute<Integer> getAverageRSSI() {
+        return this.averageRSSI;
+    }
+
+    public @Nullable FeatureAttribute<Integer> getLastKnownRSSI() {
+        return this.lastKnownRSSI;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private @Nullable FeatureAttribute<Eui64> eui64;
+        private @Nullable FeatureAttribute<Integer> averageLQI;
+        private @Nullable FeatureAttribute<Integer> lastKnownLQI;
+        private @Nullable FeatureAttribute<Integer> averageRSSI;
+        private @Nullable FeatureAttribute<Integer> lastKnownRSSI;
+
+        public Builder from(final ZigbeeDeviceFeature zigbeeDeviceFeature) {
+            Objects.requireNonNull(zigbeeDeviceFeature);
+
+            return this.eui64(zigbeeDeviceFeature.getEui64())
+                    .averageLQI(zigbeeDeviceFeature.getAverageLQI())
+                    .lastKnownLQI(zigbeeDeviceFeature.getLastKnownLQI())
+                    .averageRSSI(zigbeeDeviceFeature.getAverageRSSI())
+                    .lastKnownRSSI(zigbeeDeviceFeature.getLastKnownRSSI());
+        }
+
+        public Builder eui64(final @Nullable FeatureAttribute<Eui64> eui64) {
+            this.eui64 = eui64;
+
+            return this;
+        }
+
+        public Builder averageLQI(final @Nullable FeatureAttribute<Integer> averageLQI) {
+            this.averageLQI = averageLQI;
+
+            return this;
+        }
+
+        public Builder lastKnownLQI(final @Nullable FeatureAttribute<Integer> lastKnownLQI) {
+            this.lastKnownLQI = lastKnownLQI;
+
+            return this;
+        }
+
+        public Builder averageRSSI(final @Nullable FeatureAttribute<Integer> averageRSSI) {
+            this.averageRSSI = averageRSSI;
+
+            return this;
+        }
+
+        public Builder lastKnownRSSI(final @Nullable FeatureAttribute<Integer> lastKnownRSSI) {
+            this.lastKnownRSSI = lastKnownRSSI;
+
+            return this;
+        }
+        
+        public ZigbeeDeviceFeature build() {
+            return new ZigbeeDeviceFeature(
+                    this.eui64,
+                    this.averageLQI,
+                    this.lastKnownLQI,
+                    this.averageRSSI,
+                    this.lastKnownRSSI
+            );
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/DefaultNodeRepository.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/DefaultNodeRepository.java
@@ -1,0 +1,682 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.time.Duration;
+import java.util.*;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.dto.*;
+import org.openhab.binding.hive.internal.client.exception.*;
+import org.openhab.binding.hive.internal.client.feature.*;
+
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+/**
+ * The default implementation of {@link NodeRepository}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultNodeRepository implements NodeRepository {
+    private final HiveApiRequestFactory requestFactory;
+
+    public DefaultNodeRepository(
+            final HiveApiRequestFactory requestFactory
+    ) {
+        Objects.requireNonNull(requestFactory);
+
+        this.requestFactory = requestFactory;
+    }
+
+    private static URI getEndpointPathForNode(final NodeId nodeId) {
+        return HiveApiConstants.ENDPOINT_NODE.resolve(nodeId.toString());
+    }
+
+    private static <T> @Nullable T safeGetTargetValue(final @Nullable SettableFeatureAttribute<T> attribute) {
+        if (attribute != null) {
+            return attribute.getTargetValue();
+        } else {
+            return null;
+        }
+    }
+
+    private static BigDecimal temperatureToDtoValue(final Quantity<Temperature> temperature) {
+        // Convert temperature to celsius
+        final Quantity<Temperature> celsiusTemperature = temperature.to(Units.CELSIUS);
+
+        // Convert to BigDecimal
+        final BigDecimal celsiusTemperatureDecimal = new BigDecimal(celsiusTemperature.getValue().toString());
+
+        // Round temperature to 1 decimal place and return
+        return celsiusTemperatureDecimal.setScale(1, RoundingMode.HALF_UP);
+    }
+
+    private static AutoBoostFeature getAutoBoostFeatureFromDto(
+            final AutoBoostV1FeatureDto autoBoostV1FeatureDto
+    ) throws HiveClientResponseException {
+        // FIXME: temperature-units: Actually check temperature unit.
+        return AutoBoostFeature.builder()
+                .autoBoostDuration(FeatureAttributeFactory.getSettableFromDtoWithAdapter(
+                        Duration::ofMinutes,
+                        autoBoostV1FeatureDto.autoBoostDuration
+                ))
+                .autoBoostTargetHeatTemperature(FeatureAttributeFactory.getSettableFromDtoWithAdapter(
+                        (val) -> Quantities.getQuantity(val, Units.CELSIUS),
+                        autoBoostV1FeatureDto.autoBoostTargetHeatTemperature
+                ))
+                .build();
+    }
+
+    private static BatteryDeviceFeature getBatteryDeviceFeatureFromDto(
+            final BatteryDeviceV1FeatureDto batteryDeviceV1FeatureDto
+    ) throws HiveClientResponseException {
+        return BatteryDeviceFeature.builder()
+                .batteryLevel(FeatureAttributeFactory.getReadOnlyFromDtoWithAdapter(
+                        BatteryLevel::new,
+                        batteryDeviceV1FeatureDto.batteryLevel
+                ))
+                .batteryState(FeatureAttributeFactory.getReadOnlyFromDto(batteryDeviceV1FeatureDto.batteryState))
+                .batteryVoltage(FeatureAttributeFactory.getReadOnlyFromDtoWithAdapter(
+                        (val) -> Quantities.getQuantity(val, Units.VOLT),
+                        batteryDeviceV1FeatureDto.batteryVoltage
+                ))
+                .batteryNotificationState(FeatureAttributeFactory.getReadOnlyFromDto(batteryDeviceV1FeatureDto.notificationState))
+                .build();
+    }
+
+    private static LinksFeature getLinksFeatureFromDto(
+            final LinksV1FeatureDto linksV1FeatureDto
+    ) throws HiveClientResponseException {
+        final FeatureAttributeFactory.Adapter<Set<LinkDto>, Set<Link>> linksAdapter = (list) -> {
+            final Set<Link> links = new HashSet<>();
+
+            for (final LinkDto linkDto : list) {
+                final @Nullable NodeId boundNode = linkDto.boundNode;
+                final @Nullable GroupId bindingGroupId = linkDto.bindingGroupId;
+
+                if (boundNode == null) {
+                    throw new HiveClientResponseException("Link bound node is unexpectedly null.");
+                }
+
+                if (bindingGroupId == null) {
+                    throw new HiveClientResponseException("Link binding group id is unexpectedly null.");
+                }
+
+                links.add(new Link(boundNode, bindingGroupId));
+            }
+
+            return Collections.unmodifiableSet(links);
+        };
+
+        final FeatureAttributeFactory.Adapter<Set<ReverseLinkDto>, Set<ReverseLink>> reverseLinksAdapter = (list) -> {
+            final Set<ReverseLink> reverseLinks = new HashSet<>();
+
+            for (final ReverseLinkDto reverseLinkDto : list) {
+                final @Nullable NodeId boundNode = reverseLinkDto.boundNode;
+                final @Nullable Set<GroupId> bindingGroupId = reverseLinkDto.bindingGroupIds;
+
+                if (boundNode == null) {
+                    throw new HiveClientResponseException("Reverse link bound node is unexpectedly null.");
+                }
+
+                if (bindingGroupId == null) {
+                    throw new HiveClientResponseException("Reverse link binding group id is unexpectedly null.");
+                }
+
+                reverseLinks.add(new ReverseLink(boundNode, bindingGroupId));
+            }
+
+            return Collections.unmodifiableSet(reverseLinks);
+        };
+
+        return LinksFeature.builder()
+                .links(linksV1FeatureDto.links != null ? FeatureAttributeFactory.getReadOnlyFromDtoWithAdapter(
+                        linksAdapter,
+                        linksV1FeatureDto.links
+                ) : null)
+                .reverseLinks(linksV1FeatureDto.reverseLinks != null ? FeatureAttributeFactory.getReadOnlyFromDtoWithAdapter(
+                        reverseLinksAdapter,
+                        linksV1FeatureDto.reverseLinks
+                ) : null)
+                .build();
+    }
+
+    private static OnOffDeviceFeature getOnOffDeviceFeatureFromDto(
+            final OnOffDeviceV1FeatureDto onOffDeviceV1FeatureDto
+    ) throws HiveClientResponseException {
+        return OnOffDeviceFeature.builder()
+                .mode(FeatureAttributeFactory.getSettableFromDto(onOffDeviceV1FeatureDto.mode))
+                .build();
+    }
+
+    private static PhysicalDeviceFeature getPhysicalDeviceFeatureFromDto(
+            final PhysicalDeviceV1FeatureDto physicalDeviceV1FeatureDto
+    ) throws HiveClientResponseException {
+        final @Nullable FeatureAttribute<String> hardwareIdentifier;
+
+        final @Nullable FeatureAttributeDto<String> nativeIdentifierAttributeDto = physicalDeviceV1FeatureDto.nativeIdentifier;
+        final @Nullable FeatureAttributeDto<String> hardwareIdentifierAttributeDto = physicalDeviceV1FeatureDto.hardwareIdentifier;
+
+        if (nativeIdentifierAttributeDto != null) {
+            hardwareIdentifier = FeatureAttributeFactory.getReadOnlyFromDto(nativeIdentifierAttributeDto);
+        } else if (hardwareIdentifierAttributeDto != null) {
+            hardwareIdentifier = FeatureAttributeFactory.getReadOnlyFromDto(hardwareIdentifierAttributeDto);
+        } else {
+            hardwareIdentifier = null;
+        }
+
+        return PhysicalDeviceFeature.builder()
+                .hardwareIdentifier(hardwareIdentifier)
+                .model(FeatureAttributeFactory.getReadOnlyFromDto(physicalDeviceV1FeatureDto.model))
+                .manufacturer(FeatureAttributeFactory.getReadOnlyFromDto(physicalDeviceV1FeatureDto.manufacturer))
+                .softwareVersion(FeatureAttributeFactory.getReadOnlyFromDto(physicalDeviceV1FeatureDto.softwareVersion))
+                .build();
+    }
+
+    private static HeatingThermostatFeature getHeatingThermostatFeatureFromDto(
+            final HeatingThermostatV1FeatureDto heatingThermostatV1FeatureDto
+    ) throws HiveClientResponseException {
+        // FIXME: temperature-units: Actually check temperature unit.
+        return HeatingThermostatFeature.builder()
+                .operatingMode(FeatureAttributeFactory.getSettableFromDto(heatingThermostatV1FeatureDto.operatingMode))
+                .operatingState(FeatureAttributeFactory.getReadOnlyFromDto(heatingThermostatV1FeatureDto.operatingState))
+                .targetHeatTemperature(FeatureAttributeFactory.getSettableFromDtoWithAdapter(
+                        (val) -> Quantities.getQuantity(val, Units.CELSIUS),
+                        heatingThermostatV1FeatureDto.targetHeatTemperature
+                ))
+                .temporaryOperatingModeOverride(FeatureAttributeFactory.getSettableFromDto(heatingThermostatV1FeatureDto.temporaryOperatingModeOverride))
+                .build();
+    }
+
+    private static TemperatureSensorFeature getTemperatureSensorFeatureFromDto(
+            final TemperatureSensorV1FeatureDto temperatureSensorV1FeatureDto
+    ) throws HiveClientResponseException {
+        // FIXME: temperature-units: Actually check temperature unit.
+        return TemperatureSensorFeature.builder()
+                .temperature(FeatureAttributeFactory.getReadOnlyFromDtoWithAdapter(
+                        (val) -> Quantities.getQuantity(val, Units.CELSIUS),
+                        temperatureSensorV1FeatureDto.temperature
+                ))
+                .build();
+    }
+
+    private static TransientModeFeature getTransientModeFeatureFromDto(
+            final TransientModeV1FeatureDto transientModeV1FeatureDto
+    ) throws HiveClientResponseException {
+        return TransientModeFeature.builder()
+                .duration(FeatureAttributeFactory.getSettableFromDtoWithAdapter(
+                        Duration::ofSeconds,
+                        transientModeV1FeatureDto.duration
+                ))
+                .isEnabled(FeatureAttributeFactory.getSettableFromDto(transientModeV1FeatureDto.isEnabled))
+                .startDatetime(FeatureAttributeFactory.getReadOnlyFromDto(transientModeV1FeatureDto.startDatetime))
+                .endDatetime(FeatureAttributeFactory.getReadOnlyFromDto(transientModeV1FeatureDto.endDatetime))
+                .build();
+    }
+
+    private static TransientModeHeatingActionsFeature getTransientModeHeatingActionsFeatureFromDto(
+            final TransientModeV1FeatureDto transientModeV1FeatureDto
+    ) throws HiveClientResponseException {
+        final @Nullable FeatureAttributeDto<List<ActionDto>> actionsAttribute = transientModeV1FeatureDto.actions;
+        if (actionsAttribute == null) {
+            throw new HiveClientResponseException("Transient mode actions attribute is unexpectedly null.");
+        }
+
+        final @Nullable List<ActionDto> actions = actionsAttribute.reportedValue;
+        if (actions == null) {
+            throw new HiveClientResponseException("Transient mode action list is unexpectedly null.");
+        }
+
+        if (actions.isEmpty()) {
+            throw new HiveClientResponseException("Transient mode action list is unexpectedly empty.");
+        }
+        final @Nullable ActionDto targetTempAction = actions.get(0);
+        if (targetTempAction == null) {
+            throw new HiveClientResponseException("Transient mode action is unexpectedly null.");
+        }
+
+        final @Nullable String targetTempString = targetTempAction.value;
+        if (targetTempString == null) {
+            throw new HiveClientResponseException("Transient Target Temperature is unexpectedly null.");
+        }
+
+        // FIXME: temperature-units: Actually check temperature unit.
+        final Quantity<Temperature> targetHeatTemperature = Quantities.getQuantity(new BigDecimal(targetTempString), Units.CELSIUS);
+
+        return TransientModeHeatingActionsFeature.builder()
+                .boostTargetTemperature(FeatureAttributeFactory.getSettableFromDtoWithAdapter(
+                        (val) -> targetHeatTemperature,
+                        transientModeV1FeatureDto.actions
+                ))
+                .build();
+    }
+
+    private static WaterHeaterFeature getWaterHeaterFeatureFromDto(
+            final WaterHeaterV1FeatureDto waterHeaterV1FeatureDto
+    ) throws HiveClientResponseException {
+        return WaterHeaterFeature.builder()
+                .operatingMode(FeatureAttributeFactory.getSettableFromDto(waterHeaterV1FeatureDto.operatingMode))
+                .isOn(FeatureAttributeFactory.getReadOnlyFromDto(waterHeaterV1FeatureDto.isOn))
+                .temporaryOperatingModeOverride(FeatureAttributeFactory.getSettableFromDto(waterHeaterV1FeatureDto.temporaryOperatingModeOverride))
+                .build();
+    }
+
+    private static ZigbeeDeviceFeature getZigbeeDeviceFeatureFromDto(
+            final ZigbeeDeviceV1FeatureDto zigbeeDeviceV1FeatureDto
+    ) throws HiveClientResponseException {
+        return ZigbeeDeviceFeature.builder()
+                .eui64(FeatureAttributeFactory.getReadOnlyFromDto(zigbeeDeviceV1FeatureDto.eui64))
+                .averageLQI(FeatureAttributeFactory.getReadOnlyFromDto(zigbeeDeviceV1FeatureDto.averageLQI))
+                .lastKnownLQI(FeatureAttributeFactory.getReadOnlyFromDto(zigbeeDeviceV1FeatureDto.lastKnownLQI))
+                .averageRSSI(FeatureAttributeFactory.getReadOnlyFromDto(zigbeeDeviceV1FeatureDto.averageRSSI))
+                .lastKnownRSSI(FeatureAttributeFactory.getReadOnlyFromDto(zigbeeDeviceV1FeatureDto.lastKnownRSSI))
+                .build();
+    }
+
+    private static void updateFeaturesDtoWithAutoBoostFeature(
+            final FeaturesDto featuresDto,
+            final AutoBoostFeature autoBoostFeature
+    ) {
+        final @Nullable Duration autoBoostDurationTarget = safeGetTargetValue(autoBoostFeature.getAutoBoostDuration());
+        final @Nullable Quantity<Temperature> autoBoostTargetHeatTemperatureTarget = safeGetTargetValue(autoBoostFeature.getAutoBoostTargetHeatTemperature());
+
+        if (autoBoostDurationTarget != null
+                || autoBoostTargetHeatTemperatureTarget != null
+        ) {
+            final AutoBoostV1FeatureDto autoBoostV1FeatureDto = new AutoBoostV1FeatureDto();
+            featuresDto.autoboost_v1 = autoBoostV1FeatureDto;
+
+            if (autoBoostDurationTarget != null) {
+                final FeatureAttributeDto<Long> autoBoostDurationAttribute = new FeatureAttributeDto<>();
+                autoBoostV1FeatureDto.autoBoostDuration = autoBoostDurationAttribute;
+                // N.B. Unlike transient override we use minutes here.
+                autoBoostDurationAttribute.targetValue = Math.max(1, autoBoostDurationTarget.toMinutes());
+            }
+
+            if (autoBoostTargetHeatTemperatureTarget != null) {
+                final FeatureAttributeDto<BigDecimal> autoBoostTargetHeatTemperatureAttribute = new FeatureAttributeDto<>();
+                autoBoostV1FeatureDto.autoBoostTargetHeatTemperature = autoBoostTargetHeatTemperatureAttribute;
+                autoBoostTargetHeatTemperatureAttribute.targetValue = temperatureToDtoValue(autoBoostTargetHeatTemperatureTarget);
+            }
+        }
+    }
+
+    private static void updateFeaturesDtoWithOnOffDeviceFeature(
+            final FeaturesDto featuresDto,
+            final OnOffDeviceFeature onOffDeviceFeature
+    ) {
+        final @Nullable OnOffMode onOffModeTarget = safeGetTargetValue(onOffDeviceFeature.getMode());
+        if (onOffModeTarget != null) {
+            final OnOffDeviceV1FeatureDto onOffDeviceV1FeatureDto = new OnOffDeviceV1FeatureDto();
+            featuresDto.on_off_device_v1 = onOffDeviceV1FeatureDto;
+
+            final FeatureAttributeDto<OnOffMode> modeAttribute = new FeatureAttributeDto<>();
+            onOffDeviceV1FeatureDto.mode = modeAttribute;
+            modeAttribute.targetValue = onOffModeTarget;
+        }
+    }
+
+    private static void updateFeaturesDtoWithHeatingThermostatFeature(
+            final FeaturesDto featuresDto,
+            final HeatingThermostatFeature heatingThermostatFeature
+    ) {
+        final @Nullable HeatingThermostatOperatingMode operatingModeTarget = safeGetTargetValue(heatingThermostatFeature.getOperatingMode());
+        final @Nullable Quantity<Temperature> targetHeatTemperatureTarget = safeGetTargetValue(heatingThermostatFeature.getTargetHeatTemperature());
+        final @Nullable OverrideMode temporaryOperatingModeOverrideTarget = safeGetTargetValue(heatingThermostatFeature.getTemporaryOperatingModeOverride());
+
+        // If one of the HeatingThermostatFeature attributes has been set...
+        if (operatingModeTarget != null
+                || targetHeatTemperatureTarget != null
+                || temporaryOperatingModeOverrideTarget != null
+        ) {
+            final HeatingThermostatV1FeatureDto heatingThermostatV1FeatureDto = new HeatingThermostatV1FeatureDto();
+            featuresDto.heating_thermostat_v1 = heatingThermostatV1FeatureDto;
+
+            if (operatingModeTarget != null) {
+                final FeatureAttributeDto<HeatingThermostatOperatingMode> operatingModeFeatureAttributeDto = new FeatureAttributeDto<>();
+                heatingThermostatV1FeatureDto.operatingMode = operatingModeFeatureAttributeDto;
+                operatingModeFeatureAttributeDto.targetValue = operatingModeTarget;
+            }
+
+            if (targetHeatTemperatureTarget != null) {
+                final FeatureAttributeDto<BigDecimal> targetHeatTemperatureAttribute = new FeatureAttributeDto<>();
+                heatingThermostatV1FeatureDto.targetHeatTemperature = targetHeatTemperatureAttribute;
+                targetHeatTemperatureAttribute.targetValue = temperatureToDtoValue(targetHeatTemperatureTarget);
+            }
+
+            if (temporaryOperatingModeOverrideTarget != null) {
+                final FeatureAttributeDto<OverrideMode> temporaryOperatingModeAttributeDto = new FeatureAttributeDto<>();
+                heatingThermostatV1FeatureDto.temporaryOperatingModeOverride = temporaryOperatingModeAttributeDto;
+                temporaryOperatingModeAttributeDto.targetValue = temporaryOperatingModeOverrideTarget;
+            }
+        }
+    }
+
+    private static void updateFeaturesDtoWithTransientModeFeature(
+            final FeaturesDto featuresDto,
+            final TransientModeFeature transientModeFeature
+    ) {
+        final @Nullable Duration durationTarget = safeGetTargetValue(transientModeFeature.getDuration());
+        final @Nullable Boolean isEnabledTarget = safeGetTargetValue(transientModeFeature.getIsEnabled());
+
+        if (durationTarget != null || isEnabledTarget != null) {
+            @Nullable TransientModeV1FeatureDto transientModeV1FeatureDto = featuresDto.transient_mode_v1;
+            if (transientModeV1FeatureDto == null) {
+                transientModeV1FeatureDto = new TransientModeV1FeatureDto();
+                featuresDto.transient_mode_v1 = transientModeV1FeatureDto;
+            }
+
+            if (durationTarget != null) {
+                final FeatureAttributeDto<Long> durationAttribute = new FeatureAttributeDto<>();
+                transientModeV1FeatureDto.duration = durationAttribute;
+                durationAttribute.targetValue = Math.max(1, durationTarget.getSeconds());
+            }
+
+            if (isEnabledTarget != null) {
+                final FeatureAttributeDto<Boolean> isEnabledAttribute = new FeatureAttributeDto<>();
+                transientModeV1FeatureDto.isEnabled = isEnabledAttribute;
+                isEnabledAttribute.targetValue = isEnabledTarget;
+            }
+        }
+    }
+
+    private static void updateFeaturesDtoWithTransientModeHeatingActionsFeature(
+            final FeaturesDto featuresDto,
+            final TransientModeHeatingActionsFeature transientModeHeatingActionsFeature
+    ) {
+        final @Nullable Quantity<Temperature> boostTargetTemperatureTarget = safeGetTargetValue(transientModeHeatingActionsFeature.getBoostTargetTemperature());
+        if (boostTargetTemperatureTarget != null) {
+            @Nullable TransientModeV1FeatureDto transientModeV1FeatureDto = featuresDto.transient_mode_v1;
+            if (transientModeV1FeatureDto == null) {
+                transientModeV1FeatureDto = new TransientModeV1FeatureDto();
+                featuresDto.transient_mode_v1 = transientModeV1FeatureDto;
+            }
+
+            final ActionDto actionDto = new ActionDto();
+            actionDto.actionType = ActionType.GENERIC;
+            actionDto.featureType = FeatureType.HEATING_THERMOSTAT_V1;
+            actionDto.attribute = AttributeName.HEATING_THERMOSTAT_TARGET_HEAT_TEMPERATURE;
+            actionDto.value = temperatureToDtoValue(boostTargetTemperatureTarget).toString();
+
+            final FeatureAttributeDto<List<ActionDto>> actionsDto = new FeatureAttributeDto<>();
+            transientModeV1FeatureDto.actions = actionsDto;
+            actionsDto.targetValue = Collections.singletonList(actionDto);
+        }
+    }
+
+    private static void updateFeaturesDtoWithWaterHeaterFeature(
+            final FeaturesDto featuresDto,
+            final WaterHeaterFeature waterHeaterFeature
+    ) {
+        final @Nullable WaterHeaterOperatingMode operatingModeTarget = safeGetTargetValue(waterHeaterFeature.getOperatingMode());
+        final @Nullable OverrideMode temporaryOperatingModeOverrideTarget = safeGetTargetValue(waterHeaterFeature.getTemporaryOperatingModeOverride());
+
+        if (operatingModeTarget != null || temporaryOperatingModeOverrideTarget != null) {
+            final WaterHeaterV1FeatureDto waterHeaterV1FeatureDto = new WaterHeaterV1FeatureDto();
+            featuresDto.water_heater_v1 = waterHeaterV1FeatureDto;
+
+            if (operatingModeTarget != null) {
+                final FeatureAttributeDto<WaterHeaterOperatingMode> operatingModeAttributeDto = new FeatureAttributeDto<>();
+                waterHeaterV1FeatureDto.operatingMode = operatingModeAttributeDto;
+                operatingModeAttributeDto.targetValue = operatingModeTarget;
+            }
+
+            if (temporaryOperatingModeOverrideTarget != null) {
+                final FeatureAttributeDto<OverrideMode> temporaryOperatingModeOverrideAttribute = new FeatureAttributeDto<>();
+                waterHeaterV1FeatureDto.temporaryOperatingModeOverride = temporaryOperatingModeOverrideAttribute;
+                temporaryOperatingModeOverrideAttribute.targetValue = temporaryOperatingModeOverrideTarget;
+            }
+        }
+    }
+
+    private static Set<Node> parseNodesDto(
+            final NodesDto nodesDto
+    ) throws HiveClientResponseException {
+        final @Nullable List<@Nullable NodeDto> nodeDtos = nodesDto.nodes;
+        if (nodeDtos == null) {
+            throw new HiveClientResponseException("Nodes list is unexpectedly null.");
+        }
+
+        final Set<Node> nodes = new HashSet<>();
+        // For each node
+        for (final @Nullable NodeDto nodeDto : nodeDtos) {
+            final Node.Builder nodeBuilder = Node.builder();
+
+            if (nodeDto == null) {
+                throw new HiveClientResponseException("Node DTO is unexpectedly null.");
+            }
+
+            final @Nullable NodeId nodeId = nodeDto.id;
+            if (nodeId == null) {
+                throw new HiveClientResponseException("NodeId is unexpectedly null.");
+            }
+            nodeBuilder.id(nodeId);
+
+            final @Nullable NodeId parentNodeId = nodeDto.parentNodeId;
+            if (parentNodeId == null) {
+                throw new HiveClientResponseException("ParentNodeId is unexpectedly null.");
+            }
+            nodeBuilder.parentNodeId(parentNodeId);
+
+            final @Nullable String nodeName = nodeDto.name;
+            if (nodeName == null) {
+                throw new HiveClientResponseException("NodeName is unexpectedly null.");
+            }
+            nodeBuilder.name(nodeName);
+
+            final @Nullable NodeType nodeType = nodeDto.nodeType;
+            if (nodeType == null) {
+                throw new HiveClientResponseException("NodeType is unexpectedly null.");
+            }
+            nodeBuilder.nodeType(nodeType);
+
+            final @Nullable Protocol dtoProtocol = nodeDto.protocol;
+            final Protocol protocol;
+            if (dtoProtocol != null) {
+                protocol = dtoProtocol;
+            } else {
+                protocol = Protocol.NONE;
+            }
+            nodeBuilder.protocol(protocol);
+
+            final @Nullable FeaturesDto featuresDto = nodeDto.features;
+            if (featuresDto == null) {
+                throw new HiveClientResponseException("Node features unexpectedly null.");
+            }
+
+            final @Nullable AutoBoostV1FeatureDto autoBoostV1FeatureDto = featuresDto.autoboost_v1;
+            final @Nullable BatteryDeviceV1FeatureDto batteryDeviceV1FeatureDto = featuresDto.battery_device_v1;
+            final @Nullable DeviceManagementV1FeatureDto deviceManagementV1FeatureDto = featuresDto.device_management_v1;
+            final @Nullable HeatingThermostatV1FeatureDto heatingThermostatV1FeatureDto = featuresDto.heating_thermostat_v1;
+            final @Nullable LinksV1FeatureDto linksV1FeatureDto = featuresDto.links_v1;
+            final @Nullable OnOffDeviceV1FeatureDto onOffDeviceV1FeatureDto = featuresDto.on_off_device_v1;
+            final @Nullable PhysicalDeviceV1FeatureDto physicalDeviceV1FeatureDto = featuresDto.physical_device_v1;
+            final @Nullable TemperatureSensorV1FeatureDto temperatureSensorV1FeatureDto = featuresDto.temperature_sensor_v1;
+            final @Nullable TransientModeV1FeatureDto transientModeV1FeatureDto = featuresDto.transient_mode_v1;
+            final @Nullable WaterHeaterV1FeatureDto waterHeaterV1FeatureDto = featuresDto.water_heater_v1;
+            final @Nullable ZigbeeDeviceV1FeatureDto zigbeeDeviceV1FeatureDto = featuresDto.zigbee_device_v1;
+
+            if (autoBoostV1FeatureDto != null) {
+                nodeBuilder.putFeature(AutoBoostFeature.class, getAutoBoostFeatureFromDto(autoBoostV1FeatureDto));
+            }
+            if (batteryDeviceV1FeatureDto != null) {
+                nodeBuilder.putFeature(BatteryDeviceFeature.class, getBatteryDeviceFeatureFromDto(batteryDeviceV1FeatureDto));
+            }
+            if (heatingThermostatV1FeatureDto != null) {
+                nodeBuilder.putFeature(HeatingThermostatFeature.class, getHeatingThermostatFeatureFromDto(heatingThermostatV1FeatureDto));
+            }
+            if (linksV1FeatureDto != null) {
+                nodeBuilder.putFeature(LinksFeature.class, getLinksFeatureFromDto(linksV1FeatureDto));
+            }
+            if (onOffDeviceV1FeatureDto != null) {
+                nodeBuilder.putFeature(OnOffDeviceFeature.class, getOnOffDeviceFeatureFromDto(onOffDeviceV1FeatureDto));
+            }
+            if (physicalDeviceV1FeatureDto != null) {
+                nodeBuilder.putFeature(PhysicalDeviceFeature.class, getPhysicalDeviceFeatureFromDto(physicalDeviceV1FeatureDto));
+            }
+            if (temperatureSensorV1FeatureDto != null) {
+                nodeBuilder.putFeature(TemperatureSensorFeature.class, getTemperatureSensorFeatureFromDto(temperatureSensorV1FeatureDto));
+            }
+            if (transientModeV1FeatureDto != null) {
+                nodeBuilder.putFeature(TransientModeFeature.class, getTransientModeFeatureFromDto(transientModeV1FeatureDto));
+
+                if (heatingThermostatV1FeatureDto != null && transientModeV1FeatureDto.actions != null) {
+                    nodeBuilder.putFeature(TransientModeHeatingActionsFeature.class, getTransientModeHeatingActionsFeatureFromDto(transientModeV1FeatureDto));
+                }
+            }
+            if (waterHeaterV1FeatureDto != null) {
+                nodeBuilder.putFeature(WaterHeaterFeature.class, getWaterHeaterFeatureFromDto(waterHeaterV1FeatureDto));
+            }
+            if (zigbeeDeviceV1FeatureDto != null) {
+                nodeBuilder.putFeature(ZigbeeDeviceFeature.class, getZigbeeDeviceFeatureFromDto(zigbeeDeviceV1FeatureDto));
+            }
+
+            if (deviceManagementV1FeatureDto == null) {
+                throw new HiveClientResponseException("DeviceManagement feature is unexpectedly null.");
+            }
+
+            final @Nullable ProductType productType;
+            final @Nullable FeatureAttributeDto<ProductType> productTypeFeatureAttributeDto = deviceManagementV1FeatureDto.productType;
+            if (productTypeFeatureAttributeDto == null) {
+                // Force product type for synthetic nodes created by NANO1 hub.
+                productType = ProductType.UNKNOWN;
+            } else {
+                productType = productTypeFeatureAttributeDto.reportedValue;
+            }
+
+            if (productType == null) {
+                throw new HiveClientResponseException("ProductType is unexpectedly null.");
+            }
+            nodeBuilder.productType(productType);
+
+            nodes.add(nodeBuilder.build());
+        }
+
+        return Collections.unmodifiableSet(nodes);
+    }
+
+    @Override
+    public Set<Node> getAllNodes() throws HiveApiNotAuthorisedException, HiveClientResponseException,
+            HiveApiUnknownException, HiveClientUnknownException, HiveClientRequestException {
+        /* Send our get nodes request to the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(HiveApiConstants.ENDPOINT_NODES)
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .get();
+
+        RepositoryUtil.checkResponse("getAllNodes", response);
+
+        final NodesDto nodesDto = response.getContent(NodesDto.class);
+
+        return parseNodesDto(nodesDto);
+    }
+
+    @Override
+    public String getAllNodesJson() throws HiveApiNotAuthorisedException, HiveApiUnknownException,
+            HiveClientUnknownException, HiveClientRequestException {
+        /* Send our get nodes request to the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(HiveApiConstants.ENDPOINT_NODES)
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .get();
+
+        RepositoryUtil.checkResponse("getAllNodesJson", response);
+
+        return response.getRawContent();
+    }
+
+    @Override
+    public @Nullable Node getNode(final NodeId nodeId)
+            throws HiveApiNotAuthorisedException, HiveClientResponseException, HiveApiUnknownException,
+            HiveClientUnknownException, HiveClientRequestException {
+        /* Send our get node request to the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(getEndpointPathForNode(nodeId))
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .get();
+
+        RepositoryUtil.checkResponse("getNode", response);
+
+        final NodesDto nodesDto = response.getContent(NodesDto.class);
+        final Set<Node> nodes = parseNodesDto(nodesDto);
+
+        if (nodes.isEmpty()) {
+            // There is no node with that ID
+            return null;
+        } else if (nodes.size() == 1) {
+            return nodes.iterator().next();
+        } else {
+            // Something has gone wrong.
+            throw new HiveClientResponseException("Got multiple nodes when requesting node by ID!");
+        }
+    }
+
+    @Override
+    public @Nullable Node updateNode(final Node node) throws HiveApiNotAuthorisedException, HiveClientResponseException,
+            HiveApiUnknownException, HiveClientUnknownException, HiveClientRequestException {
+        /* Prepare DTO to send Hive API */
+        final NodeDto nodeDto = new NodeDto();
+
+        final FeaturesDto featuresDto = new FeaturesDto();
+        nodeDto.features = featuresDto;
+
+        for (final Map.Entry<Class<? extends Feature>, Feature> featureEntry : node.getFeatures().entrySet()) {
+            final @Nullable Class<? extends Feature> featureClass = featureEntry.getKey();
+            final @Nullable Feature feature = featureEntry.getValue();
+
+            if (featureClass == null || feature == null) {
+                throw new IllegalStateException("Something has gone very wrong with the feature map.");
+            }
+
+            if (featureClass.equals(AutoBoostFeature.class)) {
+                updateFeaturesDtoWithAutoBoostFeature(featuresDto, (AutoBoostFeature) feature);
+            } else if (featureClass.equals(OnOffDeviceFeature.class)) {
+                updateFeaturesDtoWithOnOffDeviceFeature(featuresDto, (OnOffDeviceFeature) feature);
+            } else if (featureClass.equals(HeatingThermostatFeature.class)) {
+                updateFeaturesDtoWithHeatingThermostatFeature(featuresDto, (HeatingThermostatFeature) feature);
+            } else if (featureClass.equals(TransientModeFeature.class)) {
+                updateFeaturesDtoWithTransientModeFeature(featuresDto, (TransientModeFeature) feature);
+            } else if (featureClass.equals(TransientModeHeatingActionsFeature.class)) {
+                updateFeaturesDtoWithTransientModeHeatingActionsFeature(featuresDto, (TransientModeHeatingActionsFeature) feature);
+            } else if (featureClass.equals(WaterHeaterFeature.class)) {
+                updateFeaturesDtoWithWaterHeaterFeature(featuresDto, (WaterHeaterFeature) feature);
+            }
+        }
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        final HiveApiResponse response = this.requestFactory.newRequest(getEndpointPathForNode(node.getId()))
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .put(nodesDto);
+
+        RepositoryUtil.checkResponse("updateNode", response);
+
+        final NodesDto responseNodesDto = response.getContent(NodesDto.class);
+        final Set<Node> responseNodes = parseNodesDto(responseNodesDto);
+
+        if (responseNodes.size() == 1) {
+            return responseNodes.iterator().next();
+        } else {
+            // Something has gone wrong.
+            throw new HiveClientResponseException("The parsed response is malformed.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/DefaultSessionRepository.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/DefaultSessionRepository.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import java.net.URI;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.dto.SessionDto;
+import org.openhab.binding.hive.internal.client.dto.SessionsDto;
+import org.openhab.binding.hive.internal.client.exception.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link SessionRepository}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultSessionRepository implements SessionRepository {
+    private final Logger logger = LoggerFactory.getLogger(DefaultSessionRepository.class);
+
+    private final HiveApiRequestFactory requestFactory;
+
+    public DefaultSessionRepository(
+            final HiveApiRequestFactory requestFactory
+    ) {
+        Objects.requireNonNull(requestFactory);
+
+        this.requestFactory = requestFactory;
+    }
+
+    private URI getEndpointPathForSession(final SessionId sessionId) {
+        return HiveApiConstants.ENDPOINT_SESSION.resolve(sessionId.toString());
+    }
+
+    @Override
+    public Session createSession(final String username, final String password) throws HiveApiAuthenticationException, HiveApiUnknownException, HiveClientResponseException, HiveClientRequestException {
+        /* Build our request entity with our user credentials */
+        final SessionDto credentials = new SessionDto();
+        credentials.username = username;
+        credentials.password = password;
+
+        final SessionsDto requestEntity = new SessionsDto();
+        requestEntity.sessions = Collections.singletonList(credentials);
+
+        /* Send our new session request to the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(HiveApiConstants.ENDPOINT_SESSIONS)
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .post(requestEntity);
+
+        if (response.getStatusCode() == HiveApiConstants.STATUS_CODE_400_BAD_REQUEST) {
+            throw new HiveApiAuthenticationException(
+                    "Creating a new session failed because an incorrect username or password was provided"
+            );
+        } else if (response.getStatusCode() != HiveApiConstants.STATUS_CODE_200_OK) {
+            throw new HiveApiUnknownException("Creating a new session failed with response code: " + response.getStatusCode());
+        }
+
+        /* Try to convert DTO into a domain object */
+        final SessionsDto responseEntity = response.getContent(SessionsDto.class);
+
+        final @Nullable List<@Nullable SessionDto> sessions = responseEntity.sessions;
+        if (sessions == null || sessions.size() == 0) {
+            throw new HiveClientResponseException("List of sessions is unexpectedly empty.");
+        }
+
+        final @Nullable SessionDto sessionDto = sessions.get(0);
+        if (sessionDto == null) {
+            throw new HiveClientResponseException("Session object is unexpectedly null.");
+        }
+
+        final @Nullable SessionId sessionId = sessionDto.sessionId;
+        final @Nullable UserId userId = sessionDto.userId;
+
+        if (sessionId != null && userId != null) {
+            logger.trace("Created new Hive API session with sessionId: {}", sessionId);
+
+            return new Session(
+                    sessionId,
+                    userId
+            );
+        } else {
+            throw new HiveClientResponseException("Session object is malformed.");
+        }
+    }
+
+    @Override
+    public void deleteSession(final Session session)
+            throws HiveApiNotAuthorisedException, HiveApiUnknownException, HiveClientUnknownException, HiveClientRequestException {
+        /* Send our delete session request to the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(getEndpointPathForSession(session.getSessionId()))
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .delete();
+
+        RepositoryUtil.checkResponse("deleteSession", response);
+    }
+
+    @Override
+    public boolean isValidSession(final @Nullable Session session) throws HiveApiUnknownException, HiveClientRequestException {
+        if (session == null) {
+            return false;
+        }
+
+        /* Try to get our own session from the Hive API. */
+        final HiveApiResponse response = this.requestFactory.newRequest(getEndpointPathForSession(session.getSessionId()))
+                .accept(HiveApiConstants.MEDIA_TYPE_API_V6_5_0_JSON)
+                .get();
+
+        if (response.getStatusCode() == HiveApiConstants.STATUS_CODE_200_OK) {
+            // If we succeeded the session is still valid.
+            return true;
+        } else if (response.getStatusCode() == HiveApiConstants.STATUS_CODE_401_UNAUTHORIZED
+                || response.getStatusCode() == HiveApiConstants.STATUS_CODE_403_FORBIDDEN) {
+            // If we failed our session has expired (or was never valid).
+            return false;
+        }
+
+        throw new HiveApiUnknownException(MessageFormat.format(
+                "Checking session failed for an unknown reason. Status: {0}. Message: {1}",
+                response.getStatusCode(),
+                response.getRawContent())
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/NodeRepository.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/NodeRepository.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.NodeId;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface NodeRepository {
+    Set<Node> getAllNodes() throws HiveException;
+
+    /**
+     * Get the raw JSON returned by the Hive API for a get all nodes request.
+     *
+     * <p>This is meant to be used for debugging purposes only</p>
+     *
+     * @return
+     *      The raw JSON string returned by the Hive API.
+     */
+    String getAllNodesJson() throws HiveException;
+
+    @Nullable Node getNode(NodeId nodeId) throws HiveException;
+
+    @Nullable Node updateNode(Node node) throws HiveException;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/RepositoryUtil.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/RepositoryUtil.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import java.text.MessageFormat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.HiveApiResponse;
+import org.openhab.binding.hive.internal.client.exception.HiveApiNotAuthorisedException;
+import org.openhab.binding.hive.internal.client.exception.HiveApiUnknownException;
+import org.openhab.binding.hive.internal.client.exception.HiveClientUnknownException;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class RepositoryUtil {
+    public static void checkResponse(final String method, final HiveApiResponse response)
+            throws HiveApiNotAuthorisedException, HiveApiUnknownException, HiveClientUnknownException {
+        if (response.getStatusCode() == HiveApiConstants.STATUS_CODE_401_UNAUTHORIZED) {
+            throw new HiveApiNotAuthorisedException();
+        } else if (HiveApiConstants.isServerError(response.getStatusCode())) {
+            throw new HiveApiUnknownException(MessageFormat.format(
+                    "{0} failed. Something went wrong with the Hive API. Status code: {1} Content: {2}",
+                    method,
+                    response.getStatusCode(),
+                    response.getRawContent()
+            ));
+        } else if (response.getStatusCode() != HiveApiConstants.STATUS_CODE_200_OK) {
+            throw new HiveClientUnknownException(MessageFormat.format(
+                    "{0} failed. Got an unexpected status code from the Hive API. Status code: {1} Content: {2}",
+                    method,
+                    response.getStatusCode(),
+                    response.getRawContent()
+            ));
+        }
+    }
+
+    private RepositoryUtil() {
+        throw new AssertionError();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/SessionRepository.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/client/repository/SessionRepository.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.hive.internal.client.Session;
+import org.openhab.binding.hive.internal.client.exception.*;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface SessionRepository {
+    /**
+     * Open a new session using a username and password.
+     *
+     * @param username
+     *      The user's Hive username (email).
+     *
+     * @param password
+     *      The user's Hive password.
+     *
+     * @return
+     *      The the newly created Session.
+     *
+     * @throws HiveApiAuthenticationException
+     *      If the provided username and password are not valid.
+     *
+     * @throws HiveApiUnknownException
+     *      If the call to the Hive API fails for an unknown reason.
+     *
+     * @throws HiveClientResponseException
+     *      If the call the the Hive API was a success but we do not understand
+     *      the response.
+     */
+    Session createSession(String username, String password) throws HiveException;
+
+    /**
+     * Delete a session with a given ID.
+     *
+     * <p>
+     *     N.B. This method does not seem to work how I expect.
+     *     The API returns 200 but the session still works.
+     * </p>
+     *
+     * @param session
+     *      The session to delete.
+     *
+     * @throws HiveApiNotAuthorisedException
+     *      If you are not authorised to delete the provided session.
+     *
+     * @throws HiveApiUnknownException
+     *      If the call to the Hive API fails for an unknown reason.
+     */
+    void deleteSession(Session session) throws HiveException;
+
+    /**
+     * Checks if a session is valid.
+     *
+     * @param session
+     *      The session to check.
+     *
+     * @return
+     *      {@code true} if the session is valid or {@code false} if it is not.
+     *
+     * @throws HiveApiUnknownException
+     *      If the call to the Hive API fails for an unknown reason.
+     */
+    boolean isValidSession(@Nullable Session session) throws HiveException;
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/DefaultHiveDiscoveryService.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/DefaultHiveDiscoveryService.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.discovery;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.NodeId;
+import org.openhab.binding.hive.internal.client.ProductType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The default implementation of {@link HiveDiscoveryService}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultHiveDiscoveryService extends AbstractDiscoveryService implements HiveDiscoveryService {
+    /**
+     * Number of seconds before discovery should timeout.
+     *
+     * <p>
+     *     N.B. Set to 0 because I want to manually mark when discovery is
+     *     finished.
+     * </p>
+     */
+    private static final int DISCOVERY_TIMEOUT_SECONDS = 0;
+
+    private final Logger logger = LoggerFactory.getLogger(DefaultHiveDiscoveryService.class);
+
+    private final @Nullable Phaser testingPhaser;
+
+    /**
+     * The {@linkplain ThingUID} of the
+     * {@linkplain org.eclipse.smarthome.core.thing.Bridge} this discovery
+     * service belongs to.
+     */
+    private final ThingUID bridgeUid;
+
+    /**
+     * The collection of currently known {@linkplain Node}s from the Hive
+     * API.
+     */
+    private final AtomicReference<Map<NodeId, Node>> lastKnownNodes = new AtomicReference<>(Collections.emptyMap());
+
+    /**
+     * Create a new {@linkplain DefaultHiveDiscoveryService}.
+     *
+     * @param bridgeUid
+     *      The {@linkplain ThingUID} of the bridge that owns this discovery
+     *      service.
+     */
+    public DefaultHiveDiscoveryService(final ThingUID bridgeUid) {
+        this(bridgeUid, null);
+    }
+
+    DefaultHiveDiscoveryService(
+            final ThingUID bridgeUid,
+            final @Nullable Phaser testingPhaser
+    ) {
+        super(
+                HiveBindingConstants.DISCOVERABLE_THING_TYPES_UIDS,
+                DISCOVERY_TIMEOUT_SECONDS
+        );
+
+        Objects.requireNonNull(bridgeUid);
+
+        this.testingPhaser = testingPhaser;
+        this.bridgeUid = bridgeUid;
+
+        if (testingPhaser != null) {
+            testingPhaser.register();
+        }
+    }
+
+    @Override
+    public void updateKnownNodes(final Set<Node> knownNodes) {
+        Objects.requireNonNull(knownNodes);
+
+        this.scheduler.execute(() -> {
+            // Create a map from NodeId -> Node to help with following links later.
+            final Map<NodeId, Node> nodeMap = Collections.unmodifiableMap(
+                    knownNodes.stream().collect(Collectors.toMap(Node::getId, Function.identity()))
+            );
+            this.lastKnownNodes.set(nodeMap);
+
+            // Trigger a new scan with the updated information.
+            this.startScan(null);
+
+            final @Nullable Phaser testingPhaser = this.testingPhaser;
+            if (testingPhaser != null) {
+                testingPhaser.arriveAndAwaitAdvance();
+            }
+        });
+    }
+
+    @Override
+    protected void startScan() {
+        // Get a local copy of nodes to prevent concurrency problems
+        final @Nullable Map<NodeId, Node> nodes = this.lastKnownNodes.get();
+        // I never allow lastKnownNodes to be set to null.
+        assert nodes != null;
+
+        // Go through the set of nodes and report their discovery.
+        for (final Node node : nodes.values()) {
+            // Convert Hive API ProductTypes into ThingTypes.
+            final ThingTypeUID thingTypeUID;
+            if (node.getProductType().equals(ProductType.BOILER_MODULE)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_BOILER_MODULE;
+            } else if (node.getProductType().equals(ProductType.HEATING)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_HEATING;
+            } else if (node.getProductType().equals(ProductType.HOT_WATER)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_HOT_WATER;
+            } else if (node.getProductType().equals(ProductType.HUB)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_HUB;
+            } else if (node.getProductType().equals(ProductType.THERMOSTAT_UI)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_THERMOSTAT;
+            } else if (node.getProductType().equals(ProductType.TRV)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_TRV;
+            } else if (node.getProductType().equals(ProductType.TRV_GROUP)) {
+                thingTypeUID = HiveBindingConstants.THING_TYPE_TRV_GROUP;
+            } else if (node.getProductType().equals(ProductType.ACTIONS)
+                    || node.getProductType().equals(ProductType.DAYLIGHT_SD)
+                    || node.getProductType().equals(ProductType.UNKNOWN)
+            ) {
+                // We do not care about these so skip.
+                continue;
+            } else {
+                logger.trace("Found a node that I cannot handle: {} - {} ({})", node.getProductType(), node.getName(), node.getId());
+
+                // We do not have a thing type for this yet so skip.
+                continue;
+            }
+
+            final ThingUID thingUID = new ThingUID(thingTypeUID, this.bridgeUid, node.getId().toString());
+
+            // Do some fiddling with node names to get more descriptive
+            // thing labels.
+            final String label;
+            if (node.getProductType().equals(ProductType.BOILER_MODULE)) {
+                label = node.getName().toString() + " (Boiler Module)";
+            } else if (node.getProductType().equals(ProductType.HEATING)) {
+                // If node is heating node use the parent name because
+                // the real name is just a generic Thermostat X.
+                final @Nullable Node parentNode = nodes.get(node.getParentNodeId());
+
+                if (parentNode != null) {
+                    label = parentNode.getName().toString() + " (Thermostat Heating Zone)";
+                } else {
+                    logger.warn("Could not find parent node with id {}", node.getParentNodeId());
+                    label = node.getName().toString();
+                }
+            } else if (node.getProductType().equals(ProductType.HOT_WATER)) {
+                label = "Hot Water";
+            } else if (node.getProductType().equals(ProductType.THERMOSTAT_UI)) {
+                label = node.getName().toString() + " (Thermostat)";
+            } else if (node.getProductType().equals(ProductType.TRV)) {
+                label = node.getName().toString() + " (Radiator Valve)";
+            } else if (node.getProductType().equals(ProductType.TRV_GROUP)) {
+                label = node.getName().toString() + " (Radiator Valve Heating Zone)";
+            } else {
+                label = node.getName().toString();
+            }
+
+            final DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
+                    .withThingType(thingTypeUID)
+                    .withBridge(this.bridgeUid)
+                    .withLabel(label)
+                    .withProperty(HiveBindingConstants.CONFIG_NODE_ID, node.getId().toString())
+                    .withRepresentationProperty(HiveBindingConstants.CONFIG_NODE_ID)
+                    .build();
+
+            thingDiscovered(discoveryResult);
+        }
+
+        stopScan();
+    }
+
+    @Override
+    protected synchronized void stopScan() {
+        super.stopScan();
+        removeOlderResults(getTimestampOfLastScan());
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+
+        // Remove Things from the inbox were discovered by this service.
+        removeOlderResults(Instant.now().toEpochMilli(), this.bridgeUid);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/HiveDiscoveryService.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/HiveDiscoveryService.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.discovery;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.openhab.binding.hive.internal.client.Node;
+
+/**
+ * An interface for a {@link DiscoveryService} used by
+ * {@link org.openhab.binding.hive.internal.handler.HiveAccountHandler}s.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveDiscoveryService extends DiscoveryService {
+    /**
+     * Provide the discovery service with a new set of known nodes from the
+     * Hive API.
+     *
+     * @param knownNodes
+     *      The new {@linkplain Set} of known {@linkplain Node}s.
+     */
+    void updateKnownNodes(Set<Node> knownNodes);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/HiveDiscoveryServiceFactory.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/discovery/HiveDiscoveryServiceFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.discovery;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingUID;
+
+/**
+ * A factory for creating {@link org.eclipse.smarthome.config.discovery.DiscoveryService}s.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveDiscoveryServiceFactory {
+    HiveDiscoveryService create(ThingUID bridgeUid);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/DefaultHiveAccountHandler.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/DefaultHiveAccountHandler.java
@@ -1,0 +1,507 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigConstants;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveAccountConfig;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveClient;
+import org.openhab.binding.hive.internal.client.HiveClientFactory;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.NodeId;
+import org.openhab.binding.hive.internal.client.exception.HiveApiAuthenticationException;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+import org.openhab.binding.hive.internal.discovery.HiveDiscoveryService;
+import org.openhab.binding.hive.internal.discovery.HiveDiscoveryServiceFactory;
+import org.openhab.binding.hive.internal.handler.strategy.ThingHandlerStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link DefaultHiveAccountHandler} is responsible for handling interaction with
+ * the Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultHiveAccountHandler extends BaseBridgeHandler implements HiveAccountHandler {
+    private static final Pattern UUID_REGEX = Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+    private static final int POLLING_MINIMAL_INTERVAL_SECONDS = 10;
+    private static final int POLLING_INITIAL_DELAY_SECONDS = 0;
+    private static final double POLLING_BACKOFF_FACTOR = 2;
+    private static final int POLLING_MAXIMUM_BACKOFF_INTERVAL_SECONDS = 600;
+    private static final Duration POLLING_MAXIMUM_RETRY_TIME = Duration.ofHours(24);
+
+    private final Logger logger = LoggerFactory.getLogger(DefaultHiveAccountHandler.class);
+
+    private final Map<NodeId, HiveThingManager> hiveThingManagers = new HashMap<>();
+
+    private final HiveClientFactory hiveClientFactory;
+    private final HiveDiscoveryService discoveryService;
+
+    private final @Nullable Phaser testingPhaser;
+
+    private @Nullable ScheduledFuture<?> pollingJob = null;
+    private int normalPollingIntervalSeconds;
+
+    private Instant lastSuccessfulPoll;
+    private boolean pollingBackingOff;
+    private int backoffPollingIntervalSeconds;
+
+
+    private @Nullable HiveClient hiveClient = null;
+
+    /**
+     *
+     * @param bridge
+     *      The {@link Bridge} that this handler is handling.
+     */
+    public DefaultHiveAccountHandler(
+            final HiveClientFactory hiveClientFactory,
+            final HiveDiscoveryServiceFactory discoveryServiceFactory,
+            final Bridge bridge
+    ) {
+        this(hiveClientFactory, discoveryServiceFactory, bridge, null);
+    }
+
+    /**
+     * Test constructor
+     */
+    DefaultHiveAccountHandler(
+            final HiveClientFactory hiveClientFactory,
+            final HiveDiscoveryServiceFactory discoveryServiceFactory,
+            final Bridge bridge,
+            final @Nullable Phaser testingPhaser
+    ) {
+        super(bridge);
+
+        Objects.requireNonNull(hiveClientFactory);
+        Objects.requireNonNull(discoveryServiceFactory);
+
+        this.hiveClientFactory = hiveClientFactory;
+        this.discoveryService = discoveryServiceFactory.create(bridge.getUID());
+        this.testingPhaser = testingPhaser;
+
+        this.lastSuccessfulPoll = Instant.EPOCH;
+
+        if (testingPhaser != null) {
+            testingPhaser.register();
+        }
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.CONFIGURATION_PENDING);
+
+        this.scheduler.execute(this::doInit);
+    }
+
+    private synchronized void doInit() {
+        // The the openHAB runtime should ensure none of these are null.
+        // Do a little dance to make the null checker happy.
+        final HiveAccountConfig config = getConfigAs(HiveAccountConfig.class);
+        final @Nullable String username = config.username;
+        final @Nullable String password = config.password;
+        final @Nullable Integer pollingInterval = config.pollingInterval;
+        if (username == null || password == null || pollingInterval == null) {
+            throw new IllegalStateException("Config is malformed");
+        }
+
+        try {
+            this.hiveClient = this.hiveClientFactory.newClient(
+                    username,
+                    password
+            );
+
+            this.pollingBackingOff = false;
+            this.normalPollingIntervalSeconds = Math.max(pollingInterval, POLLING_MINIMAL_INTERVAL_SECONDS);
+            this.backoffPollingIntervalSeconds = this.normalPollingIntervalSeconds;
+
+            this.pollingJob = this.scheduler.scheduleWithFixedDelay(
+                    this::poll,
+                    POLLING_INITIAL_DELAY_SECONDS,
+                    this.normalPollingIntervalSeconds,
+                    TimeUnit.SECONDS
+            );
+
+            updateStatus(ThingStatus.ONLINE);
+        } catch (final HiveApiAuthenticationException ex) {
+            updateStatus(
+                    ThingStatus.OFFLINE,
+                    ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Username and Password are not correct."
+            );
+        } catch (final HiveException ex) {
+            updateStatus(
+                    ThingStatus.OFFLINE,
+                    ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Something went wrong communicating with the Hive Api. Details: " + ex.getMessage()
+            );
+            this.logger.debug("Something went wrong communicating with the Hive Api while initialising an account handler.", ex);
+        } catch (final Exception ex) {
+            updateStatus(
+                    ThingStatus.OFFLINE,
+                    ThingStatusDetail.NONE,
+                    "Something went very wrong. Details: " + ex.getMessage()
+            );
+            this.logger.debug("Something very wrong initialising an account handler.", ex);
+        } finally {
+            // If we are testing synchronise with the test.
+            final @Nullable Phaser testingPhaser = this.testingPhaser;
+            if (testingPhaser != null) {
+                testingPhaser.arriveAndAwaitAdvance();
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(final ChannelUID channelUID, final Command command) {
+        if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_DUMP_NODES)) {
+            final @Nullable HiveClient hiveClient = this.hiveClient;
+            if (command instanceof OnOffType && hiveClient != null) {
+                try {
+                    final String nodesJson = hiveClient.getAllNodesJson();
+
+                    writeNodesDumpFile(nodesJson);
+                } catch (final HiveException e) {
+                    this.logger.debug("Something went wrong while trying to dump nodes.", e);
+                }
+            }
+
+            // Reset the switch
+            this.updateState(HiveBindingConstants.CHANNEL_DUMP_NODES, OnOffType.OFF);
+        }
+    }
+
+    private void writeNodesDumpFile(final String nodesJson) {
+        final String dumpFilePrefix = "hive-nodes-";
+
+        final String origDumpFileName = dumpFilePrefix + "original.json";
+        final String anonDumpFileName = dumpFilePrefix + "anon.json";
+
+        final Path origDumpFile = Paths.get(ConfigConstants.getUserDataFolder(), origDumpFileName);
+        final Path anonDumpFile = Paths.get(ConfigConstants.getUserDataFolder(), anonDumpFileName);
+
+        // Write the original file.
+        try {
+            Files.write(origDumpFile, nodesJson.getBytes());
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        // Find any UUIDs in the JSON.
+        final Matcher uuidMatcher = UUID_REGEX.matcher(nodesJson);
+        final Set<String> foundUuids = new HashSet<>();
+        while (uuidMatcher.find()) {
+            foundUuids.add(uuidMatcher.group());
+        }
+
+        // Replace all the found UUIDs with random new ones.
+        String anonNodesJson = nodesJson;
+        for (final String origUuid : foundUuids) {
+            anonNodesJson = anonNodesJson.replace(origUuid, UUID.randomUUID().toString());
+        }
+
+        // Write the "anonymized" file.
+        try {
+            Files.write(anonDumpFile, anonNodesJson.getBytes());
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        this.logger.debug("Go get your dumped nodes here: {}", anonDumpFile.toAbsolutePath().toString());
+    }
+
+    @Override
+    public void dispose() {
+        final @Nullable ScheduledFuture<?> pollingJob = this.pollingJob;
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+        }
+
+        super.dispose();
+    }
+
+    @Override
+    public DiscoveryService getDiscoveryService() {
+        return this.discoveryService;
+    }
+
+    @Override
+    public void bindHiveThingHandler(final HiveThingHandler hiveThingHandler) {
+        Objects.requireNonNull(hiveThingHandler);
+
+        final NodeId nodeId = getNodeIdFromHiveHandler(hiveThingHandler);
+
+        final HiveThingManager hiveThingManager = new HiveThingManager(hiveThingHandler);
+        hiveThingHandler.setCommandCallback(hiveThingManager);
+        this.hiveThingManagers.put(nodeId, hiveThingManager);
+    }
+
+    @Override
+    public void unbindHiveThingHandler(final HiveThingHandler hiveThingHandler) {
+        Objects.requireNonNull(hiveThingHandler);
+
+        hiveThingHandler.clearCommandCallback();
+
+        final NodeId nodeId = getNodeIdFromHiveHandler(hiveThingHandler);
+        final @Nullable HiveThingManager hiveThingManager = this.hiveThingManagers.remove(nodeId);
+        if (hiveThingManager == null) {
+            this.logger.debug("Didn't find the expected HiveThingManager for node {}", nodeId);
+        }
+    }
+
+    private synchronized void poll() {
+        // Wrap everything in a try-catch because we do not ever want the
+        // polling job to stop unless we do it ourselves.
+        try {
+            final @Nullable HiveClient hiveClient = this.hiveClient;
+            if (hiveClient == null) {
+                throw new IllegalStateException("Poll called before HiveClient has been initialised.");
+            }
+
+            // Get all nodes from the Hive API.
+            final Set<Node> nodes = hiveClient.getAllNodes();
+
+            // Tell the discovery service about the nodes we found.
+            this.discoveryService.updateKnownNodes(nodes);
+
+            /* Send updated node state to handlers */
+            for (final Node node : nodes) {
+                // Try to find a manager responsible for this node.
+                final @Nullable HiveThingManager thingManager = this.hiveThingManagers.get(node.getId());
+
+                // Give the handler an updated version of the node.
+                if (thingManager != null) {
+                    thingManager.updateState(node);
+                }
+            }
+
+            this.lastSuccessfulPoll = Instant.now();
+
+            // Everything has gone ok so return to normal polling if we have
+            // been backing off.
+            if (this.pollingBackingOff) {
+                this.logger.debug("Polling went ok! Returning to normal polling schedule.");
+
+                // Reset backoff parameters
+                this.pollingBackingOff = false;
+                this.backoffPollingIntervalSeconds = this.normalPollingIntervalSeconds;
+
+                // Make sure the old polling job is done.
+                final @Nullable ScheduledFuture<?> oldPollingJob = this.pollingJob;
+                if (oldPollingJob != null) {
+                    oldPollingJob.cancel(false);
+                }
+
+                // Start a new repeating polling job
+                this.pollingJob = this.scheduler.scheduleWithFixedDelay(
+                        this::poll,
+                        this.normalPollingIntervalSeconds,
+                        this.normalPollingIntervalSeconds,
+                        TimeUnit.SECONDS
+                );
+
+                // Make the thing online again.
+                updateStatus(ThingStatus.ONLINE);
+            }
+
+            // Update the last poll timestamp channel
+            updateState(
+                    HiveBindingConstants.CHANNEL_LAST_POLL_TIMESTAMP,
+                    new DateTimeType(this.lastSuccessfulPoll.atZone(ZoneId.systemDefault()))
+            );
+        } catch (final HiveApiAuthenticationException ex) {
+            // Stop polling. There is no point if we are not authenticated any more.
+            final @Nullable ScheduledFuture<?> pollingJob = this.pollingJob;
+            if (pollingJob != null) {
+                pollingJob.cancel(false);
+            }
+
+            updateStatus(
+                    ThingStatus.OFFLINE,
+                    ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Authentication failed - Have you changed your password?"
+            );
+        } catch (final Exception ex) {
+            this.logger.debug("Polling failed with exception", ex);
+
+            // Start backing off
+            this.pollingBackingOff = true;
+
+            // Cancel periodic polling / make sure old job is done.
+            final @Nullable ScheduledFuture<?> oldPollingJob = this.pollingJob;
+            if (oldPollingJob != null) {
+                oldPollingJob.cancel(false);
+            }
+
+            String message = MessageFormat.format(
+                    "Something went wrong polling the Hive API."
+                            + " It is now {0}."
+                            + " Last successful poll was at {1}."
+                            + " We have not had a successful poll for {2} seconds.",
+                    Instant.now().atZone(ZoneId.systemDefault()),
+                    this.lastSuccessfulPoll.atZone(ZoneId.systemDefault()),
+                    Duration.between(this.lastSuccessfulPoll, Instant.now()).getSeconds()
+            );
+            if (POLLING_MAXIMUM_RETRY_TIME.isNegative() || Duration.between(this.lastSuccessfulPoll, Instant.now()).compareTo(POLLING_MAXIMUM_RETRY_TIME) < 0) {
+                // Either the retry limit is disabled or we have not exceeded
+                // it yet.
+
+                // Increase the backoff interval.
+                this.backoffPollingIntervalSeconds = Math.min(
+                        (int) Math.ceil(this.backoffPollingIntervalSeconds * POLLING_BACKOFF_FACTOR),
+                        POLLING_MAXIMUM_BACKOFF_INTERVAL_SECONDS
+                );
+
+                // Schedule new "backed off" job.
+                this.scheduler.schedule(
+                        this::poll,
+                        this.backoffPollingIntervalSeconds,
+                        TimeUnit.SECONDS
+                );
+
+                message += MessageFormat.format(
+                        " Trying again in {0} seconds (approx {1}).",
+                        this.backoffPollingIntervalSeconds,
+                        Instant.now().plus(this.backoffPollingIntervalSeconds, ChronoUnit.SECONDS).atZone(ZoneId.systemDefault())
+                );
+            } else {
+                // We have exceeded the retry limit.
+                // Let the polling job die.
+
+                message += " Giving up as we have exceeded the retry limit.";
+            }
+
+            message += " Details: " + ex.getMessage();
+
+            this.logger.debug(message);
+
+            // Tell the user what is going on.
+            updateStatus(
+                    ThingStatus.OFFLINE,
+                    ThingStatusDetail.COMMUNICATION_ERROR,
+                    message
+            );
+        }
+    }
+
+    private NodeId getNodeIdFromHiveHandler(final ThingHandler handler) {
+        Objects.requireNonNull(handler);
+
+        return new NodeId(UUID.fromString((String) handler.getThing().getConfiguration().get(HiveBindingConstants.CONFIG_NODE_ID)));
+    }
+
+    private class HiveThingManager implements ThingHandlerCommandCallback {
+        private final HiveThingHandler hiveThingHandler;
+
+        private @Nullable Node hiveNode = null;
+
+        public HiveThingManager(final HiveThingHandler hiveThingHandler) {
+            Objects.requireNonNull(hiveThingHandler);
+
+            this.hiveThingHandler = hiveThingHandler;
+        }
+
+        @Override
+        public void handleCommand(final ChannelUID channelUID, final Command command) {
+            final @Nullable Node hiveNode = this.hiveNode;
+            if (hiveNode == null) {
+                return;
+            }
+
+            // Try each strategy until we get one that can handle the command.
+            @Nullable Node modifiedNode = null;
+            final Iterator<ThingHandlerStrategy> strategyIterator = this.hiveThingHandler.getStrategies().iterator();
+            while (strategyIterator.hasNext() && modifiedNode == null) {
+                final @Nullable ThingHandlerStrategy strategy = strategyIterator.next();
+                assert strategy != null;
+
+                modifiedNode = strategy.handleCommand(channelUID, command, hiveNode);
+            }
+
+            // If the command was handled push the update to the Hive API.
+            if (modifiedNode != null) {
+                final @Nullable HiveClient hiveClient = DefaultHiveAccountHandler.this.hiveClient;
+
+                if (hiveClient == null) {
+                    throw new IllegalStateException("UpdateNode called before HiveClient has been initialised.");
+                }
+
+                try {
+                    // Post the modified node to the Hive API and get the
+                    // canonical updated version of the node in return.
+                    final @Nullable Node updatedNode = hiveClient.updateNode(modifiedNode);
+
+                    // Handle the updated node state.
+                    // TODO: Create a better mechanism for updating state
+                    //       immediately after posting to the Hive API.
+                    //       The Hive API often provides unhelpful displayValues
+                    //       in response to posting updates that makes channel
+                    //       states "flicker".
+                    //if (updatedNode != null) {
+                    //    this.updateState(updatedNode);
+                    //}
+                } catch (final HiveException ex) {
+                    logger.debug("Something went wrong posting an update to the Hive API", ex);
+                }
+            }
+        }
+
+        public final void updateState(final Node hiveNode) {
+            Objects.requireNonNull(hiveNode);
+
+            // Save the node for use by handleCommand.
+            this.hiveNode = hiveNode;
+
+            // Update channel states using the handler strategies.
+            final @Nullable ThingHandlerCallback thingHandlerCallback = this.hiveThingHandler.getThingHandlerCallback();
+            if (thingHandlerCallback != null) {
+                for (final ThingHandlerStrategy strategy : this.hiveThingHandler.getStrategies()) {
+                    strategy.handleUpdate(this.hiveThingHandler.getThing(), thingHandlerCallback, hiveNode);
+                }
+            }
+        }
+
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/DefaultHiveThingHandler.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/DefaultHiveThingHandler.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.*;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.handler.strategy.ThingHandlerStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A base {@link org.eclipse.smarthome.core.thing.binding.ThingHandler} for
+ * Hive devices.
+ *
+ * <p>
+ *     Delegates most functionality to a provided set of
+ *     {@link ThingHandlerStrategy}s.
+ * </p>
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class DefaultHiveThingHandler extends BaseThingHandler implements HiveThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Set<ThingHandlerStrategy> handlerStrategies;
+
+    private @Nullable ThingHandlerCommandCallback commandCallback;
+
+    public DefaultHiveThingHandler(final Thing thing, final Set<ThingHandlerStrategy> handlerStrategies) {
+        super(thing);
+
+        this.handlerStrategies = Collections.unmodifiableSet(new HashSet<>(handlerStrategies));
+    }
+
+    @Override
+    public final Set<ThingHandlerStrategy> getStrategies() {
+        return this.handlerStrategies;
+    }
+
+    @Override
+    public final void setCommandCallback(final ThingHandlerCommandCallback commandCallback) {
+        Objects.requireNonNull(commandCallback);
+
+        this.commandCallback = commandCallback;
+    }
+
+    @Override
+    public final void clearCommandCallback() {
+        this.commandCallback = null;
+    }
+
+    @Override
+    public final @Nullable ThingHandlerCallback getThingHandlerCallback() {
+        return this.getCallback();
+    }
+
+    @Override
+    public void initialize() {
+        final @Nullable HiveAccountHandler accountHandler = getAccountHandler();
+
+        if (accountHandler != null) {
+            accountHandler.bindHiveThingHandler(this);
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    @Override
+    public final void handleCommand(final ChannelUID channelUID, final Command command) {
+        final @Nullable HiveAccountHandler accountHandler = getAccountHandler();
+        if (accountHandler == null) {
+            return;
+        }
+
+        final @Nullable ThingHandlerCommandCallback commandCallback = this.commandCallback;
+        if (commandCallback == null) {
+            throw new IllegalStateException("handleCommand(...) called but no CommandCallback has been set.");
+        }
+
+        commandCallback.handleCommand(channelUID, command);
+    }
+
+    @Override
+    public void dispose() {
+        // Clean up the HiveAccountHandler reference to this handler.
+        final @Nullable HiveAccountHandler accountHandler = getAccountHandler();
+        if (accountHandler != null) {
+            accountHandler.unbindHiveThingHandler(this);
+        }
+
+        super.dispose();
+    }
+
+    /**
+     * Get the HiveAccountHandler that is acting as a BridgeHandler for this thing.
+     *
+     * @return
+     *      {@code null} If the bridge has not been set.
+     */
+    private @Nullable HiveAccountHandler getAccountHandler() {
+        final @Nullable Bridge bridge = getBridge();
+        if (bridge == null) {
+            this.logger.debug("getAccountHandler() called but bridge is null.  Has something gone wrong?  Setting status to offline.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+            return null;
+        } else {
+            return (HiveAccountHandler) bridge.getHandler();
+        }
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/HiveAccountHandler.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/HiveAccountHandler.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
+
+/**
+ * The {@link HiveAccountHandler} is responsible for handling interaction with
+ * the Hive API.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveAccountHandler extends BridgeHandler {
+    DiscoveryService getDiscoveryService();
+
+    void bindHiveThingHandler(HiveThingHandler hiveThingHandler);
+    void unbindHiveThingHandler(HiveThingHandler hiveThingHandler);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/HiveThingHandler.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/HiveThingHandler.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.handler.strategy.ThingHandlerStrategy;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface HiveThingHandler extends ThingHandler {
+    Set<ThingHandlerStrategy> getStrategies();
+
+    void setCommandCallback(final ThingHandlerCommandCallback commandCallback);
+    void clearCommandCallback();
+
+    @Nullable ThingHandlerCallback getThingHandlerCallback();
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/ThingHandlerCommandCallback.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/ThingHandlerCommandCallback.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.Command;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface ThingHandlerCommandCallback {
+    void handleCommand(final ChannelUID channelUID, final Command command);
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/AutoBoostHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/AutoBoostHandlerStrategy.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.AutoBoostFeature;
+import tec.uom.se.quantity.Quantities;
+
+import javax.measure.quantity.Temperature;
+import java.time.Duration;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link AutoBoostFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class AutoBoostHandlerStrategy extends ThingHandlerStrategyBase {
+    @SuppressWarnings("unchecked")
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, AutoBoostFeature.class, autoBoostFeature -> {
+            @Nullable AutoBoostFeature updatedAutoBoostFeature = null;
+            if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_AUTO_BOOST_DURATION)
+                    && command instanceof DecimalType
+            ) {
+                final DecimalType newAutoBoostDuration = (DecimalType) command;
+
+                updatedAutoBoostFeature = autoBoostFeature.withTargetAutoBoostDuration(
+                        Duration.ofMinutes(newAutoBoostDuration.longValue())
+                );
+            } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_AUTO_BOOST_TEMPERATURE_TARGET)
+                    && command instanceof QuantityType
+            ) {
+                // N.B. Suppress unchecked because openHAB should hopefully only be passing us QuantityType<Temperature>
+                final QuantityType<Temperature> newTargetHeatTemperature = (QuantityType<Temperature>) command;
+
+                updatedAutoBoostFeature = autoBoostFeature.withTargetAutoBoostTargetHeatTemperature(
+                        Quantities.getQuantity(
+                                newTargetHeatTemperature.toBigDecimal(),
+                                newTargetHeatTemperature.getUnit()
+                        )
+                );
+            }
+
+            if (updatedAutoBoostFeature != null) {
+                return hiveNode.withFeature(AutoBoostFeature.class, updatedAutoBoostFeature);
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, AutoBoostFeature.class, autoBoostFeature -> {
+            useAttribute(hiveNode, AutoBoostFeature.class, HiveApiConstants.ATTRIBUTE_NAME_AUTO_BOOST_V1_AUTO_BOOST_DURATION, autoBoostFeature.getAutoBoostDuration(), autoBoostDurationAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_AUTO_BOOST_DURATION, autoBoostDurationChannel -> {
+                    thingHandlerCallback.stateUpdated(autoBoostDurationChannel, new DecimalType(autoBoostDurationAttribute.getDisplayValue().toMinutes()));
+                });
+            });
+
+            useAttribute(hiveNode, AutoBoostFeature.class, HiveApiConstants.ATTRIBUTE_NAME_AUTO_BOOST_V1_AUTO_BOOST_TARGET_HEAT_TEMPERATURE, autoBoostFeature.getAutoBoostTargetHeatTemperature(), autoBoostTargetHeatTemperatureAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_AUTO_BOOST_TEMPERATURE_TARGET, autoBoostTargetHeatTemperatureChannel -> {
+                    thingHandlerCallback.stateUpdated(
+                            autoBoostTargetHeatTemperatureChannel,
+                            new QuantityType<>(
+                                    autoBoostTargetHeatTemperatureAttribute.getDisplayValue().getValue(),
+                                    autoBoostTargetHeatTemperatureAttribute.getDisplayValue().getUnit()
+                            )
+                    );
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/BatteryDeviceHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/BatteryDeviceHandlerStrategy.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.BatteryDeviceFeature;
+import tec.uom.se.unit.Units;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link BatteryDeviceFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BatteryDeviceHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, BatteryDeviceFeature.class, batteryDeviceFeature -> {
+            useAttribute(hiveNode, BatteryDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_LEVEL, batteryDeviceFeature.getBatteryLevel(), batteryLevelAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_BATTERY_LEVEL, batteryLevelChannel -> {
+                    thingHandlerCallback.stateUpdated(batteryLevelChannel, new DecimalType(batteryLevelAttribute.getDisplayValue().intValue()));
+                });
+            });
+
+            useAttribute(hiveNode, BatteryDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_STATE, batteryDeviceFeature.getBatteryState(), batteryStateAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_BATTERY_STATE, batteryStateChannel -> {
+                    thingHandlerCallback.stateUpdated(batteryStateChannel, new StringType(batteryStateAttribute.getDisplayValue()));
+                });
+
+                useChannel(thing, HiveBindingConstants.CHANNEL_BATTERY_LOW, batteryLowChannel -> {
+                    final boolean batteryLow = batteryStateAttribute.getDisplayValue().equals("LOW");
+                    thingHandlerCallback.stateUpdated(batteryLowChannel, OnOffType.from(batteryLow));
+                });
+            });
+
+            useAttribute(hiveNode, BatteryDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_BATTERY_DEVICE_V1_BATTERY_VOLTAGE, batteryDeviceFeature.getBatteryVoltage(), batteryVoltageAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_BATTERY_VOLTAGE, batteryVoltageChannel -> {
+                    thingHandlerCallback.stateUpdated(batteryVoltageChannel, new QuantityType<>(batteryVoltageAttribute.getDisplayValue().getValue(), Units.VOLT));
+                });
+            });
+
+            useAttribute(hiveNode, BatteryDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_BATTERY_DEVICE_V1_NOTIFICATION_STATE, batteryDeviceFeature.getBatteryNotificationState(), batteryNotificationStateAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_BATTERY_NOTIFICATION_STATE, batteryNotificationStateChannel -> {
+                    thingHandlerCallback.stateUpdated(batteryNotificationStateChannel, new StringType(batteryNotificationStateAttribute.getDisplayValue()));
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/BoostTimeRemainingHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/BoostTimeRemainingHandlerStrategy.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.feature.HeatingThermostatFeature;
+import org.openhab.binding.hive.internal.client.feature.TransientModeFeature;
+import org.openhab.binding.hive.internal.client.feature.WaterHeaterFeature;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * A {@link ThingHandlerStrategy} that handles the "transient-remaining"
+ * channel.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class BoostTimeRemainingHandlerStrategy extends ThingHandlerStrategyBase  {
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, TransientModeFeature.class, transientModeFeature -> {
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_END_DATETIME, transientModeFeature.getEndDatetime(), endDatetimeAttribute -> {
+                long minutesRemaining = Instant.now().until(endDatetimeAttribute.getDisplayValue(), ChronoUnit.MINUTES);
+                minutesRemaining = Math.max(0, minutesRemaining);
+
+                // If we know the transient mode has been cancelled set remaining
+                // time to 0
+                final @Nullable HeatingThermostatFeature heatingThermostatFeature = hiveNode.getFeature(HeatingThermostatFeature.class);
+                final @Nullable WaterHeaterFeature waterHeaterFeature = hiveNode.getFeature(WaterHeaterFeature.class);
+                final @Nullable FeatureAttribute<OverrideMode> overrideModeAttribute;
+                if (heatingThermostatFeature != null) {
+                    overrideModeAttribute = heatingThermostatFeature.getTemporaryOperatingModeOverride();
+                } else if (waterHeaterFeature != null) {
+                    overrideModeAttribute = waterHeaterFeature.getTemporaryOperatingModeOverride();
+                } else {
+                    overrideModeAttribute = null;
+                    this.logger.trace("Could not find either of \"HeatingThermostatFeature\" or \"WaterHeaterFeature\"");
+                }
+
+                if (overrideModeAttribute != null && overrideModeAttribute.getDisplayValue() == OverrideMode.NONE) {
+                    minutesRemaining = 0;
+                }
+
+                final long finalMinutesRemaining = minutesRemaining;
+                useChannel(thing, HiveBindingConstants.CHANNEL_TRANSIENT_REMAINING, transientRemainingChannel -> {
+                    thingHandlerCallback.stateUpdated(transientRemainingChannel, new DecimalType(finalMinutesRemaining));
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatEasyHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatEasyHandlerStrategy.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.feature.HeatingThermostatFeature;
+import org.openhab.binding.hive.internal.client.feature.OnOffDeviceFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} that handles channels that provide a
+ * simplified interface with Hive Active Heating zones.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HeatingThermostatEasyHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, HeatingThermostatFeature.class, heatingThermostatFeature -> {
+            return useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+                return handleCommand(
+                        channelUID,
+                        command,
+                        hiveNode,
+                        heatingThermostatFeature,
+                        onOffDeviceFeature
+                );
+            });
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, HeatingThermostatFeature.class, heatingThermostatFeature -> {
+            useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+                handleUpdate(
+                        hiveNode,
+                        thing,
+                        thingHandlerCallback,
+                        heatingThermostatFeature,
+                        onOffDeviceFeature
+                );
+            });
+        });
+    }
+
+    private @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode,
+            final HeatingThermostatFeature heatingThermostatFeature,
+            final OnOffDeviceFeature onOffDeviceFeature
+    ) {
+        @Nullable HeatingThermostatFeature newHeatingThermostatFeature = null;
+        @Nullable OnOffDeviceFeature newOnOffDeviceFeature = null;
+
+        if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING)
+                && command instanceof StringType
+        ) {
+            final StringType newOperatingMode = (StringType) command;
+            if (newOperatingMode.toString().equals(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_MANUAL)) {
+                newHeatingThermostatFeature = heatingThermostatFeature.withTargetOperatingMode(HeatingThermostatOperatingMode.MANUAL);
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.ON);
+            } else if (newOperatingMode.toString().equals(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_SCHEDULE)) {
+                newHeatingThermostatFeature = heatingThermostatFeature.withTargetOperatingMode(HeatingThermostatOperatingMode.SCHEDULE);
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.ON);
+            } else {
+                // easy-mode-operating: OFF
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.OFF);
+            }
+        } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_EASY_MODE_BOOST)
+                && command instanceof OnOffType
+        ) {
+            final OnOffType newOverrideMode = (OnOffType) command;
+            newHeatingThermostatFeature = heatingThermostatFeature.withTargetTemporaryOperatingModeOverride(
+                    newOverrideMode == OnOffType.ON ? OverrideMode.TRANSIENT : OverrideMode.NONE
+            );
+        }
+
+        if (newHeatingThermostatFeature != null
+                || newOnOffDeviceFeature != null
+        ) {
+            final Node.Builder nodeBuilder = Node.builder();
+            nodeBuilder.from(hiveNode);
+
+            if (newHeatingThermostatFeature != null) {
+                nodeBuilder.putFeature(HeatingThermostatFeature.class, newHeatingThermostatFeature);
+            }
+
+            if (newOnOffDeviceFeature != null) {
+                nodeBuilder.putFeature(OnOffDeviceFeature.class, newOnOffDeviceFeature);
+            }
+
+            return nodeBuilder.build();
+        } else {
+            return null;
+        }
+    }
+
+    private void handleUpdate(
+            final Node hiveNode,
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final HeatingThermostatFeature heatingThermostatFeature,
+            final OnOffDeviceFeature onOffDeviceFeature
+    ) {
+        useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_MODE, heatingThermostatFeature.getOperatingMode(), operatingModeAttribute -> {
+            useAttribute(hiveNode, OnOffDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE, onOffDeviceFeature.getMode(), onOffModeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING, easyModeOperatingChannel -> {
+                    if (onOffModeAttribute.getDisplayValue() == OnOffMode.OFF) {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_OFF));
+                    } else if (operatingModeAttribute.getDisplayValue() == HeatingThermostatOperatingMode.SCHEDULE) {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_SCHEDULE));
+                    } else {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_MANUAL));
+                    }
+                });
+            });
+        });
+
+        useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TEMPORARY_OPERATING_MODE_OVERRIDE, heatingThermostatFeature.getTemporaryOperatingModeOverride(), heatingOverrideAttribute -> {
+            useChannel(thing, HiveBindingConstants.CHANNEL_EASY_MODE_BOOST, easyModeBoostChannel -> {
+                final OnOffType boostActive = OnOffType.from(heatingOverrideAttribute.getDisplayValue() == OverrideMode.TRANSIENT);
+                thingHandlerCallback.stateUpdated(easyModeBoostChannel, boostActive);
+            });
+        });
+
+        useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_STATE, heatingThermostatFeature.getOperatingState(), operatingStateAttribute -> {
+            useChannel(thing, HiveBindingConstants.CHANNEL_EASY_STATE_IS_ON, easyStateIsOnChannel -> {
+                final OnOffType isOn = OnOffType.from(operatingStateAttribute.getDisplayValue().equals(HeatingThermostatOperatingState.HEAT));
+                thingHandlerCallback.stateUpdated(easyStateIsOnChannel, isOn);
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatHandlerStrategy.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HeatingThermostatOperatingMode;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.feature.HeatingThermostatFeature;
+import tec.uom.se.quantity.Quantities;
+
+import javax.measure.quantity.Temperature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link HeatingThermostatFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HeatingThermostatHandlerStrategy extends ThingHandlerStrategyBase {
+    @SuppressWarnings("unchecked")
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, HeatingThermostatFeature.class, heatingThermostatFeature -> {
+            @Nullable HeatingThermostatFeature newHeatingThermostatFeature = null;
+
+            if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET)
+                    && command instanceof QuantityType
+            ) {
+                // N.B. Suppress unchecked because openHAB should hopefully only be passing us QuantityType<Temperature>
+                final QuantityType<Temperature> newTargetHeatTemperature = (QuantityType<Temperature>) command;
+
+                newHeatingThermostatFeature = heatingThermostatFeature.withTargetTargetHeatTemperature(
+                        Quantities.getQuantity(
+                                newTargetHeatTemperature.toBigDecimal(),
+                                newTargetHeatTemperature.getUnit()
+                        )
+                );
+            } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_MODE_OPERATING)
+                    && command instanceof StringType
+            ) {
+                final StringType newOperatingMode = (StringType) command;
+                newHeatingThermostatFeature = heatingThermostatFeature.withTargetOperatingMode(
+                        HeatingThermostatOperatingMode.valueOf(newOperatingMode.toString())
+                );
+            } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_MODE_OPERATING_OVERRIDE)
+                    && command instanceof OnOffType
+            ) {
+                final OnOffType newOverrideMode = (OnOffType) command;
+                heatingThermostatFeature.withTargetTemporaryOperatingModeOverride(
+                        newOverrideMode == OnOffType.ON ? OverrideMode.TRANSIENT : OverrideMode.NONE
+                );
+            }
+
+            if (newHeatingThermostatFeature != null) {
+                final Node.Builder nodeBuilder = Node.builder();
+                nodeBuilder.from(hiveNode);
+
+                nodeBuilder.putFeature(HeatingThermostatFeature.class, newHeatingThermostatFeature);
+
+                return nodeBuilder.build();
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, HeatingThermostatFeature.class, heatingThermostatFeature -> {
+            useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_MODE, heatingThermostatFeature.getOperatingMode(), operatingModeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_MODE_OPERATING, operatingModeChannel -> {
+                    thingHandlerCallback.stateUpdated(operatingModeChannel, new StringType(operatingModeAttribute.getDisplayValue().toString()));
+                });
+            });
+
+            useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_OPERATING_STATE, heatingThermostatFeature.getOperatingState(), operatingStateAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_STATE_OPERATING, operatingStateChannel -> {
+                    thingHandlerCallback.stateUpdated(operatingStateChannel, new StringType(operatingStateAttribute.getDisplayValue().toString()));
+                });
+            });
+
+            useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TARGET_HEAT_TEMPERATURE, heatingThermostatFeature.getTargetHeatTemperature(), targetHeatTemperatureAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET, targetHeatTemperatureChannel -> {
+                    thingHandlerCallback.stateUpdated(
+                            targetHeatTemperatureChannel,
+                            new QuantityType<>(
+                                    targetHeatTemperatureAttribute.getDisplayValue().getValue(),
+                                    targetHeatTemperatureAttribute.getDisplayValue().getUnit()
+                            )
+                    );
+                });
+            });
+
+            useAttribute(hiveNode, HeatingThermostatFeature.class, HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TEMPORARY_OPERATING_MODE_OVERRIDE, heatingThermostatFeature.getTemporaryOperatingModeOverride(), operatingModeOverrideAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_MODE_OPERATING_OVERRIDE, operatingModeOverrideChannel -> {
+                    thingHandlerCallback.stateUpdated(operatingModeOverrideChannel, OnOffType.from(operatingModeOverrideAttribute.getDisplayValue() == OverrideMode.TRANSIENT));
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingTransientModeHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/HeatingTransientModeHandlerStrategy.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.DefaultFeatureAttribute;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.TransientModeHeatingActionsFeature;
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+import java.time.Instant;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling channels that interface with
+ * the "set targetTemperature action" for transient override (boost) of
+ * Hive Active Heating zones.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class HeatingTransientModeHandlerStrategy extends ThingHandlerStrategyBase {
+    public static final Quantity<Temperature> DEFAULT_BOOST_TEMPERATURE = Quantities.getQuantity(22, Units.CELSIUS);
+
+    private static TransientModeHeatingActionsFeature getDefaultTransientModeActionsFeature() {
+        final Instant now = Instant.now();
+
+        return TransientModeHeatingActionsFeature.builder()
+                .boostTargetTemperature(
+                        DefaultFeatureAttribute.<Quantity<Temperature>>builder()
+                                .displayValue(DEFAULT_BOOST_TEMPERATURE)
+                                .reportedValue(DEFAULT_BOOST_TEMPERATURE)
+                                .reportChangedTime(now)
+                                .reportReceivedTime(now)
+                                .build()
+                )
+                .build();
+    }
+
+    private static TransientModeHeatingActionsFeature getEffectiveTransientModeActionsFeature(final Node node) {
+        @Nullable TransientModeHeatingActionsFeature transientModeActionsFeature = node.getFeature(TransientModeHeatingActionsFeature.class);
+        if (transientModeActionsFeature == null) {
+            transientModeActionsFeature = getDefaultTransientModeActionsFeature();
+        }
+
+        return transientModeActionsFeature;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        @Nullable TransientModeHeatingActionsFeature newTransientModeActionsFeature = null;
+
+        if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET_BOOST)
+                && command instanceof QuantityType
+        ) {
+            // N.B. Suppress unchecked because openHAB should hopefully only be passing us QuantityType<Temperature>
+            final QuantityType<Temperature> newTargetHeatTemperature = (QuantityType<Temperature>) command;
+
+            final TransientModeHeatingActionsFeature transientModeActionsFeature = getEffectiveTransientModeActionsFeature(hiveNode);
+
+            newTransientModeActionsFeature = transientModeActionsFeature.withTargetBoostTargetTemperature(
+                    Quantities.getQuantity(
+                            newTargetHeatTemperature.toBigDecimal(),
+                            newTargetHeatTemperature.getUnit()
+                    )
+            );
+        }
+
+        if (newTransientModeActionsFeature != null) {
+            final Node.Builder nodeBuilder = Node.builder();
+            nodeBuilder.from(hiveNode);
+
+            nodeBuilder.putFeature(TransientModeHeatingActionsFeature.class, newTransientModeActionsFeature);
+
+            return nodeBuilder.build();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        final TransientModeHeatingActionsFeature transientModeActionsFeature = getEffectiveTransientModeActionsFeature(hiveNode);
+        useAttribute(hiveNode, TransientModeHeatingActionsFeature.class, "boostTargetTemperature", transientModeActionsFeature.getBoostTargetTemperature(), boostTargetTemperatureAttribute -> {
+            useChannel(thing, HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET_BOOST, boostTargetHeatTemperatureChannel -> {
+                thingHandlerCallback.stateUpdated(
+                        boostTargetHeatTemperatureChannel,
+                        new QuantityType<>(
+                                boostTargetTemperatureAttribute.getDisplayValue().getValue(),
+                                boostTargetTemperatureAttribute.getDisplayValue().getUnit()
+                        )
+                );
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/OnOffDeviceHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/OnOffDeviceHandlerStrategy.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OnOffMode;
+import org.openhab.binding.hive.internal.client.feature.OnOffDeviceFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link OnOffDeviceFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class OnOffDeviceHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+            @Nullable OnOffDeviceFeature newOnOffDeviceFeature = null;
+
+            if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_MODE_ON_OFF)
+                    && command instanceof OnOffType) {
+                // Set the new target heating temperature.
+                final OnOffType value = (OnOffType) command;
+                final OnOffMode mode = value == OnOffType.ON ? OnOffMode.ON : OnOffMode.OFF;
+
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(mode);
+            }
+
+            if (newOnOffDeviceFeature != null) {
+                final Node.Builder nodeBuilder = Node.builder();
+                nodeBuilder.from(hiveNode);
+
+                nodeBuilder.putFeature(OnOffDeviceFeature.class, newOnOffDeviceFeature);
+
+                return nodeBuilder.build();
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+            useAttribute(hiveNode, OnOffDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE, onOffDeviceFeature.getMode(), modeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_MODE_ON_OFF, onOffModeChannel -> {
+                    final OnOffType value = modeAttribute.getDisplayValue() == OnOffMode.ON ? OnOffType.ON : OnOffType.OFF;
+                    thingHandlerCallback.stateUpdated(onOffModeChannel, value);
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategy.java
@@ -41,11 +41,11 @@ public final class PhysicalDeviceHandlerStrategy extends ThingHandlerStrategyBas
                 thing.setProperty(Thing.PROPERTY_MODEL_ID, modelAttribute.getDisplayValue());
             });
 
-            useAttribute(hiveNode, PhysicalDeviceFeature.class, "softwareVersion", physicalDeviceFeature.getModel(), softwareVersionAttribute -> {
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "softwareVersion", physicalDeviceFeature.getSoftwareVersion(), softwareVersionAttribute -> {
                 thing.setProperty(Thing.PROPERTY_FIRMWARE_VERSION, softwareVersionAttribute.getDisplayValue());
             });
 
-            useAttribute(hiveNode, PhysicalDeviceFeature.class, "hardwareIdentifier", physicalDeviceFeature.getModel(), hardwareIdentifierAttribute -> {
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "hardwareIdentifier", physicalDeviceFeature.getHardwareIdentifier(), hardwareIdentifierAttribute -> {
                 thing.setProperty(Thing.PROPERTY_SERIAL_NUMBER, hardwareIdentifierAttribute.getDisplayValue());
             });
         });

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.PhysicalDeviceFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link PhysicalDeviceFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class PhysicalDeviceHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, PhysicalDeviceFeature.class, physicalDeviceFeature -> {
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "manufacturer", physicalDeviceFeature.getManufacturer(), manufacturerAttribute -> {
+                thing.setProperty(Thing.PROPERTY_VENDOR, manufacturerAttribute.getDisplayValue());
+            });
+
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "model", physicalDeviceFeature.getModel(), modelAttribute -> {
+                thing.setProperty(Thing.PROPERTY_MODEL_ID, modelAttribute.getDisplayValue());
+            });
+
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "softwareVersion", physicalDeviceFeature.getModel(), softwareVersionAttribute -> {
+                thing.setProperty(Thing.PROPERTY_FIRMWARE_VERSION, softwareVersionAttribute.getDisplayValue());
+            });
+
+            useAttribute(hiveNode, PhysicalDeviceFeature.class, "hardwareIdentifier", physicalDeviceFeature.getModel(), hardwareIdentifierAttribute -> {
+                thing.setProperty(Thing.PROPERTY_SERIAL_NUMBER, hardwareIdentifierAttribute.getDisplayValue());
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/TemperatureSensorHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/TemperatureSensorHandlerStrategy.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.TemperatureSensorFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link TemperatureSensorFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TemperatureSensorHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, TemperatureSensorFeature.class, temperatureSensorFeature -> {
+            useAttribute(hiveNode, TemperatureSensorFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TEMPERATURE_SENSOR_V1_TEMPERATURE, temperatureSensorFeature.getTemperature(), temperatureAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TEMPERATURE_CURRENT, temperatureChannel -> {
+                    thingHandlerCallback.stateUpdated(
+                            temperatureChannel,
+                            new QuantityType<>(
+                                    temperatureAttribute.getDisplayValue().getValue(),
+                                    temperatureAttribute.getDisplayValue().getUnit()
+                            )
+                    );
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ThingHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ThingHandlerStrategy.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.client.Node;
+
+/**
+ * A strategy for how a {@link org.eclipse.smarthome.core.thing.binding.ThingHandler}
+ * should handle commands on and updates from {@link Node}s.
+ *
+ * <p>
+ *     This is intended to decouple the handling of specific
+ *     {@link org.openhab.binding.hive.internal.client.feature.Feature}s
+ *     so it can be re-used by multiple
+ *     {@link org.eclipse.smarthome.core.thing.binding.ThingHandler}s.
+ * </p>
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public interface ThingHandlerStrategy {
+    /**
+     * Called when a {@link org.eclipse.smarthome.core.thing.Channel}
+     * has received a command that needs to be handled.
+     *
+     * @param channelUID
+     *      The UID of the channel that received the command.
+     *
+     * @param command
+     *      The command that was received.
+     *
+     * @param hiveNode
+     *      The {@linkplain Node} that the {@code command} needs to be
+     *      performed on.
+     *
+     * @return
+     *      {@code null} - If the {@linkplain Node} does not need to be updated.
+     *      {@code updatedNode} - If the {@linkplain Node} needs to be updated.
+     */
+    @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    );
+
+    /**
+     * Called when a {@link Thing} must be updated with new information
+     * from a {@link Node}.
+     *
+     * @param thing
+     *      The {@linkplain Thing} to be updated.
+     *
+     * @param thingHandlerCallback
+     *      The {@linkplain ThingHandlerCallback} to use to update
+     *      {@code thing}.
+     *
+     * @param hiveNode
+     *      The {@linkplain Node} containing the information to update
+     *      {@code thing} with.
+     */
+    void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    );
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ThingHandlerStrategyBase.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ThingHandlerStrategyBase.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.client.FeatureAttribute;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * A base class that makes implementing {@link ThingHandlerStrategy}s easier.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class ThingHandlerStrategyBase implements ThingHandlerStrategy {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Represents a method that requires a nonnull {@link ChannelUID}.
+     * 
+     * @see #useChannel(Thing, String, DoWithChannelUid)
+     */
+    @FunctionalInterface
+    protected interface DoWithChannelUid {
+        void useChannelUid(ChannelUID channelUID);
+    }
+
+    /**
+     * Represents a method that requires a nonnull {@link Feature} and returns
+     * something.
+     *
+     * @see #useFeature(Node, Class, DoWithFeatureAndReturn)
+     */
+    @FunctionalInterface
+    protected interface DoWithFeatureAndReturn<F extends Feature> {
+        @Nullable Node useFeature(F feature);
+    }
+
+    /**
+     * Represents a method that requires a nonnull {@link Feature}.
+     *
+     * @see #useFeature(Node, Class, DoWithFeature)
+     */
+    @FunctionalInterface
+    protected interface DoWithFeature<F extends Feature> {
+        void useFeature(F feature);
+    }
+
+    /**
+     * Represents a method that requires a nonnull {@link FeatureAttribute}.
+     *
+     * @see #useAttribute(Node, Class, String, FeatureAttribute, DoWithFeatureAttribute)
+     */
+    @FunctionalInterface
+    protected interface DoWithFeatureAttribute<T, A extends FeatureAttribute<T>> {
+        void useAttribute(A featureAttribute);
+    }
+
+    /**
+     * Helper method to allow use of channels without worrying about
+     * {@linkplain NullPointerException}s occurring if a {@link Thing}
+     * does not have a {@link Channel} that you expect it to have.
+     *
+     * <p>
+     *     e.g. If the binding is upgraded with new channels but the
+     *     {@linkplain Thing} is not upgraded.
+     * </p>
+     *
+     * @param thing
+     *      The {@linkplain Thing} to get the channel from.
+     *
+     * @param channelName
+     *      The name of the {@linkplain Channel} you want to work with.
+     *
+     * @param thingToDo
+     *      The thing you want to do with the channel.
+     */
+    protected void useChannel(
+            final Thing thing,
+            final String channelName,
+            final DoWithChannelUid thingToDo
+    ) {
+        Objects.requireNonNull(thing);
+        Objects.requireNonNull(channelName);
+        Objects.requireNonNull(thingToDo);
+
+        final @Nullable Channel channel = thing.getChannel(channelName);
+
+        if (channel != null) {
+            final ChannelUID channelUID = channel.getUID();
+
+            thingToDo.useChannelUid(channelUID);
+        } else {
+            final @Nullable String thingLabel = thing.getLabel();
+            final String thingName = thingLabel != null ? thingLabel : thing.getUID().toString();
+
+            this.logger.debug(
+                    "Tried to do something with the nonexistent channel \"{}\" of thing \"{}\". Do you need to update your thing?",
+                    channelName,
+                    thingName
+            );
+        }
+    }
+
+    /**
+     * Helper method to allow use of features without worrying about
+     * {@linkplain NullPointerException}s occurring if a {@link Node} does
+     * not have a {@link Feature} that you expect it to have.
+     *
+     * <p>
+     *     e.g. If an incorrect {@link org.eclipse.smarthome.core.thing.binding.ThingHandler}
+     *     has been assigned to a {@linkplain Node}.
+     * </p>
+     *
+     * @param hiveNode
+     *      The {@linkplain Node} to get the {@linkplain Feature} from.
+     *
+     * @param featureClass
+     *      The {@linkplain Class} of the {@linkplain Feature} you want to use.
+     *
+     * @param thingToDo
+     *      The thing you want to do with the {@linkplain Feature}.
+     *
+     * @param <F>
+     *      The type of {@linkplain Feature} you want to use.
+     *
+     * @return
+     *      Either the result of {@code thingToDo.doStuff(F)} if the feature
+     *      is available or {@code null} if the feature is not available.
+     */
+    protected <F extends Feature> @Nullable Node useFeature(
+            final Node hiveNode,
+            final Class<F> featureClass,
+            final DoWithFeatureAndReturn<F> thingToDo
+    ) {
+        Objects.requireNonNull(hiveNode);
+        Objects.requireNonNull(featureClass);
+        Objects.requireNonNull(thingToDo);
+
+        final @Nullable F feature = hiveNode.getFeature(featureClass);
+
+        if (feature != null) {
+            return thingToDo.useFeature(feature);
+        } else {
+            this.logger.debug(
+                    "Could not get feature {} for node {} ({}). Has it been given the wrong kind of handler?",
+                    featureClass.getName(),
+                    hiveNode.getName(),
+                    hiveNode.getId()
+            );
+
+            return null;
+        }
+    }
+
+    /**
+     * Helper method to allow use of features without worrying about
+     * {@linkplain NullPointerException}s occurring if a {@link Node} does
+     * not have a {@link Feature} that you expect it to have.
+     *
+     * <p>
+     *     e.g. If an incorrect {@link org.eclipse.smarthome.core.thing.binding.ThingHandler}
+     *     has been assigned to a {@linkplain Node}.
+     * </p>
+     *
+     * @param hiveNode
+     *      The {@linkplain Node} to get the {@linkplain Feature} from.
+     *
+     * @param featureClass
+     *      The {@linkplain Class} of the {@linkplain Feature} you want to use.
+     *
+     * @param thingToDo
+     *      The thing you want to do with the {@linkplain Feature}.
+     *
+     * @param <F>
+     *      The type of {@linkplain Feature} you want to use.
+     */
+    protected <F extends Feature> void useFeature(
+            final Node hiveNode,
+            final Class<F> featureClass,
+            final DoWithFeature<F> thingToDo
+    ) {
+        useFeature(hiveNode, featureClass, (feature) -> { thingToDo.useFeature(feature); return null;});
+    }
+
+    protected <T, A extends FeatureAttribute<T>> void useAttribute(
+            final Node hiveNode,
+            final Class<? extends Feature> featureClass,
+            final String attributeName,
+            final @Nullable A featureAttribute,
+            final DoWithFeatureAttribute<T, A> thingToDo
+    ) {
+        Objects.requireNonNull(hiveNode);
+        Objects.requireNonNull(featureClass);
+        Objects.requireNonNull(attributeName);
+        Objects.requireNonNull(thingToDo);
+
+        if (featureAttribute != null) {
+            thingToDo.useAttribute(featureAttribute);
+        } else {
+            this.logger.trace(
+                    "Tried to do something with the unavailable attribute \"{}\" of feature \"{}\" in node \"{}\". Old hub?",
+                    attributeName,
+                    featureClass.getName(),
+                    hiveNode.getName()
+            );
+        }
+    }
+
+    // Default implementation that does nothing.
+    // Useful for read-only features.
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/TransientModeHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/TransientModeHandlerStrategy.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.TransientModeFeature;
+
+import java.time.Duration;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link TransientModeFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class TransientModeHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, TransientModeFeature.class, transientModeFeature -> {
+            @Nullable TransientModeFeature newTransientModeFeature = null;
+
+            if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_TRANSIENT_DURATION)
+                    && command instanceof DecimalType
+            ) {
+                final DecimalType newDurationMins = (DecimalType) command;
+
+                newTransientModeFeature = transientModeFeature.withTargetDuration(Duration.ofMinutes(newDurationMins.longValue()));
+            }
+
+            if (newTransientModeFeature != null) {
+                final Node.Builder nodeBuilder = Node.builder();
+                nodeBuilder.from(hiveNode);
+
+                nodeBuilder.putFeature(TransientModeFeature.class, newTransientModeFeature);
+
+                return nodeBuilder.build();
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, TransientModeFeature.class, transientModeFeature -> {
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_DURATION, transientModeFeature.getDuration(), durationAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TRANSIENT_DURATION, transientDurationChannel -> {
+                    final long durationMins = durationAttribute.getDisplayValue().toMinutes();
+                    thingHandlerCallback.stateUpdated(transientDurationChannel, new DecimalType(durationMins));
+                });
+            });
+
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_IS_ENABLED, transientModeFeature.getIsEnabled(), isEnabledAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TRANSIENT_ENABLED, transientEnabledChannel -> {
+                    thingHandlerCallback.stateUpdated(transientEnabledChannel, OnOffType.from(isEnabledAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_START_DATETIME, transientModeFeature.getStartDatetime(), startDatetimeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TRANSIENT_START_TIME, transientStartTimeChannel -> {
+                    thingHandlerCallback.stateUpdated(transientStartTimeChannel, new DateTimeType(startDatetimeAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_END_DATETIME, transientModeFeature.getEndDatetime(), endDatetimeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_TRANSIENT_END_TIME, transientEndTimeChannel -> {
+                    thingHandlerCallback.stateUpdated(transientEndTimeChannel, new DateTimeType(endDatetimeAttribute.getDisplayValue()));
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterEasyHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterEasyHandlerStrategy.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.feature.OnOffDeviceFeature;
+import org.openhab.binding.hive.internal.client.feature.TransientModeFeature;
+import org.openhab.binding.hive.internal.client.feature.WaterHeaterFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} that handles channels that provide a
+ * simplified interface with Hive Hot Water.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class WaterHeaterEasyHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, WaterHeaterFeature.class, waterHeaterFeature -> {
+            return useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+                return useFeature(hiveNode, TransientModeFeature.class, transientModeFeature -> {
+                    return handleCommand(
+                            channelUID,
+                            command,
+                            hiveNode,
+                            waterHeaterFeature,
+                            onOffDeviceFeature,
+                            transientModeFeature
+                    );
+                });
+            });
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, WaterHeaterFeature.class, waterHeaterFeature -> {
+            useFeature(hiveNode, OnOffDeviceFeature.class, onOffDeviceFeature -> {
+                useFeature(hiveNode, TransientModeFeature.class, transientModeFeature -> {
+                    handleUpdate(
+                            hiveNode,
+                            thing,
+                            thingHandlerCallback,
+                            waterHeaterFeature,
+                            onOffDeviceFeature,
+                            transientModeFeature
+                    );
+                });
+            });
+        });
+    }
+
+    private @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode,
+            final WaterHeaterFeature waterHeaterFeature,
+            final OnOffDeviceFeature onOffDeviceFeature,
+            final TransientModeFeature transientModeFeature
+    ) {
+        @Nullable WaterHeaterFeature newWaterHeaterFeature = null;
+        @Nullable OnOffDeviceFeature newOnOffDeviceFeature = null;
+        @Nullable TransientModeFeature newTransientModeFeature = null;
+
+        if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING)
+                && command instanceof StringType
+        ) {
+            final StringType newOperatingMode = (StringType) command;
+            if (newOperatingMode.toString().equals(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_SCHEDULE)) {
+                newWaterHeaterFeature = waterHeaterFeature.withTargetOperatingMode(WaterHeaterOperatingMode.SCHEDULE);
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.ON);
+            } else if (newOperatingMode.toString().equals(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_ON)) {
+                newWaterHeaterFeature = waterHeaterFeature.withTargetOperatingMode(WaterHeaterOperatingMode.ON);
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.ON);
+            } else {
+                // easy-mode-operating: OFF
+                newOnOffDeviceFeature = onOffDeviceFeature.withTargetMode(OnOffMode.OFF);
+            }
+        } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_EASY_MODE_BOOST)
+                && command instanceof OnOffType
+        ) {
+            final OnOffType newOverrideMode = (OnOffType) command;
+
+            if (newOverrideMode == OnOffType.ON) {
+                newTransientModeFeature = transientModeFeature.withTargetIsEnabled(true);
+                newWaterHeaterFeature = waterHeaterFeature.withTargetTemporaryOperatingModeOverride(OverrideMode.TRANSIENT);
+            } else {
+                newTransientModeFeature = transientModeFeature.withTargetIsEnabled(false);
+                newWaterHeaterFeature = waterHeaterFeature.withTargetTemporaryOperatingModeOverride(OverrideMode.NONE);
+            }
+        }
+
+        if (newWaterHeaterFeature != null
+                || newOnOffDeviceFeature != null
+                || newTransientModeFeature != null
+        ) {
+            final Node.Builder nodeBuilder = Node.builder();
+            nodeBuilder.from(hiveNode);
+
+            if (newWaterHeaterFeature != null) {
+                nodeBuilder.putFeature(WaterHeaterFeature.class, newWaterHeaterFeature);
+            }
+
+            if (newOnOffDeviceFeature != null) {
+                nodeBuilder.putFeature(OnOffDeviceFeature.class, newOnOffDeviceFeature);
+            }
+
+            if (newTransientModeFeature != null) {
+                nodeBuilder.putFeature(TransientModeFeature.class, newTransientModeFeature);
+            }
+
+            return nodeBuilder.build();
+        } else {
+            return null;
+        }
+    }
+
+    private void handleUpdate(
+            final Node hiveNode,
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final WaterHeaterFeature waterHeaterFeature,
+            final OnOffDeviceFeature onOffDeviceFeature,
+            final TransientModeFeature transientModeFeature
+    ) {
+        useAttribute(hiveNode, WaterHeaterFeature.class, HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_OPERATING_MODE, waterHeaterFeature.getOperatingMode(), operatingModeAttribute -> {
+            useAttribute(hiveNode, OnOffDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE, onOffDeviceFeature.getMode(), onOffModeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING, easyModeOperatingChannel -> {
+                    if (onOffModeAttribute.getDisplayValue() == OnOffMode.OFF) {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_OFF));
+                    } else if (operatingModeAttribute.getDisplayValue() == WaterHeaterOperatingMode.SCHEDULE) {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_SCHEDULE));
+                    } else {
+                        thingHandlerCallback.stateUpdated(easyModeOperatingChannel, new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_ON));
+                    }
+                });
+            });
+        });
+
+        useAttribute(hiveNode, WaterHeaterFeature.class, HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_TEMPORARY_OPERATING_MODE_OVERRIDE, waterHeaterFeature.getTemporaryOperatingModeOverride(), waterHeaterOverrideAttribute -> {
+            useAttribute(hiveNode, TransientModeFeature.class, HiveApiConstants.ATTRIBUTE_NAME_TRANSIENT_MODE_V1_IS_ENABLED, transientModeFeature.getIsEnabled(), transientModeEnabledAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_EASY_MODE_BOOST, easyModeBoostChannel -> {
+                    final OnOffType boostActive = OnOffType.from(waterHeaterOverrideAttribute.getDisplayValue() == OverrideMode.TRANSIENT
+                            && transientModeEnabledAttribute.getDisplayValue());
+                    thingHandlerCallback.stateUpdated(easyModeBoostChannel, boostActive);
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterHandlerStrategy.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.WaterHeaterOperatingMode;
+import org.openhab.binding.hive.internal.client.feature.WaterHeaterFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link WaterHeaterFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class WaterHeaterHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public @Nullable Node handleCommand(
+            final ChannelUID channelUID,
+            final Command command,
+            final Node hiveNode
+    ) {
+        return useFeature(hiveNode, WaterHeaterFeature.class, waterHeaterFeature -> {
+            @Nullable WaterHeaterFeature newWaterHeaterFeature = null;
+
+            if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_MODE_OPERATING)
+                    && command instanceof StringType
+            ) {
+                final StringType newOperatingMode = (StringType) command;
+
+                newWaterHeaterFeature = waterHeaterFeature.withTargetOperatingMode(
+                        WaterHeaterOperatingMode.valueOf(newOperatingMode.toString())
+                );
+            } else if (channelUID.getId().equals(HiveBindingConstants.CHANNEL_MODE_OPERATING_OVERRIDE)
+                    && command instanceof OnOffType
+            ) {
+                final OnOffType newOverrideMode = (OnOffType) command;
+                newWaterHeaterFeature = waterHeaterFeature.withTargetTemporaryOperatingModeOverride(
+                        newOverrideMode == OnOffType.ON ? OverrideMode.TRANSIENT : OverrideMode.NONE
+                );
+            }
+
+            if (newWaterHeaterFeature != null) {
+                final Node.Builder nodeBuilder = Node.builder();
+                nodeBuilder.from(hiveNode);
+
+                nodeBuilder.putFeature(WaterHeaterFeature.class, newWaterHeaterFeature);
+
+                return nodeBuilder.build();
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, WaterHeaterFeature.class, waterHeaterFeature -> {
+            useAttribute(hiveNode, WaterHeaterFeature.class, HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_OPERATING_MODE, waterHeaterFeature.getOperatingMode(), operatingModeAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_MODE_OPERATING, operatingModeChannel -> {
+                    thingHandlerCallback.stateUpdated(operatingModeChannel, new StringType(operatingModeAttribute.getDisplayValue().toString()));
+                });
+            });
+
+            useAttribute(hiveNode, WaterHeaterFeature.class, HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_IS_ON, waterHeaterFeature.getIsOn(), isOnAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_EASY_STATE_IS_ON, isOnChannel -> {
+                    thingHandlerCallback.stateUpdated(isOnChannel, OnOffType.from(isOnAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, WaterHeaterFeature.class, HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_TEMPORARY_OPERATING_MODE_OVERRIDE, waterHeaterFeature.getTemporaryOperatingModeOverride(), temporaryOperatingModeOverrideAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_MODE_OPERATING_OVERRIDE, operatingModeOverrideChannel -> {
+                    thingHandlerCallback.stateUpdated(
+                            operatingModeOverrideChannel,
+                            OnOffType.from(temporaryOperatingModeOverrideAttribute.getDisplayValue() == OverrideMode.TRANSIENT)
+                    );
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ZigbeeDeviceHandlerStrategy.java
+++ b/bundles/org.openhab.binding.hive/src/main/java/org/openhab/binding/hive/internal/handler/strategy/ZigbeeDeviceHandlerStrategy.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.ZigbeeDeviceFeature;
+
+/**
+ * A {@link ThingHandlerStrategy} for handling
+ * {@link ZigbeeDeviceFeature}.
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public final class ZigbeeDeviceHandlerStrategy extends ThingHandlerStrategyBase {
+    @Override
+    public void handleUpdate(
+            final Thing thing,
+            final ThingHandlerCallback thingHandlerCallback,
+            final Node hiveNode
+    ) {
+        useFeature(hiveNode, ZigbeeDeviceFeature.class, zigbeeDeviceFeature -> {
+            useAttribute(hiveNode, ZigbeeDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_EUI64, zigbeeDeviceFeature.getEui64(), eui64Attribute -> {
+                thing.setProperty(HiveBindingConstants.PROPERTY_EUI64, eui64Attribute.getDisplayValue().toString());
+
+                // TODO: Extract MAC address from EUI64?
+                //thing.setProperty(Thing.PROPERTY_MAC_ADDRESS, xxx);
+            });
+
+            useAttribute(hiveNode, ZigbeeDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_AVERAGE_LQI, zigbeeDeviceFeature.getAverageLQI(), averageLQIAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_RADIO_LQI_AVERAGE, averageLqiChannel -> {
+                    thingHandlerCallback.stateUpdated(averageLqiChannel, new DecimalType(averageLQIAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, ZigbeeDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_LAST_KNOWN_LQI, zigbeeDeviceFeature.getLastKnownLQI(), lastKnownLQIAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_RADIO_LQI_LAST_KNOWN, lastKnownLqiChannel -> {
+                    thingHandlerCallback.stateUpdated(lastKnownLqiChannel, new DecimalType(lastKnownLQIAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, ZigbeeDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_AVERAGE_RSSI, zigbeeDeviceFeature.getAverageRSSI(), averageRSSIAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_RADIO_RSSI_AVERAGE, averageRSSIChannel -> {
+                    thingHandlerCallback.stateUpdated(averageRSSIChannel, new DecimalType(averageRSSIAttribute.getDisplayValue()));
+                });
+            });
+
+            useAttribute(hiveNode, ZigbeeDeviceFeature.class, HiveApiConstants.ATTRIBUTE_NAME_ZIGBEE_DEVICE_V1_LAST_KNOWN_RSSI, zigbeeDeviceFeature.getLastKnownRSSI(), lastKnownRSSIAttribute -> {
+                useChannel(thing, HiveBindingConstants.CHANNEL_RADIO_RSSI_LAST_KNOWN, lastKnownRSSIChannel -> {
+                    thingHandlerCallback.stateUpdated(lastKnownRSSIChannel, new DecimalType(lastKnownRSSIAttribute.getDisplayValue()));
+                });
+            });
+        });
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="hive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Hive Binding</name>
+	<description>Integrates Hive smart home devices. (AKA Centrica Hive / British Gas Hive)</description>
+	<author>Ross Brown</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/config/hive-node.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/config/hive-node.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+		xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:hive:node">
+		<parameter name="nodeId" type="text" required="true">
+			<label>Node ID</label>
+			<description>The Hive API Node ID for this thing</description>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-auto_boost.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-auto_boost.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="auto_boost-temperature-target">
+		<item-type>Number:Temperature</item-type>
+		<label>Auto Boost Target Temperature</label>
+		<category>Heating</category>
+		<state pattern="%.1f %unit%" />
+	</channel-type>
+
+	<channel-type id="auto_boost-duration" advanced="true">
+		<item-type>Number</item-type>
+		<label>Auto Boost Duration</label>
+		<category>Heating</category>
+		<state min="1" pattern="%d minutes" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-battery_device.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-battery_device.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="battery-state">
+		<item-type>String</item-type>
+		<label>Battery State</label>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="battery-voltage" advanced="true">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Battery Voltage</label>
+		<state pattern="%.1f %unit%" readOnly="true" />
+	</channel-type>
+
+	<channel-type id="battery-notification_state" advanced="true">
+		<item-type>String</item-type>
+		<label>Battery Notification State</label>
+		<state readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-heating_thermostat.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-heating_thermostat.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="heating-mode-operating" advanced="true">
+		<item-type>String</item-type>
+		<label>Operating Mode</label>
+		<category>Heating</category>
+
+		<state>
+			<options>
+				<option value="SCHEDULE">Schedule</option>
+				<option value="MANUAL">Manual</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="heating-mode-on_off" advanced="true">
+		<item-type>Switch</item-type>
+		<label>On/Off Mode</label>
+		<category>Heating</category>
+	</channel-type>
+
+	<channel-type id="temperature-target">
+		<item-type>Number:Temperature</item-type>
+		<label>Target Temperature</label>
+		<category>Heating</category>
+		<state pattern="%.1f %unit%" />
+	</channel-type>
+
+	<channel-type id="state-operating" advanced="true">
+		<item-type>String</item-type>
+		<label>Operating State</label>
+		<category>Heating</category>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="temperature-target-boost">
+		<item-type>Number:Temperature</item-type>
+		<label>Boost Target Temperature</label>
+		<category>Heating</category>
+		<state pattern="%.1f %unit%" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-temperature_sensor.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-temperature_sensor.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="temperature-current">
+		<item-type>Number:Temperature</item-type>
+		<label>Current Temperature</label>
+		<category>Temperature</category>
+		<state pattern="%.1f %unit%" readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-transient_mode.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-transient_mode.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="mode-operating-override" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Boost Active</label>
+		<category>Heating</category>
+	</channel-type>
+
+	<channel-type id="transient-duration">
+		<item-type>Number</item-type>
+		<label>Boost Duration</label>
+		<category>Heating</category>
+		<state min="1" pattern="%d minutes" />
+	</channel-type>
+
+	<channel-type id="transient-remaining">
+		<item-type>Number</item-type>
+		<label>Boost Time Remaining</label>
+		<category>Heating</category>
+		<state readOnly="true" pattern="%d minutes" />
+	</channel-type>
+
+	<channel-type id="transient-enabled" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Boost Enabled</label>
+		<category>Heating</category>
+	</channel-type>
+
+	<channel-type id="transient-start_time" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Boost Start Time</label>
+		<category>Heating</category>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="transient-end_time" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Boost End Time</label>
+		<category>Heating</category>
+		<state readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-water_heater.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-water_heater.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="hot_water-mode-operating" advanced="true">
+		<item-type>String</item-type>
+		<label>Operating Mode</label>
+		<category>Heating</category>
+
+		<state>
+			<options>
+				<option value="SCHEDULE">Schedule</option>
+				<option value="ON">Manual</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="hot_water-mode-on_off" advanced="true">
+		<item-type>Switch</item-type>
+		<label>On/Off Mode</label>
+		<category>Heating</category>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-zigbee_device.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-feature-zigbee_device.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="radio-lqi-average" advanced="true">
+		<item-type>Number</item-type>
+		<label>Average LQI</label>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="radio-lqi-last_known" advanced="true">
+		<item-type>Number</item-type>
+		<label>Last Known LQI</label>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="radio-rssi-average" advanced="true">
+		<item-type>Number</item-type>
+		<label>Average RSSI</label>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="radio-rssi-last_known" advanced="true">
+		<item-type>Number</item-type>
+		<label>Last Known RSSI</label>
+		<state readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-simplified.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/channels-simplified.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="heating-easy-mode-operating">
+		<item-type>String</item-type>
+		<label>Mode</label>
+		<category>Heating</category>
+
+		<state>
+			<options>
+				<option value="MANUAL">Manual</option>
+				<option value="SCHEDULE">Schedule</option>
+				<option value="OFF">Off</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="hot_water-easy-mode-operating">
+		<item-type>String</item-type>
+		<label>Mode</label>
+		<category>Heating</category>
+
+		<state>
+			<options>
+				<option value="ON">On</option>
+				<option value="SCHEDULE">Schedule</option>
+				<option value="OFF">Off</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="easy-mode-boost">
+		<item-type>Switch</item-type>
+		<label>Boost</label>
+		<category>Heating</category>
+	</channel-type>
+
+	<channel-type id="easy-state-is_on">
+		<item-type>Switch</item-type>
+		<label>Is On</label>
+		<category>Heating</category>
+		<state readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-account.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-account.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="account">
+		<label>Hive Account</label>
+		<description>
+			An account for using the Hive REST API.
+			(This the same account you use to login to the Hive mobile app or my.hivehome.com)
+		</description>
+
+		<channels>
+			<channel id="last_poll_timestamp" typeId="last_poll_timestamp" />
+			<channel id="dump_nodes" typeId="dump_nodes" />
+		</channels>
+
+		<config-description>
+			<parameter name="username" type="text" required="true">
+				<label>Username</label>
+				<description>Your Hive account username (email address)</description>
+			</parameter>
+			<parameter name="password" type="text" required="true">
+				<label>Password</label>
+				<description>Your Hive account password</description>
+			</parameter>
+
+			<parameter name="pollingInterval" type="integer" min="1" required="true" unit="s">
+				<label>Polling Interval</label>
+				<description>How many seconds to wait between polling Hive API for updates</description>
+				<unitLabel>seconds</unitLabel>
+				<default>10</default>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+	<channel-type id="last_poll_timestamp" advanced="true">
+		<item-type>DateTime</item-type>
+		<label>Last Poll Timestamp</label>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="dump_nodes" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Dump Nodes</label>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-boiler_module.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-boiler_module.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="boiler_module">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Boiler Module</label>
+		<description>The physical module that controls when your boiler turns on for heating (and optionally hot water)</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="radio-lqi-average" typeId="radio-lqi-average" />
+			<channel id="radio-lqi-last_known" typeId="radio-lqi-last_known" />
+			<channel id="radio-rssi-average" typeId="radio-rssi-average" />
+			<channel id="radio-rssi-last_known" typeId="radio-rssi-last_known" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-heating.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-heating.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="heating">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Thermostat Heating Zone</label>
+		<description>A virtual zone controlled by a Hive Thermostat and Boiler Module that can be heated by the Hive Active Heating system</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="easy-mode-operating" typeId="heating-easy-mode-operating" />
+			<channel id="easy-mode-boost" typeId="easy-mode-boost" />
+			<channel id="easy-state-is_on" typeId="easy-state-is_on" />
+
+			<channel id="temperature-current" typeId="temperature-current" />
+			<channel id="temperature-target" typeId="temperature-target" />
+			<channel id="mode-operating" typeId="heating-mode-operating" />
+			<channel id="mode-on_off" typeId="heating-mode-on_off" />
+			<channel id="state-operating" typeId="state-operating" />
+
+			<channel id="mode-operating-override" typeId="mode-operating-override" />
+
+			<channel id="transient-duration" typeId="transient-duration" />
+			<channel id="transient-enabled" typeId="transient-enabled" />
+			<channel id="transient-start_time" typeId="transient-start_time" />
+			<channel id="transient-end_time" typeId="transient-end_time" />
+			<channel id="transient-remaining" typeId="transient-remaining" />
+
+			<channel id="temperature-target-boost" typeId="temperature-target-boost" />
+
+			<channel id="auto_boost-temperature-target" typeId="auto_boost-temperature-target" />
+			<channel id="auto_boost-duration" typeId="auto_boost-duration" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-hot_water.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-hot_water.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="hot_water">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Hot Water</label>
+		<description>A virtual thing that controls your hot water supply</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="easy-mode-operating" typeId="hot_water-easy-mode-operating" />
+			<channel id="easy-mode-boost" typeId="easy-mode-boost" />
+			<channel id="easy-state-is_on" typeId="easy-state-is_on" />
+
+			<channel id="mode-operating" typeId="hot_water-mode-operating" />
+			<channel id="mode-on_off" typeId="hot_water-mode-on_off" />
+
+			<channel id="mode-operating-override" typeId="mode-operating-override" />
+
+			<channel id="transient-duration" typeId="transient-duration" />
+			<channel id="transient-enabled" typeId="transient-enabled" />
+			<channel id="transient-start_time" typeId="transient-start_time" />
+			<channel id="transient-end_time" typeId="transient-end_time" />
+			<channel id="transient-remaining" typeId="transient-remaining" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-hub.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-hub.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="hub">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Hub</label>
+		<description>The physical device that bridges your wireless Hive devices to your home network / the internet</description>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-thermostat.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-thermostat.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="thermostat">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Thermostat</label>
+		<description>The physical device with controls for the temperature of a single zone</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="battery-level" typeId="system.battery-level" />
+			<channel id="battery-low" typeId="system.low-battery" />
+			<channel id="battery-state" typeId="battery-state" />
+			<channel id="battery-voltage" typeId="battery-voltage" />
+			<channel id="battery-notification_state" typeId="battery-notification_state" />
+
+			<channel id="radio-lqi-average" typeId="radio-lqi-average" />
+			<channel id="radio-lqi-last_known" typeId="radio-lqi-last_known" />
+			<channel id="radio-rssi-average" typeId="radio-rssi-average" />
+			<channel id="radio-rssi-last_known" typeId="radio-rssi-last_known" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-trv.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-trv.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="trv">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Radiator Valve</label>
+		<description>The physical device that controls turning an individual radiator on or off</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="temperature-current" typeId="temperature-current" />
+			<channel id="battery-level" typeId="system.battery-level" />
+			<channel id="battery-low" typeId="system.low-battery" />
+			<channel id="battery-state" typeId="battery-state" />
+			<channel id="battery-voltage" typeId="battery-voltage" />
+			<channel id="battery-notification_state" typeId="battery-notification_state" />
+
+			<channel id="radio-lqi-average" typeId="radio-lqi-average" />
+			<channel id="radio-lqi-last_known" typeId="radio-lqi-last_known" />
+			<channel id="radio-rssi-average" typeId="radio-rssi-average" />
+			<channel id="radio-rssi-last_known" typeId="radio-rssi-last_known" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-trv_group.xml
+++ b/bundles/org.openhab.binding.hive/src/main/resources/ESH-INF/thing/thing-trv_group.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hive"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="trv_group">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="account" />
+		</supported-bridge-type-refs>
+
+		<label>Hive Radiator Valve Heating Zone</label>
+		<description>A virtual zone controlled by Hive Radiator Valves that can be heated by the Hive Active Heating system</description>
+		<category>HVAC</category>
+
+		<channels>
+			<channel id="easy-mode-operating" typeId="heating-easy-mode-operating" />
+			<channel id="easy-mode-boost" typeId="easy-mode-boost" />
+			<channel id="easy-state-is_on" typeId="easy-state-is_on" />
+
+			<channel id="temperature-current" typeId="temperature-current" />
+			<channel id="temperature-target" typeId="temperature-target" />
+			<channel id="mode-operating" typeId="heating-mode-operating" />
+			<channel id="mode-on_off" typeId="heating-mode-on_off" />
+			<channel id="state-operating" typeId="state-operating" />
+
+			<channel id="mode-operating-override" typeId="mode-operating-override" />
+
+			<channel id="transient-duration" typeId="transient-duration" />
+			<channel id="transient-enabled" typeId="transient-enabled" />
+			<channel id="transient-start_time" typeId="transient-start_time" />
+			<channel id="transient-end_time" typeId="transient-end_time" />
+			<channel id="transient-remaining" typeId="transient-remaining" />
+
+			<channel id="temperature-target-boost" typeId="temperature-target-boost" />
+		</channels>
+
+		<config-description-ref uri="thing-type:hive:node" />
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/HiveHandlerFactoryTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/HiveHandlerFactoryTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Before;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class HiveHandlerFactoryTest {
+    @NonNullByDefault({})
+    private HiveHandlerFactory handlerFactory;
+
+    @Before
+    public void setUp() {
+        //handlerFactory = new HiveHandlerFactory();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/MultithreadedTestBase.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/MultithreadedTestBase.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import java.util.Objects;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.Before;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class MultithreadedTestBase {
+    private static final String PHASER_NULL_MESSAGE = "Phaser has not been set up yet";
+
+    private final long awaitTimeout;
+    private final TimeUnit awaitTimeUnit;
+
+    private @Nullable Phaser testingPhaser;
+
+    public MultithreadedTestBase(
+            final long awaitTimeout,
+            final TimeUnit awaitTimeUnit
+    ) {
+        if (awaitTimeout <= 0) {
+            throw new IllegalArgumentException("Timeout must be greater than 0.");
+        }
+        Objects.requireNonNull(awaitTimeUnit);
+
+        this.awaitTimeout = awaitTimeout;
+        this.awaitTimeUnit = awaitTimeUnit;
+    }
+
+    @Before
+    public void setUpTestingPhaser() {
+        final Phaser testingPhaser = new Phaser();
+        testingPhaser.register();
+        this.testingPhaser = testingPhaser;
+    }
+
+    protected Phaser getTestingPhaser() {
+        final @Nullable Phaser testingPhaser = this.testingPhaser;
+        if (testingPhaser == null) {
+            throw new IllegalStateException(PHASER_NULL_MESSAGE);
+        }
+
+        return testingPhaser;
+    }
+
+    protected void awaitTestingPhaser() throws TimeoutException, InterruptedException {
+        final @Nullable Phaser testingPhaser = this.testingPhaser;
+        if (testingPhaser == null) {
+            throw new IllegalStateException(PHASER_NULL_MESSAGE);
+        }
+
+        testingPhaser.awaitAdvanceInterruptibly(
+                this.testingPhaser.arrive(),
+                this.awaitTimeout,
+                this.awaitTimeUnit
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/TestUtil.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/TestUtil.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal;
+
+import static org.mockito.Mockito.when;
+
+import java.io.*;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.dto.*;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class TestUtil {
+    public static final String UUID_CAFEBABE = "cafebabe-cafe-babe-cafe-babecafebabe";
+    public static final String UUID_DEADBEEF = "deadbeef-dead-beef-dead-beefdeadbeef";
+
+    public static final NodeId NODE_ID_CAFEBABE = new NodeId(UUID.fromString(UUID_CAFEBABE));
+    public static final NodeId NODE_ID_DEADBEEF = new NodeId(UUID.fromString(UUID_DEADBEEF));
+
+    private TestUtil() {
+        throw new AssertionError();
+    }
+
+    /**
+     * A helper method to get a resource (e.g. a json file) as a String.
+     */
+    public static String getResourceAsString(final String resource) throws IOException {
+        try (final InputStream inputStream = TestUtil.class.getResourceAsStream(resource); final Writer writer = new StringWriter()) {
+            final Reader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+            char[] buffer = new char[1024];
+            int n;
+            while ((n = reader.read(buffer)) != -1) {
+                writer.write(buffer, 0, n);
+            }
+
+            return writer.toString();
+        }
+    }
+
+    public static Thing createHiveNodeThing(final ThingTypeUID thingTypeUID) {
+        final Configuration config = new Configuration();
+        config.put("nodeId", UUID.randomUUID().toString());
+
+        return ThingBuilder.create(thingTypeUID, "dummy-thing")
+                .withLabel("dummy-thing")
+                .withConfiguration(config)
+                .build();
+    }
+
+    public static <T> SettableFeatureAttribute<T> createSimpleFeatureAttribute(final T value) {
+        final Instant time = Instant.now();
+        return DefaultFeatureAttribute.<T>builder()
+                .displayValue(value)
+                .reportedValue(value)
+                .reportChangedTime(time)
+                .reportReceivedTime(time)
+                .build();
+    }
+
+    public static <T> FeatureAttributeDto<T> createSimpleFeatureAttributeDto(final T value) {
+        final FeatureAttributeDto<T> featureAttributeDto = new FeatureAttributeDto<>();
+        featureAttributeDto.reportedValue = value;
+        featureAttributeDto.displayValue = value;
+        featureAttributeDto.reportChangedTime = new HiveApiInstant(Instant.now());
+        featureAttributeDto.reportReceivedTime = new HiveApiInstant(Instant.now());
+
+        return featureAttributeDto;
+    }
+
+    public static NodeDto createSimpleNodeDto(final NodeId nodeId) {
+        final NodeDto nodeDto = new NodeDto();
+        nodeDto.id = nodeId;
+        nodeDto.parentNodeId = nodeId;
+        nodeDto.name = "My test node";
+        nodeDto.nodeType = NodeType.THERMOSTAT;
+        nodeDto.protocol = Protocol.ZIGBEE;
+
+        nodeDto.features = new FeaturesDto();
+        nodeDto.features.device_management_v1 = new DeviceManagementV1FeatureDto();
+        nodeDto.features.device_management_v1.productType = createSimpleFeatureAttributeDto(ProductType.HEATING);
+
+        return nodeDto;
+    }
+
+    public static Node getTestNodeWithFeatures(final Map<Class<? extends Feature>, Feature> features) {
+        return Node.builder()
+                .id(new NodeId(UUID.randomUUID()))
+                .name("dummy-node")
+                .nodeType(NodeType.THERMOSTAT)
+                .productType(ProductType.HEATING)
+                .protocol(Protocol.NONE)
+                .parentNodeId(new NodeId(UUID.randomUUID()))
+                .features(features)
+                .build();
+    }
+
+    public static void initMockChannel(
+            final Thing thingMock,
+            final String channelId,
+            final Channel channelMock,
+            final ChannelUID channelUidMock
+    ) {
+        when(thingMock.getChannel(channelId)).thenReturn(channelMock);
+        when(channelMock.getUID()).thenReturn(channelUidMock);
+        when(channelUidMock.getId()).thenReturn(channelId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/BatteryLevelTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/BatteryLevelTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class BatteryLevelTest {
+    private static final int BATTERY_FULL = 100;
+    private static final int BATTERY_NORMAL = 56;
+    private static final int BATTERY_EMPTY = 0;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTooBigBatteryLevel() {
+        new BatteryLevel(102);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTooNegativeBatteryLevel() {
+        new BatteryLevel(-2);
+    }
+
+    @Test
+    public void testFullBatteryLevel() {
+        /* When */
+        final BatteryLevel batteryLevel = new BatteryLevel(BATTERY_FULL);
+
+
+        /* Then */
+        assertThat(batteryLevel.intValue()).isEqualTo(BATTERY_FULL);
+        assertThat(batteryLevel.toString()).isEqualTo("100%");
+    }
+
+    @Test
+    public void testNormalBatteryLevel() {
+        /* When */
+        final BatteryLevel batteryLevel = new BatteryLevel(BATTERY_NORMAL);
+
+
+        /* Then */
+        assertThat(batteryLevel.intValue()).isEqualTo(BATTERY_NORMAL);
+        assertThat(batteryLevel.toString()).isEqualTo("56%");
+    }
+
+    @Test
+    public void testEmptyBatteryLevel() {
+        /* When */
+        final BatteryLevel batteryLevel = new BatteryLevel(BATTERY_EMPTY);
+
+
+        /* Then */
+        assertThat(batteryLevel.intValue()).isEqualTo(BATTERY_EMPTY);
+        assertThat(batteryLevel.toString()).isEqualTo("0%");
+    }
+
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(BatteryLevel.class)
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/DefaultHiveClientTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/DefaultHiveClientTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.exception.HiveApiAuthenticationException;
+import org.openhab.binding.hive.internal.client.exception.HiveApiUnknownException;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+import org.openhab.binding.hive.internal.client.repository.NodeRepository;
+import org.openhab.binding.hive.internal.client.repository.SessionRepository;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultHiveClientTest {
+    @NonNullByDefault({})
+    @Mock
+    private SessionAuthenticationManager authenticationManager;
+
+    @NonNullByDefault({})
+    @Mock
+    private SessionRepository sessionRepository;
+
+    @NonNullByDefault({})
+    @Mock
+    private NodeRepository nodeRepository;
+
+    @NonNullByDefault({})
+    private String username;
+
+    @NonNullByDefault({})
+    private String password;
+
+    @NonNullByDefault({})
+    private Session session;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        this.username = "hiveuser@example.com";
+        this.password = "password123";
+        this.session = new Session(
+                new SessionId("deadbeef-dead-beef-dead-beefdeadbeef"),
+                new UserId(UUID.fromString("deadbeef-dead-beef-dead-beefdeadbeef"))
+        );
+    }
+
+    private DefaultHiveClient createClient() throws HiveException {
+        return new DefaultHiveClient(
+                this.authenticationManager,
+                this.username,
+                this.password,
+                this.sessionRepository,
+                this.nodeRepository
+        );
+    }
+
+    /**
+     * Test that DefaultHiveClient tries to authenticate when it is created.
+     */
+    @Test
+    public void testGoodLogin() throws HiveException {
+        /* Given */
+        when(this.sessionRepository.createSession(any(), any())).thenReturn(this.session);
+
+
+        /* When */
+        final DefaultHiveClient hiveClient = createClient();
+
+
+        /* Then */
+        verify(this.sessionRepository, times(1)).createSession(eq(this.username), eq(this.password));
+        verify(this.authenticationManager, times(1)).setSession(eq(this.session));
+    }
+
+    /**
+     * Test that DefaultHiveClient passes on authentication exceptions.
+     */
+    @Test(expected = HiveApiAuthenticationException.class)
+    public void testBadCredentialsLogin() throws HiveException {
+        /* Given */
+        when(this.sessionRepository.createSession(any(), any())).thenThrow(new HiveApiAuthenticationException());
+
+
+        /* When / Then */
+        // This should throw HiveApiAuthenticationException.
+        // No assertThrows in this version of jUnit :(
+        final DefaultHiveClient hiveClient = createClient();
+    }
+
+    /**
+     * Test that DefaultHiveClient passes on exception when API does something unexpected.
+     */
+    @Test(expected = HiveApiUnknownException.class)
+    public void testApiErrorLogin() throws HiveException {
+        /* Given */
+        when(this.sessionRepository.createSession(any(), any())).thenThrow(new HiveApiUnknownException());
+
+
+        /* When / Then */
+        // This should throw HiveApiUnknownException.
+        // No assertThrows in this version of jUnit :(
+        final DefaultHiveClient hiveClient = createClient();
+    }
+
+    /**
+     * Test the DefaultHiveClient passes on the nodes from the NodeRepository.
+     */
+    @Test
+    public void testGetNodes() throws HiveException {
+        /* Given */
+        final Node expectedNode = TestUtil.getTestNodeWithFeatures(Collections.emptyMap());
+        final Set<Node> expectedResults = Collections.unmodifiableSet(Collections.singleton(expectedNode));
+        when(this.nodeRepository.getAllNodes()).thenReturn(expectedResults);
+
+        final DefaultHiveClient hiveClient = createClient();
+
+
+        /* When */
+        Set<Node> returnedResults = hiveClient.getAllNodes();
+
+
+        /* Then */
+        assertThat(returnedResults).containsExactly(expectedNode);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/Eui64Test.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/Eui64Test.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class Eui64Test {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(Eui64.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/GsonJsonServiceTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/GsonJsonServiceTest.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.dto.*;
+
+/**
+ * Tests for {@link GsonJsonService}.
+ *
+ * <p>
+ *     These are more like small integration tests than unit tests but it is
+ *     simpler to put here because we don't need all the OSGi stuff to work.
+ * </p>
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class GsonJsonServiceTest {
+    @NonNullByDefault({})
+    private JsonService jsonService;
+
+    @Before
+    public void setUp() {
+        this.jsonService = new GsonJsonService();
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testSessions() throws IOException {
+        /* Given */
+        final String json = TestUtil.getResourceAsString("/exampleSessions.json");
+
+        final SessionId sessionId = new SessionId("mytoken");
+        final String username = "hiveuser@example.com";
+        final UserId userId = new UserId(UUID.fromString("deadbeef-dead-beef-dead-beefdeadbeef"));
+
+
+        /* When */
+        final SessionsDto sessionsDto = jsonService.fromJson(json, SessionsDto.class);
+
+
+        /* Then */
+        assertThat(sessionsDto).isNotNull();
+        assertThat(sessionsDto.sessions).isNotNull();
+        assertThat(sessionsDto.sessions.size()).isEqualTo(1);
+
+        SessionDto sessionDto = sessionsDto.sessions.get(0);
+
+        assertThat(sessionDto.id).isEqualTo(sessionId);
+        assertThat(sessionDto.sessionId).isEqualTo(sessionId);
+        assertThat(sessionDto.username).isEqualTo(username);
+        assertThat(sessionDto.userId).isEqualTo(userId);
+        assertThat(sessionDto.extCustomerLevel).isEqualTo(1);
+        assertThat(sessionDto.latestSupportedApiVersion).isEqualTo("6");
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesRoot() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+        final NodeId nodeId = new NodeId(UUID.fromString("deadbeef-dead-beef-dead-beefdeadbeef"));
+        final String nodeName = "Thermostat 1";
+        final HiveApiInstant createdOn = new HiveApiInstant(Instant.ofEpochMilli(1513173613796L));
+        final HiveApiInstant firstInstall = new HiveApiInstant(Instant.ofEpochMilli(1513173925623L));
+        final UserId userId = new UserId(UUID.fromString("deadbeef-dead-beef-dead-beefdeadbeef"));
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+
+
+        /* Then */
+        // Check root fields parsed correctly
+        assertThat(nodesDto).isNotNull();
+        assertThat(nodesDto.nodes).isNotNull();
+        assertThat(nodesDto.nodes.size()).isEqualTo(1);
+
+        // Check node level fields parsed correctly
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+        assertThat(nodeDto.id).isEqualTo(nodeId);
+        assertThat(nodeDto.name).isEqualTo(nodeName);
+        assertThat(nodeDto.nodeType).isEqualTo(NodeType.THERMOSTAT);
+        assertThat(nodeDto.parentNodeId).isEqualTo(nodeId);
+        assertThat(nodeDto.createdOn).isEqualTo(createdOn);
+        assertThat(nodeDto.firstInstall).isEqualTo(firstInstall);
+        assertThat(nodeDto.userId).isEqualTo(userId);
+        assertThat(nodeDto.ownerId).isEqualTo(userId);
+        assertThat(nodeDto.homeId).isEqualTo("deadbeef-dead-beef-dead-beefdeadbeef");
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.lastUpgradeSucceeded).isFalse();
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureDeviceManagement() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.device_management_v1).isNotNull();
+        assertThat(nodeDto.features.device_management_v1.featureType).isNotNull();
+        assertThat(nodeDto.features.device_management_v1.featureType.reportedValue).isEqualTo(FeatureType.DEVICE_MANAGEMENT_V1);
+        assertThat(nodeDto.features.device_management_v1.productType).isNotNull();
+        assertThat(nodeDto.features.device_management_v1.productType.reportedValue).isEqualTo(ProductType.HEATING);
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureHeatingThermostat() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.heating_thermostat_v1).isNotNull();
+        assertThat(nodeDto.features.heating_thermostat_v1.featureType).isNotNull();
+        assertThat(nodeDto.features.heating_thermostat_v1.featureType.reportedValue).isEqualTo(FeatureType.HEATING_THERMOSTAT_V1);
+        assertThat(nodeDto.features.heating_thermostat_v1.operatingMode).isNotNull();
+        assertThat(nodeDto.features.heating_thermostat_v1.operatingMode.reportedValue).isEqualTo(HeatingThermostatOperatingMode.SCHEDULE);
+        assertThat(nodeDto.features.heating_thermostat_v1.targetHeatTemperature).isNotNull();
+        assertThat(nodeDto.features.heating_thermostat_v1.targetHeatTemperature.reportedValue).isEqualTo(BigDecimal.valueOf(7));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureOnOffDevice() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.on_off_device_v1).isNotNull();
+        assertThat(nodeDto.features.on_off_device_v1.featureType).isNotNull();
+        assertThat(nodeDto.features.on_off_device_v1.featureType.reportedValue).isEqualTo(FeatureType.ON_OFF_DEVICE_V1);
+        assertThat(nodeDto.features.on_off_device_v1.mode).isNotNull();
+        assertThat(nodeDto.features.on_off_device_v1.mode.reportedValue).isEqualTo(OnOffMode.ON);
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureTemperatureSensor() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.temperature_sensor_v1).isNotNull();
+        assertThat(nodeDto.features.temperature_sensor_v1.featureType).isNotNull();
+        assertThat(nodeDto.features.temperature_sensor_v1.featureType.reportedValue).isEqualTo(FeatureType.TEMPERATURE_SENSOR_V1);
+        assertThat(nodeDto.features.temperature_sensor_v1.temperature).isNotNull();
+        assertThat(nodeDto.features.temperature_sensor_v1.temperature.reportedValue).isEqualTo(BigDecimal.valueOf(19));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureTransientMode() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.transient_mode_v1).isNotNull();
+        assertThat(nodeDto.features.transient_mode_v1.duration).isNotNull();
+        assertThat(nodeDto.features.transient_mode_v1.duration.reportedValue).isEqualTo(1800);
+        assertThat(nodeDto.features.transient_mode_v1.endDatetime).isNotNull();
+        assertThat(nodeDto.features.transient_mode_v1.endDatetime.reportedValue).isEqualTo(ZonedDateTime.of(
+                2020,
+                3,
+                1,
+                22,
+                5,
+                44,
+                442000000,
+                ZoneOffset.UTC
+        ));
+
+        // TODO: Test more properties
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testNodesFeatureLinks() throws IOException {
+        /* Given */
+        String json = TestUtil.getResourceAsString("/exampleThermostatNode.json");
+
+
+        /* When */
+        final NodesDto nodesDto = jsonService.fromJson(json, NodesDto.class);
+        final NodeDto nodeDto = nodesDto.nodes.get(0);
+
+
+        /* Then */
+        assertThat(nodeDto.features).isNotNull();
+        assertThat(nodeDto.features.links_v1).isNotNull();
+        assertThat(nodeDto.features.links_v1.featureType).isNotNull();
+        assertThat(nodeDto.features.links_v1.featureType.reportedValue).isEqualTo(FeatureType.LINKS_V1);
+        assertThat(nodeDto.features.links_v1.links).isNull();
+        assertThat(nodeDto.features.links_v1.reverseLinks).isNotNull();
+
+        assertThat(nodeDto.features.links_v1.reverseLinks.reportedValue.size()).isEqualTo(2);
+        final ReverseLinkDto reverseLinkDto = nodeDto.features.links_v1.reverseLinks.reportedValue.iterator().next();
+        assertThat(reverseLinkDto.boundNode).isEqualTo(new NodeId(UUID.fromString("deadbeef-dead-beef-dead-beefdeadbeef")));
+        assertThat(reverseLinkDto.bindingGroupIds).containsExactly(GroupId.TRVBM);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/LinkTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/LinkTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class LinkTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(Link.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .verify();
+    }
+
+    @Test
+    public void testGetters() {
+        /* Given */
+        final NodeId originalNodeId = new NodeId(UUID.randomUUID());
+        final GroupId originalGroupId = GroupId.TRVS;
+
+        final Link link = new Link(
+                originalNodeId,
+                originalGroupId
+        );
+
+
+        /* When */
+        final NodeId gotNodeId = link.getNodeId();
+        final GroupId gotGroupId = link.getGroupId();
+
+
+        /* Then */
+        assertThat(gotNodeId).isEqualTo(originalNodeId);
+        assertThat(gotGroupId).isEqualTo(originalGroupId);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/NodeIdTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/NodeIdTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class NodeIdTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(NodeId.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .usingGetClass()
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/ReverseLinkTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/ReverseLinkTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ReverseLinkTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(ReverseLink.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/SessionIdTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/SessionIdTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class SessionIdTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(SessionId.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .usingGetClass()
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/SessionTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/SessionTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class SessionTest {
+    final SessionId sessionId = new SessionId("my-session-id");
+    final UserId userId = new UserId(UUID.randomUUID());
+
+    @Test
+    public void testGetters() {
+        /* Given */
+
+
+        /* When */
+        final Session session = new Session(sessionId, userId);
+
+
+        /* Then */
+        assertThat(session.getSessionId()).isEqualTo(sessionId);
+        assertThat(session.getUserId()).isEqualTo(userId);
+
+        assertThat(session.toString()).isNotNull();
+    }
+
+    @Test
+    public void testToString() {
+        /* Given */
+        final Session session = new Session(sessionId, userId);
+
+        /* When */
+
+        final String stringValue = session.toString();
+
+        /* Then */
+        assertThat(stringValue).isNotNull();
+    }
+
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(Session.class)
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/UserIdTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/UserIdTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class UserIdTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.forClass(UserId.class)
+                // Value field is not allowed to be null.
+                .suppress(Warning.NULL_FIELDS)
+                .usingGetClass()
+                .verify();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ActionTypeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ActionTypeGsonAdapterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.ActionType;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ActionTypeGsonAdapterTest extends ComplexEnumGsonAdapterTest<ActionType, ActionTypeGsonAdapter> {
+    @Override
+    protected ActionTypeGsonAdapter getAdapter() {
+        return new ActionTypeGsonAdapter();
+    }
+
+    protected List<List<Object>> getGoodParams() {
+        return Collections.singletonList(
+                Arrays.asList(ActionType.GENERIC, HiveApiConstants.ACTION_TYPE_GENERIC)
+        );
+    }
+
+    protected ActionType getUnexpectedEnum() {
+        return ActionType.UNEXPECTED;
+    }
+
+    protected String getUnexpectedString() {
+        return "http://alertme.com/schema/json/configuration/something.unexpected.json#";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/AttributeNameGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/AttributeNameGsonAdapterTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.AttributeName;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class AttributeNameGsonAdapterTest extends ComplexEnumGsonAdapterTest<AttributeName, AttributeNameGsonAdapter> {
+    @Override
+    protected AttributeNameGsonAdapter getAdapter() {
+        return new AttributeNameGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(
+                        AttributeName.HEATING_THERMOSTAT_TARGET_HEAT_TEMPERATURE,
+                        HiveApiConstants.ATTRIBUTE_NAME_HEATING_THERMOSTAT_V1_TARGET_HEAT_TEMPERATURE
+                ),
+                Arrays.asList(
+                        AttributeName.ON_OFF_DEVICE_MODE,
+                        HiveApiConstants.ATTRIBUTE_NAME_ON_OFF_DEVICE_V1_MODE
+                ),
+                Arrays.asList(
+                        AttributeName.WATER_HEATER_HEATING_OPERATING_MODE,
+                        HiveApiConstants.ATTRIBUTE_NAME_WATER_HEATER_V1_OPERATING_MODE
+                )
+        );
+    }
+
+    @Override
+    protected AttributeName getUnexpectedEnum() {
+        return AttributeName.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "somethingUnexpected";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ComplexEnumGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ComplexEnumGsonAdapterTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@RunWith(JUnitParamsRunner.class)
+@NonNullByDefault
+public abstract class ComplexEnumGsonAdapterTest<E extends Enum<E>, T extends TypeAdapter<E>> extends GsonAdapterTestBase<T> {
+    protected abstract List<List<Object>> getGoodParams();
+    protected abstract E getUnexpectedEnum();
+    protected abstract String getUnexpectedString();
+
+    @Test
+    @Parameters(method = "getGoodParams")
+    @TestCaseName("read(\"{1}\") = {0}")
+    public void testReadGoodValue(
+            final E expectedEnumValue,
+            String providedStringValue
+    ) throws IOException {
+        testReadValue(expectedEnumValue, toJsonString(providedStringValue));
+    }
+
+    @Test
+    @Parameters(method = "getGoodParams")
+    @TestCaseName("write({0}) = \"{1}\"")
+    public void testWriteGoodValue(
+            final E providedEnumValue,
+            String expectedStringValue
+    ) throws IOException {
+        testWriteValue(providedEnumValue, toJsonString(expectedStringValue));
+    }
+
+    @Test
+    public void testReadUnexpectedValue() throws IOException {
+        testReadValue(this.getUnexpectedEnum(), toJsonString(this.getUnexpectedString()));
+    }
+
+    @Test
+    public void testWriteUnexpectedValue() throws IOException {
+        testWriteValue(this.getUnexpectedEnum(), JSON_NULL);
+    }
+
+    private void testReadValue(
+            final E expectedEnumValue,
+            String providedStringValue
+    ) throws IOException {
+        /* Given */
+        final JsonReader jsonReader = new JsonReader(
+                new StringReader(providedStringValue)
+        );
+
+        final T adapter = this.getAdapter();
+
+
+        /* When */
+        final E enumValue = adapter.read(jsonReader);
+
+
+        /* Then */
+        assertThat(enumValue).isEqualTo(expectedEnumValue);
+    }
+
+    private void testWriteValue(
+            final E providedEnumValue,
+            String expectedStringValue
+    ) throws IOException {
+        /* Given */
+        final StringWriter stringWriter = new StringWriter();
+        final JsonWriter jsonWriter = new JsonWriter(stringWriter);
+
+        final T adapter = this.getAdapter();
+
+
+        /* When */
+        adapter.write(jsonWriter, providedEnumValue);
+
+
+        /* Then */
+        assertThat(stringWriter.toString()).isEqualTo(expectedStringValue);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/Eui64GsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/Eui64GsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class Eui64GsonAdapterTest extends GsonAdapterTestBase<Eui64GsonAdapter> {
+    @Override
+    protected Eui64GsonAdapter getAdapter() {
+        return new Eui64GsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/FeatureTypeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/FeatureTypeGsonAdapterTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.FeatureType;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class FeatureTypeGsonAdapterTest extends ComplexEnumGsonAdapterTest<FeatureType, FeatureTypeGsonAdapter> {
+    @Override
+    protected FeatureTypeGsonAdapter getAdapter() {
+        return new FeatureTypeGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(FeatureType.AUTOBOOST_V1, HiveApiConstants.FEATURE_TYPE_AUTOBOOST_V1),
+                Arrays.asList(FeatureType.BATTERY_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_BATTERY_DEVICE_V1),
+                Arrays.asList(FeatureType.CHILD_LOCK_V1, HiveApiConstants.FEATURE_TYPE_CHILD_LOCK_V1),
+                Arrays.asList(FeatureType.DEVICE_MANAGEMENT_V1, HiveApiConstants.FEATURE_TYPE_DEVICE_MANAGEMENT_V1),
+                Arrays.asList(FeatureType.DISPLAY_ORIENTATION_V1, HiveApiConstants.FEATURE_TYPE_DISPLAY_ORIENTATION_V1),
+                Arrays.asList(FeatureType.ETHERNET_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ETHERNET_DEVICE_V1),
+                Arrays.asList(FeatureType.FROST_PROTECT_V1, HiveApiConstants.FEATURE_TYPE_FROST_PROTECT_V1),
+                Arrays.asList(FeatureType.GROUP_V1, HiveApiConstants.FEATURE_TYPE_GROUP_V1),
+                Arrays.asList(FeatureType.HEATING_TEMPERATURE_CONTROL_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_DEVICE_V1),
+                Arrays.asList(FeatureType.HEATING_TEMPERATURE_CONTROL_V1, HiveApiConstants.FEATURE_TYPE_HEATING_TEMPERATURE_CONTROL_V1),
+                Arrays.asList(FeatureType.HEATING_THERMOSTAT_V1, HiveApiConstants.FEATURE_TYPE_HEATING_THERMOSTAT_V1),
+                Arrays.asList(FeatureType.HIVE_HUB_V1, HiveApiConstants.FEATURE_TYPE_HIVE_HUB_V1),
+                Arrays.asList(FeatureType.LIFECYCLE_STATE_V1, HiveApiConstants.FEATURE_TYPE_LIFECYCLE_STATE_V1),
+                Arrays.asList(FeatureType.LINKS_V1, HiveApiConstants.FEATURE_TYPE_LINKS_V1),
+                Arrays.asList(FeatureType.MOUNTING_MODE_V1, HiveApiConstants.FEATURE_TYPE_MOUNTING_MODE_V1),
+                Arrays.asList(FeatureType.ON_OFF_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ON_OFF_DEVICE_V1),
+                Arrays.asList(FeatureType.PI_HEATING_DEMAND_V1, HiveApiConstants.FEATURE_TYPE_PI_HEATING_DEMAND_V1),
+                Arrays.asList(FeatureType.PHYSICAL_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_PHYSICAL_DEVICE_V1),
+                Arrays.asList(FeatureType.RADIO_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_RADIO_DEVICE_V1),
+                Arrays.asList(FeatureType.STANDBY_V1, HiveApiConstants.FEATURE_TYPE_STANDBY_V1),
+                Arrays.asList(FeatureType.TEMPERATURE_SENSOR_V1, HiveApiConstants.FEATURE_TYPE_TEMPERATURE_SENSOR_V1),
+                Arrays.asList(FeatureType.TRANSIENT_MODE_V1, HiveApiConstants.FEATURE_TYPE_TRANSIENT_MODE_V1),
+                Arrays.asList(FeatureType.TRV_CALIBRATION_V1, HiveApiConstants.FEATURE_TYPE_TRV_CALIBRATION_V1),
+                Arrays.asList(FeatureType.TRV_ERROR_DIAGNOSTICS_V1, HiveApiConstants.FEATURE_TYPE_TRV_ERROR_DIAGNOSTICS_V1),
+                Arrays.asList(FeatureType.WATER_HEATER_V1, HiveApiConstants.FEATURE_TYPE_WATER_HEATER_V1),
+                Arrays.asList(FeatureType.ZIGBEE_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ZIGBEE_DEVICE_V1),
+                Arrays.asList(FeatureType.ZIGBEE_ROUTING_DEVICE_V1, HiveApiConstants.FEATURE_TYPE_ZIGBEE_ROUTING_DEVICE_V1)
+        );
+    }
+
+    @Override
+    protected FeatureType getUnexpectedEnum() {
+        return FeatureType.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "http://alertme.com/schema/json/feature/node.feature.something_unexpected.v1.json#";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/GroupIdGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/GroupIdGsonAdapterTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.GroupId;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class GroupIdGsonAdapterTest extends ComplexEnumGsonAdapterTest<GroupId, GroupIdGsonAdapter> {
+    @Override
+    protected GroupIdGsonAdapter getAdapter() {
+        return new GroupIdGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(
+                        GroupId.TRVBM,
+                        HiveApiConstants.GROUP_ID_TRVBM
+                ),
+                Arrays.asList(
+                        GroupId.TRVS,
+                        HiveApiConstants.GROUP_ID_TRVS
+                )
+        );
+    }
+
+    @Override
+    protected GroupId getUnexpectedEnum() {
+        return GroupId.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "unexpectedGroup";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/GsonAdapterTestBase.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/GsonAdapterTestBase.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Test;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public abstract class GsonAdapterTestBase<T extends TypeAdapter<?>> {
+    public static final String JSON_NULL = "null";
+
+    protected abstract T getAdapter();
+
+    protected String toJsonString(final String string) {
+        return "\"" + string + "\"";
+    }
+
+    /**
+     * Makes sure we actually output null instead of throwing a NPE.
+     */
+    @Test
+    public void testNullValue() throws IOException {
+        /* Given */
+        final StringWriter stringWriter = new StringWriter();
+        final JsonWriter jsonWriter = new JsonWriter(stringWriter);
+
+        final T adapter = getAdapter();
+
+
+        /* When */
+        adapter.write(jsonWriter, null);
+
+
+        /* Then */
+        // No exceptions hopefully!
+        assertThat(stringWriter.toString()).isEqualTo(JSON_NULL);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/HiveApiInstantGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/HiveApiInstantGsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class HiveApiInstantGsonAdapterTest extends GsonAdapterTestBase<HiveApiInstantGsonAdapter> {
+    @Override
+    protected HiveApiInstantGsonAdapter getAdapter() {
+        return new HiveApiInstantGsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/NodeIdGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/NodeIdGsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class NodeIdGsonAdapterTest extends GsonAdapterTestBase<NodeIdGsonAdapter> {
+    @Override
+    protected NodeIdGsonAdapter getAdapter() {
+        return new NodeIdGsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/NodeTypeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/NodeTypeGsonAdapterTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.NodeType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class NodeTypeGsonAdapterTest extends ComplexEnumGsonAdapterTest<NodeType, NodeTypeGsonAdapter> {
+    @Override
+    protected NodeTypeGsonAdapter getAdapter() {
+        return new NodeTypeGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(NodeType.HUB, HiveApiConstants.NODE_TYPE_HUB),
+                Arrays.asList(NodeType.RADIATOR_VALVE, HiveApiConstants.NODE_TYPE_RADIATOR_VALVE),
+                Arrays.asList(NodeType.SYNTHETIC_DAYLIGHT, HiveApiConstants.NODE_TYPE_SYNTHETIC_DAYLIGHT),
+                Arrays.asList(NodeType.SYNTHETIC_HOME_STATE, HiveApiConstants.NODE_TYPE_SYNTHETIC_HOME_STATE),
+                Arrays.asList(NodeType.SYNTHETIC_RULE, HiveApiConstants.NODE_TYPE_SYNTHETIC_RULE),
+                Arrays.asList(NodeType.THERMOSTAT, HiveApiConstants.NODE_TYPE_THERMOSTAT),
+                Arrays.asList(NodeType.THERMOSTAT_UI, HiveApiConstants.NODE_TYPE_THERMOSTAT_UI)
+        );
+    }
+
+    @Override
+    protected NodeType getUnexpectedEnum() {
+        return NodeType.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "http://alertme.com/schema/json/node.class.something.unexpected.json#";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ProductTypeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ProductTypeGsonAdapterTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.ProductType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ProductTypeGsonAdapterTest extends ComplexEnumGsonAdapterTest<ProductType, ProductTypeGsonAdapter> {
+    @Override
+    protected ProductTypeGsonAdapter getAdapter() {
+        return new ProductTypeGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(ProductType.ACTIONS, HiveApiConstants.PRODUCT_TYPE_ACTIONS),
+                Arrays.asList(ProductType.BOILER_MODULE, HiveApiConstants.PRODUCT_TYPE_BOILER_MODULE),
+                Arrays.asList(ProductType.DAYLIGHT_SD, HiveApiConstants.PRODUCT_TYPE_DAYLIGHT_SD),
+                Arrays.asList(ProductType.HEATING, HiveApiConstants.PRODUCT_TYPE_HEATING),
+                Arrays.asList(ProductType.HOT_WATER, HiveApiConstants.PRODUCT_TYPE_HOT_WATER),
+                Arrays.asList(ProductType.HUB, HiveApiConstants.PRODUCT_TYPE_HUB),
+                Arrays.asList(ProductType.THERMOSTAT_UI, HiveApiConstants.PRODUCT_TYPE_THERMOSTAT_UI),
+                Arrays.asList(ProductType.TRV, HiveApiConstants.PRODUCT_TYPE_TRV),
+                Arrays.asList(ProductType.TRV_GROUP, HiveApiConstants.PRODUCT_TYPE_TRV_GROUP),
+                Arrays.asList(ProductType.UNKNOWN, HiveApiConstants.PRODUCT_TYPE_UNKNOWN)
+        );
+    }
+
+    @Override
+    protected ProductType getUnexpectedEnum() {
+        return ProductType.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "SOMETHING_UNEXPECTED";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ProtocolGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ProtocolGsonAdapterTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.Protocol;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ProtocolGsonAdapterTest extends ComplexEnumGsonAdapterTest<Protocol, ProtocolGsonAdapter> {
+    @Override
+    protected ProtocolGsonAdapter getAdapter() {
+        return new ProtocolGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Arrays.asList(
+                Arrays.asList(
+                        Protocol.MQTT,
+                        HiveApiConstants.PROTOCOL_MQTT
+                ),
+                Arrays.asList(
+                        Protocol.PROXIED,
+                        HiveApiConstants.PROTOCOL_PROXIED
+                ),
+                Arrays.asList(
+                        Protocol.SYNTHETIC,
+                        HiveApiConstants.PROTOCOL_SYNTHETIC
+                ),
+                Arrays.asList(
+                        Protocol.VIRTUAL,
+                        HiveApiConstants.PROTOCOL_VIRTUAL
+                ),
+                Arrays.asList(
+                        Protocol.XMPP,
+                        HiveApiConstants.PROTOCOL_XMPP
+                ),
+                Arrays.asList(
+                        Protocol.ZIGBEE,
+                        HiveApiConstants.PROTOCOL_ZIGBEE
+                )
+        );
+    }
+
+    @Override
+    protected Protocol getUnexpectedEnum() {
+        return Protocol.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "SOMETHING_UNEXPECTED";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ScheduleTypeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ScheduleTypeGsonAdapterTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hive.internal.client.HiveApiConstants;
+import org.openhab.binding.hive.internal.client.ScheduleType;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ScheduleTypeGsonAdapterTest extends ComplexEnumGsonAdapterTest<ScheduleType, ScheduleTypeGsonAdapter> {
+    @Override
+    protected ScheduleTypeGsonAdapter getAdapter() {
+        return new ScheduleTypeGsonAdapter();
+    }
+
+    @Override
+    protected List<List<Object>> getGoodParams() {
+        return Collections.singletonList(
+                Arrays.asList(
+                        ScheduleType.WEEKLY,
+                        HiveApiConstants.SCHEDULE_TYPE_WEEKLY
+                )
+        );
+    }
+
+    @Override
+    protected ScheduleType getUnexpectedEnum() {
+        return ScheduleType.UNEXPECTED;
+    }
+
+    @Override
+    protected String getUnexpectedString() {
+        return "http://alertme.com/schema/json/configuration/configuration.device.schedule.unexpected.type.v1.json#";
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/SessionIdGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/SessionIdGsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class SessionIdGsonAdapterTest extends GsonAdapterTestBase<SessionIdGsonAdapter> {
+    @Override
+    protected SessionIdGsonAdapter getAdapter() {
+        return new SessionIdGsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/UserIdGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/UserIdGsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class UserIdGsonAdapterTest extends GsonAdapterTestBase<UserIdGsonAdapter> {
+    @Override
+    protected UserIdGsonAdapter getAdapter() {
+        return new UserIdGsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ZonedDateTimeGsonAdapterTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/adapter/ZonedDateTimeGsonAdapterTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.adapter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ZonedDateTimeGsonAdapterTest extends GsonAdapterTestBase<ZonedDateTimeGsonAdapter> {
+    @Override
+    protected ZonedDateTimeGsonAdapter getAdapter() {
+        return new ZonedDateTimeGsonAdapter();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/repository/DefaultNodeRepositoryTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/repository/DefaultNodeRepositoryTest.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.dto.*;
+import org.openhab.binding.hive.internal.client.exception.HiveClientRequestException;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+import org.openhab.binding.hive.internal.client.feature.*;
+
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultNodeRepositoryTest {
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiRequestFactory requestFactory;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiRequest request;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiResponse response;
+
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    private void setUpSuccessResponse(final NodesDto content) throws HiveClientRequestException {
+        when(this.requestFactory.newRequest(any())).thenReturn(this.request);
+
+        when(this.request.accept(any())).thenReturn(this.request);
+        when(this.request.get()).thenReturn(this.response);
+
+        when(this.response.getStatusCode()).thenReturn(200);
+
+        when(this.response.getContent(eq(NodesDto.class))).thenReturn(content);
+    }
+
+    private static HeatingThermostatV1FeatureDto getGoodHeatingThermostatV1FeatureDto() {
+        final HeatingThermostatV1FeatureDto heatingThermostatV1FeatureDto = new HeatingThermostatV1FeatureDto();
+        heatingThermostatV1FeatureDto.operatingMode = TestUtil.createSimpleFeatureAttributeDto(HeatingThermostatOperatingMode.SCHEDULE);
+        heatingThermostatV1FeatureDto.operatingState = TestUtil.createSimpleFeatureAttributeDto(HeatingThermostatOperatingState.OFF);
+        heatingThermostatV1FeatureDto.targetHeatTemperature = TestUtil.createSimpleFeatureAttributeDto(BigDecimal.valueOf(20));
+        heatingThermostatV1FeatureDto.temporaryOperatingModeOverride = TestUtil.createSimpleFeatureAttributeDto(OverrideMode.NONE);
+
+        return heatingThermostatV1FeatureDto;
+    }
+
+    private static TransientModeV1FeatureDto getGoodTransientModeV1FeatureDtoWithoutActions() {
+        final TransientModeV1FeatureDto transientModeV1FeatureDto = new TransientModeV1FeatureDto();
+        transientModeV1FeatureDto.duration = TestUtil.createSimpleFeatureAttributeDto(60000L);
+        transientModeV1FeatureDto.isEnabled = TestUtil.createSimpleFeatureAttributeDto(true);
+        transientModeV1FeatureDto.startDatetime = TestUtil.createSimpleFeatureAttributeDto(Instant.now().atZone(ZoneId.systemDefault()));
+        transientModeV1FeatureDto.endDatetime = TestUtil.createSimpleFeatureAttributeDto(Instant.now().atZone(ZoneId.systemDefault()));
+
+        return transientModeV1FeatureDto;
+    }
+
+    @Test
+    public void testGetNode() throws HiveException {
+        /* Given */
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.emptyList();
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final NodeId nodeId = TestUtil.NODE_ID_DEADBEEF;
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        nodeRepository.getNode(nodeId);
+
+
+        /* Then */
+        verify(this.requestFactory, times(1)).newRequest(URI.create("nodes/" + nodeId.toString()));
+    }
+
+    /**
+     * Make sure an exception is not thrown when the transient mode feature has
+     * no actions.
+     */
+    @Test
+    public void testHeatingWithMissingTransientActions() throws HiveException {
+        /* Given */
+        final NodeId nodeId = TestUtil.NODE_ID_DEADBEEF;
+        final NodeDto nodeDto = TestUtil.createSimpleNodeDto(nodeId);
+        assert nodeDto.features != null;
+
+        // Add Heating Thermostat feature
+        nodeDto.features.heating_thermostat_v1 = getGoodHeatingThermostatV1FeatureDto();
+
+        // Add Transient Mode but leave actions null
+        nodeDto.features.transient_mode_v1 = getGoodTransientModeV1FeatureDtoWithoutActions();
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        final @Nullable Node node = nodeRepository.getNode(nodeId);
+
+
+        /* Then */
+        // No exceptions hopefully!
+        assertThat(node).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = node.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        final @Nullable TransientModeFeature transientModeFeature = node.getFeature(TransientModeFeature.class);
+        assertThat(transientModeFeature).isNotNull();
+
+        final @Nullable TransientModeHeatingActionsFeature transientModeHeatingActionsFeature = node.getFeature(TransientModeHeatingActionsFeature.class);
+        assertThat(transientModeHeatingActionsFeature).isNull();
+    }
+
+    @Test
+    public void testHeatingWithGoodTransientActions() throws HiveException {
+        /* Given */
+        final NodeId nodeId = TestUtil.NODE_ID_DEADBEEF;
+        final NodeDto nodeDto = TestUtil.createSimpleNodeDto(nodeId);
+        assert nodeDto.features != null;
+
+        // Add Heating Thermostat feature
+        nodeDto.features.heating_thermostat_v1 = getGoodHeatingThermostatV1FeatureDto();
+
+        // Add Transient Mode with action
+        final int boostTargetTemperature = 22;
+        final ActionDto actionDto = new ActionDto();
+        actionDto.actionType = ActionType.GENERIC;
+        actionDto.attribute = AttributeName.HEATING_THERMOSTAT_TARGET_HEAT_TEMPERATURE;
+        actionDto.value = Integer.toString(boostTargetTemperature);
+
+        nodeDto.features.transient_mode_v1 = getGoodTransientModeV1FeatureDtoWithoutActions();
+        nodeDto.features.transient_mode_v1.actions = TestUtil.createSimpleFeatureAttributeDto(Collections.singletonList(actionDto));
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        final @Nullable Node node = nodeRepository.getNode(nodeId);
+
+
+        /* Then */
+        assertThat(node).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = node.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        final @Nullable TransientModeFeature transientModeFeature = node.getFeature(TransientModeFeature.class);
+        assertThat(transientModeFeature).isNotNull();
+
+        final @Nullable TransientModeHeatingActionsFeature transientModeHeatingActionsFeature = node.getFeature(TransientModeHeatingActionsFeature.class);
+        assertThat(transientModeHeatingActionsFeature).isNotNull();
+        assertThat(transientModeHeatingActionsFeature.getBoostTargetTemperature().getDisplayValue()).isEqualTo(Quantities.getQuantity(boostTargetTemperature, Units.CELSIUS));
+    }
+
+    @Test
+    public void testLinksFeatureNoLinks() throws HiveException {
+        /* Given */
+        final ReverseLinkDto reverseLinkDto = new ReverseLinkDto();
+        reverseLinkDto.boundNode = TestUtil.NODE_ID_CAFEBABE;
+        reverseLinkDto.bindingGroupIds = Collections.singleton(GroupId.TRVBM);
+
+        final NodeDto nodeDto = TestUtil.createSimpleNodeDto(TestUtil.NODE_ID_DEADBEEF);
+        assert nodeDto.features != null;
+        nodeDto.features.links_v1 = new LinksV1FeatureDto();
+        nodeDto.features.links_v1.reverseLinks = TestUtil.createSimpleFeatureAttributeDto(Collections.singleton(reverseLinkDto));
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        final @Nullable Node linksNode = nodeRepository.getNode(TestUtil.NODE_ID_DEADBEEF);
+
+
+        /* Then */
+        // No exceptions hopefully!
+        assertThat(linksNode).isNotNull();
+
+        final @Nullable LinksFeature linksFeature = linksNode.getFeature(LinksFeature.class);
+        assertThat(linksFeature).isNotNull();
+
+        assertThat(linksFeature.getLinks()).isNull();
+        assertThat(linksFeature.getReverseLinks()).isNotNull();
+
+        // TODO: verify more
+    }
+
+    @Test
+    public void testLinksFeatureNoReverseLinks() throws HiveException {
+        /* Given */
+        final LinkDto linkDto = new LinkDto();
+        linkDto.boundNode = TestUtil.NODE_ID_CAFEBABE;
+        linkDto.bindingGroupId = GroupId.TRVBM;
+
+        final NodeDto nodeDto = TestUtil.createSimpleNodeDto(TestUtil.NODE_ID_DEADBEEF);
+        nodeDto.features.links_v1 = new LinksV1FeatureDto();
+        nodeDto.features.links_v1.links = TestUtil.createSimpleFeatureAttributeDto(Collections.singleton(linkDto));
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        final @Nullable Node linksNode = nodeRepository.getNode(TestUtil.NODE_ID_DEADBEEF);
+
+
+        /* Then */
+        // No exceptions hopefully!
+        assertThat(linksNode).isNotNull();
+
+        final @Nullable LinksFeature linksFeature = linksNode.getFeature(LinksFeature.class);
+        assertThat(linksFeature).isNotNull();
+
+        assertThat(linksFeature.getLinks()).isNotNull();
+        assertThat(linksFeature.getReverseLinks()).isNull();
+
+        // TODO: verify more
+    }
+
+    @Test
+    public void testAutoBoostFeature() throws HiveException {
+        /* Given */
+        final long autoBoostDurationMins = 30L;
+        final BigDecimal autoBoostTargetHeatTemperature = BigDecimal.valueOf(22);
+
+        final AutoBoostV1FeatureDto autoBoostV1FeatureDto = new AutoBoostV1FeatureDto();
+        autoBoostV1FeatureDto.autoBoostDuration = TestUtil.createSimpleFeatureAttributeDto(autoBoostDurationMins);
+        autoBoostV1FeatureDto.autoBoostTargetHeatTemperature = TestUtil.createSimpleFeatureAttributeDto(autoBoostTargetHeatTemperature);
+
+        final NodeDto nodeDto = TestUtil.createSimpleNodeDto(TestUtil.NODE_ID_DEADBEEF);
+        assert nodeDto.features != null;
+        nodeDto.features.autoboost_v1 = autoBoostV1FeatureDto;
+
+        final NodesDto nodesDto = new NodesDto();
+        nodesDto.nodes = Collections.singletonList(nodeDto);
+
+        this.setUpSuccessResponse(nodesDto);
+
+        final DefaultNodeRepository nodeRepository = new DefaultNodeRepository(this.requestFactory);
+
+
+        /* When */
+        final @Nullable Node node = nodeRepository.getNode(TestUtil.NODE_ID_DEADBEEF);
+
+
+        /* Then */
+        // No exceptions hopefully!
+        assertThat(node).isNotNull();
+
+        final @Nullable AutoBoostFeature autoBoostFeature = node.getFeature(AutoBoostFeature.class);
+        assertThat(autoBoostFeature).isNotNull();
+
+        assertThat(autoBoostFeature.getAutoBoostDuration().getReportedValue()).isEqualTo(Duration.ofMinutes(autoBoostDurationMins));
+        assertThat(autoBoostFeature.getAutoBoostDuration().getDisplayValue()).isEqualTo(Duration.ofMinutes(autoBoostDurationMins));
+
+        assertThat(autoBoostFeature.getAutoBoostTargetHeatTemperature().getReportedValue()).isEqualTo(Quantities.getQuantity(autoBoostTargetHeatTemperature, Units.CELSIUS));
+        assertThat(autoBoostFeature.getAutoBoostTargetHeatTemperature().getDisplayValue()).isEqualTo(Quantities.getQuantity(autoBoostTargetHeatTemperature, Units.CELSIUS));
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/repository/DefaultSessionRepositoryTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/client/repository/DefaultSessionRepositoryTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.client.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.dto.HeatingThermostatV1FeatureDto;
+import org.openhab.binding.hive.internal.client.dto.SessionDto;
+import org.openhab.binding.hive.internal.client.dto.SessionsDto;
+import org.openhab.binding.hive.internal.client.exception.HiveApiAuthenticationException;
+import org.openhab.binding.hive.internal.client.exception.HiveApiUnknownException;
+import org.openhab.binding.hive.internal.client.exception.HiveClientRequestException;
+import org.openhab.binding.hive.internal.client.exception.HiveClientResponseException;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultSessionRepositoryTest {
+    private static final SessionId SESSION_ID = new SessionId("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJob25leWNvbWIiLCJleHAiOjE1ODc2MDUwMDYsInV1aWQiOiIzZTgzYzQzZS1mN2Y2LTRhNDMtYjM5Zi0yYjFkOTc2MjVlY2EiLCJ1c2VybmFtZSI6ImpvaG4uc21pdGhAZXhhbXBsZS5jb20iLCJqdGkiOiIwMGNhN2NhOC0wMTM4LTQxMTctYTAyNi0zMWYwMzg5YTk5NTkiLCJpYXQiOjE1ODc2MDE0MDZ9.vTao7fUmEBzBY1Ha1PR4di6pngnRQ9i9tDD6gFp9M-I");
+    private static final UserId USER_ID = new UserId(UUID.fromString(TestUtil.UUID_DEADBEEF));
+    private static final String USERNAME = "john.smith@example.com";
+    private static final String PASSWORD = "super_secret_password";
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiRequestFactory requestFactory;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiRequest request;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveApiResponse response;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    private void setUpSuccessResponse(final SessionsDto content) throws HiveClientRequestException {
+        when(this.requestFactory.newRequest(any())).thenReturn(this.request);
+
+        when(this.request.accept(any())).thenReturn(this.request);
+        when(this.request.post(any())).thenReturn(this.response);
+
+        when(this.response.getStatusCode()).thenReturn(200);
+
+        when(this.response.getContent(eq(SessionsDto.class))).thenReturn(content);
+    }
+
+    private static HeatingThermostatV1FeatureDto getGoodHeatingThermostatV1FeatureDto() {
+        final HeatingThermostatV1FeatureDto heatingThermostatV1FeatureDto = new HeatingThermostatV1FeatureDto();
+        heatingThermostatV1FeatureDto.operatingMode = TestUtil.createSimpleFeatureAttributeDto(HeatingThermostatOperatingMode.SCHEDULE);
+        heatingThermostatV1FeatureDto.operatingState = TestUtil.createSimpleFeatureAttributeDto(HeatingThermostatOperatingState.OFF);
+        heatingThermostatV1FeatureDto.targetHeatTemperature = TestUtil.createSimpleFeatureAttributeDto(BigDecimal.valueOf(20));
+        heatingThermostatV1FeatureDto.temporaryOperatingModeOverride = TestUtil.createSimpleFeatureAttributeDto(OverrideMode.NONE);
+
+        return heatingThermostatV1FeatureDto;
+    }
+
+    @Test
+    public void testGoodCreateSession() throws HiveClientRequestException, HiveClientResponseException,
+            HiveApiUnknownException, HiveApiAuthenticationException {
+        /* Given */
+        final SessionDto sessionDto = new SessionDto();
+        sessionDto.username = USERNAME;
+        sessionDto.userId = USER_ID;
+        sessionDto.id = SESSION_ID;
+        sessionDto.sessionId = SESSION_ID;
+        sessionDto.extCustomerLevel = 1;
+        sessionDto.latestSupportedApiVersion = "6";
+
+        final SessionsDto sessionsDto = new SessionsDto();
+        sessionsDto.sessions = Collections.singletonList(sessionDto);
+
+        this.setUpSuccessResponse(sessionsDto);
+
+        final DefaultSessionRepository sessionRepository = new DefaultSessionRepository(this.requestFactory);
+
+
+        /* When */
+        final Session session = sessionRepository.createSession(USERNAME, PASSWORD);
+
+
+        /* Then */
+        // Make sure the API was called correctly
+        verify(this.requestFactory, times(1)).newRequest(HiveApiConstants.ENDPOINT_SESSIONS);
+
+        final ArgumentCaptor<SessionsDto> sessionsDtoArgumentCaptor = ArgumentCaptor.forClass(SessionsDto.class);
+        verify(this.request, times(1)).post(sessionsDtoArgumentCaptor.capture());
+        final SessionsDto putSessionsDto = sessionsDtoArgumentCaptor.getValue();
+        assertThat(putSessionsDto).isNotNull();
+        assertThat(putSessionsDto.sessions).isNotNull();
+        assertThat(putSessionsDto.sessions.size()).isEqualTo(1);
+        final @Nullable SessionDto putSessionDto = putSessionsDto.sessions.get(0);
+        assertThat(putSessionDto).isNotNull();
+        assertThat(putSessionDto.username).isEqualTo(USERNAME);
+        assertThat(putSessionDto.password).isEqualTo(PASSWORD);
+        assertThat(putSessionDto.id).isNull();
+        assertThat(putSessionDto.uuid).isNull();
+        assertThat(putSessionDto.userId).isNull();
+        assertThat(putSessionDto.sessionDuration).isNull();
+        assertThat(putSessionDto.extCustomerLevel).isNull();
+        assertThat(putSessionDto.href).isNull();
+
+        // Make sure the returned session is correct
+        assertThat(session.getSessionId()).isEqualTo(SESSION_ID);
+        assertThat(session.getUserId()).isEqualTo(USER_ID);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/discovery/DefaultHiveDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/discovery/DefaultHiveDiscoveryServiceTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.discovery;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.discovery.DiscoveryListener;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.MultithreadedTestBase;
+
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultHiveDiscoveryServiceTest extends MultithreadedTestBase {
+    private static final ThingUID BRIDGE_UID = new ThingUID(HiveBindingConstants.THING_TYPE_ACCOUNT, "mybridge");
+
+    @NonNullByDefault({})
+    @Mock
+    private DiscoveryListener discoveryListener;
+
+    public DefaultHiveDiscoveryServiceTest() {
+        super(200, TimeUnit.MILLISECONDS);
+    }
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testNoDiscoveries() throws TimeoutException, InterruptedException {
+        /* Given */
+        final DefaultHiveDiscoveryService defaultHiveDiscoveryService = new DefaultHiveDiscoveryService(BRIDGE_UID, this.getTestingPhaser());
+        defaultHiveDiscoveryService.addDiscoveryListener(this.discoveryListener);
+
+
+        /* When */
+        defaultHiveDiscoveryService.updateKnownNodes(Collections.emptySet());
+
+
+        /* Then */
+        this.awaitTestingPhaser();
+
+        verify(this.discoveryListener, never()).thingDiscovered(any(), any());
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/DefaultHiveAccountHandlerTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/DefaultHiveAccountHandlerTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.MultithreadedTestBase;
+import org.openhab.binding.hive.internal.client.HiveClient;
+import org.openhab.binding.hive.internal.client.HiveClientFactory;
+import org.openhab.binding.hive.internal.client.exception.HiveApiAuthenticationException;
+import org.openhab.binding.hive.internal.client.exception.HiveApiUnknownException;
+import org.openhab.binding.hive.internal.client.exception.HiveException;
+import org.openhab.binding.hive.internal.discovery.HiveDiscoveryService;
+import org.openhab.binding.hive.internal.discovery.HiveDiscoveryServiceFactory;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class DefaultHiveAccountHandlerTest extends MultithreadedTestBase {
+    private final Bridge bridge;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveClientFactory hiveClientFactory;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveClient hiveClient;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveDiscoveryServiceFactory hiveDiscoveryServiceFactory;
+
+    @NonNullByDefault({})
+    @Mock
+    private HiveDiscoveryService hiveDiscoveryService;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    public DefaultHiveAccountHandlerTest() {
+        super(200, TimeUnit.MILLISECONDS);
+
+        final Configuration bridgeConfig = new Configuration();
+        bridgeConfig.put("username", "hiveuser@example.com");
+        bridgeConfig.put("password", "supersecretpassword");
+        bridgeConfig.put("pollingInterval", "10");
+
+        this.bridge = BridgeBuilder.create(HiveBindingConstants.THING_TYPE_ACCOUNT, "dummy-account")
+                .withConfiguration(bridgeConfig)
+                .build();
+    }
+
+    @Before
+    public void setUp() throws HiveException {
+        initMocks(this);
+
+        when(this.hiveClient.getAllNodes()).thenReturn(Collections.emptySet());
+
+        when(this.hiveDiscoveryServiceFactory.create(any())).thenReturn(this.hiveDiscoveryService);
+    }
+
+    @Test
+    public void testDiscoveryServiceCreated() {
+        /* When */
+        final DefaultHiveAccountHandler accountHandler = new DefaultHiveAccountHandler(
+                this.hiveClientFactory,
+                this.hiveDiscoveryServiceFactory,
+                this.bridge
+        );
+
+
+        /* Then */
+        // Check the discovery service was created.
+        verify(this.hiveDiscoveryServiceFactory).create(this.bridge.getUID());
+
+        // Check the discovery service was stored.
+        assertThat(accountHandler.getDiscoveryService()).isEqualTo(this.hiveDiscoveryService);
+    }
+
+    @Test
+    public void testInitGood() throws TimeoutException, InterruptedException, HiveException {
+        /* Given */
+        final DefaultHiveAccountHandler accountHandler = new DefaultHiveAccountHandler(
+                this.hiveClientFactory,
+                this.hiveDiscoveryServiceFactory,
+                this.bridge,
+                this.getTestingPhaser()
+        );
+
+        accountHandler.setCallback(this.thingHandlerCallback);
+
+        // Throw an authentication exception when we try to create hive client.
+        when(this.hiveClientFactory.newClient(any(), any())).thenReturn(this.hiveClient);
+
+
+        /* When */
+        // Try to initialise handler
+        accountHandler.initialize();
+
+
+        /* Then */
+        // Wait for all initialize() tasks to execute
+        this.awaitTestingPhaser();
+
+        // Check the thing status was updated correctly.
+        final ArgumentCaptor<ThingStatusInfo> capturedThingStatusInfo = ArgumentCaptor.forClass(ThingStatusInfo.class);
+        verify(this.thingHandlerCallback, atLeastOnce()).statusUpdated(eq(this.bridge), capturedThingStatusInfo.capture());
+        final ThingStatusInfo lastStatusInfo = capturedThingStatusInfo.getValue();
+        assertThat(lastStatusInfo.getStatus()).isEqualTo(ThingStatus.ONLINE);
+    }
+
+    @Test
+    public void testInitBadCredentials() throws TimeoutException, InterruptedException, HiveException {
+        /* Given */
+        final DefaultHiveAccountHandler accountHandler = new DefaultHiveAccountHandler(
+                this.hiveClientFactory,
+                this.hiveDiscoveryServiceFactory,
+                this.bridge,
+                this.getTestingPhaser()
+        );
+
+        accountHandler.setCallback(this.thingHandlerCallback);
+
+        // Throw an authentication exception when we try to create hive client.
+        when(this.hiveClientFactory.newClient(any(), any())).thenThrow(
+                new HiveApiAuthenticationException()
+        );
+
+
+        /* When */
+        // Try to initialise handler
+        accountHandler.initialize();
+
+
+        /* Then */
+        // Wait for all initialize() tasks to execute
+        this.awaitTestingPhaser();
+
+        // Check the thing status was updated correctly.
+        final ArgumentCaptor<ThingStatusInfo> capturedThingStatusInfo = ArgumentCaptor.forClass(ThingStatusInfo.class);
+        verify(this.thingHandlerCallback, atLeastOnce()).statusUpdated(eq(this.bridge), capturedThingStatusInfo.capture());
+        final ThingStatusInfo lastStatusInfo = capturedThingStatusInfo.getValue();
+        assertThat(lastStatusInfo.getStatus()).isEqualTo(ThingStatus.OFFLINE);
+        assertThat(lastStatusInfo.getStatusDetail()).isEqualTo(ThingStatusDetail.CONFIGURATION_ERROR);
+    }
+
+    @Test
+    public void testInitApiException() throws TimeoutException, InterruptedException, HiveException {
+        /* Given */
+        final DefaultHiveAccountHandler accountHandler = new DefaultHiveAccountHandler(
+                this.hiveClientFactory,
+                this.hiveDiscoveryServiceFactory,
+                this.bridge,
+                this.getTestingPhaser()
+        );
+
+        accountHandler.setCallback(this.thingHandlerCallback);
+
+        // Throw an authentication exception when we try to create hive client.
+        when(this.hiveClientFactory.newClient(any(), any())).thenThrow(
+                new HiveApiUnknownException()
+        );
+
+
+        /* When */
+        // Try to initialise handler
+        accountHandler.initialize();
+
+
+        /* Then */
+        // Wait for all initialize() tasks to execute
+        this.awaitTestingPhaser();
+
+        // Check the thing status was updated correctly.
+        final ArgumentCaptor<ThingStatusInfo> capturedThingStatusInfo = ArgumentCaptor.forClass(ThingStatusInfo.class);
+        verify(this.thingHandlerCallback, atLeastOnce()).statusUpdated(eq(this.bridge), capturedThingStatusInfo.capture());
+        final ThingStatusInfo lastStatusInfo = capturedThingStatusInfo.getValue();
+        assertThat(lastStatusInfo.getStatus()).isEqualTo(ThingStatus.OFFLINE);
+        assertThat(lastStatusInfo.getStatusDetail()).isEqualTo(ThingStatusDetail.COMMUNICATION_ERROR);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatEasyHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatEasyHandlerStrategyTest.java
@@ -1,0 +1,551 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.*;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+import org.openhab.binding.hive.internal.client.feature.HeatingThermostatFeature;
+import org.openhab.binding.hive.internal.client.feature.OnOffDeviceFeature;
+
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class HeatingThermostatEasyHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyOperatingModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyOperatingModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyBoostModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyBoostModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyIsOnStateChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyIsOnStateChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING,
+                this.easyOperatingModeChannel,
+                this.easyOperatingModeChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_MODE_BOOST,
+                this.easyBoostModeChannel,
+                this.easyBoostModeChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_STATE_IS_ON,
+                this.easyIsOnStateChannel,
+                this.easyIsOnStateChannelUid
+        );
+    }
+
+    @Test
+    public void testNormalUpdateScheduleHeatNoneOn() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.SCHEDULE;
+        final HeatingThermostatOperatingState operatingState = HeatingThermostatOperatingState.HEAT;
+        final OverrideMode overrideMode = OverrideMode.NONE;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNode(
+                operatingMode,
+                operatingState,
+                overrideMode,
+                onOffMode
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyOperatingModeChannelUid),
+                eq(new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_SCHEDULE))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyBoostModeChannelUid),
+                eq(OnOffType.OFF)
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyIsOnStateChannelUid),
+                eq(OnOffType.ON)
+        );
+    }
+
+    @Test
+    public void testNormalUpdateManualHeatNoneOn() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.MANUAL;
+        final HeatingThermostatOperatingState operatingState = HeatingThermostatOperatingState.HEAT;
+        final OverrideMode overrideMode = OverrideMode.NONE;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNode(
+                operatingMode,
+                operatingState,
+                overrideMode,
+                onOffMode
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyOperatingModeChannelUid),
+                eq(new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_MANUAL))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyBoostModeChannelUid),
+                eq(OnOffType.OFF)
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyIsOnStateChannelUid),
+                eq(OnOffType.ON)
+        );
+    }
+
+    @Test
+    public void testNormalUpdateScheduleOffNoneOff() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.SCHEDULE;
+        final HeatingThermostatOperatingState operatingState = HeatingThermostatOperatingState.OFF;
+        final OverrideMode overrideMode = OverrideMode.NONE;
+        final OnOffMode onOffMode = OnOffMode.OFF;
+
+        // Create the test node
+        final Node node = getGoodNode(
+                operatingMode,
+                operatingState,
+                overrideMode,
+                onOffMode
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyOperatingModeChannelUid),
+                eq(new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_OFF))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyBoostModeChannelUid),
+                eq(OnOffType.OFF)
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyIsOnStateChannelUid),
+                eq(OnOffType.OFF)
+        );
+    }
+
+    @Test
+    public void testNormalUpdateScheduleHeatTransientOn() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.SCHEDULE;
+        final HeatingThermostatOperatingState operatingState = HeatingThermostatOperatingState.HEAT;
+        final OverrideMode overrideMode = OverrideMode.TRANSIENT;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNode(
+                operatingMode,
+                operatingState,
+                overrideMode,
+                onOffMode
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyOperatingModeChannelUid),
+                eq(new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_SCHEDULE))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyBoostModeChannelUid),
+                eq(OnOffType.ON)
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyIsOnStateChannelUid),
+                eq(OnOffType.ON)
+        );
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeManual() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.SCHEDULE;
+        final OnOffMode onOffMode = OnOffMode.OFF;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_MANUAL),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = updatedNode.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(heatingThermostatFeature.getOperatingMode().getTargetValue()).isEqualTo(HeatingThermostatOperatingMode.MANUAL);
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.ON);
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeSchedule() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.MANUAL;
+        final OnOffMode onOffMode = OnOffMode.OFF;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_SCHEDULE),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = updatedNode.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(heatingThermostatFeature.getOperatingMode().getTargetValue()).isEqualTo(HeatingThermostatOperatingMode.SCHEDULE);
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.ON);
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeOff() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.MANUAL;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HEATING_EASY_MODE_OPERATING_OFF),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.OFF);
+    }
+
+    @Test
+    public void testNormalCommandBoostOn() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForBoostCommandTest(OverrideMode.NONE);
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                OnOffType.ON,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = updatedNode.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        assertThat(heatingThermostatFeature.getTemporaryOperatingModeOverride().getTargetValue()).isEqualTo(OverrideMode.TRANSIENT);
+    }
+
+    @Test
+    public void testNormalCommandBoostOff() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForBoostCommandTest(OverrideMode.TRANSIENT);
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                OnOffType.OFF,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable HeatingThermostatFeature heatingThermostatFeature = updatedNode.getFeature(HeatingThermostatFeature.class);
+        assertThat(heatingThermostatFeature).isNotNull();
+
+        assertThat(heatingThermostatFeature.getTemporaryOperatingModeOverride().getTargetValue()).isEqualTo(OverrideMode.NONE);
+    }
+
+    @Test
+    public void testNormalRefreshOperatingMode() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForRefreshTest();
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                RefreshType.REFRESH,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNull();
+    }
+
+    @Test
+    public void testNormalRefreshBoost() {
+        /* Given */
+        final HeatingThermostatEasyHandlerStrategy strategy = new HeatingThermostatEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForRefreshTest();
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                RefreshType.REFRESH,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNull();
+    }
+
+    private static Node getGoodNodeForRefreshTest() {
+        return getGoodNode(
+                HeatingThermostatOperatingMode.SCHEDULE,
+                HeatingThermostatOperatingState.OFF,
+                OverrideMode.NONE,
+                OnOffMode.ON
+        );
+    }
+
+    private static Node getGoodNodeForBoostCommandTest(
+            final OverrideMode overrideMode
+    ) {
+        return getGoodNode(
+                HeatingThermostatOperatingMode.SCHEDULE,
+                HeatingThermostatOperatingState.OFF,
+                overrideMode,
+                OnOffMode.ON
+        );
+    }
+
+    private static Node getGoodNodeForOperatingModeCommandTest(
+            final HeatingThermostatOperatingMode operatingMode,
+            final OnOffMode onOffMode
+    ) {
+        return getGoodNode(
+                operatingMode,
+                HeatingThermostatOperatingState.OFF,
+                OverrideMode.NONE,
+                onOffMode
+        );
+    }
+
+    private static Node getGoodNode(
+            final HeatingThermostatOperatingMode operatingMode,
+            final HeatingThermostatOperatingState operatingState,
+            final OverrideMode overrideMode,
+            final OnOffMode onOffMode
+    ) {
+        final Map<Class<? extends Feature>, Feature> features = new HashMap<>();
+
+        // Create HeatingThermostatFeature
+        final Quantity<Temperature> targetHeatTemperature = Quantities.getQuantity(20, Units.CELSIUS);
+        final HeatingThermostatFeature heatingThermostatFeature = HeatingThermostatFeature.builder()
+                .operatingMode(TestUtil.createSimpleFeatureAttribute(operatingMode))
+                .operatingState(TestUtil.createSimpleFeatureAttribute(operatingState))
+                .targetHeatTemperature(TestUtil.createSimpleFeatureAttribute(targetHeatTemperature))
+                .temporaryOperatingModeOverride(TestUtil.createSimpleFeatureAttribute(overrideMode))
+                .build();
+
+        features.put(HeatingThermostatFeature.class, heatingThermostatFeature);
+
+        // Create OnOffDeviceFeature
+        final OnOffDeviceFeature onOffDeviceFeature = OnOffDeviceFeature.builder()
+                .mode(TestUtil.createSimpleFeatureAttribute(onOffMode))
+                .build();
+
+        features.put(OnOffDeviceFeature.class, onOffDeviceFeature);
+
+        return TestUtil.getTestNodeWithFeatures(features);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingThermostatHandlerStrategyTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.HeatingThermostatOperatingMode;
+import org.openhab.binding.hive.internal.client.HeatingThermostatOperatingState;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+import org.openhab.binding.hive.internal.client.feature.HeatingThermostatFeature;
+
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class HeatingThermostatHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Channel operatingModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID operatingModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel operatingStateChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID operatingStateChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel targetHeatTemperatureChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID targetHeatTemperatureChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel overrideModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID overrideModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_MODE_OPERATING,
+                this.operatingModeChannel,
+                this.operatingModeChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_STATE_OPERATING,
+                this.operatingStateChannel,
+                this.operatingStateChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET,
+                this.targetHeatTemperatureChannel,
+                this.targetHeatTemperatureChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_MODE_OPERATING_OVERRIDE,
+                this.overrideModeChannel,
+                this.overrideModeChannelUid
+        );
+    }
+
+    @Test
+    public void testNormalUpdate() {
+        /* Given */
+        final HeatingThermostatHandlerStrategy strategy = new HeatingThermostatHandlerStrategy();
+
+        final HeatingThermostatOperatingMode operatingMode = HeatingThermostatOperatingMode.SCHEDULE;
+        final HeatingThermostatOperatingState operatingState = HeatingThermostatOperatingState.HEAT;
+        final Quantity<Temperature> targetHeatTemperature = Quantities.getQuantity(20, Units.CELSIUS);
+        final OverrideMode overrideMode = OverrideMode.NONE;
+
+        final HeatingThermostatFeature heatingThermostatFeature = HeatingThermostatFeature.builder()
+                .operatingMode(TestUtil.createSimpleFeatureAttribute(operatingMode))
+                .operatingState(TestUtil.createSimpleFeatureAttribute(operatingState))
+                .targetHeatTemperature(TestUtil.createSimpleFeatureAttribute(targetHeatTemperature))
+                .temporaryOperatingModeOverride(TestUtil.createSimpleFeatureAttribute(overrideMode))
+                .build();
+
+        final Map<Class<? extends Feature>, Feature> features = new HashMap<>();
+        features.put(HeatingThermostatFeature.class, heatingThermostatFeature);
+
+        final Node node = TestUtil.getTestNodeWithFeatures(features);
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.operatingModeChannelUid),
+                eq(new StringType(operatingMode.toString()))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.operatingStateChannelUid),
+                eq(new StringType(operatingState.toString()))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.targetHeatTemperatureChannelUid),
+                eq(new QuantityType<>(targetHeatTemperature.getValue(), SIUnits.CELSIUS))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.overrideModeChannelUid),
+                eq(OnOffType.OFF)
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingTransientModeHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/HeatingTransientModeHandlerStrategyTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.TransientModeHeatingActionsFeature;
+
+import tec.uom.se.quantity.Quantities;
+import tec.uom.se.unit.Units;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class HeatingTransientModeHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Channel boostTargetTemperatureChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID boostTargetTemperatureChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_TEMPERATURE_TARGET_BOOST,
+                this.boostTargetTemperatureChannel,
+                this.boostTargetTemperatureChannelUid
+        );
+    }
+
+    @Test
+    public void testNormalUpdate() {
+        /* Given */
+        final HeatingTransientModeHandlerStrategy strategy = new HeatingTransientModeHandlerStrategy();
+
+        final Quantity<Temperature> boostTargetTemperature = Quantities.getQuantity(25, Units.CELSIUS);
+
+        // Create the test node
+        final TransientModeHeatingActionsFeature transientModeHeatingActionsFeature = TransientModeHeatingActionsFeature.builder()
+                .boostTargetTemperature(TestUtil.createSimpleFeatureAttribute(boostTargetTemperature))
+                .build();
+
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.singletonMap(
+                TransientModeHeatingActionsFeature.class, transientModeHeatingActionsFeature)
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.boostTargetTemperatureChannelUid),
+                eq(new QuantityType<>(boostTargetTemperature.getValue(), boostTargetTemperature.getUnit()))
+        );
+    }
+
+    @Test
+    public void testMissingFeatureUpdate() {
+        /* Given */
+        final HeatingTransientModeHandlerStrategy strategy = new HeatingTransientModeHandlerStrategy();
+
+        // Create the test node
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.emptyMap());
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.boostTargetTemperatureChannelUid),
+                eq(new QuantityType<>(
+                        HeatingTransientModeHandlerStrategy.DEFAULT_BOOST_TEMPERATURE.getValue(),
+                        HeatingTransientModeHandlerStrategy.DEFAULT_BOOST_TEMPERATURE.getUnit()
+                ))
+        );
+    }
+
+    @Test
+    public void testNormalCommand() {
+        /* Given */
+        final HeatingTransientModeHandlerStrategy strategy = new HeatingTransientModeHandlerStrategy();
+
+        final Quantity<Temperature> boostTargetTemperature = Quantities.getQuantity(25, Units.CELSIUS);
+        final Quantity<Temperature> newBoostTargetTemperature = Quantities.getQuantity(24, Units.CELSIUS);
+
+        // Create the test node
+        final TransientModeHeatingActionsFeature transientModeHeatingActionsFeature = TransientModeHeatingActionsFeature.builder()
+                .boostTargetTemperature(TestUtil.createSimpleFeatureAttribute(boostTargetTemperature))
+                .build();
+
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.singletonMap(
+                TransientModeHeatingActionsFeature.class, transientModeHeatingActionsFeature)
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.boostTargetTemperatureChannelUid,
+                new QuantityType<>(
+                        newBoostTargetTemperature.getValue(),
+                        newBoostTargetTemperature.getUnit()
+                ),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable TransientModeHeatingActionsFeature newTransientModeHeatingActionsFeature = updatedNode.getFeature(TransientModeHeatingActionsFeature.class);
+        assertThat(newTransientModeHeatingActionsFeature).isNotNull();
+
+        assertThat(newTransientModeHeatingActionsFeature.getBoostTargetTemperature().getTargetValue())
+                .isEqualTo(newBoostTargetTemperature);
+    }
+
+    @Test
+    public void testNormalRefresh() {
+        /* Given */
+        final HeatingTransientModeHandlerStrategy strategy = new HeatingTransientModeHandlerStrategy();
+
+        // Create the test node
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.emptyMap());
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.boostTargetTemperatureChannelUid,
+                RefreshType.REFRESH,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNull();
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/PhysicalDeviceHandlerStrategyTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.PhysicalDeviceFeature;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class PhysicalDeviceHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testUpdate() {
+        /* Given */
+        final String manufacturer = "TestManufacturer";
+        final String model = "TestModel";
+        final String softwareVersion = "TestSoftwareVersion";
+        final String hardwareIdentifier = "TestHardwareIdentifier";
+
+        final PhysicalDeviceHandlerStrategy strategy = new PhysicalDeviceHandlerStrategy();
+
+        // Create the test node
+        final PhysicalDeviceFeature physicalDeviceFeature = PhysicalDeviceFeature.builder()
+                .manufacturer(TestUtil.createSimpleFeatureAttribute(manufacturer))
+                .model(TestUtil.createSimpleFeatureAttribute(model))
+                .softwareVersion(TestUtil.createSimpleFeatureAttribute(softwareVersion))
+                .hardwareIdentifier(TestUtil.createSimpleFeatureAttribute(hardwareIdentifier))
+                .build();
+
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.singletonMap(
+                PhysicalDeviceFeature.class,
+                physicalDeviceFeature
+        ));
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thing).setProperty(
+                eq(Thing.PROPERTY_VENDOR),
+                eq(manufacturer)
+        );
+
+        verify(this.thing).setProperty(
+                eq(Thing.PROPERTY_MODEL_ID),
+                eq(model)
+        );
+
+        verify(this.thing).setProperty(
+                eq(Thing.PROPERTY_FIRMWARE_VERSION),
+                eq(softwareVersion)
+        );
+
+        verify(this.thing).setProperty(
+                eq(Thing.PROPERTY_SERIAL_NUMBER),
+                eq(hardwareIdentifier)
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterEasyHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/WaterHeaterEasyHandlerStrategyTest.java
@@ -1,0 +1,524 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.OnOffMode;
+import org.openhab.binding.hive.internal.client.OverrideMode;
+import org.openhab.binding.hive.internal.client.WaterHeaterOperatingMode;
+import org.openhab.binding.hive.internal.client.feature.Feature;
+import org.openhab.binding.hive.internal.client.feature.OnOffDeviceFeature;
+import org.openhab.binding.hive.internal.client.feature.TransientModeFeature;
+import org.openhab.binding.hive.internal.client.feature.WaterHeaterFeature;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@RunWith(JUnitParamsRunner.class)
+@NonNullByDefault
+public class WaterHeaterEasyHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyOperatingModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyOperatingModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyBoostModeChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyBoostModeChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel easyIsOnStateChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID easyIsOnStateChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_MODE_OPERATING,
+                this.easyOperatingModeChannel,
+                this.easyOperatingModeChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_MODE_BOOST,
+                this.easyBoostModeChannel,
+                this.easyBoostModeChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_EASY_STATE_IS_ON,
+                this.easyIsOnStateChannel,
+                this.easyIsOnStateChannelUid
+        );
+    }
+
+    @Test
+    @Parameters(method = "getUpdateParams")
+    @TestCaseName("Test Update [operatingMode: {0}, onOffMode: {3}, isOn: {1}, overrideMode: {2}] = [mode:{4}, boost:{5}]")
+    public void testUpdateEasyOperatingMode(
+            final WaterHeaterOperatingMode operatingMode,
+            final boolean isOn,
+            final OverrideMode overrideMode,
+            final OnOffMode onOffMode,
+            final String expectedEasyOperatingMode,
+            final OnOffType expectedBoostMode
+    ) {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+        // Create the test node
+        final Node node = getGoodNode(
+                operatingMode,
+                isOn,
+                overrideMode,
+                onOffMode
+        );
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyOperatingModeChannelUid),
+                eq(new StringType(expectedEasyOperatingMode))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.easyBoostModeChannelUid),
+                eq(expectedBoostMode)
+        );
+    }
+
+    public List<List<Object>> getUpdateParams() {
+        return Arrays.asList(
+                Arrays.asList(
+                        WaterHeaterOperatingMode.SCHEDULE,
+                        true,
+                        OverrideMode.NONE,
+                        OnOffMode.ON,
+                        HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_SCHEDULE,
+                        OnOffType.OFF
+                ),
+                Arrays.asList(
+                        WaterHeaterOperatingMode.ON,
+                        true,
+                        OverrideMode.NONE,
+                        OnOffMode.ON,
+                        HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_ON,
+                        OnOffType.OFF
+                ),
+                Arrays.asList(
+                        WaterHeaterOperatingMode.ON,
+                        false,
+                        OverrideMode.NONE,
+                        OnOffMode.OFF,
+                        HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_OFF,
+                        OnOffType.OFF
+                ),
+                Arrays.asList(
+                        WaterHeaterOperatingMode.SCHEDULE,
+                        false,
+                        OverrideMode.NONE,
+                        OnOffMode.OFF,
+                        HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_OFF,
+                        OnOffType.OFF
+                ),
+                Arrays.asList(
+                        WaterHeaterOperatingMode.SCHEDULE,
+                        true,
+                        OverrideMode.TRANSIENT,
+                        OnOffMode.ON,
+                        HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_SCHEDULE,
+                        OnOffType.ON
+                )
+        );
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeOnFromSchedule() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+        final WaterHeaterOperatingMode operatingMode = WaterHeaterOperatingMode.SCHEDULE;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_ON),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(waterHeaterFeature.getOperatingMode().getTargetValue()).isEqualTo(WaterHeaterOperatingMode.ON);
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.ON);
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeOnFromOff() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+        final WaterHeaterOperatingMode operatingMode = WaterHeaterOperatingMode.ON;
+        final OnOffMode onOffMode = OnOffMode.OFF;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_ON),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(waterHeaterFeature.getOperatingMode().getTargetValue()).isEqualTo(WaterHeaterOperatingMode.ON);
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.ON);
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeSchedule() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+        final WaterHeaterOperatingMode operatingMode = WaterHeaterOperatingMode.ON;
+        final OnOffMode onOffMode = OnOffMode.OFF;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_SCHEDULE),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(waterHeaterFeature.getOperatingMode().getTargetValue()).isEqualTo(WaterHeaterOperatingMode.SCHEDULE);
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.ON);
+    }
+
+    @Test
+    public void testNormalCommandOperatingModeOff() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+        final WaterHeaterOperatingMode operatingMode = WaterHeaterOperatingMode.ON;
+        final OnOffMode onOffMode = OnOffMode.ON;
+
+        // Create the test node
+        final Node node = getGoodNodeForOperatingModeCommandTest(
+                operatingMode,
+                onOffMode
+        );
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                new StringType(HiveBindingConstants.HOT_WATER_EASY_MODE_OPERATING_OFF),
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable OnOffDeviceFeature onOffDeviceFeature = updatedNode.getFeature(OnOffDeviceFeature.class);
+        assertThat(onOffDeviceFeature).isNotNull();
+
+        assertThat(onOffDeviceFeature.getMode().getTargetValue()).isEqualTo(OnOffMode.OFF);
+    }
+
+    @Test
+    public void testNormalCommandBoostOn() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForBoostCommandTest(OverrideMode.NONE);
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                OnOffType.ON,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable TransientModeFeature transientModeFeature = updatedNode.getFeature(TransientModeFeature.class);
+        assertThat(transientModeFeature).isNotNull();
+
+        assertThat(waterHeaterFeature.getTemporaryOperatingModeOverride().getTargetValue()).isEqualTo(OverrideMode.TRANSIENT);
+        assertThat(transientModeFeature.getIsEnabled().getTargetValue()).isEqualTo(true);
+    }
+
+    @Test
+    public void testNormalCommandBoostOff() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForBoostCommandTest(OverrideMode.TRANSIENT);
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                OnOffType.OFF,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNotNull();
+
+        final @Nullable WaterHeaterFeature waterHeaterFeature = updatedNode.getFeature(WaterHeaterFeature.class);
+        assertThat(waterHeaterFeature).isNotNull();
+
+        final @Nullable TransientModeFeature transientModeFeature = updatedNode.getFeature(TransientModeFeature.class);
+        assertThat(transientModeFeature).isNotNull();
+
+        assertThat(waterHeaterFeature.getTemporaryOperatingModeOverride().getTargetValue()).isEqualTo(OverrideMode.NONE);
+        assertThat(transientModeFeature.getIsEnabled().getTargetValue()).isEqualTo(false);
+    }
+
+    @Test
+    public void testNormalRefreshOperatingMode() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForRefreshTest();
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyOperatingModeChannelUid,
+                RefreshType.REFRESH,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNull();
+    }
+
+    @Test
+    public void testNormalRefreshBoost() {
+        /* Given */
+        final WaterHeaterEasyHandlerStrategy strategy = new WaterHeaterEasyHandlerStrategy();
+
+
+        // Create the test node
+        final Node node = getGoodNodeForRefreshTest();
+
+
+        /* When */
+        final @Nullable Node updatedNode = strategy.handleCommand(
+                this.easyBoostModeChannelUid,
+                RefreshType.REFRESH,
+                node
+        );
+
+
+        /* Then */
+        assertThat(updatedNode).isNull();;
+    }
+
+    private static Node getGoodNodeForRefreshTest() {
+        return getGoodNode(
+                WaterHeaterOperatingMode.SCHEDULE,
+                false,
+                OverrideMode.NONE,
+                OnOffMode.ON
+        );
+    }
+
+    private static Node getGoodNodeForBoostCommandTest(
+            final OverrideMode overrideMode
+    ) {
+        return getGoodNode(
+                WaterHeaterOperatingMode.SCHEDULE,
+                false,
+                overrideMode,
+                OnOffMode.ON
+        );
+    }
+
+    private static Node getGoodNodeForOperatingModeCommandTest(
+            final WaterHeaterOperatingMode operatingMode,
+            final OnOffMode onOffMode
+    ) {
+        return getGoodNode(
+                operatingMode,
+                false,
+                OverrideMode.NONE,
+                onOffMode
+        );
+    }
+
+    private static Node getGoodNode(
+            final WaterHeaterOperatingMode operatingMode,
+            final boolean isOn,
+            final OverrideMode overrideMode,
+            final OnOffMode onOffMode
+    ) {
+        final Map<Class<? extends Feature>, Feature> features = new HashMap<>();
+
+        // Create WaterHeaterFeature
+        final WaterHeaterFeature waterHeaterFeature = WaterHeaterFeature.builder()
+                .operatingMode(TestUtil.createSimpleFeatureAttribute(operatingMode))
+                .isOn(TestUtil.createSimpleFeatureAttribute(isOn))
+                .temporaryOperatingModeOverride(TestUtil.createSimpleFeatureAttribute(overrideMode))
+                .build();
+        features.put(WaterHeaterFeature.class, waterHeaterFeature);
+
+        // Create OnOffDeviceFeature
+        final OnOffDeviceFeature onOffDeviceFeature = OnOffDeviceFeature.builder()
+                .mode(TestUtil.createSimpleFeatureAttribute(onOffMode))
+                .build();
+        features.put(OnOffDeviceFeature.class, onOffDeviceFeature);
+
+        // Create TransientModeFeature
+        final TransientModeFeature transientModeFeature = TransientModeFeature.builder()
+                .duration(TestUtil.createSimpleFeatureAttribute(Duration.ofMinutes(30)))
+                .isEnabled(TestUtil.createSimpleFeatureAttribute(overrideMode == OverrideMode.TRANSIENT))
+                .startDatetime(TestUtil.createSimpleFeatureAttribute(Instant.now().atZone(ZoneId.systemDefault())))
+                .endDatetime(TestUtil.createSimpleFeatureAttribute(Instant.now().plus(Duration.ofMinutes(30)).atZone(ZoneId.systemDefault())))
+                .build();
+        features.put(TransientModeFeature.class, transientModeFeature);
+
+        return TestUtil.getTestNodeWithFeatures(features);
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/ZigbeeDeviceHandlerStrategyTest.java
+++ b/bundles/org.openhab.binding.hive/src/test/java/org/openhab/binding/hive/internal/handler/strategy/ZigbeeDeviceHandlerStrategyTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.hive.internal.handler.strategy;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.openhab.binding.hive.internal.HiveBindingConstants;
+import org.openhab.binding.hive.internal.TestUtil;
+import org.openhab.binding.hive.internal.client.Eui64;
+import org.openhab.binding.hive.internal.client.Node;
+import org.openhab.binding.hive.internal.client.feature.ZigbeeDeviceFeature;
+
+/**
+ *
+ *
+ * @author Ross Brown - Initial contribution
+ */
+@NonNullByDefault
+public class ZigbeeDeviceHandlerStrategyTest {
+    @NonNullByDefault({})
+    @Mock
+    private Channel averageLQIChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID averageLQIChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel lastKnownLQIChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID lastKnownLQIChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel averageRSSIChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID averageRSSIChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Channel lastKnownRSSIChannel;
+
+    @NonNullByDefault({})
+    @Mock
+    private ChannelUID lastKnownRSSIChannelUid;
+
+    @NonNullByDefault({})
+    @Mock
+    private Thing thing;
+
+    @NonNullByDefault({})
+    @Mock
+    private ThingHandlerCallback thingHandlerCallback;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_RADIO_LQI_AVERAGE,
+                this.averageLQIChannel,
+                this.averageLQIChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_RADIO_LQI_LAST_KNOWN,
+                this.lastKnownLQIChannel,
+                this.lastKnownLQIChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_RADIO_RSSI_AVERAGE,
+                this.averageRSSIChannel,
+                this.averageRSSIChannelUid
+        );
+
+        TestUtil.initMockChannel(
+                this.thing,
+                HiveBindingConstants.CHANNEL_RADIO_RSSI_LAST_KNOWN,
+                this.lastKnownRSSIChannel,
+                this.lastKnownRSSIChannelUid
+        );
+    }
+
+    @Test
+    public void testUpdate() {
+        /* Given */
+        final String eui64 = "DEADBEEFDEADBEEF";
+        final int averageLQI = 99;
+        final int lastKnownLQI = 98;
+        final int averageRSSI = 97;
+        final int lastKnownRSSI = 96;
+
+        final ZigbeeDeviceHandlerStrategy strategy = new ZigbeeDeviceHandlerStrategy();
+
+        // Create the test node
+        final ZigbeeDeviceFeature zigbeeDeviceFeature = ZigbeeDeviceFeature.builder()
+                .eui64(TestUtil.createSimpleFeatureAttribute(new Eui64(eui64)))
+                .averageLQI(TestUtil.createSimpleFeatureAttribute(averageLQI))
+                .lastKnownLQI(TestUtil.createSimpleFeatureAttribute(lastKnownLQI))
+                .averageRSSI(TestUtil.createSimpleFeatureAttribute(averageRSSI))
+                .lastKnownRSSI(TestUtil.createSimpleFeatureAttribute(lastKnownRSSI))
+                .build();
+
+        final Node node = TestUtil.getTestNodeWithFeatures(Collections.singletonMap(
+                ZigbeeDeviceFeature.class,
+                zigbeeDeviceFeature
+        ));
+
+
+        /* When */
+        strategy.handleUpdate(
+                this.thing,
+                this.thingHandlerCallback,
+                node
+        );
+
+
+        /* Then */
+        verify(this.thing).setProperty(
+                eq(HiveBindingConstants.PROPERTY_EUI64),
+                eq(eui64)
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.averageLQIChannelUid),
+                eq(new DecimalType(averageLQI))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.lastKnownLQIChannelUid),
+                eq(new DecimalType(lastKnownLQI))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.averageRSSIChannelUid),
+                eq(new DecimalType(averageRSSI))
+        );
+
+        verify(this.thingHandlerCallback).stateUpdated(
+                eq(this.lastKnownRSSIChannelUid),
+                eq(new DecimalType(lastKnownRSSI))
+        );
+    }
+}

--- a/bundles/org.openhab.binding.hive/src/test/resources/exampleSessions.json
+++ b/bundles/org.openhab.binding.hive/src/test/resources/exampleSessions.json
@@ -1,0 +1,15 @@
+{
+  "meta": {},
+  "links": {},
+  "linked": {},
+  "sessions": [
+    {
+      "id": "mytoken",
+      "username": "hiveuser@example.com",
+      "userId": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "extCustomerLevel": 1,
+      "latestSupportedApiVersion": "6",
+      "sessionId": "mytoken"
+    }
+  ]
+}

--- a/bundles/org.openhab.binding.hive/src/test/resources/exampleThermostatNode.json
+++ b/bundles/org.openhab.binding.hive/src/test/resources/exampleThermostatNode.json
@@ -1,0 +1,1566 @@
+{
+  "meta": {},
+  "links": {},
+  "linked": {},
+  "nodes": [
+    {
+      "id": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "href": "https://api.prod.bgchprod.info/omnia/nodes/deadbeef-dead-beef-dead-beefdeadbeef",
+      "name": "Thermostat 1",
+      "nodeType": "http://alertme.com/schema/json/node.class.thermostat.json#",
+      "parentNodeId": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "createdOn": 1513173613796,
+      "firstInstall": 1513173925623,
+      "userId": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "ownerId": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "homeId": "deadbeef-dead-beef-dead-beefdeadbeef",
+      "features": {
+        "autoboost_v1": {
+          "autoBoostDuration": {
+            "reportedValue": 30,
+            "displayValue": 30,
+            "reportReceivedTime": 1580088557573,
+            "reportChangedTime": 1580088557423
+          },
+          "autoBoostTargetHeatTemperature": {
+            "reportedValue": 19,
+            "displayValue": 19,
+            "reportReceivedTime": 1582534962795,
+            "reportChangedTime": 1582534962698
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#"
+          }
+        },
+        "failure_alert_v1": {
+          "failureStatus": {
+            "reportedValue": "NORMAL",
+            "displayValue": "NORMAL",
+            "reportReceivedTime": 1580088560757,
+            "reportChangedTime": 1580088560428
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.failure_alert.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.failure_alert.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.failure_alert.v1.json#"
+          }
+        },
+        "lifecycle_state_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#"
+          },
+          "lifeCycleState": {
+            "reportedValue": "NORMAL",
+            "displayValue": "NORMAL",
+            "reportReceivedTime": 1580088569616,
+            "reportChangedTime": 1580088569252
+          }
+        },
+        "standby_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#"
+          },
+          "isActive": {
+            "reportedValue": false,
+            "displayValue": false,
+            "reportReceivedTime": 1582891616180,
+            "reportChangedTime": 1582891615961
+          },
+          "previousConfiguration": {
+            "reportedValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "displayValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "reportReceivedTime": 1582955849075,
+            "reportChangedTime": 1582955848675
+          }
+        },
+        "frost_protect_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#"
+          },
+          "frostProtectTemperature": {
+            "reportedValue": 7,
+            "displayValue": 7,
+            "reportReceivedTime": 1580088582935,
+            "reportChangedTime": 1580088579088
+          }
+        },
+        "heating_temperature_control_v1": {
+          "controlMode": {
+            "reportedValue": "TPI",
+            "displayValue": "TPI",
+            "reportReceivedTime": 1580088577031,
+            "reportChangedTime": 1580088574442
+          },
+          "delayCompensatedTemperature": {
+            "reportedValue": 0,
+            "displayValue": 0,
+            "reportReceivedTime": 1580088624129,
+            "reportChangedTime": 1580088623620
+          },
+          "delayCompensationTime": {
+            "reportedValue": 0,
+            "displayValue": 0,
+            "reportReceivedTime": 1580088577312,
+            "reportChangedTime": 1580088574783
+          },
+          "errorIntegral": {
+            "reportedValue": 0.27,
+            "displayValue": 0.27,
+            "reportReceivedTime": 1583098705492,
+            "reportChangedTime": 1583098705425
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#"
+          },
+          "heatingRateEstimate": {
+            "reportedValue": 124,
+            "displayValue": 124,
+            "reportReceivedTime": 1583049923890,
+            "reportChangedTime": 1583049923798
+          },
+          "minimumOffCycles": {
+            "reportedValue": 3,
+            "displayValue": 3,
+            "reportReceivedTime": 1580088577496,
+            "reportChangedTime": 1580088575039
+          },
+          "optimumStartAdvanceTimeFactor": {
+            "reportedValue": 100,
+            "displayValue": 100,
+            "reportReceivedTime": 1580088579476,
+            "reportChangedTime": 1580088576012
+          },
+          "optimumStartAdvanceTimeOffset": {
+            "reportedValue": 15,
+            "displayValue": 15,
+            "reportReceivedTime": 1580088578998,
+            "reportChangedTime": 1580088575778
+          },
+          "optimumStartEnabled": {
+            "reportedValue": false,
+            "displayValue": false,
+            "reportReceivedTime": 1580088576937,
+            "reportChangedTime": 1580088574444
+          },
+          "optimumStartMaximumAdvanceTime": {
+            "reportedValue": 60,
+            "displayValue": 60,
+            "reportReceivedTime": 1580088577731,
+            "reportChangedTime": 1580088575294
+          },
+          "optimumStartMinimumTemperatureChange": {
+            "reportedValue": 0.5,
+            "displayValue": 0.5,
+            "reportReceivedTime": 1580088578570,
+            "reportChangedTime": 1580088575573
+          },
+          "proportionalThreshold": {
+            "reportedValue": 0.05,
+            "displayValue": 0.05,
+            "reportReceivedTime": 1583049923780,
+            "reportChangedTime": 1583049923712
+          }
+        },
+        "device_alerts_v1": {
+          "deviceAlerts": {
+            "reportedValue": {},
+            "displayValue": {},
+            "reportReceivedTime": 1581538930290,
+            "reportChangedTime": 1581538930130
+          },
+          "deviceStatus": {
+            "reportedValue": "NORMAL",
+            "displayValue": "NORMAL",
+            "reportReceivedTime": 1581538930194,
+            "reportChangedTime": 1581538930131
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.device_alerts.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.device_alerts.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.device_alerts.v1.json#"
+          }
+        },
+        "transient_mode_v1": {
+          "actions": {
+            "reportedValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "19.0"
+              }
+            ],
+            "displayValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "19.0"
+              }
+            ],
+            "reportReceivedTime": 1582924865774,
+            "reportChangedTime": 1582924865608
+          },
+          "duration": {
+            "reportedValue": 1800,
+            "displayValue": 1800,
+            "reportReceivedTime": 1582924866820,
+            "reportChangedTime": 1582924865663
+          },
+          "endDatetime": {
+            "reportedValue": "2020-03-01T22:05:44.442+0000",
+            "displayValue": "2020-03-01T22:05:44.442+0000",
+            "reportReceivedTime": 1583098545214,
+            "reportChangedTime": 1583098544465
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#"
+          },
+          "isEnabled": {
+            "reportedValue": true,
+            "displayValue": true,
+            "reportReceivedTime": 1580088563191,
+            "reportChangedTime": 1580088563131
+          },
+          "previousConfiguration": {
+            "reportedValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "displayValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "reportReceivedTime": 1582955849009,
+            "reportChangedTime": 1582955848647
+          },
+          "startDatetime": {
+            "reportedValue": "2020-03-01T21:35:44.442+0000",
+            "displayValue": "2020-03-01T21:35:44.442+0000",
+            "reportReceivedTime": 1583098545133,
+            "reportChangedTime": 1583098544444
+          }
+        },
+        "boilermodule_interlock_v1": {
+          "callingForHeatUUIDs": {
+            "reportedValue": [],
+            "displayValue": [],
+            "reportReceivedTime": 1583099141612,
+            "reportChangedTime": 1583099141438
+          },
+          "enableControlState": {
+            "reportedValue": "ENABLED",
+            "displayValue": "ENABLED",
+            "reportReceivedTime": 1582975130034,
+            "reportChangedTime": 1582975129955
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.boilermodule_interlock.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.boilermodule_interlock.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.boilermodule_interlock.v1.json#"
+          }
+        },
+        "device_management_v1": {
+          "defaultNameFlag": {
+            "reportedValue": false,
+            "displayValue": false,
+            "reportReceivedTime": 1580088508559,
+            "reportChangedTime": 1580088468170
+          },
+          "deviceName": {
+            "reportedValue": "Thermostat 1",
+            "displayValue": "Thermostat 1",
+            "reportReceivedTime": 1580088508560,
+            "reportChangedTime": 1580088468159
+          },
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#"
+          },
+          "parentNodeId": {
+            "reportedValue": "deadbeef-dead-beef-dead-beefdeadbeef",
+            "displayValue": "deadbeef-dead-beef-dead-beefdeadbeef",
+            "reportReceivedTime": 1580088508560,
+            "reportChangedTime": 1580088468146
+          },
+          "productType": {
+            "reportedValue": "HEATING",
+            "displayValue": "HEATING",
+            "reportReceivedTime": 1580088569222,
+            "reportChangedTime": 1580088569075
+          },
+          "supportedFeatures": {
+            "reportedValue": [
+              "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.device_alerts.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.links.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.failure_alert.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.boilermodule_interlock.v1.json#",
+              "http://alertme.com/schema/json/node.class.thermostat.json#",
+              "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#"
+            ],
+            "displayValue": [
+              "http://alertme.com/schema/json/feature/node.feature.transient_mode.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.heating_temperature_control.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.lifecycle_state.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.autoboost.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.device_management.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.device_alerts.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.links.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.failure_alert.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.boilermodule_interlock.v1.json#",
+              "http://alertme.com/schema/json/node.class.thermostat.json#",
+              "http://alertme.com/schema/json/feature/node.feature.standby.v1.json#",
+              "http://alertme.com/schema/json/feature/node.feature.frost_protect.v1.json#"
+            ],
+            "reportReceivedTime": 1582099810519,
+            "reportChangedTime": 1582099810216
+          }
+        },
+        "heating_thermostat_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#"
+          },
+          "heatSchedule": {
+            "reportedValue": {
+              "scheduleType": "http://alertme.com/schema/json/configuration/configuration.device.schedule.weekly.v1.json#",
+              "maxNumSetpointsPerDay": 6,
+              "setpoints": [
+                {
+                  "dayIndex": 1,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                }
+              ],
+              "setpointOverridden": false
+            },
+            "displayValue": {
+              "scheduleType": "http://alertme.com/schema/json/configuration/configuration.device.schedule.weekly.v1.json#",
+              "maxNumSetpointsPerDay": 6,
+              "setpoints": [
+                {
+                  "dayIndex": 1,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 1,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 2,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 3,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 4,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 5,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 6,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "05:45",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                      "attribute": "targetHeatTemperature",
+                      "value": "14.0"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                },
+                {
+                  "dayIndex": 7,
+                  "time": "22:00",
+                  "actions": [
+                    {
+                      "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                      "featureType": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+                      "attribute": "mode",
+                      "value": "OFF"
+                    }
+                  ]
+                }
+              ],
+              "setpointOverridden": false
+            },
+            "reportReceivedTime": 1582896748230,
+            "reportChangedTime": 1582896748033
+          },
+          "maxHeatTargetTemperature": {
+            "reportedValue": 32,
+            "displayValue": 32,
+            "reportReceivedTime": 1580088554789,
+            "reportChangedTime": 1580088554543
+          },
+          "minHeatTargetTemperature": {
+            "reportedValue": 5,
+            "displayValue": 5,
+            "reportReceivedTime": 1580088554653,
+            "reportChangedTime": 1580088554593
+          },
+          "operatingMode": {
+            "reportedValue": "SCHEDULE",
+            "displayValue": "SCHEDULE",
+            "reportReceivedTime": 1582894946674,
+            "reportChangedTime": 1582894946331
+          },
+          "operatingState": {
+            "reportedValue": "OFF",
+            "displayValue": "OFF",
+            "reportReceivedTime": 1583099144393,
+            "reportChangedTime": 1583099143158
+          },
+          "operatingStateReason": {
+            "reportedValue": "NORMAL",
+            "displayValue": "NORMAL",
+            "reportReceivedTime": 1583099141806,
+            "reportChangedTime": 1583099141483
+          },
+          "previousConfiguration": {
+            "reportedValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "displayValue": [
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "operatingMode",
+                "value": "SCHEDULE"
+              },
+              {
+                "actionType": "http://alertme.com/schema/json/configuration/configuration.device.action.generic.v1.json#",
+                "featureType": "http://alertme.com/schema/json/feature/node.feature.heating_thermostat.v1.json#",
+                "attribute": "targetHeatTemperature",
+                "value": "14.0"
+              }
+            ],
+            "reportReceivedTime": 1582955848949,
+            "reportChangedTime": 1582955848624
+          },
+          "targetHeatTemperature": {
+            "reportedValue": 7,
+            "displayValue": 7,
+            "reportReceivedTime": 1583100005689,
+            "reportChangedTime": 1583100005567
+          },
+          "temporaryOperatingModeOverride": {
+            "reportedValue": "NONE",
+            "displayValue": "NONE",
+            "reportReceivedTime": 1583099143088,
+            "reportChangedTime": 1583099142419
+          }
+        },
+        "temperature_sensor_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.temperature_sensor.v1.json#"
+          },
+          "temperature": {
+            "reportedValue": 19,
+            "displayValue": 19,
+            "reportReceivedTime": 1583101678598,
+            "reportChangedTime": 1583101678475
+          }
+        },
+        "on_off_device_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.on_off_device.v1.json#"
+          },
+          "mode": {
+            "reportedValue": "ON",
+            "displayValue": "ON",
+            "reportReceivedTime": 1581357337075,
+            "reportChangedTime": 1581357336967
+          }
+        },
+        "links_v1": {
+          "featureType": {
+            "reportedValue": "http://alertme.com/schema/json/feature/node.feature.links.v1.json#",
+            "targetValue": "http://alertme.com/schema/json/feature/node.feature.links.v1.json#",
+            "displayValue": "http://alertme.com/schema/json/feature/node.feature.links.v1.json#"
+          },
+          "reverseLinks": {
+            "reportedValue": [
+              {
+                "bindingGroupIds": [
+                  "trvbm"
+                ],
+                "boundNode": "deadbeef-dead-beef-dead-beefdeadbeef"
+              },
+              {
+                "bindingGroupIds": [
+                  "trvbm"
+                ],
+                "boundNode": "deadbeef-dead-beef-dead-beefdeadbeef"
+              }
+            ],
+            "displayValue": [
+              {
+                "bindingGroupIds": [
+                  "trvbm"
+                ],
+                "boundNode": "deadbeef-dead-beef-dead-beefdeadbeef"
+              },
+              {
+                "bindingGroupIds": [
+                  "trvbm"
+                ],
+                "boundNode": "deadbeef-dead-beef-dead-beefdeadbeef"
+              }
+            ],
+            "reportReceivedTime": 1582975101358,
+            "reportChangedTime": 1582975101227
+          }
+        }
+      },
+      "lastUpgradeSucceeded": false
+    }
+  ]
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -106,6 +106,7 @@
     <module>org.openhab.binding.hdpowerview</module>
     <module>org.openhab.binding.helios</module>
     <module>org.openhab.binding.heos</module>
+    <module>org.openhab.binding.hive</module>
     <module>org.openhab.binding.homematic</module>
     <module>org.openhab.binding.hpprinter</module>
     <module>org.openhab.binding.hue</module>


### PR DESCRIPTION
Adds initial support for Centrica Hive / British Gas Hive smart home devices using the Hive REST API (Issue https://github.com/openhab/openhab-addons/issues/4617)

The currently proposed Hive binding (PR https://github.com/openhab/openhab-addons/pull/4619) only supports a single thermostat.
I have a more complex setup and saw that the proposed binding had been inactive for a while so I decided to make my own alternative binding.

This binding supports:
- Multizone heating control (thermostat based)
- Smart radiator valve control
- Hot water control

(see README for all features)

N.B. This is a completely new implementation. It is not based on the previously mentioned binding by @chrissfoot.

# Links
- [README](https://github.com/rbrownwsws/openhab-addons/blob/hive/release/pr1/bundles/org.openhab.binding.hive/README.md)
- [JAR file](https://github.com/rbrownwsws/openhab-addons/releases)
- [Community Post](https://community.openhab.org/t/new-binding-for-centrica-hive-british-gas-hive-with-multizone-heating-and-radiator-valve-support/94737/10)
