### PR TITLE
[lutron] Add an additional output type to discovery

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -391,6 +391,7 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                 case NON_DIM:
                 case NON_DIM_INC:
                 case NON_DIM_ELV:
+                case RELAY_LIGHTING:
                     notifyDiscovery(THING_TYPE_SWITCH, output.getIntegrationId(), label);
                     break;
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/project/OutputType.java
@@ -33,6 +33,7 @@ public enum OutputType {
     NON_DIM,
     NON_DIM_ELV,
     NON_DIM_INC,
+    RELAY_LIGHTING,
     SHEER_BLIND,
     SYSTEM_SHADE,
     VENETIAN_BLIND,


### PR DESCRIPTION
This is a very small commit that adds the RELAY_LIGHTING output type to discovery.
