### PR TITLE
Update README.md

### DIFF
--- a/bundles/org.openhab.binding.kostalinverter/README.md
+++ b/bundles/org.openhab.binding.kostalinverter/README.md
@@ -32,6 +32,8 @@ Currently supported things are:
 
 Others may be supported (like future devices using the same SCB or offering the same Web API, branded OEM devices, ...), but they were not tested!
 
+Kostal bindings to third generation devices require Java's strong cryptography to be enabled in order to establish connections. In case you are allowed to use strong cryptography in your country, you can achieve this by modifying the $JAVA_HOME/jre/lib/security/java.security file (find the line *crypto.policy=limited* and set it to *unlimited*). If you're using the official openHAB docker image you may also enable Java's strong cryptography by specifying an environment variable *CRYPTO_POLICY="unlimited"*.
+
 ## Discovery
 
 None


### PR DESCRIPTION
[kostal-inverter] added troubleshooting information to the README file for authentication issues with 3rd gen kostal-inverter binding

I've added a little section to the README file of the kostal-inverter binding indicating that the third generation devices (SCB) require Java's strong cryptography to be enabled for successfully establishing connections. Moreover I've added some lines that describe how to enable strong cryptography (including legal law restrictions for some countries).

Maybe you could re-arrange the positioning of my text and put it into a troubleshooting section. The content should be fine.

There were no changes made to the source code, just to the documentation. And I've also tested my fix instructions with the latest official docker image of openHAB.