### PR TITLE
[modbus] Use gnu.io [3.12,6) version range

### DIFF
--- a/bundles/org.openhab.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.io.transport.modbus/pom.xml
@@ -15,6 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: IO :: Modbus Transport</name>
 
   <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
     <dep.noembedding>commons-pool2</dep.noembedding>
   </properties>
 


### PR DESCRIPTION
The gnu.io package is not only used in tests but is also a transitive dependency of net.wimpi:jamod

Related to #7589

---

This should also fix the failing add-ons port build:

https://ci.openhab.org/job/openHAB-Addons-port/125/console