### PR TITLE
[hpprinter] Status Bugfix and Channel Improvements

### DIFF
--- a/bundles/org.openhab.binding.hpprinter/README.md
+++ b/bundles/org.openhab.binding.hpprinter/README.md
@@ -27,25 +27,25 @@ Thing hpprinter:printer:djprinter "Printer" @ "Office" [ ipAddress="192.168.1.1"
 
 ## Channels
 
-| Channel                                    | Name                 | Data Type | Dynamic |
-| ------------------------------------------ | -------------------- | --------- | ------- |
-| Printer Status                             | status               | String    | no      |
-| Black Colour Level                         | blackLevel           | Number    | no      |
-| Colour Level                               | colorLevel           | Number    | yes     |
-| Cyan Colour Level                          | cyanLevel            | Number    | yes     |
-| Magenta Colour Level                       | magentaLevel         | Number    | yes     |
-| Yellow Colour Level                        | yellowLevel          | Number    | yes     |
-| Black Marking Used                         | blackMarker          | Number    | yes     |
-| Colour Marking Used                        | colorMarker          | Number    | yes     |
-| Cyan Marking Used                          | cyanMarker           | Number    | yes     |
-| Magenta Marking Used                       | magentaMarker        | Number    | yes     |
-| Yellow Marking Used                        | yellowMarker         | Number    | yes     |
-| Total Number of Pages Printed              | totalCount           | Number    | no      |
-| Total Number of Colour Pages Printed       | totalColorCount      | Number    | yes     |
-| Total Number of Monochrome Pages Printed   | totalMonochromeCount | Number    | yes     |
-| Jam Events                                 | jamEvents            | Number    | yes     |
-| Mispick Events                             | mispickEvents        | Number    | yes     |
-| Front Panel Cancel Count                   | fpCount              | Number    | yes     |
+| Channel                                    | Name                 | Data Type            | Dynamic |
+| ------------------------------------------ | -------------------- | -------------------- | ------- |
+| Printer Status                             | status               | String               | no      |
+| Black Colour Level                         | blackLevel           | Number:Dimensionless | no      |
+| Colour Level                               | colorLevel           | Number:Dimensionless | yes     |
+| Cyan Colour Level                          | cyanLevel            | Number:Dimensionless | yes     |
+| Magenta Colour Level                       | magentaLevel         | Number:Dimensionless | yes     |
+| Yellow Colour Level                        | yellowLevel          | Number:Dimensionless | yes     |
+| Black Marking Used                         | blackMarker          | Number:Volume        | yes     |
+| Colour Marking Used                        | colorMarker          | Number:Volume        | yes     |
+| Cyan Marking Used                          | cyanMarker           | Number:Volume        | yes     |
+| Magenta Marking Used                       | magentaMarker        | Number:Volume        | yes     |
+| Yellow Marking Used                        | yellowMarker         | Number:Volume        | yes     |
+| Total Number of Pages Printed              | totalCount           | Number               | no      |
+| Total Number of Colour Pages Printed       | totalColorCount      | Number               | yes     |
+| Total Number of Monochrome Pages Printed   | totalMonochromeCount | Number               | yes     |
+| Jam Events                                 | jamEvents            | Number               | yes     |
+| Mispick Events                             | mispickEvents        | Number               | yes     |
+| Front Panel Cancel Count                   | fpCount              | Number               | yes     |
 
 > The `colorLevel` is used on Printers that have only a single colour cartridge instead of separate Cyan, Magenta and Yellow cartridges.
 
@@ -55,19 +55,39 @@ Thing hpprinter:printer:djprinter "Printer" @ "Office" [ ipAddress="192.168.1.1"
 String PrinterStatus "Status" { channel="pprinter:printer:djprinter:status#status" }
 Number PrinterTotalPages "Total Pages" { channel="hpprinter:printer:djprinter:usage#totalCount" }
 
-Number PrinterBlackMarkingUsed "Black Marking Used" { channel="hpprinter:printer:djprinter:usage#blackMarker" }
-Number PrinterCyanMarkingUsed "Cyan Marking Used" { channel="hpprinter:printer:djprinter:usage#cyanMarker" }
-Number PrinterMagentaMarkingUsed "Magenta Marking Used" { channel="hpprinter:printer:djprinter:usage#magentaMarker" }
-Number PrinterYellowMarkingUsed "Yellow Marking Used" { channel="hpprinter:printer:djprinter:usage#yellowMarker" }
+Number:Volume PrinterBlackMarkingUsed "Black Marking Used" { channel="hpprinter:printer:djprinter:usage#blackMarker" }
+Number:Volume PrinterCyanMarkingUsed "Cyan Marking Used" { channel="hpprinter:printer:djprinter:usage#cyanMarker" }
+Number:Volume PrinterMagentaMarkingUsed "Magenta Marking Used" { channel="hpprinter:printer:djprinter:usage#magentaMarker" }
+Number:Volume PrinterYellowMarkingUsed "Yellow Marking Used" { channel="hpprinter:printer:djprinter:usage#yellowMarker" }
 
 Number:Dimensionless PrinterBlackLevel "Black Level" { channel="hpprinter:printer:djprinter:ink#blackLevel" }
-Number PrinterCyanLevel "Cyan Level" { channel="hpprinter:printer:djprinter:ink#cyanLevel" }
-Number PrinterMagentaLevel "Magenta Level" { channel="hpprinter:printer:djprinter:ink#magentaLevel" }
-Number PrinterYellowLevel "Yellow Level" { channel="hpprinter:printer:djprinter:ink#yellowLevel" }
+Number:Dimensionless PrinterCyanLevel "Cyan Level" { channel="hpprinter:printer:djprinter:ink#cyanLevel" }
+Number:Dimensionless PrinterMagentaLevel "Magenta Level" { channel="hpprinter:printer:djprinter:ink#magentaLevel" }
+Number:Dimensionless PrinterYellowLevel "Yellow Level" { channel="hpprinter:printer:djprinter:ink#yellowLevel" }
 
 Number PrinterTotalColourPages "Total Colour Pages" { channel="hpprinter:printer:djprinter:usage#totalColorCount" }
 Number PrinterTotalMonochromePages "Total Monochrome Pages" { channel="hpprinter:printer:djprinter:usage#totalMonochromeCount" }
 Number PrinterJamEvents "Jam Events" { channel="hpprinter:printer:djprinter:usage#jamEvents" }
 Number PrinterMispickEvents "Mispick Events" { channel="hpprinter:printer:djprinter:usage#mispickEvents" }
 Number PrinterSubscriptionCount "Subscription Count" { channel="hpprinter:printer:djprinter:usage#subsciptionCount" }
+```
+
+### Sample Sitemap Items
+
+Black Ink displayed as a whole percentage - `60 %`
+
+```
+Text item=hpprinter_printer_djprinter_ink_blackLevel label="Black [%.0f %unit%]"
+```
+
+Black Marker displayed in millilitres - `21 ml`
+
+```
+Text item=hpprinter_printer_djprinter_usage_blackMarker label="Black Marker [%.0f %unit%]"
+```
+
+Black Marker displayed in litres - `0.021 l`
+
+```
+Text item=hpprinter_printer_djprinter_usage_blackMarker label="Black Marker [%.3f l]"
 ```

--- a/bundles/org.openhab.binding.hpprinter/README.md
+++ b/bundles/org.openhab.binding.hpprinter/README.md
@@ -1,4 +1,4 @@
-# HPPrinter Binding
+# HP Printer Binding
 
 Get HP Printer statistics from an _Embedded Web Server_ over Network.
 
@@ -19,7 +19,7 @@ The available settings are:
 | Usage Refresh Interval (seconds)  | usageInterval   | number  |          | 30      |
 | Status Refresh Interval (seconds) | statusInterval  | number  |          | 4       |
 
-An example configuration is below:
+### Sample Configuration
 
 ```
 Thing hpprinter:printer:djprinter "Printer" @ "Office" [ ipAddress="192.168.1.1", usageInterval="30", statusInterval="4" ]
@@ -48,3 +48,26 @@ Thing hpprinter:printer:djprinter "Printer" @ "Office" [ ipAddress="192.168.1.1"
 | Front Panel Cancel Count                   | fpCount              | Number    | yes     |
 
 > The `colorLevel` is used on Printers that have only a single colour cartridge instead of separate Cyan, Magenta and Yellow cartridges.
+
+### Sample Items
+
+```
+String PrinterStatus "Status" { channel="pprinter:printer:djprinter:status#status" }
+Number PrinterTotalPages "Total Pages" { channel="hpprinter:printer:djprinter:usage#totalCount" }
+
+Number PrinterBlackMarkingUsed "Black Marking Used" { channel="hpprinter:printer:djprinter:usage#blackMarker" }
+Number PrinterCyanMarkingUsed "Cyan Marking Used" { channel="hpprinter:printer:djprinter:usage#cyanMarker" }
+Number PrinterMagentaMarkingUsed "Magenta Marking Used" { channel="hpprinter:printer:djprinter:usage#magentaMarker" }
+Number PrinterYellowMarkingUsed "Yellow Marking Used" { channel="hpprinter:printer:djprinter:usage#yellowMarker" }
+
+Number:Dimensionless PrinterBlackLevel "Black Level" { channel="hpprinter:printer:djprinter:ink#blackLevel" }
+Number PrinterCyanLevel "Cyan Level" { channel="hpprinter:printer:djprinter:ink#cyanLevel" }
+Number PrinterMagentaLevel "Magenta Level" { channel="hpprinter:printer:djprinter:ink#magentaLevel" }
+Number PrinterYellowLevel "Yellow Level" { channel="hpprinter:printer:djprinter:ink#yellowLevel" }
+
+Number PrinterTotalColourPages "Total Colour Pages" { channel="hpprinter:printer:djprinter:usage#totalColorCount" }
+Number PrinterTotalMonochromePages "Total Monochrome Pages" { channel="hpprinter:printer:djprinter:usage#totalMonochromeCount" }
+Number PrinterJamEvents "Jam Events" { channel="hpprinter:printer:djprinter:usage#jamEvents" }
+Number PrinterMispickEvents "Mispick Events" { channel="hpprinter:printer:djprinter:usage#mispickEvents" }
+Number PrinterSubscriptionCount "Subscription Count" { channel="hpprinter:printer:djprinter:usage#subsciptionCount" }
+```

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBindingConstants.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBindingConstants.java
@@ -36,6 +36,9 @@ public class HPPrinterBindingConstants {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream.of(THING_PRINTER)
             .collect(Collectors.toSet());
 
+    // ********** Channel Types **********
+    public static final String CHAN_TYPE_CUMLMARK = "Number:Volume";
+    public static final String CHAN_TYPE_INK = "Number:Dimensionless";
     // ********** List of all Channel ids **********
     public static final String CHANNEL_STATUS = "status";
 

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPStatus.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPStatus.java
@@ -32,12 +32,12 @@ public class HPStatus {
 
     private static final Map<String, String> STATUS_MESSAGES = initializeStatus();
 
-    private final @Nullable String printerStatus;
+    private final String printerStatus;
 
     public HPStatus(Document document) {
         NodeList nodes = document.getDocumentElement().getElementsByTagName("psdyn:Status");
 
-        String localPrinterStatus = null;
+        String localPrinterStatus = "Unknown";
         for (int i = 0; i < nodes.getLength(); i++) {
             Element element = (Element) nodes.item(i);
             String statusCategory = element.getElementsByTagName("pscat:StatusCategory").item(0).getTextContent();
@@ -51,18 +51,18 @@ public class HPStatus {
     private static Map<String, String> initializeStatus() {
         Map<String, String> statusMap = new HashMap<>();
 
-        statusMap.put("processing", "Printing");
-        statusMap.put("scanProcessing", "Scanning");
+        statusMap.put("processing", "Printing...");
+        statusMap.put("scanProcessing", "Scanning...");
         statusMap.put("inPowerSave", "Power Save");
         statusMap.put("ready", "Idle");
         statusMap.put("initializing", "Initializing...");
         statusMap.put("closeDoorOrCover", "Door/Cover Open");
-        statusMap.put("inkSystemInitializing", "Loading Ink");
-        statusMap.put("shuttingDown", "Shutting Down");
+        statusMap.put("inkSystemInitializing", "Loading Ink...");
+        statusMap.put("shuttingDown", "Shutting Down...");
         return statusMap;
     }
 
     public @Nullable String getPrinterStatus() {
-        return STATUS_MESSAGES.get(printerStatus);
+        return printerStatus;
     }
 }

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/binder/HPPrinterBinder.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/binder/HPPrinterBinder.java
@@ -36,6 +36,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.openhab.binding.hpprinter.internal.HPPrinterBindingConstants;
 import org.openhab.binding.hpprinter.internal.HPPrinterConfiguration;
 import org.openhab.binding.hpprinter.internal.api.HPProperties;
 import org.openhab.binding.hpprinter.internal.api.HPServerResult;
@@ -116,7 +117,7 @@ public class HPPrinterBinder {
 
             if (data.hasCumulativeMarking()) {
                 channels.add(ChannelBuilder
-                        .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_BLACK_MARKING), CoreItemFactory.NUMBER)
+                        .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_BLACK_MARKING), HPPrinterBindingConstants.CHAN_TYPE_CUMLMARK)
                         .withLabel("Black Marking Used").withDescription("The amount of Black Marking used")
                         .withType(new ChannelTypeUID("hpprinter:cumlMarkingUsed")).build());
             }
@@ -126,13 +127,13 @@ public class HPPrinterBinder {
                     if (data.hasCumulativeMarking()) {
                         channels.add(ChannelBuilder
                                 .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_COLOR_MARKING),
-                                        CoreItemFactory.NUMBER)
+                                HPPrinterBindingConstants.CHAN_TYPE_CUMLMARK)
                                 .withLabel("Colour Marking Used").withDescription("The amount of Colour Marking used")
                                 .withType(new ChannelTypeUID("hpprinter:cumlMarkingUsed")).build());
                     }
 
                     channels.add(ChannelBuilder
-                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_COLOR_LEVEL), CoreItemFactory.NUMBER)
+                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_COLOR_LEVEL), HPPrinterBindingConstants.CHAN_TYPE_INK)
                             .withLabel("Color Level").withDescription("Shows the amount of Colour Ink/Toner remaining")
                             .withType(new ChannelTypeUID("hpprinter:inkLevel")).build());
 
