### PR TITLE
[mqtt.homeassistant] Create trigger channels for stateless sensors

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
@@ -126,6 +126,7 @@ public class CChannel {
         private @Nullable String state_topic;
         private @Nullable String command_topic;
         private boolean retain;
+        private boolean trigger;
         private @Nullable Integer qos;
         private ChannelStateUpdateListener channelStateUpdateListener;
 
@@ -179,6 +180,11 @@ public class CChannel {
             return this;
         }
 
+        public Builder trigger(boolean trigger) {
+            this.trigger = trigger;
+            return this;
+        }
+
         public CChannel build() {
             return build(true);
         }
@@ -195,10 +201,10 @@ public class CChannel {
                     channelUID.getGroupId() + "_" + channelID);
             channelState = new ChannelState(
                     ChannelConfigBuilder.create().withRetain(retain).withQos(qos).withStateTopic(state_topic)
-                            .withCommandTopic(command_topic).build(),
+                            .withCommandTopic(command_topic).makeTrigger(trigger).build(),
                     channelUID, valueState, channelStateUpdateListener);
 
-            if (StringUtils.isBlank(state_topic)) {
+            if (StringUtils.isBlank(state_topic) || this.trigger) {
                 type = ChannelTypeBuilder.trigger(channelTypeUID, label)
                         .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HA_CHANNEL)).build();
             } else {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
@@ -12,8 +12,7 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -30,7 +29,7 @@ import org.openhab.binding.mqtt.generic.values.Value;
 @NonNullByDefault
 public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelConfiguration> {
     public static final String sensorChannelID = "sensor"; // Randomly chosen channel "ID"
-    private static final List<String> triggerIcons = Arrays.asList("mdi:toggle", "mdi:gesture");
+    private static final Pattern triggerIcons = Pattern.compile("^mdi:(toggle|gesture).*$");
 
     /**
      * Configuration class for MQTT component
@@ -67,10 +66,7 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
 
         String icon = channelConfiguration.icon;
 
-        boolean trigger = false;
-        if (!icon.isEmpty()) {
-            trigger = triggerIcons.stream().anyMatch(triggerIcon -> icon.startsWith(triggerIcon));
-        }
+        boolean trigger = triggerIcons.matcher(icon).matches();
 
         buildChannel(sensorChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.mqtt.homeassistant.internal;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -27,6 +30,7 @@ import org.openhab.binding.mqtt.generic.values.Value;
 @NonNullByDefault
 public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelConfiguration> {
     public static final String sensorChannelID = "sensor"; // Randomly chosen channel "ID"
+    private static final List<String> triggerObjectIDs = Arrays.asList(new String[] { "click", "action" });
 
     /**
      * Configuration class for MQTT component
@@ -61,8 +65,12 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
             value = new TextValue();
         }
 
+        String objectId = componentConfiguration.getHaID().objectID;
+
+        boolean trigger = triggerObjectIDs.contains(objectId);
+
         buildChannel(sensorChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//
-                .build();
+                .trigger(trigger).build();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/ComponentSensor.java
@@ -30,7 +30,7 @@ import org.openhab.binding.mqtt.generic.values.Value;
 @NonNullByDefault
 public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelConfiguration> {
     public static final String sensorChannelID = "sensor"; // Randomly chosen channel "ID"
-    private static final List<String> triggerObjectIDs = Arrays.asList(new String[] { "click", "action" });
+    private static final List<String> triggerIcons = Arrays.asList("mdi:toggle", "mdi:gesture");
 
     /**
      * Configuration class for MQTT component
@@ -65,9 +65,12 @@ public class ComponentSensor extends AbstractComponent<ComponentSensor.ChannelCo
             value = new TextValue();
         }
 
-        String objectId = componentConfiguration.getHaID().objectID;
+        String icon = channelConfiguration.icon;
 
-        boolean trigger = triggerObjectIDs.contains(objectId);
+        boolean trigger = false;
+        if (!icon.isEmpty()) {
+            trigger = triggerIcons.stream().anyMatch(triggerIcon -> icon.startsWith(triggerIcon));
+        }
 
         buildChannel(sensorChannelID, value, channelConfiguration.name, componentConfiguration.getUpdateListener())//
                 .stateTopic(channelConfiguration.state_topic, channelConfiguration.value_template)//


### PR DESCRIPTION
This PR creates trigger channels (and not state channels) for HA sensor components that send stateless information (action and button press events, mainly). The implementation is not device specific and it should be generic enough to be accepted. We can also add more objectIDs if they are used to send this type of information, but, in theory, this list should be short.

What do you think? @jochen314? 

Closes: #6878

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>