### PR TITLE
[satel] Fix for incorrect date/time set in the alarm system

### DIFF
--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStatusCommand.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/command/IntegraStatusCommand.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.satel.internal.command;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.satel.internal.event.EventDispatcher;
@@ -43,11 +45,17 @@ public class IntegraStatusCommand extends SatelCommandBase {
     /**
      * @return date and time
      */
-    public LocalDateTime getIntegraTime() {
+    public Optional<LocalDateTime> getIntegraTime() {
         // parse current date and time
-        final byte[] payload = getResponse().getPayload();
-        return LocalDateTime.of(bcdToInt(payload, 0, 2), bcdToInt(payload, 2, 1), bcdToInt(payload, 3, 1),
-                bcdToInt(payload, 4, 1), bcdToInt(payload, 5, 1), bcdToInt(payload, 6, 1));
+        try {
+            final byte[] payload = getResponse().getPayload();
+            return Optional
+                    .of(LocalDateTime.of(bcdToInt(payload, 0, 2), bcdToInt(payload, 2, 1), bcdToInt(payload, 3, 1),
+                            bcdToInt(payload, 4, 1), bcdToInt(payload, 5, 1), bcdToInt(payload, 6, 1)));
+        } catch (DateTimeException e) {
+            logger.debug("Invalid date/time set in the system", e);
+            return Optional.empty();
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStatusEvent.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/IntegraStatusEvent.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.satel.internal.event;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -24,7 +25,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class IntegraStatusEvent implements SatelEvent {
 
-    private LocalDateTime integraTime;
+    private Optional<LocalDateTime> integraTime;
     private boolean serviceMode;
     private boolean troubles;
     private boolean acu100Present;
@@ -40,7 +41,7 @@ public class IntegraStatusEvent implements SatelEvent {
      * @param statusByte1 status bits, byte #1
      * @param statusByte2 status bits, byte #2
      */
-    public IntegraStatusEvent(LocalDateTime integraTime, byte statusByte1, byte statusByte2) {
+    public IntegraStatusEvent(Optional<LocalDateTime> integraTime, byte statusByte1, byte statusByte2) {
         this.integraTime = integraTime;
         this.serviceMode = (statusByte1 & 0x80) != 0;
         this.troubles = (statusByte1 & 0x40) != 0;
@@ -52,9 +53,10 @@ public class IntegraStatusEvent implements SatelEvent {
     }
 
     /**
-     * @return current date and time on connected Integra
+     * @return current date and time on connected Integra or <code>Optional.empty()</code> if date/time set in the
+     *         system is incorrect
      */
-    public LocalDateTime getIntegraTime() {
+    public Optional<LocalDateTime> getIntegraTime() {
         return integraTime;
     }
 
@@ -111,7 +113,7 @@ public class IntegraStatusEvent implements SatelEvent {
     public String toString() {
         return String.format(
                 "IntegraStatusEvent: type = %d, time = %s, service mode = %b, troubles = %b, troubles memory = %b, ACU-100 = %b, INT-RX = %b, grade 2/3 = %b",
-                this.integraType, this.integraTime, this.serviceMode, this.troubles, this.troublesMemory,
-                this.acu100Present, this.intRxPresent, this.grade23Set);
+                this.integraType, this.integraTime.map(LocalDateTime::toString).orElse("N/A"), this.serviceMode,
+                this.troubles, this.troublesMemory, this.acu100Present, this.intRxPresent, this.grade23Set);
     }
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelSystemHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/SatelSystemHandler.java
@@ -30,6 +30,8 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.binding.satel.internal.command.ClearTroublesCommand;
 import org.openhab.binding.satel.internal.command.IntegraStatusCommand;
 import org.openhab.binding.satel.internal.command.SatelCommand;
@@ -79,7 +81,9 @@ public class SatelSystemHandler extends SatelStateThingHandler {
         if (getThingConfig().isCommandOnly()) {
             return;
         }
-        updateState(CHANNEL_DATE_TIME, new DateTimeType(event.getIntegraTime().atZone(getBridgeHandler().getZoneId())));
+        updateState(CHANNEL_DATE_TIME,
+                event.getIntegraTime().map(dt -> (State) new DateTimeType(dt.atZone(getBridgeHandler().getZoneId())))
+                        .orElse(UnDefType.UNDEF));
         updateSwitch(CHANNEL_SERVICE_MODE, event.inServiceMode());
         updateSwitch(CHANNEL_TROUBLES, event.troublesPresent());
         updateSwitch(CHANNEL_TROUBLES_MEMORY, event.troublesMemory());


### PR DESCRIPTION
This PR contais a fix for incorrect date and time set on the alarm system. 
Instead of restarting communication the binding logs a message and ignores received value.

Issue described here: https://community.openhab.org/t/solved-satel-disconnections-after-integra-mainboard-upgrade/79227

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>
