### PR TITLE
[bluetooth] Change abstract BluetoothAdapter implementation into a ThingHandlerService.

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -27,6 +27,7 @@ import org.openhab.binding.bluetooth.BluetoothCompletionStatus;
 import org.openhab.binding.bluetooth.BluetoothDescriptor;
 import org.openhab.binding.bluetooth.BluetoothDevice;
 import org.openhab.binding.bluetooth.BluetoothService;
+import org.openhab.binding.bluetooth.bluegiga.handler.BlueGigaAdapterService;
 import org.openhab.binding.bluetooth.bluegiga.handler.BlueGigaBridgeHandler;
 import org.openhab.binding.bluetooth.bluegiga.internal.BlueGigaEventListener;
 import org.openhab.binding.bluetooth.bluegiga.internal.BlueGigaResponse;
@@ -114,17 +115,22 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
      * @param address the {@link BluetoothAddress} for this device
      * @param addressType the {@link BluetoothAddressType} of this device
      */
-    public BlueGigaBluetoothDevice(BlueGigaBridgeHandler bgHandler, BluetoothAddress address,
+    public BlueGigaBluetoothDevice(BlueGigaAdapterService adapterService, BluetoothAddress address,
             BluetoothAddressType addressType) {
-        super(bgHandler, address);
+        super(adapterService, address);
 
         logger.debug("Creating new BlueGiga device {}", address);
 
-        this.bgHandler = bgHandler;
+        this.bgHandler = adapterService.getHandler();
         this.addressType = addressType;
 
         bgHandler.addEventListener(this);
         updateLastSeenTime();
+    }
+
+    @Override
+    public BlueGigaAdapterService getAdapter() {
+        return (BlueGigaAdapterService) super.getAdapter();
     }
 
     @Override
@@ -367,7 +373,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
                     new BluetoothConnectionStatusNotification(ConnectionState.DISCOVERED));
 
             // Notify the bridge - for inbox notifications
-            bgHandler.deviceDiscovered(this);
+            getAdapter().deviceDiscovered(this);
         }
 
         // Notify listeners of all scan records - for RSSI, beacon processing (etc)

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaAdapterService.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaAdapterService.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth.bluegiga.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.bluetooth.AbstractBluetoothAdapterService;
+import org.openhab.binding.bluetooth.BluetoothAdapter;
+import org.openhab.binding.bluetooth.BluetoothAddress;
+import org.openhab.binding.bluetooth.bluegiga.BlueGigaBluetoothDevice;
+import org.openhab.binding.bluetooth.bluegiga.internal.enumeration.BluetoothAddressType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BlueGigaAdapterService} is implements BlueGiga's {@link BluetoothAdapter} instance to be exposed to
+ * the openHAB bluetooth framework.
+ *
+ * @author Connor Petty - Initial contribution
+ */
+@NonNullByDefault
+public class BlueGigaAdapterService extends AbstractBluetoothAdapterService<BlueGigaBluetoothDevice>
+        implements BluetoothAdapter {
+
+    private final Logger logger = LoggerFactory.getLogger(BlueGigaAdapterService.class);
+
+    @Override
+    public BluetoothAddress getAddress() {
+        return getHandler().getAddress();
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        super.setThingHandler(handler);
+        getHandler().setBlueGigaAdapterService(this);
+    }
+
+    public BlueGigaBridgeHandler getHandler() {
+        return (BlueGigaBridgeHandler) handler;
+    }
+
+    @Override
+    protected BlueGigaBluetoothDevice createDevice(BluetoothAddress address) {
+        return new BlueGigaBluetoothDevice(this, address, BluetoothAddressType.UNKNOWN);
+    }
+
+    @Override
+    public void scanStart() {
+        super.scanStart();
+        logger.debug("Start active scan");
+        // Stop the passive scan
+        getHandler().cancelScheduledPassiveScan();
+        getHandler().bgEndProcedure();
+
+        // Start a active scan
+        getHandler().bgStartScanning(true);
+    }
+
+    @Override
+    public void scanStop() {
+        super.scanStop();
+        logger.debug("Stop active scan");
+
+        // Stop the active scan
+        getHandler().bgEndProcedure();
+
+        // Start a passive scan after idle delay
+        getHandler().schedulePassiveScan();
+    }
+}

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/internal/factory/BlueGigaHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/internal/factory/BlueGigaHandlerFactory.java
@@ -13,9 +13,6 @@
 package org.openhab.binding.bluetooth.bluegiga.internal.factory;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,16 +21,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.core.thing.UID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
