### PR TITLE
[opengarage] Adds invert option to switch

### DIFF
--- a/bundles/org.openhab.binding.opengarage/README.md
+++ b/bundles/org.openhab.binding.opengarage/README.md
@@ -23,13 +23,13 @@ As a minimum, the IP address is needed:
 
 ## Channels
 
-| channel              | type          | description                                            |
-|----------------------|---------------|--------------------------------------------------------|
-| distance             | Number:Length | Distance reading from the OpenGarage controller (default in cm)       |
-| status-switch        | Switch        | Door status (OFF = Closed, ON = Open)                  |
-| status-contact       | Contact       | Door status (Open or Closed)                           |
-| status-rollershutter | Rollershutter | Door status (DOWN = Closed, UP = Open)                 |
-| vehicle              | String        | Report vehicle presence from the OpenGarage controller |
+| channel              | type          | description                                                                           |
+|----------------------|---------------|---------------------------------------------------------------------------------------|
+| distance             | Number:Length | Distance reading from the OpenGarage controller (default in cm)                       |
+| status-switch        | Switch        | Door status (OFF = Closed, ON = Open), set "invert=true" on channel to invert switch  |
+| status-contact       | Contact       | Door status (Open or Closed)                                                          |
+| status-rollershutter | Rollershutter | Door status (DOWN = Closed, UP = Open)                                                |
+| vehicle-status       | Number        | Report vehicle presence (0=Not Detected, 1=Detected, 2=Unknown)                       |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.opengarage/src/main/java/org/openhab/binding/opengarage/internal/OpenGarageChannelConfiguration.java
+++ b/bundles/org.openhab.binding.opengarage/src/main/java/org/openhab/binding/opengarage/internal/OpenGarageChannelConfiguration.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.opengarage.internal;
+
+/**
+ * The OpenGarageChannelConfiguration class contains fields mapping thing configuration parameters.
+ *
+ * @author Dan Cunningham - Initial contribution
+ */
+
+public class OpenGarageChannelConfiguration {
+    boolean invert = false;
+}

--- a/bundles/org.openhab.binding.opengarage/src/main/java/org/openhab/binding/opengarage/internal/OpenGarageChannelConfiguration.java
+++ b/bundles/org.openhab.binding.opengarage/src/main/java/org/openhab/binding/opengarage/internal/OpenGarageChannelConfiguration.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.binding.opengarage.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The OpenGarageChannelConfiguration class contains fields mapping thing configuration parameters.
  *
  * @author Dan Cunningham - Initial contribution
  */
-
+@NonNullByDefault
 public class OpenGarageChannelConfiguration {
-    boolean invert = false;
+    public boolean invert = false;
 }

--- a/bundles/org.openhab.binding.opengarage/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.opengarage/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -53,11 +53,35 @@
 		<item-type>Switch</item-type>
 		<label>Status</label>
 		<description>On/Off Status of the OG unit (now deprecated, use status-switch instead)</description>
+		<config-description>
+			<parameter name="invert" type="boolean">
+				<label>Invert Switch</label>
+				<description>Invert switch to ON=Closed, OFF=Open</description>
+				<default>false</default>
+				<options>
+					<option value="true">Yes</option>
+					<option value="false">No</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+			</parameter>
+		</config-description>
 	</channel-type>
 	<channel-type id="opengarage-status-switch">
 		<item-type>Switch</item-type>
 		<label>Status</label>
 		<description>On/Off Status of the OG unit</description>
+		<config-description>
+			<parameter name="invert" type="boolean">
+				<label>Invert Switch</label>
+				<description>Invert switch to ON=Closed, OFF=Open</description>
+				<default>false</default>
+				<options>
+					<option value="true">Yes</option>
+					<option value="false">No</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+			</parameter>
+		</config-description>
 	</channel-type>
 	<channel-type id="opengarage-status-contact">
 		<item-type>Contact</item-type>


### PR DESCRIPTION
Signed-off-by: digitaldan <dan@digitaldan.com>

This adds the ability to invert the switch state so that OFF=OPEN and ON=Closed.  This allows the state to be more aligned with other close/locking things like Z-wave locks, while maintaining backwards compatibility for existing users. 
