### PR TITLE
[homekit] Add workaround for color picker

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitColorfulLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitColorfulLightbulbImpl.java
@@ -35,6 +35,8 @@ import io.github.hapjava.accessories.DimmableLightbulb;
 class HomekitColorfulLightbulbImpl extends AbstractHomekitLightbulbImpl<ColorItem>
         implements ColorfulLightbulb, DimmableLightbulb {
 
+    private PercentType saturationValue;
+
     public HomekitColorfulLightbulbImpl(HomekitTaggedItem taggedItem, ItemRegistry itemRegistry,
             HomekitAccessoryUpdater updater) {
         super(taggedItem, itemRegistry, updater, ColorItem.class);
@@ -79,7 +81,7 @@ class HomekitColorfulLightbulbImpl extends AbstractHomekitLightbulbImpl<ColorIte
         State state = getItem().getStateAs(HSBType.class);
         if (state instanceof HSBType) {
             HSBType hsb = (HSBType) state;
-            HSBType newState = new HSBType(new DecimalType(hue), hsb.getSaturation(), hsb.getBrightness());
+            HSBType newState = new HSBType(new DecimalType(hue), saturationValue, hsb.getBrightness());
             ((ColorItem) getItem()).send(newState);
             return CompletableFuture.completedFuture(null);
         } else {
@@ -91,16 +93,9 @@ class HomekitColorfulLightbulbImpl extends AbstractHomekitLightbulbImpl<ColorIte
     @Override
     public CompletableFuture<Void> setSaturation(Double value) throws Exception {
         final int saturation = value == null ? 0 : value.intValue();
-        State state = getItem().getStateAs(HSBType.class);
-        if (state instanceof HSBType) {
-            HSBType hsb = (HSBType) state;
-            HSBType newState = new HSBType(hsb.getHue(), new PercentType(saturation), hsb.getBrightness());
-            ((ColorItem) getItem()).send(newState);
-            return CompletableFuture.completedFuture(null);
-        } else {
-            // state is undefined (light is not connected)
-            return CompletableFuture.completedFuture(null);
-        }
+        saturationValue = new PercentType(saturation);
+
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override


### PR DESCRIPTION
HomeKit sends saturation and hue separately. This leads to two conflicting commands being sent.

```
20:48:13.238 [WARN ] [essories.AbstractHomekitAccessoryImpl] - Changing saturation to 5.0
20:48:13.250 [WARN ] [essories.AbstractHomekitAccessoryImpl] - Changing hue to 63.0
20:48:13.272 [INFO ] [smarthome.event.ItemCommandEvent     ] - Item 'Homekit_Test' received command 222,5,100
20:48:13.281 [INFO ] [arthome.event.ItemStatePredictedEvent] - Homekit_Test predicted to become 222,5,100
20:48:13.354 [INFO ] [smarthome.event.ItemCommandEvent     ] - Item 'Homekit_Test' received command 63.0,44,100
20:48:13.361 [INFO ] [smarthome.event.ItemStateChangedEvent] - Homekit_Test changed from 222,44,100 to 222,5,100
20:48:13.367 [INFO ] [arthome.event.ItemStatePredictedEvent] - Homekit_Test predicted to become 63.0,44,100
20:48:13.391 [INFO ] [smarthome.event.ItemStateChangedEvent] - Homekit_Test changed from 222,5,100 to 63.0,44,100
```

The workaround is to just do nothing when the saturation is set and only send a command once the hue is set. This is not ideal, but it seems to work a lot better now.

I am using hue lights and nanoleaf panels.
