### PR TITLE
Don't limit serial port options

### DIFF
--- a/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -57,6 +57,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>Serial Or USB Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>The name of the serial port used to connect to the Alarm Decoder device</description>
 			</parameter>
 			<parameter name="bitrate" type="integer">

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/resources/ESH-INF/thing/bluegiga.xml
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/resources/ESH-INF/thing/bluegiga.xml
@@ -12,6 +12,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial Port</description>
 			</parameter>
 			<parameter name="backgroundDiscovery" type="boolean">

--- a/bundles/org.openhab.binding.cm11a/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.cm11a/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial port used to communicate with the CM11a</description>
 			</parameter>
 			<parameter name="refresh" type="integer" min="1">

--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/bridge.xml
@@ -23,6 +23,7 @@
 			<parameter name="port" type="text" required="true" groupName="port">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Set the serial port used to access PRT3 device</description>
 				<default></default>
 			</parameter>

--- a/bundles/org.openhab.binding.dscalarm/src/main/resources/ESH-INF/thing/it100bridge.xml
+++ b/bundles/org.openhab.binding.dscalarm/src/main/resources/ESH-INF/thing/it100bridge.xml
@@ -22,6 +22,7 @@
 		<config-description>
 			<parameter name="serialPort" type="text" required="true">
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<label>IT-100 Bridge Serial Port</label>
 				<description>The serial port name for the DSC IT-100. Valid values
 					are e.g. COM1 for Windows and /dev/ttyS0 or

--- a/bundles/org.openhab.binding.dsmr/src/main/resources/ESH-INF/config/configuration_parameters.xml
+++ b/bundles/org.openhab.binding.dsmr/src/main/resources/ESH-INF/config/configuration_parameters.xml
@@ -7,6 +7,7 @@
 	<config-description uri="thing-type:dsmr:bridgesettings">
 		<parameter name="serialPort" type="text" required="true">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>The serial port where the P1 port of the Smart Meter is connected (e.g. Linux: /dev/ttyUSB0, Windows:
 				COM1)</description>
@@ -65,6 +66,7 @@
 	<config-description uri="thing-type:dsmr:smartybridgesettings">
 		<parameter name="serialPort" type="text" required="true">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>The serial port where the P1 port of the Smart Meter is connected (e.g. Linux: /dev/ttyUSB0, Windows:
 				COM1)</description>

--- a/bundles/org.openhab.binding.elerotransmitterstick/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.elerotransmitterstick/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
 				<label>Port Name</label>
 				<description>The name of the port to which the Elero Transmitter Stick is connected.</description>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 			</parameter>
 			<parameter name="updateInterval" type="integer" min="5" max="3600" unit="s" step="5">
 				<label>Update Interval</label>

--- a/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.jeelink/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -13,6 +13,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>@text/parameter.serialport.label</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>@text/parameter.serialport.description</description>
 			</parameter>
 			<parameter name="initCommands" type="text" required="false">
@@ -49,6 +50,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>@text/parameter.serialport.label</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>@text/parameter.serialportlgw.description</description>
 			</parameter>
 			<parameter name="initCommands" type="text" required="false">

--- a/bundles/org.openhab.binding.lgtvserial/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.lgtvserial/src/main/resources/ESH-INF/config/config.xml
@@ -6,10 +6,10 @@
 	<config-description uri="thing-type:lgtvserial:serial">
 		<parameter name="port" type="text">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Select serial port (COM1, /dev/ttyS0, ...)</description>
 			<required>true</required>
-			<default>/dev/ttyS0</default>
 		</parameter>
 		<parameter name="setId" type="integer">
 			<label>Set ID</label>

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -889,6 +889,7 @@
 		<config-description>
 			<parameter name="serialPort" type="text" required="true">
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<label>HomeWorks Bridge Serial Port</label>
 				<description>
 					The serial port name for the HomeWorks processor. Valid values
@@ -973,6 +974,7 @@
 		<config-description>
 			<parameter name="portName" type="text" required="true">
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<label>Serial Port</label>
 				<description>The serial port to use to communicate with a Lutron RadioRA system</description>
 			</parameter>

--- a/bundles/org.openhab.binding.meteostick/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.meteostick/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -15,6 +15,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial port that the Meteostick is plugged into</description>
 			</parameter>
 			<parameter name="mode" type="integer" required="true">

--- a/bundles/org.openhab.binding.modbus/src/main/resources/ESH-INF/thing/bridge-serial.xml
+++ b/bundles/org.openhab.binding.modbus/src/main/resources/ESH-INF/thing/bridge-serial.xml
@@ -10,8 +10,8 @@
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial port to use, for example /dev/ttyS0 or COM1</description>
-				<default>/dev/ttyS0</default>
 			</parameter>
 
 			<parameter name="id" type="integer">

--- a/bundles/org.openhab.binding.nikobus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikobus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -12,6 +12,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>The serial port used to connect to the Nikobus PC Link.</description>
 			</parameter>
 			<parameter name="refreshInterval" type="integer" max="65535" min="10" required="false">

--- a/bundles/org.openhab.binding.oceanic/src/main/resources/ESH-INF/thing/serial.xml
+++ b/bundles/org.openhab.binding.oceanic/src/main/resources/ESH-INF/thing/serial.xml
@@ -55,6 +55,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial Port the Oceanic Water Softener is connected to</description>
 			</parameter>
 			<parameter name="interval" type="decimal" required="true">

--- a/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -15,6 +15,7 @@
 				<description>Serial Port the PHC modules are connected to</description>
 				<required>true</required>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -325,6 +325,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>Serial Port Name</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>The Serial port name to use to connect to the AVR.</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.plugwise/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.plugwise/src/main/resources/ESH-INF/config/config.xml
