### PR TITLE
[coolmasternet] Fix set_temp channel bug

### DIFF
--- a/bundles/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/handler/HVACHandler.java
+++ b/bundles/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/handler/HVACHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -162,9 +161,11 @@ public class HVACHandler extends BaseThingHandler {
                             final QuantityType<?> value = new QuantityType<>(temp, controller.getUnit());
                             updateState(SET_TEMP, value);
                         }
-                    } else if (command instanceof DecimalType) {
-                        final DecimalType temp = (DecimalType) command;
-                        controller.sendCommand(String.format("temp %s %s", uid, temp));
+                    } else if (command instanceof QuantityType) {
+                        final QuantityType<?> temp = (QuantityType) command;
+                        final QuantityType<?> converted = temp.toUnit(controller.getUnit());
+                        final String formatted = converted.format("%.1f");
+                        controller.sendCommand(String.format("temp %s %s", uid, formatted));
                     }
                     break;
                 case MODE:


### PR DESCRIPTION
This commit corrects a regression introduced in #7546 where the `set_temp` channel was changed to a `QuantityType`.

This has been tested on a CoolMasterNet deployment using a `Setpoint` element in the sitemap.
