### PR TITLE
[hue] Refactored state handling and fix polling after command

### DIFF
--- a/bundles/org.openhab.binding.hue/.classpath
+++ b/bundles/org.openhab.binding.hue/.classpath
@@ -28,5 +28,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
@@ -27,6 +27,7 @@ public class StateUpdate extends ConfigUpdate {
 
     private Integer colorTemperature;
     private Integer brightness;
+    private Long transitiontime;
 
     /**
      * Turn light on.
@@ -193,7 +194,12 @@ public class StateUpdate extends ConfigUpdate {
         }
 
         commands.add(new Command("transitiontime", timeMillis / 100));
+        this.transitiontime = timeMillis;
         return this;
+    }
+
+    public Long getTransitionTime() {
+        return transitiontime;
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/StateUpdate.java
@@ -27,7 +27,6 @@ public class StateUpdate extends ConfigUpdate {
 
     private Integer colorTemperature;
     private Integer brightness;
-    private Long transitiontime;
 
     /**
      * Turn light on.
@@ -194,12 +193,7 @@ public class StateUpdate extends ConfigUpdate {
         }
 
         commands.add(new Command("transitiontime", timeMillis / 100));
-        this.transitiontime = timeMillis;
         return this;
-    }
-
-    public Long getTransitionTime() {
-        return transitiontime;
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -203,7 +203,7 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
 
     @Override
     public boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light) {
-        return true;
+        return false;
     }
 
     private @Nullable ThingUID getThingUID(FullHueObject hueObject) {
@@ -276,7 +276,7 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
 
     @Override
     public boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
-        return true;
+        return false;
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -202,8 +202,8 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void onLightStateChanged(@Nullable HueBridge bridge, FullLight light) {
-        // nothing to do
+    public boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light) {
+        return true;
     }
 
     private @Nullable ThingUID getThingUID(FullHueObject hueObject) {
@@ -275,8 +275,18 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
-        // nothing to do
+    public boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
+        return true;
+    }
+
+    @Override
+    public String getLightId() {
+        return "DISCOVERY";
+    }
+
+    @Override
+    public String getSensorId() {
+        return "DISCOVERY";
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -41,8 +41,6 @@ import org.openhab.binding.hue.internal.handler.GroupStatusListener;
 import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
 import org.openhab.binding.hue.internal.handler.HueGroupHandler;
 import org.openhab.binding.hue.internal.handler.HueLightHandler;
-import org.openhab.binding.hue.internal.handler.LightStatusListener;
-import org.openhab.binding.hue.internal.handler.SensorStatusListener;
 import org.openhab.binding.hue.internal.handler.sensors.ClipHandler;
 import org.openhab.binding.hue.internal.handler.sensors.DimmerSwitchHandler;
 import org.openhab.binding.hue.internal.handler.sensors.LightLevelHandler;
@@ -129,11 +127,11 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
     public void startScan() {
         List<FullLight> lights = hueBridgeHandler.getFullLights();
         for (FullLight l : lights) {
-            onLightAddedInternal(l);
+            addLightDiscovery(l);
         }
         List<FullSensor> sensors = hueBridgeHandler.getFullSensors();
         for (FullSensor s : sensors) {
-            onSensorAddedInternal(s);
+            addSensorDiscovery(s);
         }
         List<FullGroup> groups = hueBridgeHandler.getFullGroups();
         for (FullGroup g : groups) {
@@ -149,12 +147,7 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         removeOlderResults(getTimestampOfLastScan(), hueBridgeHandler.getThing().getUID());
     }
 
-    @Override
-    public void onLightAdded(@Nullable HueBridge bridge, FullLight light) {
-        onLightAddedInternal(light);
-    }
-
-    private void onLightAddedInternal(FullLight light) {
+    public void addLightDiscovery(FullLight light) {
         ThingUID thingUID = getThingUID(light);
         ThingTypeUID thingTypeUID = getThingTypeUID(light);
 
@@ -183,27 +176,12 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         }
     }
 
-    @Override
-    public void onLightGone(@Nullable HueBridge bridge, FullLight light) {
-        onLightRemovedInternal(light);
-    }
-
-    @Override
-    public void onLightRemoved(@Nullable HueBridge bridge, FullLight light) {
-        onLightRemovedInternal(light);
-    }
-
-    private void onLightRemovedInternal(FullLight light) {
+    public void removeLightDiscovery(FullLight light) {
         ThingUID thingUID = getThingUID(light);
 
         if (thingUID != null) {
             thingRemoved(thingUID);
         }
-    }
-
-    @Override
-    public boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light) {
-        return false;
     }
 
     private @Nullable ThingUID getThingUID(FullHueObject hueObject) {
@@ -223,12 +201,7 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         return thingTypeId != null ? new ThingTypeUID(BINDING_ID, thingTypeId) : null;
     }
 
-    @Override
-    public void onSensorAdded(@Nullable HueBridge bridge, FullSensor sensor) {
-        onSensorAddedInternal(sensor);
-    }
-
-    private void onSensorAddedInternal(FullSensor sensor) {
+    public void addSensorDiscovery(FullSensor sensor) {
         ThingUID thingUID = getThingUID(sensor);
         ThingTypeUID thingTypeUID = getThingTypeUID(sensor);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/GroupStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/GroupStatusListener.java
@@ -26,13 +26,21 @@ import org.openhab.binding.hue.internal.HueBridge;
 public interface GroupStatusListener {
 
     /**
+     * This method returns the group id of listener
+     * 
+     * @return groupId String
+     */
+    String getGroupId();
+
+    /**
      * This method is called whenever the state of the given group has changed. The new state can be obtained by
      * {@link FullGroup#getState()}.
      *
      * @param bridge The bridge the changed group is connected to.
      * @param group The group which received the state update.
+     * @return
      */
-    void onGroupStateChanged(@Nullable HueBridge bridge, FullGroup group);
+    boolean onGroupStateChanged(@Nullable HueBridge bridge, FullGroup group);
 
     /**
      * This method is called whenever a group is removed.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -745,6 +745,10 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     public boolean registerDiscoveryListener(HueLightDiscoveryService listener) {
         if (discoveryListener == null) {
             discoveryListener = listener;
+
+            getFullLights().forEach(listener::addLightDiscovery);
+            getFullSensors().forEach(listener::addSensorDiscovery);
+
             return true;
         }
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -195,7 +195,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         protected void doConnectedRun() throws IOException, ApiException {
             Map<String, FullSensor> lastSensorStateCopy = new HashMap<>(lastSensorStates);
 
-            final SensorStatusListener discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryListener;
 
             for (final FullSensor sensor : hueBridge.getSensors()) {
                 String sensorId = sensor.getId();
@@ -206,7 +206,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                     logger.debug("Hue sensor '{}' added.", sensorId);
 
                     if (discovery != null) {
-                        discovery.onSensorAdded(hueBridge, sensor);
+                        discovery.addSensorDiscovery(sensor);
                     }
 
                     lastSensorStates.put(sensorId, sensor);
@@ -232,7 +232,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 }
 
                 if (discovery != null) {
-                    discovery.onSensorRemoved(hueBridge, sensor);
+                    discovery.removeSensorDiscovery(sensor);
                 }
             });
         }
@@ -250,7 +250,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 lights = hueBridge.getFullConfig().getLights();
             }
 
-            final LightStatusListener discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryListener;
 
             for (final FullLight fullLight : lights) {
                 final String lightId = fullLight.getId();
@@ -456,9 +456,9 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing light: {}", e.getMessage(), e);
-            final LightStatusListener discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryListener;
             if (discovery != null) {
-                discovery.onLightGone(hueBridge, light);
+                discovery.removeLightDiscovery(light);
             }
 
             final LightStatusListener lightStatusListener = lightStatusListeners.get(light.getId());
@@ -478,9 +478,9 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing sensor: {}", e.getMessage(), e);
-            final SensorStatusListener discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryListener;
             if (discovery != null) {
-                discovery.onSensorGone(hueBridge, sensor);
+                discovery.removeSensorDiscovery(sensor);
             }
 
             final SensorStatusListener sensorStatusListener = sensorStatusListeners.get(sensor.getId());
@@ -514,9 +514,9 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing sensor: {}", e.getMessage(), e);
-            final SensorStatusListener discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryListener;
             if (discovery != null) {
-                discovery.onSensorGone(hueBridge, sensor);
+                discovery.removeSensorDiscovery(sensor);
             }
 
             final SensorStatusListener sensorStatusListener = sensorStatusListeners.get(sensor.getId());

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -50,6 +50,7 @@ import org.openhab.binding.hue.internal.FullLight;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.HueConfigStatusMessage;
+import org.openhab.binding.hue.internal.State;
 import org.openhab.binding.hue.internal.StateUpdate;
 import org.openhab.binding.hue.internal.config.HueBridgeConfig;
 import org.openhab.binding.hue.internal.discovery.HueLightDiscoveryService;
@@ -90,9 +91,10 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     private final Map<String, FullSensor> lastSensorStates = new ConcurrentHashMap<>();
     private final Map<String, FullGroup> lastGroupStates = new ConcurrentHashMap<>();
 
-    private final List<LightStatusListener> lightStatusListeners = new CopyOnWriteArrayList<>();
-    private final List<SensorStatusListener> sensorStatusListeners = new CopyOnWriteArrayList<>();
-    private final List<GroupStatusListener> groupStatusListeners = new CopyOnWriteArrayList<>();
+    private @Nullable HueLightDiscoveryService discoveryService;
+    private final Map<String, LightStatusListener> lightStatusListeners = new ConcurrentHashMap<>();
+    private final Map<String, SensorStatusListener> sensorStatusListeners = new ConcurrentHashMap<>();
+    private final Map<String, GroupStatusListener> groupStatusListeners = new ConcurrentHashMap<>();
 
     final ReentrantLock pollingLock = new ReentrantLock();
 
@@ -165,7 +167,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         protected void doConnectedRun() throws IOException, ApiException {
             Map<String, FullSensor> lastSensorStateCopy = new HashMap<>(lastSensorStates);
 
-            final HueLightDiscoveryService discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryService;
 
             for (final FullSensor sensor : hueBridge.getSensors()) {
                 String sensorId = sensor.getId();
@@ -181,7 +183,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
 
                     lastSensorStates.put(sensorId, sensor);
                 } else {
-                    logger.trace("Hue sensor '{}' state update.", sensorId);
                     if (sensorStatusListener.onSensorStateChanged(hueBridge, sensor)) {
                         lastSensorStates.put(sensorId, sensor);
                     }
@@ -192,13 +193,10 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             lastSensorStateCopy.forEach((sensorId, sensor) -> {
                 logger.debug("Hue sensor '{}' removed.", sensorId);
                 lastSensorStates.remove(sensorId);
+
                 final SensorStatusListener sensorStatusListener = sensorStatusListeners.get(sensorId);
                 if (sensorStatusListener != null) {
-                    try {
-                        sensorStatusListener.onSensorRemoved(hueBridge, sensor);
-                    } catch (Exception e) {
-                        logger.error("An exception occurred while calling the Sensor Listeners", e);
-                    }
+                    sensorStatusListener.onSensorRemoved(hueBridge, sensor);
                 }
 
                 if (discovery != null) {
@@ -220,30 +218,42 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 lights = hueBridge.getFullConfig().getLights();
             }
 
-            final HueLightDiscoveryService discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryService;
 
             for (final FullLight fullLight : lights) {
                 final String lightId = fullLight.getId();
-                lastLightStates.put(lightId, fullLight);
-                if (lastLightStateCopy.containsKey(lightId)) {
-                    final FullLight lastFullLight = lastLightStateCopy.remove(lightId);
-                    final State lastFullLightState = lastFullLight.getState();
-                    if (!lastFullLightState.equals(fullLight.getState())) {
-                        logger.debug("Status update for Hue light '{}' detected.", lightId);
-                        notifyLightStatusListeners(fullLight, StatusType.CHANGED);
-                    }
-                } else {
+                lastLightStateCopy.remove(lightId);
+
+                final LightStatusListener lightStatusListener = lightStatusListeners.get(lightId);
+                if (lightStatusListener == null) {
                     logger.debug("Hue light '{}' added.", lightId);
-                    notifyLightStatusListeners(fullLight, StatusType.ADDED);
+
+                    if (discovery != null) {
+                        discovery.addLightDiscovery(fullLight);
+                    }
+
+                    lastLightStates.put(lightId, fullLight);
+                } else {
+                    if (lightStatusListener.onLightStateChanged(hueBridge, fullLight)) {
+                        lastLightStates.put(lightId, fullLight);
+                    }
                 }
             }
 
             // Check for removed lights
-            for (Entry<String, FullLight> fullLightEntry : lastLightStateCopy.entrySet()) {
-                lastLightStates.remove(fullLightEntry.getKey());
-                logger.debug("Hue light '{}' removed.", fullLightEntry.getKey());
-                notifyLightStatusListeners(fullLightEntry.getValue(), StatusType.REMOVED);
-            }
+            lastLightStateCopy.forEach((lightId, light) -> {
+                logger.debug("Hue light '{}' removed.", lightId);
+                lastLightStates.remove(lightId);
+
+                final LightStatusListener lightStatusListener = lightStatusListeners.get(lightId);
+                if (lightStatusListener != null) {
+                    lightStatusListener.onLightRemoved(hueBridge, light);
+                }
+
+                if (discovery != null) {
+                    discovery.removeLightDiscovery(light);
+                }
+            });
 
             Map<String, FullGroup> lastGroupStateCopy = new HashMap<>(lastGroupStates);
 
@@ -293,28 +303,41 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                         fullGroup.getType(), groupState.isOn(), groupState.getBrightness(), groupState.getHue(),
                         groupState.getSaturation(), groupState.getColorTemperature(), groupState.getColorMode(),
                         groupState.getXY());
+
                 String groupId = fullGroup.getId();
-                lastGroupStates.put(groupId, fullGroup);
-                if (lastGroupStateCopy.containsKey(groupId)) {
-                    final FullGroup lastFullGroup = lastGroupStateCopy.remove(groupId);
-                    final State lastFullGroupState = lastFullGroup.getState();
-                    if (!lastFullGroupState.equals(fullGroup.getState())) {
-                        logger.debug("Status update for Hue group '{}' detected.", groupId);
-                        notifyGroupStatusListeners(fullGroup, StatusType.CHANGED);
-                    }
-                } else {
+                lastGroupStateCopy.remove(groupId);
+
+                final GroupStatusListener groupStatusListener = groupStatusListeners.get(groupId);
+                if (groupStatusListener == null) {
                     logger.debug("Hue group '{}' ({}) added (nb lights {}).", groupId, fullGroup.getName(),
                             fullGroup.getLights().size());
-                    notifyGroupStatusListeners(fullGroup, StatusType.ADDED);
+
+                    if (discovery != null) {
+                        discovery.addGroupDiscovery(fullGroup);
+                    }
+
+                    lastGroupStates.put(groupId, fullGroup);
+                } else {
+                    if (groupStatusListener.onGroupStateChanged(hueBridge, fullGroup)) {
+                        lastGroupStates.put(groupId, fullGroup);
+                    }
                 }
             }
 
             // Check for removed groups
-            for (Entry<String, FullGroup> fullGroupEntry : lastGroupStateCopy.entrySet()) {
-                lastGroupStates.remove(fullGroupEntry.getKey());
-                logger.debug("Hue group '{}' removed.", fullGroupEntry.getKey());
-                notifyGroupStatusListeners(fullGroupEntry.getValue(), StatusType.REMOVED);
-            }
+            lastGroupStateCopy.forEach((groupId, group) -> {
+                logger.debug("Hue group '{}' removed.", groupId);
+                lastGroupStates.remove(groupId);
+
+                final GroupStatusListener groupStatusListener = groupStatusListeners.get(groupId);
+                if (groupStatusListener != null) {
+                    groupStatusListener.onGroupRemoved(hueBridge, group);
+                }
+
+                if (discovery != null) {
+                    discovery.removeGroupDiscovery(group);
+                }
+            });
         }
     };
 
@@ -341,29 +364,21 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     }
 
     @Override
-    public void updateLightState(FullLight light, StateUpdate stateUpdate) {
-        final LightStatusListener listener = lightStatusListeners.get(light.getId());
-        if (listener == null) {
-            logger.debug("Update light state without handler skipped {}.", light.getId());
-            return;
-        }
-        updateLightState(listener, light, stateUpdate);
-    }
-
-    @Override
-    public void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate) {
+    public void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate,
+            long fadeTime) {
         if (hueBridge != null) {
-            listener.enablePollBypassBeforeCmd();
+            listener.setPollBypassBeforeCmd();
             hueBridge.setLightState(light, stateUpdate).thenAccept(result -> {
                 try {
                     hueBridge.handleErrors(result);
-                    listener.enablePollBypassAfterCmd(stateUpdate.getTransitionTime());
+                    listener.setPollBypassFadeTime(fadeTime);
                 } catch (Exception e) {
-                    listener.disablePollBypass();
-                    handleStateUpdateException(listener, light, stateUpdate, e);
+                    listener.unsetPollBypass();
+                    handleStateUpdateException(listener, light, stateUpdate, fadeTime, e);
                 }
             }).exceptionally(e -> {
-                handleStateUpdateException(listener, light, stateUpdate, e);
+                listener.unsetPollBypass();
+                handleStateUpdateException(listener, light, stateUpdate, fadeTime, e);
                 return null;
             });
         } else {
@@ -426,29 +441,26 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     }
 
     private void handleStateUpdateException(LightStatusListener listener, FullLight light, StateUpdate stateUpdate,
-            Throwable e) {
+            long fadeTime, Throwable e) {
         if (e instanceof DeviceOffException) {
             if (stateUpdate.getColorTemperature() != null && stateUpdate.getBrightness() == null) {
                 // If there is only a change of the color temperature, we do not want the light
                 // to be turned on (i.e. change its brightness).
                 return;
             } else {
-                updateLightState(listener, light, LightStateConverter.toOnOffLightState(OnOffType.ON));
-                updateLightState(listener, light, stateUpdate);
+                updateLightState(listener, light, LightStateConverter.toOnOffLightState(OnOffType.ON), fadeTime);
+                updateLightState(listener, light, stateUpdate, fadeTime);
             }
         } else if (e instanceof IOException) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing light: {}", e.getMessage(), e);
-            final HueLightDiscoveryService discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryService;
             if (discovery != null) {
                 discovery.removeLightDiscovery(light);
             }
 
-            final LightStatusListener lightStatusListener = lightStatusListeners.get(light.getId());
-            if (lightStatusListener != null) {
-                lightStatusListener.onLightGone(hueBridge, light);
-            }
+            listener.onLightGone(hueBridge, light);
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.
             logger.warn("Error while accessing light: {}", e.getMessage(), e);
@@ -462,14 +474,14 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing sensor: {}", e.getMessage(), e);
-            final HueLightDiscoveryService discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryService;
             if (discovery != null) {
                 discovery.removeSensorDiscovery(sensor);
             }
 
-            final SensorStatusListener sensorStatusListener = sensorStatusListeners.get(sensor.getId());
-            if (sensorStatusListener != null) {
-                sensorStatusListener.onSensorGone(hueBridge, sensor);
+            final SensorStatusListener listener = sensorStatusListeners.get(sensor.getId());
+            if (listener != null) {
+                listener.onSensorGone(hueBridge, sensor);
             }
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.
@@ -484,7 +496,15 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing group: {}", e.getMessage(), e);
-            notifyGroupStatusListeners(group, StatusType.GONE);
+            final HueLightDiscoveryService discovery = discoveryService;
+            if (discovery != null) {
+                discovery.removeGroupDiscovery(group);
+            }
+
+            final GroupStatusListener listener = groupStatusListeners.get(group.getId());
+            if (listener != null) {
+                listener.onGroupGone(hueBridge, group);
+            }
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.
             logger.warn("Error while accessing group: {}", e.getMessage(), e);
@@ -498,14 +518,14 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof EntityNotAvailableException) {
             logger.debug("Error while accessing sensor: {}", e.getMessage(), e);
-            final HueLightDiscoveryService discovery = discoveryListener;
+            final HueLightDiscoveryService discovery = discoveryService;
             if (discovery != null) {
                 discovery.removeSensorDiscovery(sensor);
             }
 
-            final SensorStatusListener sensorStatusListener = sensorStatusListeners.get(sensor.getId());
-            if (sensorStatusListener != null) {
-                sensorStatusListener.onSensorGone(hueBridge, sensor);
+            final SensorStatusListener listener = sensorStatusListeners.get(sensor.getId());
+            if (listener != null) {
+                listener.onSensorGone(hueBridge, sensor);
             }
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.
@@ -726,22 +746,23 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 "@text/offline.conf-error-creation-username");
     }
 
+    @Override
     public boolean registerDiscoveryListener(HueLightDiscoveryService listener) {
-        if (discoveryListener == null) {
-            discoveryListener = listener;
-
+        if (discoveryService == null) {
+            discoveryService = listener;
             getFullLights().forEach(listener::addLightDiscovery);
             getFullSensors().forEach(listener::addSensorDiscovery);
-
+            getFullGroups().forEach(listener::addGroupDiscovery);
             return true;
         }
 
         return false;
     }
 
-    public boolean unregisterDiscoveryListener(HueLightDiscoveryService listener) {
-        if (discoveryListener != null) {
-            discoveryListener = null;
+    @Override
+    public boolean unregisterDiscoveryListener() {
+        if (discoveryService != null) {
+            discoveryService = null;
             return true;
         }
 
@@ -750,56 +771,59 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
 
     @Override
     public boolean registerLightStatusListener(LightStatusListener lightStatusListener) {
-        boolean result = lightStatusListeners.add(lightStatusListener);
-        if (result && hueBridge != null) {
-            // inform the listener initially about all lights and their states
-            for (FullLight light : lastLightStates.values()) {
-                lightStatusListener.onLightAdded(hueBridge, light);
+        final String lightId = lightStatusListener.getLightId();
+        if (!lightStatusListeners.containsKey(lightId)) {
+            lightStatusListeners.put(lightId, lightStatusListener);
+            if (hueBridge != null) {
+                lightStatusListener.onLightAdded(hueBridge, lastLightStates.get(lightId));
             }
-        }
 
-        return true;
+            return true;
+        }
+        return false;
     }
 
     @Override
     public boolean unregisterLightStatusListener(LightStatusListener lightStatusListener) {
-        return lightStatusListeners.remove(lightStatusListener);
+        return lightStatusListeners.remove(lightStatusListener.getLightId()) != null;
     }
 
     @Override
     public boolean registerSensorStatusListener(SensorStatusListener sensorStatusListener) {
-        boolean result = sensorStatusListeners.add(sensorStatusListener);
-        if (result && hueBridge != null) {
-            // inform the listener initially about all sensors and their states
-            for (FullSensor sensor : lastSensorStates.values()) {
-                sensorStatusListener.onSensorAdded(hueBridge, sensor);
+        final String sensorId = sensorStatusListener.getSensorId();
+        if (!sensorStatusListeners.containsKey(sensorId)) {
+            sensorStatusListeners.put(sensorId, sensorStatusListener);
+            if (hueBridge != null) {
+                sensorStatusListener.onSensorAdded(hueBridge, lastSensorStates.get(sensorId));
             }
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     @Override
     public boolean unregisterSensorStatusListener(SensorStatusListener sensorStatusListener) {
-        return sensorStatusListeners.remove(sensorStatusListener);
+        return sensorStatusListeners.remove(sensorStatusListener.getSensorId()) != null;
     }
 
     @Override
     public boolean registerGroupStatusListener(GroupStatusListener groupStatusListener) {
-        boolean result = groupStatusListeners.add(groupStatusListener);
-        if (result && hueBridge != null) {
-            // inform the listener initially about all groups and their states
-            for (FullGroup group : lastGroupStates.values()) {
-                groupStatusListener.onGroupAdded(hueBridge, group);
+        final String groupId = groupStatusListener.getGroupId();
+        if (!groupStatusListeners.containsKey(groupId)) {
+            groupStatusListeners.put(groupId, groupStatusListener);
+            if (hueBridge != null) {
+                groupStatusListener.onGroupAdded(hueBridge, lastGroupStates.get(groupId));
             }
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     @Override
     public boolean unregisterGroupStatusListener(GroupStatusListener groupStatusListener) {
-        return groupStatusListeners.remove(groupStatusListener);
+        return groupStatusListeners.remove(groupStatusListener.getGroupId()) != null;
     }
 
     @Override
@@ -868,102 +892,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             }
         }
         return null;
-    }
-
-    /**
-     * Iterate through lightStatusListeners and notify them about a status change.
-     *
-     * @param fullLight
-     * @param type the type of change
-     */
-    private void notifyLightStatusListeners(final FullLight fullLight, StatusType type) {
-        if (lightStatusListeners.isEmpty()) {
-            logger.debug("No light status listeners to notify of light change for light '{}'", fullLight.getId());
-            return;
-        }
-
-        for (LightStatusListener lightStatusListener : lightStatusListeners) {
-            try {
-                switch (type) {
-                    case ADDED:
-                        logger.debug("Sending lightAdded for light '{}'", fullLight.getId());
-                        lightStatusListener.onLightAdded(hueBridge, fullLight);
-                        break;
-                    case REMOVED:
-                        lightStatusListener.onLightRemoved(hueBridge, fullLight);
-                        break;
-                    case GONE:
-                        lightStatusListener.onLightGone(hueBridge, fullLight);
-                        break;
-                    case CHANGED:
-                        logger.debug("Sending lightStateChanged for light '{}'", fullLight.getId());
-                        lightStatusListener.onLightStateChanged(hueBridge, fullLight);
-                        break;
-                }
-            } catch (Exception e) {
-                logger.debug("An exception occurred while calling the BridgeHeartbeatListener", e);
-            }
-        }
-    }
-
-    private void notifySensorStatusListeners(final FullSensor fullSensor, StatusType type) {
-        if (sensorStatusListeners.isEmpty()) {
-            logger.debug("No sensor status listeners to notify of sensor change for sensor '{}'", fullSensor.getId());
-            return;
-        }
-
-        for (SensorStatusListener sensorStatusListener : sensorStatusListeners) {
-            try {
-                switch (type) {
-                    case ADDED:
-                        logger.debug("Sending sensorAdded for sensor '{}'", fullSensor.getId());
-                        sensorStatusListener.onSensorAdded(hueBridge, fullSensor);
-                        break;
-                    case REMOVED:
-                        sensorStatusListener.onSensorRemoved(hueBridge, fullSensor);
-                        break;
-                    case GONE:
-                        sensorStatusListener.onSensorGone(hueBridge, fullSensor);
-                        break;
-                    case CHANGED:
-                        logger.debug("Sending sensorStateChanged for sensor '{}'", fullSensor.getId());
-                        sensorStatusListener.onSensorStateChanged(hueBridge, fullSensor);
-                        break;
-                }
-            } catch (Exception e) {
-                logger.debug("An exception occurred while calling the Sensor Listeners", e);
-            }
-        }
-    }
-
-    private void notifyGroupStatusListeners(final FullGroup fullGroup, StatusType type) {
-        if (groupStatusListeners.isEmpty()) {
-            logger.debug("No group status listeners to notify of group change for group '{}'", fullGroup.getId());
-            return;
-        }
-
-        for (GroupStatusListener groupStatusListener : groupStatusListeners) {
-            try {
-                switch (type) {
-                    case ADDED:
-                        logger.debug("Sending groupAdded for group '{}'", fullGroup.getId());
-                        groupStatusListener.onGroupAdded(hueBridge, fullGroup);
-                        break;
-                    case REMOVED:
-                        groupStatusListener.onGroupRemoved(hueBridge, fullGroup);
-                        break;
-                    case GONE:
-                        groupStatusListener.onGroupGone(hueBridge, fullGroup);
-                        break;
-                    case CHANGED:
-                        logger.debug("Sending groupStateChanged for group '{}'", fullGroup.getId());
-                        groupStatusListener.onGroupStateChanged(hueBridge, fullGroup);
-                        break;
-                }
-            } catch (Exception e) {
-                logger.debug("An exception occurred while calling the Group Listeners", e);
-            }
-        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -460,7 +460,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             final LightStatusListener listener = lightStatusListeners.get(lightId);
             if (listener != null) {
                 listener.unsetPollBypass();
-                ;
             }
         });
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -84,13 +84,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
 
     private static final String DEVICE_TYPE = "EclipseSmartHome";
 
-    private static enum StatusType {
-        ADDED,
-        REMOVED,
-        GONE,
-        CHANGED
-    }
-
     private final Logger logger = LoggerFactory.getLogger(HueBridgeHandler.class);
 
     private final Map<String, FullLight> lastLightStates = new ConcurrentHashMap<>();
@@ -166,29 +159,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             return true;
         }
     }
