### PR TITLE
[knx] Fix disposal of DeviceThingHandler

### DIFF
--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/AbstractKNXThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/AbstractKNXThingHandler.java
@@ -51,7 +51,7 @@ public abstract class AbstractKNXThingHandler extends BaseThingHandler implement
     private static final int INITIAL_PING_DELAY = 5;
     private final Logger logger = LoggerFactory.getLogger(AbstractKNXThingHandler.class);
 
-    private @Nullable IndividualAddress address;
+    protected @Nullable IndividualAddress address;
     private @Nullable Future<?> descriptionJob;
     private boolean filledDescription = false;
     private final Random random = new Random();

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
@@ -74,7 +74,6 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
     private final Set<OutboundSpec> groupAddressesRespondingSpec = new HashSet<>();
     private final Map<GroupAddress, @Nullable ScheduledFuture<?>> readFutures = new HashMap<>();
     private final Map<ChannelUID, @Nullable ScheduledFuture<?>> channelFutures = new HashMap<>();
-    private @Nullable IndividualAddress address;
     private int readInterval;
 
     public DeviceThingHandler(Thing thing) {
@@ -95,6 +94,28 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
             groupAddresses.addAll(selector.getWriteAddresses(channelConfiguration));
             groupAddresses.addAll(selector.getListenAddresses(channelConfiguration));
         });
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        cancelChannelFutures();
+        freeGroupAdresses();
+    }
+
+    private void cancelChannelFutures() {
+        for (ScheduledFuture<?> future : channelFutures.values()) {
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+        }
+        channelFutures.clear();
+    }
+
+    private void freeGroupAdresses() {
+        groupAddresses.clear();
+        groupAddressesWriteBlockedOnce.clear();
+        groupAddressesRespondingSpec.clear();
     }
 
     @Override

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
@@ -98,9 +98,9 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
 
     @Override
     public void dispose() {
-        super.dispose();
         cancelChannelFutures();
         freeGroupAdresses();
+        super.dispose();
     }
 
     private void cancelChannelFutures() {


### PR DESCRIPTION
On disposal of the DeviceThingHandler several scheduled futures were not
canceled and internal datastructures were not reset.

This leads to a problem if one changes the thing configuration, for example
via editing the .things file. Then `dispose()` and `initialize()` will be
called and the datastructures will still also contain the old values.

This is nasty in cases where one wants to change the group addresses for
channels.

Also the `address` field from the `AbstractKNXThingHandler` was redefined
in the `DeviceThingHandler` but never ever set there.

Signed-off-by: Stefan Triller <github@stefantriller.de>