### PR TITLE
[miio] Fix representation property in discovery

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
@@ -160,10 +160,11 @@ public class MiIoDiscovery extends AbstractDiscoveryService {
             logger.debug(
                     "No token discovered for device {}. For options how to get the token, check the binding readme.",
                     id);
-            dr = dr.withRepresentationProperty(id).withLabel(label);
+            dr = dr.withRepresentationProperty(PROPERTY_DID).withLabel(label);
         } else {
             logger.debug("Discovered token for device {}: {}", id, token);
-            dr = dr.withProperty(PROPERTY_TOKEN, token).withRepresentationProperty(id).withLabel(label + " with token");
+            dr = dr.withProperty(PROPERTY_TOKEN, token).withRepresentationProperty(PROPERTY_DID)
+                    .withLabel(label + " with token");
         }
         if (!country.isEmpty() && isOnline) {
             dr = dr.withProperty(PROPERTY_CLOUDSERVER, country);

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscoveryParticipant.java
@@ -107,8 +107,8 @@ public class MiIoDiscoveryParticipant implements MDNSDiscoveryParticipant {
             String label = "Xiaomi Mi Device " + id + " (" + Long.parseUnsignedLong(id, 16) + ") " + service.getName();
             properties.put(PROPERTY_HOST_IP, inetAddress);
             properties.put(PROPERTY_DID, id);
-            result = DiscoveryResultBuilder.create(uid).withProperties(properties).withRepresentationProperty(id)
-                    .withLabel(label).build();
+            result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                    .withRepresentationProperty(PROPERTY_DID).withLabel(label).build();
             logger.debug("Mi IO mDNS Discovery found {} with address '{}:{}' name '{}'", uid, inetAddress,
                     service.getPort(), label);
         }


### PR DESCRIPTION
The property has to be set to the property name and not to its value.

Signed-off-by: Stefan Triller <github@stefantriller.de>