### PR TITLE
[miio] Establish connection in initialize() rather than the constructor

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -92,7 +92,6 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
         super(thing, miIoDatabaseWatchService);
         this.cloudConnector = cloudConnector;
         mapChannelUid = new ChannelUID(thing.getUID(), CHANNEL_VACUUM_MAP);
-        initializeData();
         status = new ExpiringCache<>(CACHE_EXPIRY, () -> {
             try {
                 int ret = sendCommand(MiIoCommand.GET_STATUS);
@@ -404,8 +403,7 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
     @Override
     protected boolean initializeData() {
         updateState(CHANNEL_CONSUMABLE_RESET, new StringType("none"));
-        this.miioCom = getConnection();
-        return true;
+        return super.initializeData();
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>