### PR TITLE
[homematic] Use async Jetty http request to support larger buffers

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/client/RpcClient.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 public abstract class RpcClient<T> {
     private final Logger logger = LoggerFactory.getLogger(RpcClient.class);
     protected static final int MAX_RPC_RETRY = 1;
+    protected static final int RESP_BUFFER_SIZE = 8192;
 
     protected HomematicConfig config;
 


### PR DESCRIPTION
Solves #6963

For HM installations with a large number of devices the maximum buffer size used by sync HTTP request was too small. Async requests allow larger buffers.

Signed-off-by: Martin Herbst <develop@mherbst.de>