-
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_BRIDGE);
-
-    private static final String DEVICE_TYPE = "EclipseSmartHome";
-
-    private final Logger logger = LoggerFactory.getLogger(HueBridgeHandler.class);
-
-    private final Map<String, FullLight> lastLightStates = new ConcurrentHashMap<>();
-    private final Map<String, FullSensor> lastSensorStates = new ConcurrentHashMap<>();
-
-    private boolean lastBridgeConnectionState = false;
-
-    private boolean propertiesInitializedSuccessfully = false;
-
-    private @Nullable HueLightDiscoveryService discoveryListener;
-    private final Map<String, LightStatusListener> lightStatusListeners = new ConcurrentHashMap<>();
-    private final Map<String, SensorStatusListener> sensorStatusListeners = new ConcurrentHashMap<>();
-
-    private @Nullable ScheduledFuture<?> lightPollingJob;
-    private @Nullable ScheduledFuture<?> sensorPollingJob;
-
-    private @NonNullByDefault({}) HueBridge hueBridge = null;
-    private @NonNullByDefault({}) HueBridgeConfig hueBridgeConfig = null;
 
     private final Runnable sensorPollingRunnable = new PollingRunnable() {
         @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -427,13 +427,17 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     @Override
     public void updateGroupState(FullGroup group, StateUpdate stateUpdate, long fadeTime) {
         if (hueBridge != null) {
+            setGroupPollBypass(group, BYPASS_MIN_DURATION_BEFORE_CMD);
             hueBridge.setGroupState(group, stateUpdate).thenAccept(result -> {
                 try {
                     hueBridge.handleErrors(result);
+                    setGroupPollBypass(group, fadeTime);
                 } catch (Exception e) {
+                    unsetGroupPollBypass(group);
                     handleStateUpdateException(group, stateUpdate, e);
                 }
             }).exceptionally(e -> {
+                unsetGroupPollBypass(group);
                 handleStateUpdateException(group, stateUpdate, e);
                 return null;
             });

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -209,6 +209,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                     if (discovery != null) {
                         discovery.onSensorAdded(hueBridge, sensor);
                     }
+
+                    lastSensorStates.put(sensorId, sensor);
                 } else {
                     lastSensorStateCopy.remove(sensorId);
                     if (sensorStatusListener.onSensorStateChanged(hueBridge, sensor)) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -142,5 +142,5 @@ public interface HueClient {
      * @param group the group to be updated
      * @param stateUpdate the state update
      */
-    void updateGroupState(FullGroup group, StateUpdate stateUpdate);
+    void updateGroupState(FullGroup group, StateUpdate stateUpdate, long fadeTime);
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -19,6 +19,7 @@ import org.openhab.binding.hue.internal.FullGroup;
 import org.openhab.binding.hue.internal.FullLight;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.StateUpdate;
+import org.openhab.binding.hue.internal.discovery.HueLightDiscoveryService;
 
 /**
  * Access to the Hue system for light handlers.
@@ -30,6 +31,10 @@ import org.openhab.binding.hue.internal.StateUpdate;
  */
 @NonNullByDefault
 public interface HueClient {
+
+    boolean registerDiscoveryListener(HueLightDiscoveryService listener);
+
+    boolean unregisterDiscoveryListener();
 
     /**
      * Register a light status listener.
@@ -109,18 +114,11 @@ public interface HueClient {
     /**
      * Updates the given light.
      *
+     * @param listener the light status listener to set bypass time
      * @param light the light to be updated
      * @param stateUpdate the state update
      */
-    void updateLightState(FullLight light, StateUpdate stateUpdate);
-
-    /**
-     * Updates the given light.
-     *
-     * @param light the light to be updated
-     * @param stateUpdate the state update
-     */
-    void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate);
+    void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate, long fadeTime);
 
     /**
      * Updates the given sensors config.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -115,6 +115,14 @@ public interface HueClient {
     void updateLightState(FullLight light, StateUpdate stateUpdate);
 
     /**
+     * Updates the given light.
+     *
+     * @param light the light to be updated
+     * @param stateUpdate the state update
+     */
+    void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate);
+
+    /**
      * Updates the given sensors config.
      *
      * @param sensor the light to be updated

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueClient.java
@@ -32,8 +32,19 @@ import org.openhab.binding.hue.internal.discovery.HueLightDiscoveryService;
 @NonNullByDefault
 public interface HueClient {
 
+    /**
+     * Register {@link HueLightDiscoveryService} to bridge handler
+     * 
+     * @param listener the discovery service
+     * @return {@code true} if the new discovery service is accepted
+     */
     boolean registerDiscoveryListener(HueLightDiscoveryService listener);
 
+    /**
+     * Unregister {@link HueLightDiscoveryService} from bridge handler
+     * 
+     * @return {@code true} if the discovery service was removed
+     */
     boolean unregisterDiscoveryListener();
 
     /**
@@ -114,9 +125,10 @@ public interface HueClient {
     /**
      * Updates the given light.
      *
-     * @param listener the light status listener to set bypass time
+     * @param listener the light status listener to block it for state updates
      * @param light the light to be updated
      * @param stateUpdate the state update
+     * @param fadeTime the status listener will be blocked for this duration after command
      */
     void updateLightState(LightStatusListener listener, FullLight light, StateUpdate stateUpdate, long fadeTime);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
@@ -387,23 +387,17 @@ public class HueGroupHandler extends BaseThingHandler implements GroupStatusList
 
     @Override
     public void onGroupAdded(@Nullable HueBridge bridge, FullGroup group) {
-        if (group.getId().equals(groupId)) {
-            onGroupStateChanged(bridge, group);
-        }
+        onGroupStateChanged(bridge, group);
     }
 
     @Override
     public void onGroupRemoved(@Nullable HueBridge bridge, FullGroup group) {
-        if (group.getId().equals(groupId)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.group-removed");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.group-removed");
     }
 
     @Override
     public void onGroupGone(@Nullable HueBridge bridge, FullGroup group) {
-        if (group.getId().equals(groupId)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.group-removed");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.group-removed");
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
@@ -266,7 +266,7 @@ public class HueGroupHandler extends BaseThingHandler implements GroupStatusList
             if (tmpColorTemp != null) {
                 lastSentColorTemp = tmpColorTemp;
             }
-            bridgeHandler.updateGroupState(group, groupState);
+            bridgeHandler.updateGroupState(group, groupState, fadeTime);
         } else {
             logger.debug("Command sent to an unknown channel id: {}:{}", getThing().getUID(), channel);
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueGroupHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -341,7 +342,7 @@ public class HueGroupHandler extends BaseThingHandler implements GroupStatusList
         logger.trace("onGroupStateChanged() was called for group {}", group.getId());
 
         final FullGroup lastState = lastFullGroup;
-        if (lastState == null || !lastState.getState().equals(group.getState())) {
+        if (lastState == null || !Objects.equals(lastState.getState(), group.getState())) {
             lastFullGroup = group;
         } else {
             return true;

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -81,8 +81,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             THING_TYPE_COLOR_TEMPERATURE_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_EXTENDED_COLOR_LIGHT,
             THING_TYPE_ON_OFF_LIGHT, THING_TYPE_ON_OFF_PLUG, THING_TYPE_DIMMABLE_PLUG).collect(Collectors.toSet());
 
-    private static final long BYPASS_MIN_DURATION_BEFORE_CMD = 1500L;
-
     // @formatter:off
     private static final Map<String, List<String>> VENDOR_MODEL_MAP = Stream.of(
             new SimpleEntry<>("Philips",
@@ -440,13 +438,8 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
     }
 
     @Override
-    public void setPollBypassBeforeCmd() {
-        endBypassTime = System.currentTimeMillis() + BYPASS_MIN_DURATION_BEFORE_CMD;
-    }
-
-    @Override
-    public void setPollBypassFadeTime(long fadeTime) {
-        endBypassTime = System.currentTimeMillis() + fadeTime;
+    public void setPollBypass(long bypassTime) {
+        endBypassTime = System.currentTimeMillis() + bypassTime;
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -458,9 +458,10 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
     public boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight fullLight) {
         logger.trace("onLightStateChanged() was called");
 
+        // TODO Maybe this check is obsolete
         if (!fullLight.getId().equals(lightId)) {
             logger.trace("Received state change for another handler's light ({}). Will be ignored.", fullLight.getId());
-            return true;
+            return false;
         }
 
         if (System.currentTimeMillis() - lastTimeCmd <= BYPASS_LIGHT_POLL_DURATION) {
@@ -534,21 +535,21 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
 
     @Override
     public void onLightRemoved(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) {
+        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.light-removed");
         }
     }
 
     @Override
     public void onLightGone(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) {
+        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.light-not-reachable");
         }
     }
 
     @Override
     public void onLightAdded(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) {
+        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
             onLightStateChanged(bridge, light);
         }
     }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -458,12 +458,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
     public boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight fullLight) {
         logger.trace("onLightStateChanged() was called");
 
-        // TODO Maybe this check is obsolete
-        if (!fullLight.getId().equals(lightId)) {
-            logger.debug("Received state change for another handler's light ({}). Will be ignored.", fullLight.getId());
-            return false;
-        }
-
         if (System.currentTimeMillis() - lastTimeCmd <= BYPASS_LIGHT_POLL_DURATION) {
             logger.debug("Bypass light update after command ({}).", lightId);
             return false;
@@ -537,23 +531,17 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
 
     @Override
     public void onLightRemoved(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.light-removed");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.light-removed");
     }
 
     @Override
     public void onLightGone(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.light-not-reachable");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.light-not-reachable");
     }
 
     @Override
     public void onLightAdded(@Nullable HueBridge bridge, FullLight light) {
-        if (light.getId().equals(lightId)) { // TODO Maybe this check is obsolete
-            onLightStateChanged(bridge, light);
-        }
+        onLightStateChanged(bridge, light);
     }
 
     /**

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -94,10 +94,11 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
 
     private static final String OSRAM_PAR16_50_TW_MODEL_ID = "PAR16_50_TW";
 
+    private final Logger logger = LoggerFactory.getLogger(HueLightHandler.class);
+
     private static final long BYPASS_LIGHT_POLL_DURATION = 1000;
 
-    @NonNullByDefault({})
-    private String lightId;
+    private @NonNullByDefault({}) String lightId;
 
     private @Nullable FullLight lastFullLight;
     private Long lastTimeCmd = 0L;
@@ -143,15 +144,11 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             }
 
             lightId = configLightId;
-            // note: this call implicitly registers our handler as a listener on
-            // the bridge
-            final HueClient bridgeHandler = getHueClient();
-
+            // note: this call implicitly registers our handler as a listener on the bridge
+            HueClient bridgeHandler = getHueClient();
             if (bridgeHandler != null) {
                 if (bridgeStatus == ThingStatus.ONLINE) {
-                    FullLight fullLight = bridgeHandler.getLightById(lightId);
-                    lastFullLight = fullLight;
-                    initializeProperties(fullLight);
+                    initializeProperties(bridgeHandler.getLightById(lightId));
                     updateStatus(ThingStatus.ONLINE);
                 } else {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
@@ -228,7 +225,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             return;
         }
 
-        final FullLight light = lastFullLight;
+        FullLight light = lastFullLight;
         if (light == null) {
             logger.debug("hue light not known on bridge. Cannot handle command.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -102,7 +102,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
     private @Nullable FullLight lastFullLight;
     private Long lastTimeCmd = 0L;
 
-    // TODO think those two can be refactored with lastFullLight
     private @Nullable Integer lastSentColorTemp;
     private @Nullable Integer lastSentBrightness;
 
@@ -166,28 +165,19 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         }
     }
 
-    private synchronized void initializeProperties(@Nullable FullHueObject fullLight) {
-        if (!propertiesInitializedSuccessfully) {
-            if (fullLight != null) {
-                Map<String, String> properties = editProperties();
-                String softwareVersion = fullLight.getSoftwareVersion();
-                if (softwareVersion != null) {
-                    properties.put(PROPERTY_FIRMWARE_VERSION, softwareVersion);
-                }
-                String modelId = fullLight.getNormalizedModelID();
-                if (modelId != null) {
-                    properties.put(PROPERTY_MODEL_ID, modelId);
-                    String vendor = getVendor(modelId);
-                    if (vendor != null) {
-                        properties.put(PROPERTY_VENDOR, vendor);
-                    }
-                } else {
-                    properties.put(PROPERTY_VENDOR, fullLight.getManufacturerName());
-                }
-                properties.put(PRODUCT_NAME, fullLight.getProductName());
-                String uniqueID = fullLight.getUniqueID();
-                if (uniqueID != null) {
-                    properties.put(UNIQUE_ID, uniqueID);
+    private synchronized void initializeProperties(@Nullable FullLight fullLight) {
+        if (!propertiesInitializedSuccessfully && fullLight != null) {
+            Map<String, String> properties = editProperties();
+            String softwareVersion = fullLight.getSoftwareVersion();
+            if (softwareVersion != null) {
+                properties.put(PROPERTY_FIRMWARE_VERSION, softwareVersion);
+            }
+            String modelId = fullLight.getNormalizedModelID();
+            if (modelId != null) {
+                properties.put(PROPERTY_MODEL_ID, modelId);
+                String vendor = getVendor(modelId);
+                if (vendor != null) {
+                    properties.put(PROPERTY_VENDOR, vendor);
                 }
             } else {
                 properties.put(PROPERTY_VENDOR, fullLight.getManufacturerName());
@@ -362,9 +352,9 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             if (tmpColorTemp != null) {
                 lastSentColorTemp = tmpColorTemp;
             }
-            hueBridge.updateLightState(light, lightState);
 
             lastTimeCmd = System.currentTimeMillis();
+            bridgeHandler.updateLightState(light, lightState);
         } else {
             logger.warn("Command sent to an unknown channel id: {}:{}", getThing().getUID(), channel);
         }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -460,21 +460,23 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
 
         // TODO Maybe this check is obsolete
         if (!fullLight.getId().equals(lightId)) {
-            logger.trace("Received state change for another handler's light ({}). Will be ignored.", fullLight.getId());
+            logger.debug("Received state change for another handler's light ({}). Will be ignored.", fullLight.getId());
             return false;
         }
 
         if (System.currentTimeMillis() - lastTimeCmd <= BYPASS_LIGHT_POLL_DURATION) {
-            logger.trace("Bypass light update after command ({}).", fullLight.getId());
+            logger.debug("Bypass light update after command ({}).", lightId);
             return false;
         }
 
-        final FullLight lastState = lastFullLight;
-        if (lastState == null || !lastState.equals(fullLight)) {
+        final FullLight lastLight = lastFullLight;
+        if (lastLight == null || !lastLight.getState().equals(fullLight.getState())) {
             lastFullLight = fullLight;
         } else {
             return true;
         }
+
+        logger.trace("New state for light {}", lightId);
 
         initializeProperties(fullLight);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -225,7 +225,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             return;
         }
 
-        FullLight light = lastFullLight;
+        final FullLight light = lastFullLight;
         if (light == null) {
             logger.debug("hue light not known on bridge. Cannot handle command.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueLightHandler.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -457,7 +458,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         }
 
         final FullLight lastState = lastFullLight;
-        if (lastState == null || !lastState.getState().equals(fullLight.getState())) {
+        if (lastState == null || !Objects.equals(lastState.getState(), fullLight.getState())) {
             lastFullLight = fullLight;
         } else {
             return true;

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -229,7 +230,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         logger.trace("onSensorStateChanged() was called");
 
         final FullSensor lastSensor = lastFullSensor;
-        if (lastSensor == null || !lastSensor.getState().equals(sensor.getState())) {
+        if (lastSensor == null || !Objects.equals(lastSensor.getState(), sensor.getState())) {
             lastFullSensor = sensor;
         } else {
             return true;

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -174,6 +174,12 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
             return;
         }
 
+        HueClient bridgeHandler = getHueClient();
+        if (bridgeHandler == null) {
+            logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
+            return;
+        }
+
         StateUpdate sensorState = new StateUpdate();
         switch (channel) {
             case STATE_STATUS:

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -165,18 +165,18 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
     }
 
     public void handleCommand(String channel, Command command) {
+        HueClient bridgeHandler = getHueClient();
+        if (bridgeHandler == null) {
+            logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
+            return;
+        }
+
         // updateSensorState
         final FullSensor sensor = lastFullSensor;
         if (sensor == null) {
             logger.debug("hue sensor not known on bridge. Cannot handle command.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-wrong-sensor-id");
-            return;
-        }
-
-        HueClient bridgeHandler = getHueClient();
-        if (bridgeHandler == null) {
-            logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
             return;
         }
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -230,12 +230,12 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
     }
 
     @Override
-    public void onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
+    public boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
         logger.trace("onSensorStateChanged() was called");
 
         if (!sensor.getId().equals(sensorId)) {
             logger.trace("Received state change for another handler's sensor ({}). Will be ignored.", sensor.getId());
-            return;
+            return true;
         }
 
         initializeProperties(sensor);
@@ -297,6 +297,8 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
             updateConfiguration(config);
             configInitializedSuccessfully = true;
         }
+
+        return true;
     }
 
     @Override
@@ -347,5 +349,10 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         if (sensor.getId().equals(sensorId)) {
             onSensorStateChanged(bridge, sensor);
         }
+    }
+
+    @Override
+    public String getSensorId() {
+        return sensorId;
     }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -237,16 +237,18 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
         // TODO Maybe this check is obsolete
         if (!sensor.getId().equals(sensorId)) {
-            logger.trace("Received state change for another handler's sensor ({}). Will be ignored.", sensor.getId());
+            logger.debug("Received state change for another handler's sensor ({}). Will be ignored.", sensor.getId());
             return false;
         }
 
-        final FullSensor lastState = lastFullSensor;
-        if (lastState == null || !lastState.equals(sensor)) {
+        final FullSensor lastSensor = lastFullSensor;
+        if (lastSensor == null || !lastSensor.getState().equals(sensor.getState())) {
             lastFullSensor = sensor;
         } else {
             return true;
         }
+
+        logger.trace("New state for sensor {}", sensorId);
 
         initializeProperties(sensor);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -93,9 +93,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
             if (bridgeHandler != null) {
                 if (bridgeStatus == ThingStatus.ONLINE) {
-                    FullSensor fullSensor = bridgeHandler.getSensorById(sensorId);
-                    lastFullSensor = fullSensor;
-                    initializeProperties(fullSensor);
+                    initializeProperties(bridgeHandler.getSensorById(sensorId));
                     updateStatus(ThingStatus.ONLINE);
                 } else {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
@@ -109,26 +107,16 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         }
     }
 
-    private synchronized void initializeProperties(@Nullable FullHueObject fullSensor) {
-        if (!propertiesInitializedSuccessfully) {
-            if (fullSensor != null) {
-                Map<String, String> properties = editProperties();
-                String softwareVersion = fullSensor.getSoftwareVersion();
-                if (softwareVersion != null) {
-                    properties.put(PROPERTY_FIRMWARE_VERSION, softwareVersion);
-                }
-                String modelId = fullSensor.getNormalizedModelID();
-                if (modelId != null) {
-                    properties.put(PROPERTY_MODEL_ID, modelId);
-                }
-                properties.put(PROPERTY_VENDOR, fullSensor.getManufacturerName());
-                properties.put(PRODUCT_NAME, fullSensor.getProductName());
-                String uniqueID = fullSensor.getUniqueID();
-                if (uniqueID != null) {
-                    properties.put(UNIQUE_ID, uniqueID);
-                }
-                updateProperties(properties);
-                propertiesInitializedSuccessfully = true;
+    private synchronized void initializeProperties(@Nullable FullSensor fullSensor) {
+        if (!propertiesInitializedSuccessfully && fullSensor != null) {
+            Map<String, String> properties = editProperties();
+            String softwareVersion = fullSensor.getSoftwareVersion();
+            if (softwareVersion != null) {
+                properties.put(PROPERTY_FIRMWARE_VERSION, softwareVersion);
+            }
+            String modelId = fullSensor.getNormalizedModelID();
+            if (modelId != null) {
+                properties.put(PROPERTY_MODEL_ID, modelId);
             }
             properties.put(PROPERTY_VENDOR, fullSensor.getManufacturerName());
             properties.put(PRODUCT_NAME, fullSensor.getProductName());

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -89,8 +89,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         if (configSensorId != null) {
             sensorId = configSensorId;
             // note: this call implicitly registers our handler as a listener on the bridge
-            final HueClient bridgeHandler = getHueClient();
-
+            HueClient bridgeHandler = getHueClient();
             if (bridgeHandler != null) {
                 if (bridgeStatus == ThingStatus.ONLINE) {
                     initializeProperties(bridgeHandler.getSensorById(sensorId));
@@ -171,8 +170,8 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
             return;
         }
 
-        // updateSensorState
-        final FullSensor sensor = lastFullSensor;
+        FullSensor sensor = lastFullSensor;
+
         if (sensor == null) {
             logger.debug("hue sensor not known on bridge. Cannot handle command.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -217,7 +217,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
                 return;
             }
 
-            FullSensor sensor = hueBridge.getSensorById(sensorId);
+            FullSensor sensor = lastFullSensor;
             if (sensor == null) {
                 logger.debug("hue sensor not known on bridge. Cannot handle command.");
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -234,12 +234,6 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
     @Override
     public boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor) {
         logger.trace("onSensorStateChanged() was called");
-
-        // TODO Maybe this check is obsolete
-        if (!sensor.getId().equals(sensorId)) {
-            logger.debug("Received state change for another handler's sensor ({}). Will be ignored.", sensor.getId());
-            return false;
-        }
 
         final FullSensor lastSensor = lastFullSensor;
         if (lastSensor == null || !lastSensor.getState().equals(sensor.getState())) {
@@ -341,23 +335,17 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
     @Override
     public void onSensorRemoved(@Nullable HueBridge bridge, FullSensor sensor) {
-        if (sensor.getId().equals(sensorId)) { // TODO Maybe this check is obsolete
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.sensor-not-reachable");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "@text/offline.sensor-not-reachable");
     }
 
     @Override
     public void onSensorGone(@Nullable HueBridge bridge, FullSensor sensor) {
-        if (sensor.getId().equals(sensorId)) {// TODO Maybe this check is obsolete
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.conf-error-wrong-sensor-id");
-        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "@text/offline.conf-error-wrong-sensor-id");
     }
 
     @Override
     public void onSensorAdded(@Nullable HueBridge bridge, FullSensor sensor) {
-        if (sensor.getId().equals(sensorId)) {// TODO Maybe this check is obsolete
-            onSensorStateChanged(bridge, sensor);
-        }
+        onSensorStateChanged(bridge, sensor);
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -170,7 +170,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
             return;
         }
 
-        FullSensor sensor = lastFullSensor;
+        final FullSensor sensor = lastFullSensor;
 
         if (sensor == null) {
             logger.debug("hue sensor not known on bridge. Cannot handle command.");
@@ -210,7 +210,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
                 return;
             }
 
-            FullSensor sensor = lastFullSensor;
+            final FullSensor sensor = lastFullSensor;
             if (sensor == null) {
                 logger.debug("hue sensor not known on bridge. Cannot handle command.");
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -26,6 +26,11 @@ import org.openhab.binding.hue.internal.HueBridge;
 @NonNullByDefault
 public interface LightStatusListener {
 
+    /**
+     * This method returns the light Id
+     * 
+     * @return lightId of thing or DISCOVERY for discovery service
+     */
     String getLightId();
 
     /**
@@ -34,6 +39,7 @@ public interface LightStatusListener {
      *
      * @param bridge The bridge the changed light is connected to.
      * @param light The light which received the state update.
+     * @return The light handler returns true if it accepts the new state.
      */
     boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light);
 

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -29,7 +29,7 @@ public interface LightStatusListener {
     /**
      * This method returns the light id of the listener
      * 
-     * @return lightId
+     * @return
      */
     String getLightId();
 
@@ -67,7 +67,15 @@ public interface LightStatusListener {
      */
     void onLightAdded(@Nullable HueBridge bridge, FullLight light);
 
+    /**
+     * The thing will block state updates for set time.
+     * 
+     * @param bypassTime
+     */
     void setPollBypass(long bypassTime);
 
+    /**
+     * Unblock state updates.
+     */
     void unsetPollBypass();
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -66,4 +66,10 @@ public interface LightStatusListener {
      * @param light The light which is added.
      */
     void onLightAdded(@Nullable HueBridge bridge, FullLight light);
+
+    void enablePollBypassBeforeCmd();
+
+    void enablePollBypassAfterCmd(@Nullable Long fadeTime);
+
+    void disablePollBypass();
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -26,6 +26,8 @@ import org.openhab.binding.hue.internal.HueBridge;
 @NonNullByDefault
 public interface LightStatusListener {
 
+    String getLightId();
+
     /**
      * This method is called whenever the state of the given light has changed. The new state can be obtained by
      * {@link FullLight#getState()}.
@@ -33,7 +35,7 @@ public interface LightStatusListener {
      * @param bridge The bridge the changed light is connected to.
      * @param light The light which received the state update.
      */
-    void onLightStateChanged(@Nullable HueBridge bridge, FullLight light);
+    boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light);
 
     /**
      * This method is called whenever a light is removed.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -67,9 +67,7 @@ public interface LightStatusListener {
      */
     void onLightAdded(@Nullable HueBridge bridge, FullLight light);
 
-    void setPollBypassBeforeCmd();
-
-    void setPollBypassFadeTime(long fadeTime);
+    void setPollBypass(long bypassTime);
 
     void unsetPollBypass();
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStatusListener.java
@@ -27,9 +27,9 @@ import org.openhab.binding.hue.internal.HueBridge;
 public interface LightStatusListener {
 
     /**
-     * This method returns the light Id
+     * This method returns the light id of the listener
      * 
-     * @return lightId of thing or DISCOVERY for discovery service
+     * @return lightId
      */
     String getLightId();
 
@@ -39,7 +39,7 @@ public interface LightStatusListener {
      *
      * @param bridge The bridge the changed light is connected to.
      * @param light The light which received the state update.
-     * @return The light handler returns true if it accepts the new state.
+     * @return
      */
     boolean onLightStateChanged(@Nullable HueBridge bridge, FullLight light);
 
@@ -67,9 +67,9 @@ public interface LightStatusListener {
      */
     void onLightAdded(@Nullable HueBridge bridge, FullLight light);
 
-    void enablePollBypassBeforeCmd();
+    void setPollBypassBeforeCmd();
 
-    void enablePollBypassAfterCmd(@Nullable Long fadeTime);
+    void setPollBypassFadeTime(long fadeTime);
 
-    void disablePollBypass();
+    void unsetPollBypass();
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/SensorStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/SensorStatusListener.java
@@ -33,7 +33,7 @@ public interface SensorStatusListener {
      * @param bridge The bridge the changed sensor is connected to.
      * @param sensor The sensor which received the state update.
      */
-    void onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor);
+    boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor);
 
     /**
      * This method is called whenever a sensor is removed.
@@ -58,4 +58,6 @@ public interface SensorStatusListener {
      * @param sensor The added sensor
      */
     void onSensorAdded(@Nullable HueBridge bridge, FullSensor sensor);
+
+    String getSensorId();
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/SensorStatusListener.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/SensorStatusListener.java
@@ -27,11 +27,19 @@ import org.openhab.binding.hue.internal.HueBridge;
 public interface SensorStatusListener {
 
     /**
+     * This method returns the sensor Id
+     * 
+     * @return sensor id of thing or DISCOVERY for discovery service
+     */
+    String getSensorId();
+
+    /**
      * This method is called whenever the state of the given sensor has changed. The new state can be obtained by
      * {@link FullSensor#getState()}.
      *
      * @param bridge The bridge the changed sensor is connected to.
      * @param sensor The sensor which received the state update.
+     * @return The sensor handler returns true if it accepts the new state.
      */
     boolean onSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor);
 
@@ -58,6 +66,4 @@ public interface SensorStatusListener {
      * @param sensor The added sensor
      */
     void onSensorAdded(@Nullable HueBridge bridge, FullSensor sensor);
-
-    String getSensorId();
 }

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
@@ -390,7 +390,8 @@ public class HueLightHandlerTest {
         hueLightHandler.handleCommand(new ChannelUID(new ThingUID("hue::test"), channel), command);
 
         ArgumentCaptor<StateUpdate> captorStateUpdate = ArgumentCaptor.forClass(StateUpdate.class);
-        verify(mockClient).updateLightState(any(FullLight.class), captorStateUpdate.capture());
+        verify(mockClient).updateLightState(any(LightStatusListener.class), any(FullLight.class),
+                captorStateUpdate.capture());
         assertJson(expectedReply, captorStateUpdate.getValue().toJson());
     }
 

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
@@ -371,6 +371,8 @@ public class HueLightHandlerTest {
         HueClient mockClient = mock(HueClient.class);
         when(mockClient.getLightById(any())).thenReturn(light);
 
+        long fadeTime = 400;
+
         HueLightHandler hueLightHandler = new HueLightHandler(mockThing) {
             @Override
             protected synchronized HueClient getHueClient() {
@@ -391,7 +393,7 @@ public class HueLightHandlerTest {
 
         ArgumentCaptor<StateUpdate> captorStateUpdate = ArgumentCaptor.forClass(StateUpdate.class);
         verify(mockClient).updateLightState(any(LightStatusListener.class), any(FullLight.class),
-                captorStateUpdate.capture());
+                captorStateUpdate.capture(), eq(fadeTime));
         assertJson(expectedReply, captorStateUpdate.getValue().toJson());
     }
 

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
@@ -135,7 +135,7 @@ public class HueLightDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent 
             }
         });
 
-        discoveryService.onLightAdded(null, light);
+        discoveryService.addLightDiscovery(light);
         waitForAssert(() -> {
             assertTrue(resultWrapper.get() != null);
         });


### PR DESCRIPTION
Complete refactoring of state handling inside bridge handler to light and sensor handlers, for alternative to PR #7493 fix for issue #7039 

Open points:
- Think polling jobs can be started at initialize of bridge handler and stopped on dispose, because while refactoring I noticed that the lists of light and senor listeners will be never empty because of registered discovery service
- In light and sensor handler there are several checks for IDs (marked with TODOs) which I think they are obsolete now, because bridge only notifies the single handler now.
- Didn't check the tests right now