@@ -155,36 +156,36 @@ public class HPPrinterBinder {
                     if (data.hasCumulativeMarking()) {
                         channels.add(ChannelBuilder
                                 .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_CYAN_MARKING),
-                                        CoreItemFactory.NUMBER)
+                                HPPrinterBindingConstants.CHAN_TYPE_CUMLMARK)
                                 .withLabel("Cyan Marking Used").withDescription("The amount of Cyan Marking used")
                                 .withType(new ChannelTypeUID("hpprinter:cumlMarkingUsed")).build());
 
                         channels.add(ChannelBuilder
                                 .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_MAGENTA_MARKING),
-                                        CoreItemFactory.NUMBER)
+                                HPPrinterBindingConstants.CHAN_TYPE_CUMLMARK)
                                 .withLabel("Magenta Marking Used").withDescription("The amount of Magenta Marking used")
                                 .withType(new ChannelTypeUID("hpprinter:cumlMarkingUsed")).build());
 
                         channels.add(ChannelBuilder
                                 .create(new ChannelUID(thingUid, CGROUP_USAGE, CHANNEL_YELLOW_MARKING),
-                                        CoreItemFactory.NUMBER)
+                                HPPrinterBindingConstants.CHAN_TYPE_CUMLMARK)
                                 .withLabel("Yellow Marking Used").withDescription("The amount of Yellow Marking used")
                                 .withType(new ChannelTypeUID("hpprinter:cumlMarkingUsed")).build());
                     }
 
                     channels.add(ChannelBuilder
-                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_CYAN_LEVEL), CoreItemFactory.NUMBER)
+                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_CYAN_LEVEL), HPPrinterBindingConstants.CHAN_TYPE_INK)
                             .withLabel("Cyan Level").withDescription("Shows the amount of Cyan Ink/Toner remaining")
                             .withType(new ChannelTypeUID("hpprinter:inkLevel")).build());
 
                     channels.add(ChannelBuilder
-                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_MAGENTA_LEVEL), CoreItemFactory.NUMBER)
+                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_MAGENTA_LEVEL), HPPrinterBindingConstants.CHAN_TYPE_INK)
                             .withLabel("Magenta Level")
                             .withDescription("Shows the amount of Magenta Ink/Toner remaining")
                             .withType(new ChannelTypeUID("hpprinter:inkLevel")).build());
 
                     channels.add(ChannelBuilder
-                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_YELLOW_LEVEL), CoreItemFactory.NUMBER)
+                            .create(new ChannelUID(thingUid, CGROUP_INK, CHANNEL_YELLOW_LEVEL), HPPrinterBindingConstants.CHAN_TYPE_INK)
                             .withLabel("Yellow Level").withDescription("Shows the amount of Yellow Ink/Toner remaining")
                             .withType(new ChannelTypeUID("hpprinter:inkLevel")).build());
 


### PR DESCRIPTION
This PR fixes a bug introduced in a previous PR which caused the Status Channel to no longer display the Status from the Printer.

This also fixes a bug in the Colour Ink Levels - they were supposed to be of type `Number:Dimensionless` like the Black Ink Level channel but were of type `Number`

This improves the Ink Marking channels by changing the channel type to `Number:Volume`. This means that you can use the built in openHAB functionality to display in the unit you want (these channels were intended to be this type).

There is also an update to the Readme with some sample channels based on a stale PR #6717 that the original user opened but then went AWOL.