### PR TITLE
[samsungtv] Add UE50MU6179 and additional documentation

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -21,6 +21,7 @@ Tested TV models:
 | LE40D579    | PARTIAL | Supported channels: `volume`, `mute`, `channel`, `keyCode`, `sourceName`,  `programTitle`, `channelName`,  `power`                                     |
 | LE40C650    | PARTIAL | Supported channels: `volume`, `mute`, `channel`, `keyCode`, `brightness`, `contrast`, `colorTemperature`, `power` (only power off, unable to power on) |
 | UE55LS003   | PARTIAL | Supported channels: `volume`, `mute`, `sourceApp`, `url`, `keyCode`, `power`, `artMode`                                                                |
+| UE50MU6179  | PARTIAL | Supported channels: `volume`, `mute`, `power`, `keyCode`, `channel`, `sourceApp`, `url` (at least)                                                                |
 | UE43MU6199  | PARTIAL | Supported channels: `volume`, `mute`, `power` (at least)                                                                |
 | UE46F6510SS  | PARTIAL | Supported channels: `volume`, `mute`, `channel` (at least)                                                                |
 
@@ -86,3 +87,18 @@ String  TV_KeyCode       "Key Code"                            (gLivingRoomTV)  
 Switch  TV_Power         "Power"                               (gLivingRoomTV)   { channel="samsungtv:tv:livingroom:power" }
 Switch  TV_ArtMode       "Art Mode"                            (gLivingRoomTV)   { channel="samsungtv:tv:livingroom:artMode" }
 ```
+
+### Apps
+
+List of known apps and the respectve name that can be passed on to the `sourceApp` channel. Values are confirme to work on UE50MU6179.
+
+| App           | Value in sourceApp | Description                       |
+|---------------|--------------------|-----------------------------------|
+| ARD Mediathek | `ARD Mediathek`    | German public TV broadcasting app |
+| Browser       | `Internet`         | Built-in WWW browser              |
+| Netflix       | `Netflix`          | Netflix App                       |
+| Prime Video   | `Prime Video`      | Prime Video App                   |
+| YouTube       | `YouTube`          | Prime Video App                   |
+| ZDF Mediathek | `ZDF mediathek`    | German public TV broadcasting app |
+
+As part of discovery, log file `/var/log/openhab2/openhab.log` will contain a debug line with installed apps.

--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -90,7 +90,8 @@ Switch  TV_ArtMode       "Art Mode"                            (gLivingRoomTV)  
 
 ### Apps
 
-List of known apps and the respectve name that can be passed on to the `sourceApp` channel. Values are confirme to work on UE50MU6179.
+List of known apps and the respective name that can be passed on to the `sourceApp` channel.
+Values are confirmed to work on UE50MU6179.
 
 | App           | Value in sourceApp | Description                       |
 |---------------|--------------------|-----------------------------------|

--- a/bundles/org.openhab.binding.samsungtv/README.md
+++ b/bundles/org.openhab.binding.samsungtv/README.md
@@ -21,7 +21,7 @@ Tested TV models:
 | LE40D579    | PARTIAL | Supported channels: `volume`, `mute`, `channel`, `keyCode`, `sourceName`,  `programTitle`, `channelName`,  `power`                                     |
 | LE40C650    | PARTIAL | Supported channels: `volume`, `mute`, `channel`, `keyCode`, `brightness`, `contrast`, `colorTemperature`, `power` (only power off, unable to power on) |
 | UE55LS003   | PARTIAL | Supported channels: `volume`, `mute`, `sourceApp`, `url`, `keyCode`, `power`, `artMode`                                                                |
-| UE50MU6179  | PARTIAL | Supported channels: `volume`, `mute`, `power`, `keyCode`, `channel`, `sourceApp`, `url` (at least)                                                                |
+| UE50MU6179  | PARTIAL | Supported channels: `volume`, `mute`, `power`, `keyCode`, `channel`, `sourceApp`, `url` |
 | UE43MU6199  | PARTIAL | Supported channels: `volume`, `mute`, `power` (at least)                                                                |
 | UE46F6510SS  | PARTIAL | Supported channels: `volume`, `mute`, `channel` (at least)                                                                |
 


### PR DESCRIPTION
Added UE50MU6179 as I was able to use a number of channels. Let me know if any additional details or proof are needed.

Added a table with valid values for some common apps for users' convenience as well as a reference to the log file to find any additionally installed apps.

Side note: Key codes for remote control simulation might be useful as well since online documentation seems rather weak. I'm happy to contribute as I learn more - just unsure how this should be structured, by TV type or remote type.

Signed-off-by: Andreas Liewen github.andreas@liewen.net

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
