### PR TITLE
[daikin] Improve handling of illegal commands

### DIFF
--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAcUnitHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.daikin.internal.handler;
 
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.util.Optional;
 
 import org.eclipse.jetty.client.HttpClient;
@@ -120,21 +121,42 @@ public class DaikinAcUnitHandler extends DaikinBaseHandler {
 
     @Override
     protected void changeMode(String mode) throws DaikinCommunicationException {
+        Mode newMode;
+        try {
+            newMode = Mode.valueOf(mode);
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid mode: {}. Valid values: {}", mode, Mode.values());
+            return;
+        }
         ControlInfo info = webTargets.getControlInfo();
-        info.mode = Mode.valueOf(mode);
+        info.mode = newMode;
         webTargets.setControlInfo(info);
     }
 
     @Override
     protected void changeFanSpeed(String fanSpeed) throws DaikinCommunicationException {
+        FanSpeed newSpeed;
+        try {
+            newSpeed = FanSpeed.valueOf(fanSpeed);
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid fan speed: {}. Valid values: {}", fanSpeed, FanSpeed.values());
+            return;
+        }
         ControlInfo info = webTargets.getControlInfo();
-        info.fanSpeed = FanSpeed.valueOf(fanSpeed);
+        info.fanSpeed = newSpeed;
         webTargets.setControlInfo(info);
     }
 
     protected void changeFanDir(String fanDir) throws DaikinCommunicationException {
+        FanMovement newMovement;
+        try {
+            newMovement = FanMovement.valueOf(fanDir);
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid fan direction: {}. Valid values: {}", fanDir, FanMovement.values());
+            return;
+        }
         ControlInfo info = webTargets.getControlInfo();
-        info.fanMovement = FanMovement.valueOf(fanDir);
+        info.fanMovement = newMovement;
         webTargets.setControlInfo(info);
     }
 

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinAirbaseUnitHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.daikin.internal.handler;
 
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -132,7 +133,13 @@ public class DaikinAirbaseUnitHandler extends DaikinBaseHandler {
 
     @Override
     protected void changeMode(String mode) throws DaikinCommunicationException {
-        AirbaseMode newMode = AirbaseMode.valueOf(mode);
+        AirbaseMode newMode;
+        try {
+            newMode = AirbaseMode.valueOf(mode);
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid mode: {}. Valid values: {}", mode, AirbaseMode.values());
+            return;
+        }
         if (airbaseModelInfo != null) {
             if ((newMode == AirbaseMode.AUTO && !airbaseModelInfo.features.contains(AirbaseFeature.AUTO))
                     || (newMode == AirbaseMode.DRY && !airbaseModelInfo.features.contains(AirbaseFeature.DRY))) {
@@ -147,7 +154,13 @@ public class DaikinAirbaseUnitHandler extends DaikinBaseHandler {
 
     @Override
     protected void changeFanSpeed(String speed) throws DaikinCommunicationException {
-        AirbaseFanSpeed newFanSpeed = AirbaseFanSpeed.valueOf(speed);
+        AirbaseFanSpeed newFanSpeed;
+        try {
+            newFanSpeed = AirbaseFanSpeed.valueOf(speed);
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Invalid fan speed: {}. Valid values: {}", speed, AirbaseFanSpeed.values());
+            return;
+        }
         if (airbaseModelInfo != null) {
             if (EnumSet.range(AirbaseFanSpeed.AUTO_LEVEL_1, AirbaseFanSpeed.AUTO_LEVEL_5).contains(newFanSpeed)
                     && !airbaseModelInfo.features.contains(AirbaseFeature.FRATE_AUTO)) {

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.daikin.internal.handler;
 
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +132,8 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
             }
             logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command,
                     thing.getUID().getAsString(), channelUID.getId());
+        } catch (IllegalArgumentException ex) {
+            logger.warn("Illegal argument for channel {}: {}. {}", channelUID.getId(), command.toString(), ex.getMessage());
         } catch (DaikinCommunicationException ex) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
         }

--- a/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
+++ b/bundles/org.openhab.binding.daikin/src/main/java/org/openhab/binding/daikin/internal/handler/DaikinBaseHandler.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.daikin.internal.handler;
 
 import java.io.IOException;
-import java.lang.IllegalArgumentException;
 import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -132,8 +131,6 @@ public abstract class DaikinBaseHandler extends BaseThingHandler {
             }
             logger.debug("Received command ({}) of wrong type for thing '{}' on channel {}", command,
                     thing.getUID().getAsString(), channelUID.getId());
-        } catch (IllegalArgumentException ex) {
-            logger.warn("Illegal argument for channel {}: {}. {}", channelUID.getId(), command.toString(), ex.getMessage());
         } catch (DaikinCommunicationException ex) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, ex.getMessage());
         }


### PR DESCRIPTION
Currently the binding doesn't catch IllegalArgumentExceptions for invalid channel values. This small PR deals with that and prevents the Thing from going offline.

Reported here: https://community.openhab.org/t/daikin-airbase-binding/77179/193

