### PR TITLE
Use gnu.io [3.12,6) version range in package imports

### DIFF
--- a/bundles/org.openhab.binding.cm11a/pom.xml
+++ b/bundles/org.openhab.binding.cm11a/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: CM11A Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.digiplex/pom.xml
+++ b/bundles/org.openhab.binding.digiplex/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Digiplex/EVO Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.dscalarm/pom.xml
+++ b/bundles/org.openhab.binding.dscalarm/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: DSCAlarm Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.elerotransmitterstick/pom.xml
+++ b/bundles/org.openhab.binding.elerotransmitterstick/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: EleroTransmitterStick Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.jeelink/pom.xml
+++ b/bundles/org.openhab.binding.jeelink/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: JeeLink Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.knx/pom.xml
+++ b/bundles/org.openhab.binding.knx/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: KNX Binding</name>
 
   <properties>
-    <bnd.importpackage>javax.microedition.io.*;resolution:="optional",javax.usb.*;resolution:="optional",org.usb4java.*;resolution:="optional"</bnd.importpackage>
+    <bnd.importpackage>gnu.io;version="[3.12,6)",javax.microedition.io.*;resolution:="optional",javax.usb.*;resolution:="optional",org.usb4java.*;resolution:="optional"</bnd.importpackage>
   </properties>
 
   <dependencies>

--- a/bundles/org.openhab.binding.lgtvserial/pom.xml
+++ b/bundles/org.openhab.binding.lgtvserial/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: LG TV Serial Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.lutron/pom.xml
+++ b/bundles/org.openhab.binding.lutron/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Lutron Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.meteostick/pom.xml
+++ b/bundles/org.openhab.binding.meteostick/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: meteostick Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.nibeheatpump/pom.xml
+++ b/bundles/org.openhab.binding.nibeheatpump/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Nibe Heatpump Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.oceanic/pom.xml
+++ b/bundles/org.openhab.binding.oceanic/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Oceanic Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.pentair/pom.xml
+++ b/bundles/org.openhab.binding.pentair/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Pentair Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.phc/pom.xml
+++ b/bundles/org.openhab.binding.phc/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: PHC Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.regoheatpump/pom.xml
+++ b/bundles/org.openhab.binding.regoheatpump/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: RegoHeatPump Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.rme/pom.xml
+++ b/bundles/org.openhab.binding.rme/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: RME Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.smartmeter/pom.xml
+++ b/bundles/org.openhab.binding.smartmeter/pom.xml
@@ -14,6 +14,10 @@
 
   <name>openHAB Add-ons :: Bundles :: Smartmeter Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/bundles/org.openhab.binding.urtsi/pom.xml
+++ b/bundles/org.openhab.binding.urtsi/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Somfy URTSI II binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>

--- a/bundles/org.openhab.binding.velbus/pom.xml
+++ b/bundles/org.openhab.binding.velbus/pom.xml
@@ -14,4 +14,8 @@
 
   <name>openHAB Add-ons :: Bundles :: Velbus Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
 </project>


### PR DESCRIPTION
The first version of nrjavaserial with OSGi manifest entries is 3.12.0.
The interface has not changed and is still the same with nrjavaserial 5.x.
So defining a [3.12,6) version range allows for maximum flexibility.

Related to: openhab/openhab-core#1464

---

When the serial transport is used for these add-ons (#7573) we should remove these imports again. Though it can still take a while for all add-ons to be updated. Especially if we also need to add extra functionality to the transport which cannot be used on the 2.5.x branch.