### PR TITLE
[satel] Fix for older ETHM-1/INT-RS firmware version

### DIFF
--- a/bundles/org.openhab.binding.satel/README.md
+++ b/bundles/org.openhab.binding.satel/README.md
@@ -41,13 +41,14 @@ You can configure the following settings for this bridge:
 
 | Name          | Required | Description                                                                                                                                                                                                                                                                  |
 |---------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| host          | yes      | Host name or IP addres of ETHM-1 module                                                                                                                                                                                                                                      |
-| port          | no       | TCP port for the integration protocol, defaults to 7094                                                                                                                                                                                                                      |
-| timeout       | no       | Timeout value in milliseconds for connect, read and write operations, defaults to 5000 (5secs)                                                                                                                                                                               |
+| host          | yes      | Host name or IP addres of ETHM-1 module.                                                                                                                                                                                                                                     |
+| port          | no       | TCP port for the integration protocol, defaults to 7094.                                                                                                                                                                                                                     |
+| timeout       | no       | Timeout value in milliseconds for connect, read and write operations, defaults to 5000 (5secs).                                                                                                                                                                              |
 | refresh       | no       | Polling interval in milliseconds, defaults to 5000 (5secs). As of version 2.03 ETHM-1 Plus firmware the module disconnects after 25 seconds of inactivity. Setting this parameter to value greater than 25000 will cause inability to correctly communicate with the module. |
-| userCode      | no       | Security code of the user in behalf of all operations will be executed. If empty, only read operations are allowed                                                                                                                                                           |
-| encryptionKey | no       | Encryption key used to encrypt data sent and received, if empty communication is not encrypted                                                                                                                                                                               |
-| encoding      | no       | Encoding for all the texts received from the module                                                                                                                                                                                                                          |
+| userCode      | no       | Security code of the user in behalf of all operations will be executed. If empty, only read operations are allowed.                                                                                                                                                          |
+| encryptionKey | no       | Encryption key used to encrypt data sent and received. If empty, communication is not encrypted.                                                                                                                                                                             |
+| encoding      | no       | Encoding for all the texts received from the module.                                                                                                                                                                                                                         |
+| extCommands   | no       | Check this option to enable extended commands, supported by ETHM-1 Plus and newer versions of ETHM-1. Enabled by default, turn off in case of communication timeouts.                                                                                                        |
 
 Example:
 
@@ -63,13 +64,14 @@ In case you have troubles connecting to the system using this module, please mak
 
 You can configure the following settings for this bridge:
 