-import org.openhab.binding.bluetooth.BluetoothAdapter;
 import org.openhab.binding.bluetooth.bluegiga.BlueGigaAdapterConstants;
 import org.openhab.binding.bluetooth.bluegiga.handler.BlueGigaBridgeHandler;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -50,8 +43,6 @@ public class BlueGigaHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .singleton(BlueGigaAdapterConstants.THING_TYPE_BLUEGIGA);
-
-    private final Map<ThingUID, ServiceRegistration<?>> serviceRegs = new HashMap<>();
 
     private Optional<SerialPortManager> serialPortManager = Optional.empty();
 
@@ -75,28 +66,10 @@ public class BlueGigaHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(BlueGigaAdapterConstants.THING_TYPE_BLUEGIGA)) {
-            BlueGigaBridgeHandler handler = new BlueGigaBridgeHandler((Bridge) thing, serialPortManager.get());
-            registerBluetoothAdapter(handler);
-            return handler;
+            return new BlueGigaBridgeHandler((Bridge) thing, serialPortManager.get());
         } else {
             return null;
         }
     }
 
-    private synchronized void registerBluetoothAdapter(BluetoothAdapter adapter) {
-        this.serviceRegs.put(adapter.getUID(),
-                bundleContext.registerService(BluetoothAdapter.class.getName(), adapter, new Hashtable<>()));
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    protected synchronized void removeHandler(ThingHandler thingHandler) {
-        if (thingHandler instanceof BluetoothAdapter) {
-            UID uid = ((BluetoothAdapter) thingHandler).getUID();
-            ServiceRegistration<?> serviceReg = this.serviceRegs.remove(uid);
-            if (serviceReg != null) {
-                serviceReg.unregister();
-            }
-        }
-    }
 }

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/BlueZBluetoothDevice.java
@@ -26,7 +26,7 @@ import org.openhab.binding.bluetooth.BluetoothCharacteristic;
 import org.openhab.binding.bluetooth.BluetoothCompletionStatus;
 import org.openhab.binding.bluetooth.BluetoothDescriptor;
 import org.openhab.binding.bluetooth.BluetoothService;
-import org.openhab.binding.bluetooth.bluez.handler.BlueZBridgeHandler;
+import org.openhab.binding.bluetooth.bluez.handler.BlueZAdapterService;
 import org.openhab.binding.bluetooth.notification.BluetoothConnectionStatusNotification;
 import org.openhab.binding.bluetooth.notification.BluetoothScanNotification;
 import org.slf4j.Logger;
@@ -58,17 +58,9 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice {
      * @param address the Bluetooth address of the device
      * @param name the name of the device
      */
-    public BlueZBluetoothDevice(BlueZBridgeHandler adapter, BluetoothAddress address) {
+    public BlueZBluetoothDevice(BlueZAdapterService adapter, BluetoothAddress address) {
         super(adapter, address);
         logger.debug("Creating BlueZ device with address '{}'", address);
-    }
-
-    /**
-     * Initializes a newly created instance of this class.
-     * This method should always be called directly after creating a new object instance.
-     */
-    public void initialize() {
-        updateLastSeenTime();
     }
 
     /**

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/handler/BlueZAdapterService.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/handler/BlueZAdapterService.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth.bluez.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.bluetooth.AbstractBluetoothAdapterService;
+import org.openhab.binding.bluetooth.BluetoothAdapter;
+import org.openhab.binding.bluetooth.BluetoothAddress;
+import org.openhab.binding.bluetooth.bluez.BlueZBluetoothDevice;
+
+/**
+ * The {@link BlueZAdapterService} is implements the BlueZ {@link BluetoothAdapter} instance to be exposed to
+ * the openHAB bluetooth framework.
+ *
+ * @author Connor Petty - Initial contribution
+ */
+@NonNullByDefault
+public class BlueZAdapterService extends AbstractBluetoothAdapterService<BlueZBluetoothDevice>
+        implements BluetoothAdapter {
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        super.setThingHandler(handler);
+        getHandler().setBluezAdapterService(this);
+    }
+
+    private BlueZBridgeHandler getHandler() {
+        return (BlueZBridgeHandler) handler;
+    }
+
+    @Override
+    public BluetoothAddress getAddress() {
+        return getHandler().getAddress();
+    }
+
+    @Override
+    protected BlueZBluetoothDevice createDevice(BluetoothAddress address) {
+        return new BlueZBluetoothDevice(this, address);
+    }
+
+}

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
@@ -14,7 +14,6 @@ package org.openhab.binding.bluetooth.bluez.internal;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,11 +21,9 @@ import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.core.thing.UID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
-import org.openhab.binding.bluetooth.BluetoothAdapter;
 import org.openhab.binding.bluetooth.bluez.BlueZAdapterConstants;
 import org.openhab.binding.bluetooth.bluez.handler.BlueZBridgeHandler;
 import org.osgi.framework.ServiceRegistration;
@@ -56,27 +53,10 @@ public class BlueZHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(BlueZAdapterConstants.THING_TYPE_BLUEZ)) {
-            BlueZBridgeHandler handler = new BlueZBridgeHandler((Bridge) thing);
-            registerBluetoothAdapter(handler);
-            return handler;
+            return new BlueZBridgeHandler((Bridge) thing);
         } else {
             return null;
         }
     }
 
