### PR TITLE
[jinja] Remove dependency on jersey-all

### DIFF
--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -16,6 +16,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.10</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.22.0-GA</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>com.hubspot.jinjava.jinjava</artifactId>
       <version>2.5.0</version>

--- a/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.jinja/src/main/feature/feature.xml
@@ -12,6 +12,7 @@
 		<bundle dependency="true">mvn:de.odysseus.juel/juel-api/2.2.7</bundle>
 		<bundle dependency="true">mvn:de.odysseus.juel/juel-impl/2.2.7</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>
+		<bundle dependency="true">mvn:org.javassist/javassist/3.22.0-GA</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.hubspot.jinjava.jinjava/2.5.0</bundle>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.jinja/${project.version}</bundle>
 	</feature>


### PR DESCRIPTION
It will fail to compile when jersey-all is removed because that artifact also contains the jackson and javassist packages.

Related to openhab/openhab-core#1443