### PR TITLE
[pioneeravr] support REFRESH command type where applicable

### DIFF
--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/handler/AbstractAvrHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.pioneeravr.internal.PioneerAvrBindingConstants;
 import org.openhab.binding.pioneeravr.internal.protocol.RequestResponseFactory;
@@ -120,7 +121,7 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
         // When the AVR is Powered ON, query the volume, the mute state and the source input of the zone
         connection.sendVolumeQuery(zone);
         connection.sendMuteQuery(zone);
-        connection.sendSourceInputQuery(zone);
+        connection.sendInputSourceQuery(zone);
         connection.sendListeningModeQuery(zone);
     }
 
@@ -166,16 +167,37 @@ public abstract class AbstractAvrHandler extends BaseThingHandler
             boolean unknownCommand = false;
 
             if (channelUID.getId().contains(PioneerAvrBindingConstants.POWER_CHANNEL)) {
-                commandSent = connection.sendPowerCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                if (command == RefreshType.REFRESH) {
+                    commandSent = connection.sendPowerQuery(getZoneFromChannelUID(channelUID.getId()));
+                } else {
+                    commandSent = connection.sendPowerCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                }
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.VOLUME_DIMMER_CHANNEL)
                     || channelUID.getId().contains(PioneerAvrBindingConstants.VOLUME_DB_CHANNEL)) {
-                commandSent = connection.sendVolumeCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                if (command == RefreshType.REFRESH) {
+                    commandSent = connection.sendVolumeQuery(getZoneFromChannelUID(channelUID.getId()));
+                } else {
+                    commandSent = connection.sendVolumeCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                }
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.SET_INPUT_SOURCE_CHANNEL)) {
-                commandSent = connection.sendInputSourceCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                if (command == RefreshType.REFRESH) {
+                    commandSent = connection.sendInputSourceQuery(getZoneFromChannelUID(channelUID.getId()));
+                } else {
+                    commandSent = connection.sendInputSourceCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                }
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.LISTENING_MODE_CHANNEL)) {
-                commandSent = connection.sendListeningModeCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                if (command == RefreshType.REFRESH) {
+                    commandSent = connection.sendListeningModeQuery(getZoneFromChannelUID(channelUID.getId()));
+                } else {
+                    commandSent = connection.sendListeningModeCommand(command,
+                            getZoneFromChannelUID(channelUID.getId()));
+                }
             } else if (channelUID.getId().contains(PioneerAvrBindingConstants.MUTE_CHANNEL)) {
-                commandSent = connection.sendMuteCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                if (command == RefreshType.REFRESH) {
+                    commandSent = connection.sendMuteQuery(getZoneFromChannelUID(channelUID.getId()));
+                } else {
+                    commandSent = connection.sendMuteCommand(command, getZoneFromChannelUID(channelUID.getId()));
+                }
             } else {
                 unknownCommand = true;
             }

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
@@ -186,7 +186,7 @@ public abstract class StreamAvrConnection implements AvrConnection {
     }
 
     @Override
-    public boolean sendSourceInputQuery(int zone) {
+    public boolean sendInputSourceQuery(int zone) {
         return sendCommand(RequestResponseFactory.getIpControlCommand(SimpleCommandType.INPUT_QUERY, zone));
     }
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
@@ -86,7 +86,7 @@ public interface AvrConnection {
      * @param zone
      * @return
      */
-    public boolean sendSourceInputQuery(int zone);
+    public boolean sendInputSourceQuery(int zone);
 
     /**
      * Send a listening mode state query to the AVR


### PR DESCRIPTION
This PR adds support for REFRESH commands on Pioneer AVR channels where this makes sense.

This way the REFRESH caused by BaseThingHandler.channelLinked() is properly handled.

Signed-off-by: Nils Schnabel <github@to.nilsschnabel.de>