### PR TITLE
[homekit] bugfix #7701. set correct configuration revision on bundle start. 

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryRegistry.java
@@ -40,6 +40,10 @@ class HomekitAccessoryRegistry {
         configurationRevision = revision;
     }
 
+    public int getConfigurationRevision() {
+        return configurationRevision;
+    }
+
     public int makeNewConfigurationRevision() {
         configurationRevision = (configurationRevision + 1) % 65535;
         final HomekitRoot bridge = this.bridge;

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -193,6 +193,10 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         return this.accessoryRegistry.getAllAccessories();
     }
 
+    public int getConfigurationRevision() {
+        return this.accessoryRegistry.getConfigurationRevision();
+    }
+
     /**
      * creates one or more HomeKit items for given openhab item.
      * one openhab item can linked to several HomeKit accessories or characteristics.

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -124,6 +124,7 @@ public class HomekitImpl implements Homekit {
                     FrameworkUtil.getBundle(getClass()).getVersion().toString(), HomekitSettings.SERIAL_NUMBER,
                     HomekitSettings.FIRMWARE_REVISION, HomekitSettings.HARDWARE_REVISION);
             changeListener.setBridge(bridge);
+            bridge.setConfigurationIndex(changeListener.getConfigurationRevision());
             bridge.start();
             this.bridge = bridge;
         } else {


### PR DESCRIPTION
HomeKit uses configuration revision number to indicate changes in the configuration of accessories and bridges. 
Bridge (in our case openHAB) communicates the revision number to all clients (home apps) and  should increase it with every change in configuration (in our case items config). This is supported by HomeKit addon. However, on HomeKit bundle restart the revision was set to 1.  

e.g. before bundle restart the revision was 34. after bundle restart the revision was set to 1.
This could lead in some cases to a configuration reset in home app so that all changes done in home app (e.g. room assignment, scenes, renaming) will get lost. See #7701 

This PR ensures that the configuration revision is set correctly on the bundle start.

Signed-off-by: Eugen Freiter <freiter@gmx.de>
