### PR TITLE
[nikohomecontrol] Fixes to rollershutter and energy meter.

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
@@ -95,7 +95,12 @@ public class NhcAction2 extends NhcAction {
     @Override
     public void setState(int state) {
         this.state = state;
-        if (booleanState) { // only send the update to the event handler if on
+        if (getType().equals(ActionType.DIMMER)) { // for dimmers, only send the update to the event
+                                                   // handler if on
+            if (booleanState) {
+                updateState();
+            }
+        } else {
             updateState();
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -407,10 +407,12 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 thermostats.put(device.uuid, nhcThermostat);
             }
         } else if ("centralmeter".equals(device.type)) {
-            logger.debug("Niko Home Control: adding centralmeter device {}, {}", device.uuid, device.name);
-            NhcEnergyMeter2 nhcEnergyMeter = new NhcEnergyMeter2(device.uuid, device.name, device.model,
-                    device.technology, this, scheduler);
-            energyMeters.put(device.uuid, nhcEnergyMeter);
+            if (!energyMeters.containsKey(device.uuid)) {
+                logger.debug("Niko Home Control: adding centralmeter device {}, {}", device.uuid, device.name);
+                NhcEnergyMeter2 nhcEnergyMeter = new NhcEnergyMeter2(device.uuid, device.name, device.model,
+                        device.technology, this, scheduler);
+                energyMeters.put(device.uuid, nhcEnergyMeter);
+            }
         } else {
             logger.debug("Niko Home Control: device type {} not supported for {}, {}", device.type, device.uuid,
                     device.name);
@@ -559,7 +561,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 .ifPresent(electricalPower -> {
                     try {
                         energyMeter.setPower(Integer.parseInt(electricalPower));
-                        logger.debug("Niko Home Control: setting energy meter {} power to {}", energyMeter.getId(),
+                        logger.trace("Niko Home Control: setting energy meter {} power to {}", energyMeter.getId(),
                                 electricalPower);
                     } catch (NumberFormatException e) {
                         energyMeter.setPower(null);
@@ -774,7 +776,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
             notificationEvt(message);
         } else if ((profile + "/control/devices/evt").equals(topic)) {
-            logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.trace("Niko Home Control: received topic {}, payload {}", topic, message);
             devicesEvt(message);
         } else if ((profile + "/control/devices/rsp").equals(topic)) {
             logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -484,10 +484,8 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
     private void updateRollershutterState(NhcAction2 action, NhcDevice2 device) {
         Optional<NhcProperty> positionProperty = device.properties.stream().filter(p -> (p.position != null))
                 .findFirst();
-        Optional<NhcProperty> movingProperty = device.properties.stream().filter(p -> (p.moving != null)).findFirst();
 
-        if (!(movingProperty.isPresent() && Boolean.parseBoolean(movingProperty.get().moving))
-                && positionProperty.isPresent()) {
+        if (positionProperty.isPresent()) {
             action.setState(Integer.parseInt(positionProperty.get().position));
             logger.debug("Niko Home Control: setting action {} internally to {}", action.getId(),
                     positionProperty.get().position);


### PR DESCRIPTION
- Fix energy meter behaviour at reconnection and reduce log level to avoid logs every 2s.
- Fix rollershutter position status feedback and pass on intermediate position info when moving to OH.