-| Name     | Required | Description                                                                                                        |
-|----------|----------|--------------------------------------------------------------------------------------------------------------------|
-| port     | yes      | Serial port connected to the module                                                                                |
-| timeout  | no       | Timeout value in milliseconds for connect, read and write operations, defaults to 5000 (5secs)                     |
-| refresh  | no       | Polling interval in milliseconds, defaults to 5000 (5secs)                                                         |
-| userCode | no       | Security code of the user in behalf of all operations will be executed. If empty, only read operations are allowed |
-| encoding | no       | Encoding for all the texts received from the module                                                                |
+| Name        | Required | Description                                                                                                                                         |
+|-------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| port        | yes      | Serial port connected to the module.                                                                                                                |
+| timeout     | no       | Timeout value in milliseconds for connect, read and write operations, defaults to 5000 (5secs).                                                     |
+| refresh     | no       | Polling interval in milliseconds, defaults to 5000 (5secs).                                                                                         |
+| userCode    | no       | Security code of the user in behalf of all operations will be executed. If empty, only read operations are allowed.                                 |
+| encoding    | no       | Encoding for all the texts received from the module.                                                                                                |
+| extCommands | no       | Check this option to enable extended commands, supported by version 2.xx of INT-RS. Enabled by default, turn off in case of communication timeouts. |
 
 Example:
 

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/config/SatelBridgeConfig.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/config/SatelBridgeConfig.java
@@ -29,6 +29,7 @@ public class SatelBridgeConfig {
     private int refresh;
     private @Nullable String userCode;
     private @Nullable String encoding;
+    private boolean extCommands;
 
     /**
      * @return value of timeout in milliseconds
@@ -58,5 +59,12 @@ public class SatelBridgeConfig {
     public Charset getEncoding() {
         final String encoding = this.encoding;
         return encoding == null ? Charset.defaultCharset() : Charset.forName(encoding);
+    }
+
+    /**
+     * @return <code>true</code> if the module supports extended commands
+     */
+    public boolean hasExtCommandsSupport() {
+        return extCommands;
     }
 }

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/Ethm1BridgeHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/Ethm1BridgeHandler.java
@@ -56,7 +56,7 @@ public class Ethm1BridgeHandler extends SatelBridgeHandler {
         Ethm1Config config = getConfigAs(Ethm1Config.class);
         if (StringUtils.isNotBlank(config.getHost())) {
             SatelModule satelModule = new Ethm1Module(config.getHost(), config.getPort(), config.getTimeout(),
-                    config.getEncryptionKey());
+                    config.getEncryptionKey(), config.hasExtCommandsSupport());
             super.initialize(satelModule);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/IntRSBridgeHandler.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/handler/IntRSBridgeHandler.java
@@ -60,7 +60,8 @@ public class IntRSBridgeHandler extends SatelBridgeHandler {
         final IntRSConfig config = getConfigAs(IntRSConfig.class);
         final String port = config.getPort();
         if (port != null && StringUtils.isNotBlank(port)) {
-            SatelModule satelModule = new IntRSModule(port, serialPortManager, config.getTimeout());
+            SatelModule satelModule = new IntRSModule(port, serialPortManager, config.getTimeout(),
+                    config.hasExtCommandsSupport());
             super.initialize(satelModule);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/Ethm1Module.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/Ethm1Module.java
@@ -50,13 +50,15 @@ public class Ethm1Module extends SatelModule {
      * Creates new instance with host, port, timeout and encryption key set to
      * specified values.
      *
-     * @param host host name or IP of ETHM-1 module
-     * @param port TCP port the module listens on
-     * @param timeout timeout value in milliseconds for connect/read/write operations
-     * @param encryptionKey encryption key for encrypted communication
+     * @param host              host name or IP of ETHM-1 module
+     * @param port              TCP port the module listens on
+     * @param timeout           timeout value in milliseconds for connect/read/write operations
+     * @param encryptionKey     encryption key for encrypted communication
+     * @param extPayloadSupport if <code>true</code>, the module supports extended command payload for reading
+     *                              INTEGRA 256 state
      */
-    public Ethm1Module(String host, int port, int timeout, String encryptionKey) {
-        super(timeout);
+    public Ethm1Module(String host, int port, int timeout, String encryptionKey, boolean extPayloadSupport) {
+        super(timeout, extPayloadSupport);
 
         this.host = host;
         this.port = port;

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/IntRSModule.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/protocol/IntRSModule.java
@@ -46,12 +46,14 @@ public class IntRSModule extends SatelModule {
     /**
      * Creates new instance with port and timeout set to specified values.
      *
-     * @param port serial port the module is connected to
+     * @param port              serial port the module is connected to
      * @param serialPortManager serial port manager object
-     * @param timeout timeout value in milliseconds for connect/read/write operations
+     * @param timeout           timeout value in milliseconds for connect/read/write operations
+     * @param extPayloadSupport if <code>true</code>, the module supports extended command payload for reading
+     *                              INTEGRA 256 state
      */
-    public IntRSModule(String port, SerialPortManager serialPortManager, int timeout) {
-        super(timeout);
+    public IntRSModule(String port, SerialPortManager serialPortManager, int timeout, boolean extPayloadSupport) {
+        super(timeout, extPayloadSupport);
 
         this.port = port;
         this.serialPortManager = serialPortManager;

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/ethm-1.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/ethm-1.xml
@@ -47,6 +47,11 @@
 				<description>Encoding used for all the texts received from the module.</description>
 				<default>windows-1250</default>
 			</parameter>
+			<parameter name="extCommands" type="boolean">
+				<label>Extended Commands Support</label>
+				<description>Check this option to enable extended commands supported only by ETHM-1 Plus and newer versions of ETHM-1. Turn off in case of communication timeouts.</description>
+				<default>true</default>
+			</parameter>
 		</config-description>
 	</bridge-type>
 

--- a/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/int-rs.xml
+++ b/bundles/org.openhab.binding.satel/src/main/resources/ESH-INF/thing/int-rs.xml
@@ -37,6 +37,11 @@
 				<description>Encoding for all the texts received from the module.</description>
 				<default>windows-1250</default>
 			</parameter>
+			<parameter name="extCommands" type="boolean">
+				<label>Extended Commands Support</label>
+				<description>Check this option to enable extended commands supported only by version 2.xx of INT-RS. Turn off in case of communication timeouts.</description>
+				<default>true</default>
+			</parameter>
 		</config-description>
 	</bridge-type>
 


### PR DESCRIPTION
This PR introduces new configuration option "extCommands" for both bridge things. This option replaces existing way of checking whether a bridge supports extended commands.

It turned out that older firmware versions does not respond to command that gives information about features of the bridge.

Relevant discussion starts here: https://community.openhab.org/t/satel-binding-support-announcements-and-feature-requests/56135/158

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>