### PR TITLE
[onewire] Fix that DS2406_DS2413 are reading uncached like other IODevices (#7148) + spotless

### DIFF
--- a/bundles/org.openhab.binding.onewire/pom.xml
+++ b/bundles/org.openhab.binding.onewire/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/device/DS2406_DS2413.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/device/DS2406_DS2413.java
@@ -33,12 +33,12 @@ public class DS2406_DS2413 extends AbstractDigitalOwDevice {
     @Override
     public void configureChannels() throws OwException {
         ioConfig.clear();
-        ioConfig.add(new DigitalIoConfig(callback.getThing(), 0, new OwserverDeviceParameter("/sensed.A"),
+        ioConfig.add(new DigitalIoConfig(callback.getThing(), 0, new OwserverDeviceParameter("uncached/", "/sensed.A"),
                 new OwserverDeviceParameter("/PIO.A")));
-        ioConfig.add(new DigitalIoConfig(callback.getThing(), 1, new OwserverDeviceParameter("/sensed.B"),
+        ioConfig.add(new DigitalIoConfig(callback.getThing(), 1, new OwserverDeviceParameter("uncached/", "/sensed.B"),
                 new OwserverDeviceParameter("/PIO.B")));
 
-        fullInParam = new OwserverDeviceParameter("/sensed.BYTE");
+        fullInParam = new OwserverDeviceParameter("uncached/", "/sensed.BYTE");
         fullOutParam = new OwserverDeviceParameter("/PIO.BYTE");
 
         super.configureChannels();

--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/owserver/OwserverConnectionState.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/owserver/OwserverConnectionState.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.onewire.internal.owserver;
 
-import org.openhab.binding.onewire.internal.handler.OwserverBridgeHandler;
-
 /**
  * The {@link OwserverConnectionState} defines the state for connections to owservers
  *


### PR DESCRIPTION
## Changes

* Fixed that DS2406_DS2413 are reading uncached (like other IODevices) - issue: https://github.com/openhab/openhab-addons/issues/7148
* Fixed spotless formatter issue introduced by jenkins prep job on 17th of May in pom.xml (see https://github.com/Urmel/openhab-addons/commit/b6edbac44965ec5ed3e32425217c14683b5685a9#diff-3450cdb8b77d7a8d583d3374d14a6676)
* Removed unused import in OwserverConnectionState as it produced a warning

## Notes

Maybe the jenkins job should be fixed....?