### PR TITLE
[squeezebox] Discovery: make use of representation property

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -91,7 +91,8 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
             logger.debug("player added {} : {} ", player.getMacAddress(), player.getName());
 
             Map<String, Object> properties = new HashMap<>(1);
-            properties.put("mac", player.getMacAddress());
+            String representationPropertyName = "mac";
+            properties.put(representationPropertyName, player.getMacAddress());
 
             // Added other properties
             properties.put("modelId", player.getModel());
@@ -100,7 +101,8 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
             properties.put("ip", player.getIpAddr());
 
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                    .withBridge(bridgeUID).withLabel(player.getName()).build();
+                    .withRepresentationProperty(representationPropertyName).withBridge(bridgeUID)
+                    .withLabel(player.getName()).build();
 
             thingDiscovered(discoveryResult);
         }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxServerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxServerDiscoveryParticipant.java
@@ -82,12 +82,13 @@ public class SqueezeBoxServerDiscoveryParticipant implements UpnpDiscoveryPartic
 
             String label = device.getDetails().getFriendlyName();
 
-            properties.put("ipAddress", host);
+            String representationPropertyName = "ipAddress";
+            properties.put(representationPropertyName, host);
             properties.put("webport", new Integer(webPort));
             properties.put("cliPort", new Integer(cliPort));
 
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
-                    .build();
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                    .withRepresentationProperty(representationPropertyName).withLabel(label).build();
 
             logger.debug("Created a DiscoveryResult for device '{}' with UDN '{}'",
                     device.getDetails().getFriendlyName(), device.getIdentity().getUdn().getIdentifierString());

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -12,6 +12,8 @@
 			<channel id="favoritesList" typeId="favoritesList"/>
 		</channels>
 
+		<representation-property>ipAddress</representation-property>
+
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<label>IP or Host Name</label>
@@ -90,6 +92,8 @@
 			<property name="uid"></property>
 			<property name="ip"></property>
 		</properties>
+
+		<representation-property>mac</representation-property>
 
 		<config-description>
 			<parameter name="mac" type="text" required="true">


### PR DESCRIPTION
Setting this property to the required fields of the bridge and things
will make the discovery skip adding the result to the inbox if a bridge or
thing with such a property already exists, i.e. due to a .things file.

Signed-off-by: Stefan Triller <github@stefantriller.de>