### PR TITLE
[daikin] Add BRP069B41 to documentation

### DIFF
--- a/bundles/org.openhab.binding.daikin/README.md
+++ b/bundles/org.openhab.binding.daikin/README.md
@@ -5,7 +5,7 @@ In order to do so, your Daikin air conditioning unit must have a BRP072A42, BRP0
 
 ## Supported Things
 
-Daikin air conditioning units with a BRP072A42, BRP072C42 or BRP15B61 installed.
+Daikin air conditioning units with a BRP069B41, BRP072A42, BRP072C42 or BRP15B61 installed.
 This may work with the older KRP series of wired adapters, but has not been tested with them.
 
 ## Discovery
@@ -42,7 +42,7 @@ For the BRP072A42 and BRP072C42:
 | outdoortemp  | The outdoor temperature as measured by the external part of the air conditioning system. May not be available when unit is off. |
 | humidity     | The indoor humidity as measured by the unit. This is not available on all units.            |
 | mode         | The mode set for the unit (AUTO, DEHUMIDIFIER, COLD, HEAT, FAN)                             |
-| homekitmode  | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool)            |
+| homekitmode  | A mode that is compatible with homekit/alexa/google home (off, auto, heat, cool). Not tested for BRP069B41 |
 | fanspeed     | The fan speed set for the unit (AUTO, SILENCE, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5) |
 | fandir       | The fan blade direction (STOPPED, VERTICAL, HORIZONTAL, VERTICAL_AND_HORIZONTAL)            |
 
@@ -71,7 +71,7 @@ For the BRP15B61:
 daikin.things:
 
 ```
-// for BRP072A42
+// for BRP069B41 or BRP072A42
 daikin:ac_unit:living_room_ac [ host="192.168.0.5" ]
 // for BRP072C42
 daikin:ac_unit:living_room_ac [ host="192.168.0.5", secure=true, uuid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", key="xxxxxxxxxxxxx" ]
@@ -83,7 +83,7 @@ daikin:airbase_ac_unit:living_room_ac [ host="192.168.0.5" ]
 daikin.items:
 
 ```
-// for BRP072A42 or BRP072C42
+// for BRP069B41, BRP072A42 or BRP072C42
 Switch DaikinACUnit_Power { channel="daikin:ac_unit:living_room_ac:power" }
 Number:Temperature DaikinACUnit_SetPoint { channel="daikin:ac_unit:living_room_ac:settemp" }
 String DaikinACUnit_Mode { channel="daikin:ac_unit:living_room_ac:mode" }
@@ -116,7 +116,7 @@ Switch DaikinACUnit_Zone8 { channel="daikin:airbase_ac_unit:living_room_ac:zone8
 daikin.sitemap:
 
 ```
-// for BRP072A42 or BRP072C42
+// for BRP069B41, BRP072A42 or BRP072C42
 Switch item=DaikinACUnit_Power
 Setpoint item=DaikinACUnit_SetPoint visibility=[DaikinACUnit_Power==ON]
 Selection item=DaikinACUnit_Mode mappings=["AUTO"="Auto", "DEHUMIDIFIER"="Dehumidifier", "COLD"="Cold", "HEAT"="Heat", "FAN"="Fan"] visibility=[DaikinACUnit_Power==ON]


### PR DESCRIPTION
Added BRP069B41 as a compatible Wifi device. I tested all channels but homekitmode of the non-airbase section. I'm running BRP069B41 on 3 devices. Let me know if you need any additional details or proof.

Side note. The Thing Configuration section refers to a refresh option but it is not used in the Full Example section. Is it still a valid option? Then it should probably be used in the full example. If it's not longer of use then it might be removed from the section above.

Signed-off-by: Andreas Liewen github.andreas@liewen.net

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
