### PR TITLE
[lutron] Replace gnu.io with OH serial transport

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.net.http.HttpClientFactory;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.lutron.internal.discovery.LutronDeviceDiscoveryService;
 import org.openhab.binding.lutron.internal.grxprg.GrafikEyeHandler;
 import org.openhab.binding.lutron.internal.grxprg.PrgBridgeHandler;
@@ -65,6 +66,7 @@ import org.openhab.binding.lutron.internal.radiora.RadioRAConstants;
 import org.openhab.binding.lutron.internal.radiora.handler.PhantomButtonHandler;
 import org.openhab.binding.lutron.internal.radiora.handler.RS232Handler;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -103,8 +105,16 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(LutronHandlerFactory.class);
 
+    private final SerialPortManager serialPortManager;
+
     private @NonNullByDefault({}) HttpClient httpClient;
     // shared instance obtained from HttpClientFactory service and passed to device discovery service
+
+    @Activate
+    public LutronHandlerFactory(final @Reference SerialPortManager serialPortManager) {
+        // Obtain the serial port manager service using an OSGi reference
+        this.serialPortManager = serialPortManager;
+    }
 
     @Reference
     protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
@@ -180,7 +190,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
         } else if (thingTypeUID.equals(PrgConstants.THING_TYPE_GRAFIKEYE)) {
             return new GrafikEyeHandler(thing);
         } else if (thingTypeUID.equals(RadioRAConstants.THING_TYPE_RS232)) {
-            return new RS232Handler((Bridge) thing);
+            return new RS232Handler((Bridge) thing, serialPortManager);
         } else if (thingTypeUID.equals(RadioRAConstants.THING_TYPE_DIMMER)) {
             return new org.openhab.binding.lutron.internal.radiora.handler.DimmerHandler(thing);
         } else if (thingTypeUID.equals(RadioRAConstants.THING_TYPE_SWITCH)) {
@@ -188,7 +198,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
         } else if (thingTypeUID.equals(RadioRAConstants.THING_TYPE_PHANTOM)) {
             return new PhantomButtonHandler(thing);
         } else if (thingTypeUID.equals(HwConstants.THING_TYPE_HWSERIALBRIDGE)) {
-            return new HwSerialBridgeHandler((Bridge) thing);
+            return new HwSerialBridgeHandler((Bridge) thing, serialPortManager);
         } else if (thingTypeUID.equals(HwConstants.THING_TYPE_HWDIMMER)) {
             return new HwDimmerHandler(thing);
         }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwSerialBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwSerialBridgeHandler.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.TooManyListenersException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -102,13 +101,6 @@ public class HwSerialBridgeHandler extends BaseBridgeHandler implements SerialPo
 
     private void openConnection() {
         SerialPortIdentifier portIdentifier;
-
-        // Exit if no identifiers exist to work around possible library bug. May not be needed in 3.0.
-        Stream<SerialPortIdentifier> serialPortIdentifiers = serialPortManager.getIdentifiers();
-        if (!serialPortIdentifiers.findAny().isPresent()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No serial ports found");
-            return;
-        }
 
         portIdentifier = serialPortManager.getIdentifier(serialPortName);
         if (portIdentifier == null) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwSerialBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/hw/HwSerialBridgeHandler.java
@@ -100,9 +100,7 @@ public class HwSerialBridgeHandler extends BaseBridgeHandler implements SerialPo
     }
 
     private void openConnection() {
-        SerialPortIdentifier portIdentifier;
-
-        portIdentifier = serialPortManager.getIdentifier(serialPortName);
+        SerialPortIdentifier portIdentifier = serialPortManager.getIdentifier(serialPortName);
         if (portIdentifier == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Invalid port: " + serialPortName);
             return;

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
@@ -15,22 +15,19 @@ package org.openhab.binding.lutron.internal.radiora;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.TooManyListenersException;
+import java.util.stream.Stream;
 
+import org.eclipse.smarthome.io.transport.serial.PortInUseException;
+import org.eclipse.smarthome.io.transport.serial.SerialPort;
+import org.eclipse.smarthome.io.transport.serial.SerialPortEvent;
+import org.eclipse.smarthome.io.transport.serial.SerialPortEventListener;
+import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
+import org.eclipse.smarthome.io.transport.serial.UnsupportedCommOperationException;
 import org.openhab.binding.lutron.internal.radiora.protocol.RadioRAFeedback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import gnu.io.CommPortIdentifier;
-import gnu.io.NoSuchPortException;
-import gnu.io.PortInUseException;
-import gnu.io.SerialPort;
-import gnu.io.SerialPortEvent;
-import gnu.io.SerialPortEventListener;
-import gnu.io.UnsupportedCommOperationException;
 
 /**
  * RS232 connection to the RadioRA Classic system.
@@ -42,6 +39,7 @@ public class RS232Connection implements RadioRAConnection, SerialPortEventListen
 
     private final Logger logger = LoggerFactory.getLogger(RS232Connection.class);
 
+    protected SerialPortManager serialPortManager;
     protected SerialPort serialPort;
 
     protected BufferedReader inputReader;
@@ -49,25 +47,34 @@ public class RS232Connection implements RadioRAConnection, SerialPortEventListen
     protected RadioRAFeedbackListener listener;
     protected RS232MessageParser parser = new RS232MessageParser();
 
+    public RS232Connection(SerialPortManager serialPortManager) {
+        super();
+        this.serialPortManager = serialPortManager;
+    }
+
     @Override
     public void open(String portName, int baud) throws RadioRAConnectionException {
-        CommPortIdentifier commPort = null;
+        SerialPortIdentifier portIdentifier;
 
-        try {
-            commPort = CommPortIdentifier.getPortIdentifier(portName);
-        } catch (NoSuchPortException e) {
-            logAvailablePorts();
+        // Exit if no identifiers exist to work around possible library bug. May not be needed in 3.0.
+        Stream<SerialPortIdentifier> serialPortIdentifiers = serialPortManager.getIdentifiers();
+        if (!serialPortIdentifiers.findAny().isPresent()) {
+            throw new RadioRAConnectionException(String.format("No serial ports found", portName));
+        }
+
+        portIdentifier = serialPortManager.getIdentifier(portName);
+        if (portIdentifier == null) {
             throw new RadioRAConnectionException(String.format("Port not found", portName));
         }
 
         try {
-            serialPort = commPort.open("openhab", 5000);
+            serialPort = portIdentifier.open("openhab", 5000);
             serialPort.notifyOnDataAvailable(true);
             serialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
             serialPort.addEventListener(this);
             inputReader = new BufferedReader(new InputStreamReader(serialPort.getInputStream()));
         } catch (PortInUseException e) {
-            throw new RadioRAConnectionException(String.format("Port %s already in use", commPort.getName()));
+            throw new RadioRAConnectionException(String.format("Port %s already in use", portIdentifier.getName()));
         } catch (UnsupportedCommOperationException e) {
             throw new RadioRAConnectionException("Error initializing - Failed to set serial port params");
         } catch (TooManyListenersException e) {
@@ -90,28 +97,6 @@ public class RS232Connection implements RadioRAConnection, SerialPortEventListen
     @Override
     public void disconnect() {
         serialPort.close();
-    }
-
-    private void logAvailablePorts() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Available ports:");
-            for (CommPortIdentifier port : getAvailableSerialPorts()) {
-                logger.debug("{}", port.getName());
-            }
-        }
-    }
-
-    protected List<CommPortIdentifier> getAvailableSerialPorts() {
-        List<CommPortIdentifier> ports = new ArrayList<>();
-        Enumeration<?> portIds = CommPortIdentifier.getPortIdentifiers();
-        while (portIds.hasMoreElements()) {
-            CommPortIdentifier id = (CommPortIdentifier) portIds.nextElement();
-            if (CommPortIdentifier.PORT_SERIAL == id.getPortType()) {
-                ports.add(id);
-            }
-        }
-
-        return ports;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
@@ -16,7 +16,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.TooManyListenersException;
-import java.util.stream.Stream;
 
 import org.eclipse.smarthome.io.transport.serial.PortInUseException;
 import org.eclipse.smarthome.io.transport.serial.SerialPort;
@@ -55,12 +54,6 @@ public class RS232Connection implements RadioRAConnection, SerialPortEventListen
     @Override
     public void open(String portName, int baud) throws RadioRAConnectionException {
         SerialPortIdentifier portIdentifier;
-
-        // Exit if no identifiers exist to work around possible library bug. May not be needed in 3.0.
-        Stream<SerialPortIdentifier> serialPortIdentifiers = serialPortManager.getIdentifiers();
-        if (!serialPortIdentifiers.findAny().isPresent()) {
-            throw new RadioRAConnectionException(String.format("No serial ports found", portName));
-        }
 
         portIdentifier = serialPortManager.getIdentifier(portName);
         if (portIdentifier == null) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/RS232Connection.java
@@ -53,9 +53,7 @@ public class RS232Connection implements RadioRAConnection, SerialPortEventListen
 
     @Override
     public void open(String portName, int baud) throws RadioRAConnectionException {
-        SerialPortIdentifier portIdentifier;
-
-        portIdentifier = serialPortManager.getIdentifier(portName);
+        SerialPortIdentifier portIdentifier = serialPortManager.getIdentifier(portName);
         if (portIdentifier == null) {
             throw new RadioRAConnectionException(String.format("Port not found", portName));
         }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/handler/RS232Handler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/handler/RS232Handler.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.lutron.internal.radiora.RS232Connection;
 import org.openhab.binding.lutron.internal.radiora.RadioRAConnection;
 import org.openhab.binding.lutron.internal.radiora.RadioRAConnectionException;
@@ -48,10 +49,10 @@ public class RS232Handler extends BaseBridgeHandler implements RadioRAFeedbackLi
 
     private ScheduledFuture<?> zoneMapScheduledTask;
 
-    public RS232Handler(Bridge bridge) {
+    public RS232Handler(Bridge bridge, SerialPortManager serialPortManager) {
         super(bridge);
 
-        this.connection = new RS232Connection();
+        this.connection = new RS232Connection(serialPortManager);
         this.connection.setListener(this);
     }
 


### PR DESCRIPTION
This update contains changes which replace direct use of the gnu.io serial library (aka RXTX) with calls to OH serial transport. It impacts the bridge handlers for the original RadioRA system (ra-rs232), and the original HomeWorks system (hwserialbridge).

The need for this is discussed in issue #7573.

Note that **I have no way to test these changes** so I would appreciate it if the original authors, @jjlauterbach and @andrewshilliday could review and test this code!

A jar file containing the binding with these changes is available here:
https://github.com/bobadair/openhab2-addons/releases/tag/serial-beta-1
