### PR TITLE
[sonyaudio] Add Night Mode (volume limiting) for Soundbars/AV receivers

### DIFF
--- a/bundles/org.openhab.binding.sonyaudio/README.md
+++ b/bundles/org.openhab.binding.sonyaudio/README.md
@@ -63,6 +63,7 @@ The devices support the following channels:
 | radio#broadcastFreq        | Number    | R           | Current radio frequency                                                               | STR-1080                                               |
 | radio#broadcastStation     | Number    | RW          | Set or get current preset radio station                                               | STR-1080                                               |
 | radio#broadcastSeekStation | String    | W           | Seek for new broadcast station, forward search "fwdSeeking" and backward "bwdSeeking" | STR-1080                                               |
+| nightMode                  | Switch    | RW          | Set or get the Night Mode state                                                       | HT-ZF9                                                 |
 
 
 ## Full Example

--- a/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/SonyAudioBindingConstants.java
+++ b/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/SonyAudioBindingConstants.java
@@ -90,6 +90,8 @@ public class SonyAudioBindingConstants {
     public static final String CHANNEL_RADIO_STATION = "radio#broadcastStation";
     public static final String CHANNEL_RADIO_SEEK_STATION = "radio#broadcastSeekStation";
 
+    public static final String CHANNEL_NIGHTMODE = "nightMode";
+
     // Used for Discovery service
     public static final String MANUFACTURER = "SONY";
     public static final String UPNP_DEVICE_TYPE = "MediaRenderer";

--- a/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/handler/SonyAudioHandler.java
+++ b/bundles/org.openhab.binding.sonyaudio/src/main/java/org/openhab/binding/sonyaudio/internal/handler/SonyAudioHandler.java
@@ -233,8 +233,11 @@ abstract class SonyAudioHandler extends BaseThingHandler implements SonyAudioEve
                 case CHANNEL_RADIO_SEEK_STATION:
                     handleRadioSeekStationCommand(command, channelUID);
                     break;
+                case CHANNEL_NIGHTMODE:
+                    handleNightMode(command, channelUID);
+                    break;
                 default:
-                    logger.error("Channel {} not supported!", id);
+                    logger.error("Command {}, {} not supported by {}!", id, command, channelUID);
             }
         } catch (IOException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
@@ -252,6 +255,20 @@ abstract class SonyAudioHandler extends BaseThingHandler implements SonyAudioEve
         if (command instanceof StringType) {
             logger.debug("handleSoundSettings set {}", command);
             connection.setSoundSettings("soundField", ((StringType) command).toString());
+        }
+    }
+
+    public void handleNightMode(Command command, ChannelUID channelUID) throws IOException {
+        if (command instanceof RefreshType) {
+            logger.debug("handleNightMode RefreshType");
+            Map<String, String> result = soundSettingsCache.getValue();
+            if (result != null) {
+                updateState(channelUID, new StringType(result.get("nightMode")));
+            }
+        }
+        if (command instanceof OnOffType) {
+            logger.debug("handleNightMode set {}",  command);
+            connection.setSoundSettings("nightMode", ((OnOffType) command) == OnOffType.ON ? "on" : "off");
         }
     }
 

--- a/bundles/org.openhab.binding.sonyaudio/src/main/resources/ESH-INF/thing/ht-z9f-zf9.xml
+++ b/bundles/org.openhab.binding.sonyaudio/src/main/resources/ESH-INF/thing/ht-z9f-zf9.xml
@@ -40,6 +40,12 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="nightMode">
+		<item-type>Switch</item-type>
+		<label>Night Mode</label>
+		<description>Enable/Disable Night Mode</description>
+	</channel-type>
+
 	<!-- HT-z9f Thing Type -->
 	<thing-type id="HT-Z9F">
 		<label>SONY Soundbar HT-Z9F</label>
@@ -59,11 +65,12 @@
 		<label>SONY Soundbar HT-ZF9</label>
 		<description>SONY Soundbar HT-ZF9</description>
 		<channels>
-			<channel id="power" typeId="power"/>
-			<channel id="input" typeId="input-z9f-zf9"/>
-			<channel id="volume" typeId="volume"/>
-			<channel id="mute" typeId="mute"/>
-			<channel id="soundField" typeId="sound-field-z9f-zf9"/>
+			<channel id="power" typeId="power" />
+			<channel id="input" typeId="input-z9f-zf9" />
+			<channel id="volume" typeId="volume" />
+			<channel id="mute" typeId="mute" />
+			<channel id="soundField" typeId="sound-field-z9f-zf9" />
+			<channel id="nightMode" typeId="nightMode" />
 		</channels>
 		<config-description-ref uri="thing-type:sonyaudio:config"/>
 	</thing-type>


### PR DESCRIPTION
Sony Soundbars, or at least the HT-ZF9, have a boolean setting
called Night Mode. This limits the maximum loudness, AFAICT doing
dynamic range compression.
This commit adds support for enabling/disabling Night Mode to the
handler and the definition to the ThingType for the ZF9.
It's actually a setting in the "Soundsettings" JSON but I think
exposing it as a boolean at the top level is the most sensible way
of presenting the interface.

Signed-off-by: Jack Challen <jackchallen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