-    private synchronized void registerBluetoothAdapter(BluetoothAdapter adapter) {
-        this.serviceRegs.put(adapter.getUID(),
-                bundleContext.registerService(BluetoothAdapter.class.getName(), adapter, new Hashtable<>()));
-    }
-
-    @Override
-    protected synchronized void removeHandler(ThingHandler thingHandler) {
-        if (thingHandler instanceof BluetoothAdapter) {
-            UID uid = ((BluetoothAdapter) thingHandler).getUID();
-            ServiceRegistration<?> serviceReg = this.serviceRegs.remove(uid);
-            if (serviceReg != null) {
-                serviceReg.unregister();
-            }
-        }
-    }
 }

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BaseBluetoothDevice.java
@@ -97,7 +97,7 @@ public abstract class BaseBluetoothDevice extends BluetoothDevice {
      * @return The last time this device was active
      */
     @Override
-    public ZonedDateTime getLastSeenTime() {
+    public @Nullable ZonedDateTime getLastSeenTime() {
         return lastSeenTime;
     }
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -80,6 +80,8 @@ public abstract class BluetoothDevice {
      */
     protected final BluetoothAddress address;
 
+    transient final ZonedDateTime createTime = ZonedDateTime.now();
+
     /**
      * Construct a Bluetooth device taking the Bluetooth address
      *
@@ -96,7 +98,7 @@ public abstract class BluetoothDevice {
      *
      * @return The last time this device was active
      */
-    public abstract ZonedDateTime getLastSeenTime();
+    public abstract @Nullable ZonedDateTime getLastSeenTime();
 
     /**
      * Updates the last activity timestamp for this device.

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
@@ -35,7 +35,7 @@ public abstract class DelegateBluetoothDevice extends BluetoothDevice {
     protected abstract BluetoothDevice getDelegate();
 
     @Override
-    public ZonedDateTime getLastSeenTime() {
+    public @Nullable ZonedDateTime getLastSeenTime() {
         return getDelegate().getLastSeenTime();
     }
 


### PR DESCRIPTION
Signed-off-by: Connor Petty <mistercpp2000+gitsignoff@gmail.com>

There is a new mqtt->bluetoothadapter binding that is in the works that runs into some issues when trying to implement a thing handler that is both a subclass of the mqtt abstract handler and the abstract bluetooth handler. Since a handler can't have two concrete parent classes there were only a couple of options that could be done.
1. Create a single handler class and subclass from one of the two parent classes and then copy over the code from the other parent class.
2. Implement two handler classes that would somehow share the same Thing and ThingCallback instances. Theoretically can be done but then you have a weird architecture where both handlers could update thing status and channels.
3. Find a way to abstract all the necessary logic from one of the parent classes into a ThingHandlerService.

This PR represents approach 3 and it actually cleans up some of the BluetoothAdapter osgi registration logic since the abstract BluetoothAdapter implementation is now a ThingHandlerService.

I've tried to minimize the amount of conflicts that this will have with the other PRs so you might see some changes that are present in the others.

After this PR goes through I can delete the AbstractBluetoothBridgeHandler class. But I'm keeping it for now to make merges easier with my other PRs.