### PR TITLE
[homekit] Fix CLOSED keyword for GarageDoorOpener

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -38,7 +38,7 @@ public class HomekitSettings {
     public String thermostatCurrentModeOff = "Off";
     public String doorCurrentStateOpen = "OPEN";
     public String doorCurrentStateOpening = "OPENING";
-    public String doorCurrentStateClosed = "CLOSE";
+    public String doorCurrentStateClosed = "CLOSED";
     public String doorCurrentStateClosing = "CLOSING";
     public String doorCurrentStateStopped = "STOPPED";
     public String doorTargetStateClosed = "CLOSED";


### PR DESCRIPTION
Signed-off-by: Ethan Dye <mrtops03@gmail.com>
