### PR TITLE
[insteon] Added support to 2472D OutletLinc Dimmer for LED On/Off, LED Brightness, Local Ramp Rate and Beep

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -55,7 +55,7 @@
 				<description>Insteon binding product key that is used to identify the model of the device.</description>
 				<options>
 					<option value="F00.00.01">2477D SwitchLinc Dimmer - F00.00.01</option>
-					<option value="F00.00.02">2477S SwitchLinc Switch- F00.00.02</option>
+					<option value="F00.00.02">2477S SwitchLinc Switch - F00.00.02</option>
 					<option value="F00.00.03">2845-222 Hidden Door Sensor - F00.00.03</option>
 					<option value="F00.00.04">2876S ICON Switch - F00.00.04</option>
 					<option value="F00.00.05">2456D3 LampLinc V2 - F00.00.05</option>
@@ -95,7 +95,7 @@
 					<option value="0x000049">2843-222 Wireless Open/Close Sensor - 0x000049</option>
 					<option value="0x00004A">2842-222 Motion Sensor - 0x00004A</option>
 					<option value="0x000051">2486DWH8 KeypadLinc Dimmer - 0x000051</option>
-					<option value="0x000068">2472D OutletLincDimmer - 0x000068</option>
+					<option value="0x000068">2472D OutletLinc Dimmer - 0x000068</option>
 					<option value="X00.00.01">X10 switch Generic X10 switch - X00.00.01</option>
 					<option value="X00.00.02">X10 dimmer Generic X10 dimmer - X00.00.02</option>
 					<option value="X00.00.03">X10 motion Generic X10 motion sensor - X00.00.03</option>

--- a/bundles/org.openhab.binding.insteon/src/main/resources/device_types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/device_types.xml
@@ -81,6 +81,7 @@
 		<feature name="data">MotionSensorData</feature>
 		<feature name="lastheardfrom">GenericLastTime</feature>
 	</device>
+
 	<device productKey="0x000050">
 		<model>2486DWH6</model>
 		<description>KeypadLinc Dimmer - 6 Button</description>
@@ -96,6 +97,7 @@
 		</feature_group>
 		<feature name="lastheardfrom">GenericLastTime</feature>
 	</device>
+
 	<device productKey="0x000051">
 		<model>2486DWH8</model>
 		<description>KeypadLinc Dimmer - 8 Button</description>
@@ -118,11 +120,17 @@
 
 	<device productKey="0x000068">
 		<model>2472D</model>
-		<description>OutletLincDimmer</description>
+		<description>OutletLinc Dimmer</description>
 		<feature name="dimmer">GenericDimmer</feature>
 		<feature name="manualchange">ManualChange</feature>
 		<feature name="fastonoff">FastOnOff</feature>
 		<feature name="lastheardfrom">GenericLastTime</feature>
+		<feature name="ledonoff">LEDOnOff</feature>
+		<feature name="beep">Beep</feature>
+		<feature_group name="ext_group" type="ExtStatusGroup">
+			<feature name="ledbrightness">LEDBrightness</feature>
+			<feature name="ramprate">RampRate</feature>
+		</feature_group>
 	</device>
 
 	<!-- #################################################
@@ -576,5 +584,4 @@
 		</feature_group>
 		<feature name="lastheardfrom">GenericLastTime</feature>
 	</device>
-
 </xml>


### PR DESCRIPTION
Recently bought one of these and these features were not supported by OH.

Interesting note, I suspected this would act just like a 2477D dimmer and it mostly does, but it does not respond to local on-level changes so I left that feature out. You can set the local on-level and reading the Status, you can see it takes the change, but pressing the hardware button still goes to full brightness - disregarding the OL setting.

This is for Feature Request: https://github.com/openhab/openhab-addons/issues/7469