### PR TITLE
[ecobee] Add ChannelTypeUID for dynamic channels

### DIFF
--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.openhab.binding.ecobee.internal.dto.thermostat.AlertDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.EventDTO;
 import org.openhab.binding.ecobee.internal.dto.thermostat.HouseDetailsDTO;
@@ -375,6 +376,12 @@ public class EcobeeBindingConstants {
     public static final String CH_SENSOR_TYPE = "type";
     public static final String CH_SENSOR_CODE = "code";
     public static final String CH_SENSOR_IN_USE = "inUse";
+
+    // Channel Type UIDs for dynamically created sensor channels
+    public static final ChannelTypeUID CHANNELTYPEUID_TEMPERATURE = new ChannelTypeUID("ecobee:sensorTemperature");
+    public static final ChannelTypeUID CHANNELTYPEUID_HUMIDITY = new ChannelTypeUID("ecobee:sensorHumidity");
+    public static final ChannelTypeUID CHANNELTYPEUID_OCCUPANCY = new ChannelTypeUID("ecobee:sensorOccupancy");
+    public static final ChannelTypeUID CHANNELTYPEUID_GENERIC = new ChannelTypeUID("ecobee:sensorGeneric");
 
     public static final AlertDTO EMPTY_ALERT = new AlertDTO();
     public static final EventDTO EMPTY_EVENT = new EventDTO();

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBindingConstants.java
@@ -378,10 +378,10 @@ public class EcobeeBindingConstants {
     public static final String CH_SENSOR_IN_USE = "inUse";
 
     // Channel Type UIDs for dynamically created sensor channels
-    public static final ChannelTypeUID CHANNELTYPEUID_TEMPERATURE = new ChannelTypeUID("ecobee:sensorTemperature");
-    public static final ChannelTypeUID CHANNELTYPEUID_HUMIDITY = new ChannelTypeUID("ecobee:sensorHumidity");
-    public static final ChannelTypeUID CHANNELTYPEUID_OCCUPANCY = new ChannelTypeUID("ecobee:sensorOccupancy");
-    public static final ChannelTypeUID CHANNELTYPEUID_GENERIC = new ChannelTypeUID("ecobee:sensorGeneric");
+    public static final ChannelTypeUID CHANNELTYPEUID_TEMPERATURE = new ChannelTypeUID(BINDING_ID, "sensorTemperature");
+    public static final ChannelTypeUID CHANNELTYPEUID_HUMIDITY = new ChannelTypeUID(BINDING_ID, "sensorHumidity");
+    public static final ChannelTypeUID CHANNELTYPEUID_OCCUPANCY = new ChannelTypeUID(BINDING_ID, "sensorOccupancy");
+    public static final ChannelTypeUID CHANNELTYPEUID_GENERIC = new ChannelTypeUID(BINDING_ID, "sensorGeneric");
 
     public static final AlertDTO EMPTY_ALERT = new AlertDTO();
     public static final EventDTO EMPTY_EVENT = new EventDTO();
@@ -389,8 +389,8 @@ public class EcobeeBindingConstants {
     public static final HouseDetailsDTO EMPTY_HOUSEDETAILS = new HouseDetailsDTO();
     public static final ManagementDTO EMPTY_MANAGEMENT = new ManagementDTO();
     public static final TechnicianDTO EMPTY_TECHNICIAN = new TechnicianDTO();
-    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO> emptyList();
-    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO> emptyList();
+    public static final List<RemoteSensorDTO> EMPTY_SENSORS = Collections.<RemoteSensorDTO>emptyList();
+    public static final List<ThermostatDTO> EMPTY_THERMOSTATS = Collections.<ThermostatDTO>emptyList();
 
     public static final String ECOBEE_BASE_URL = "https://api.ecobee.com/";
     public static final String ECOBEE_AUTHORIZE_URL = ECOBEE_BASE_URL + "authorize";

--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeSensorThingHandler.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/handler/EcobeeSensorThingHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -119,8 +120,10 @@ public class EcobeeSensorThingHandler extends BaseThingHandler {
             logger.debug("SensorThing: Create channel '{}'", uid);
             ThingBuilder thingBuilder;
             thingBuilder = editThing();
-            thingBuilder.withChannel(ChannelBuilder.create(uid, getChannelType(capability.type))
-                    .withLabel("Sensor " + WordUtils.capitalize(capability.type)).build());
+            channel = ChannelBuilder.create(uid, getAcceptedItemType(capability.type))
+                    .withLabel("Sensor " + WordUtils.capitalize(capability.type))
+                    .withType(getChannelTypeUID(capability.type)).build();
+            thingBuilder.withChannel(channel);
             updateThing(thingBuilder.build());
         }
         logger.trace("Capability '{}' has type '{}' with value '{}'", capability.id, capability.type, capability.value);
@@ -128,27 +131,50 @@ public class EcobeeSensorThingHandler extends BaseThingHandler {
     }
 
     // adc, co2, dryContact, humidity, temperature, occupancy, unknown.
-    private String getChannelType(String capabilityType) {
-        String type;
+    private String getAcceptedItemType(String capabilityType) {
+        String acceptedItemType;
         switch (capabilityType) {
             case CAPABILITY_TEMPERATURE:
-                type = "Number:Temperature";
+                acceptedItemType = "Number:Temperature";
                 break;
             case CAPABILITY_HUMIDITY:
-                type = "Number:Dimensionless";
+                acceptedItemType = "Number:Dimensionless";
                 break;
             case CAPABILITY_OCCUPANCY:
-                type = "Switch";
+                acceptedItemType = "Switch";
                 break;
             case CAPABILITY_ADC:
             case CAPABILITY_CO2:
             case CAPABILITY_DRY_CONTACT:
             case CAPABILITY_UNKNOWN:
             default:
-                type = "String";
+                acceptedItemType = "String";
                 break;
         }
-        return type;
+        return acceptedItemType;
+    }
+
+    private ChannelTypeUID getChannelTypeUID(String capabilityType) {
+        ChannelTypeUID channelTypeUID;
+        switch (capabilityType) {
+            case CAPABILITY_TEMPERATURE:
+                channelTypeUID = CHANNELTYPEUID_TEMPERATURE;
+                break;
+            case CAPABILITY_HUMIDITY:
+                channelTypeUID = CHANNELTYPEUID_HUMIDITY;
+                break;
+            case CAPABILITY_OCCUPANCY:
+                channelTypeUID = CHANNELTYPEUID_OCCUPANCY;
+                break;
+            case CAPABILITY_ADC:
+            case CAPABILITY_CO2:
+            case CAPABILITY_DRY_CONTACT:
+            case CAPABILITY_UNKNOWN:
+            default:
+                channelTypeUID = CHANNELTYPEUID_GENERIC;
+                break;
+        }
+        return channelTypeUID;
     }
 
     private void updateCapabilityState(String capabilityType, String value) {

--- a/bundles/org.openhab.binding.ecobee/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ecobee/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1722,5 +1722,10 @@
 		<label>Sensor Occupancy</label>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
+	<channel-type id="sensorGeneric">
+		<item-type>String</item-type>
+		<label>Generic Sensor</label>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
Fixes NPE in thing update REST API caused by a missing ChannelTypeUID on dynamically created channels on sensor thing.

See [here](https://community.openhab.org/t/ecobee-binding-v2/97733/7?u=mhilbush) and [here](https://github.com/openhab/openhab-core/issues/1457).

Signed-off-by: Mark Hilbush <mark@hilbush.com>
