### PR TITLE
[pjlink] Null characters fix

### DIFF
--- a/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
+++ b/bundles/org.openhab.binding.pjlinkdevice/src/main/java/org/openhab/binding/pjlinkdevice/internal/device/PJLinkDevice.java
@@ -22,6 +22,7 @@ import java.net.NoRouteToHostException;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
+import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -232,7 +233,8 @@ public class PJLinkDevice {
                     fullCommand.replaceAll("\r", "\\\\r"));
         }
         if (response == null) {
-            throw new ResponseException("Response to request '" + fullCommand.replaceAll("\r", "\\\\r") + "' was null");
+            throw new ResponseException(MessageFormat.format("Response to request ''{0}'' was null",
+                    fullCommand.replaceAll("\r", "\\\\r")));
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Got response '{}' ({}) for request '{}' from {}", response,


### PR DESCRIPTION
This at least improves the situation reported in issue #6725. 

Some PJLink devices seem to be not fully compliant, and send \0 bytes in front of messages.
The device does seem to have other issues, but this one is rather easy to fix by removing leading \0 bytes and also does not have negative impact on compliant devices.