@@ -8,8 +8,8 @@
 		<parameter name="serialPort" type="text" required="true">
 			<label>Serial Port</label>
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<description>The serial port of the Stick, e.g. "/dev/ttyUSB0" for Linux or "COM1" for Windows</description>
-			<default>/dev/ttyUSB0</default>
 		</parameter>
 		<parameter name="messageWaitTime" type="integer" min="0" max="500" step="50">
 			<label>Message Wait Time</label>

--- a/bundles/org.openhab.binding.powermax/src/main/resources/ESH-INF/thing/serial.xml
+++ b/bundles/org.openhab.binding.powermax/src/main/resources/ESH-INF/thing/serial.xml
@@ -40,6 +40,7 @@
 		<config-description>
 			<parameter name="serialPort" type="text" required="true">
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<label>Serial Port</label>
 				<description>The serial port to use for connecting to the serial interface of the alarm system e.g. COM1 for Windows
 					and /dev/ttyS0 or /dev/ttyUSB0 for Linux.</description>

--- a/bundles/org.openhab.binding.regoheatpump/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.regoheatpump/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -57,6 +57,7 @@
 			<parameter name="portName" type="text" required="true">
 				<label>Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>The serial port used to connect to the Rego controller.</description>
 			</parameter>
 			<parameter name="refreshInterval" type="integer" max="65535" min="10" required="false">
@@ -109,6 +110,7 @@
 			<parameter name="portName" type="text" required="true">
 				<label>Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>The serial port used to connect to the Husdata interface.</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/bridge.xml
@@ -12,6 +12,7 @@
 			<parameter name="serialPort" type="text" required="true">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial port where RFXCOM transceiver is connected.</description>
 			</parameter>
 			<parameter name="disableDiscovery" type="boolean" required="true">

--- a/bundles/org.openhab.binding.rme/src/main/resources/ESH-INF/thing/rme.xml
+++ b/bundles/org.openhab.binding.rme/src/main/resources/ESH-INF/thing/rme.xml
@@ -39,6 +39,7 @@
 			<parameter name="port" type="text">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>Serial Port the RME Rain Manager is connected to</description>
 				<required>true</required>
 			</parameter>

--- a/bundles/org.openhab.binding.rotel/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.rotel/src/main/resources/ESH-INF/config/config.xml
@@ -8,6 +8,7 @@
 	<config-description uri="thing-type:rotel:serial">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -25,6 +26,7 @@
 	<config-description uri="thing-type:rotel:serialandip">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -45,6 +47,7 @@
 	<config-description uri="thing-type:rotel:serialandip2">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -65,6 +68,7 @@
 	<config-description uri="thing-type:rotel:serialandipandprotocol">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -96,6 +100,7 @@
 	<config-description uri="thing-type:rotel:serialandprotocol">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -124,6 +129,7 @@
 	<config-description uri="thing-type:rotel:serial2">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -161,6 +167,7 @@
 	<config-description uri="thing-type:rotel:serial3">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -210,6 +217,7 @@
 	<config-description uri="thing-type:rotel:serial4">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>
@@ -263,6 +271,7 @@
 	<config-description uri="thing-type:rotel:serial5">
 		<parameter name="serialPort" type="text" required="false">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Serial port to use for connecting to the Rotel device</description>
 		</parameter>

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/int-rs.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/int-rs.xml
@@ -13,6 +13,7 @@
 				<label>Serial Port</label>
 				<description>Serial port connected to the module.</description>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 			</parameter>
 			<parameter name="timeout" type="integer" unit="ms">
 				<label>Timeout</label>

--- a/bundles/org.openhab.binding.serialbutton/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.serialbutton/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -16,6 +16,7 @@
 			<parameter name="port" type="text">
 				<label>Serial Port</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<required>true</required>
 				<description>The serial port that the button is connected to</description>
 			</parameter>

--- a/bundles/org.openhab.binding.sonyprojector/src/main/resources/ESH-INF/thing/serial.xml
+++ b/bundles/org.openhab.binding.sonyprojector/src/main/resources/ESH-INF/thing/serial.xml
@@ -45,6 +45,7 @@
 		<config-description>
 			<parameter name="port" type="text" required="true">
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<label>Serial Port</label>
 				<description>Serial port to use for connecting to the projector</description>
 			</parameter>

--- a/bundles/org.openhab.binding.urtsi/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.urtsi/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -14,6 +14,7 @@
 			<parameter name="port" type="text" required="true">
 				<label>@text/urtsiDevicePortLabel</label>
 				<context>serial-port</context>
+				<limitToOptions>false</limitToOptions>
 				<description>@text/urtsiDevicePortDescription</description>
 			</parameter>
 			<parameter name="commandInterval" type="integer" required="false" min="50" max="5000">

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
@@ -7,6 +7,7 @@
 	<config-description uri="bridge-type:velbus:bridge">
 		<parameter name="port" type="text">
 			<context>serial-port</context>
+			<limitToOptions>false</limitToOptions>
 			<label>Serial Port</label>
 			<description>Select serial port (COM1, /dev/ttyS0, ...)</description>
 			<required>true</required>


### PR DESCRIPTION
When serial port options are limited it is only possible to configure discovered ports.
RXTX discovery only detects standard serial ports.
The serial transport adds undiscovered ports to 'gnu.io.rxtx.SerialPorts' so this way users do not need to manually configure it.
RFC2217 ports cannot be detected so if the ports are limited it is not possible to configure these using UIs.

Related to:

* https://github.com/openhab/openhab-core/issues/1029
* https://github.com/openhab/openhab-core/issues/1462