### PR TITLE
[smartmeter] Remove unused gnu.io import package

### DIFF
--- a/bundles/org.openhab.binding.smartmeter/pom.xml
+++ b/bundles/org.openhab.binding.smartmeter/pom.xml
@@ -14,10 +14,6 @@
 
   <name>openHAB Add-ons :: Bundles :: Smartmeter Binding</name>
 
-  <properties>
-    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>


### PR DESCRIPTION
It only has a reference to gnu.io in a JavaDoc so it shouldn't have been added in #7589.