### PR TITLE
Corrected syntax error in example pentair items

### DIFF
--- a/bundles/org.openhab.binding.pentair/README.md
+++ b/bundles/org.openhab.binding.pentair/README.md
@@ -150,8 +150,8 @@ Number PoolHeatMode            "Pool Heat Mode [%d]"                          (g
 String PoolHeatModeStr         "Pool Heat Mode [%s]"                          (gPool)   { channel="pentair:easytouch:1:main:poolheatmodestr" }
 Number SpaHeatMode             "Spa Heat Mode [%d]"                           (gPool)   { channel="pentair:easytouch:1:main:spaheatmode" }
 String SpaHeatModeStr          "Spa Heat Mode [%s]"                           (gPool)   { channel="pentair:easytouch:1:main:spaheatmodestr" }
-PoolSetPoint                   "Pool Set Point [%.1f °F]"                     (gPool)   { channel="pentair:easytouch:1:main:poolsetpoint" }
-Number SpaSetPoint             "Spa Set Point [%.1f °F]"                      (gPool)   { channel="pentair:easytouch:1:main:spasetpoint" }    
+Number PoolSetPoint            "Pool Set Point [%.1f °F]"     <temperature>   (gPool)   { channel="pentair:easytouch:1:main:poolsetpoint" }
+Number SpaSetPoint             "Spa Set Point [%.1f °F]"      <temperature>   (gPool)   { channel="pentair:easytouch:1:main:spasetpoint" }    
 Number HeatActive              "Heat Active [%d]"                             (gPool)  { channel="pentair:easytouch:1:main:heatactive" }
 
 Switch Mode_Spa                 "Spa Mode"                                    (gPool)  { channel = "pentair:easytouch:1:main:spa" }


### PR DESCRIPTION
Adding missing type declaration on the PoolSetPoint line which resulted in a syntax error when being used directly.  Also added the temperature type to the pool and spa set point values so they display correctly.
