### PR TITLE
[mqtt] Correctly unsubscribe after message is received

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
  */
 @NonNullByDefault
 public class WaitForTopicValue {
-    private final CompletableFuture<String> future = new CompletableFuture<>();
     private final CompletableFuture<String> composeFuture;
 
     /**
@@ -42,8 +41,8 @@ public class WaitForTopicValue {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public WaitForTopicValue(MqttBrokerConnection connection, String topic)
-            throws InterruptedException, ExecutionException {
+    public WaitForTopicValue(MqttBrokerConnection connection, String topic) {
+        final CompletableFuture<String> future = new CompletableFuture<>();
         final MqttMessageSubscriber mqttMessageSubscriber = (t, payload) -> {
             try {
                 future.complete(new String(payload, "UTF-8"));

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
@@ -24,14 +24,14 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
 
 /**
- * Waits for a topic value to appear on a MQTT topic. One-time useable only per instance.
+ * Waits for a topic value to appear on a MQTT topic. One-time usable only per instance.
  *
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
 public class WaitForTopicValue {
     private CompletableFuture<String> future = new CompletableFuture<>();
-    private final CompletableFuture<Boolean> subscripeFuture;
+    private final CompletableFuture<Boolean> subscribeFuture;
 
     /**
      * Creates an a instance.
@@ -46,11 +46,11 @@ public class WaitForTopicValue {
         final MqttMessageSubscriber mqttMessageSubscriber = (t, payload) -> {
             future.complete(new String(payload));
         };
-        future = future.whenComplete((r, e) -> {
+        future.whenComplete((r, e) -> {
             connection.unsubscribe(topic, mqttMessageSubscriber);
         });
 
-        subscripeFuture = connection.subscribe(topic, mqttMessageSubscriber);
+        subscribeFuture = connection.subscribe(topic, mqttMessageSubscriber);
     }
 
     /**
@@ -68,7 +68,7 @@ public class WaitForTopicValue {
      */
     public @Nullable String waitForTopicValue(int timeoutInMS) {
         try {
-            return subscripeFuture.thenCompose(b -> future).get(timeoutInMS, TimeUnit.MILLISECONDS);
+            return subscribeFuture.thenCompose(b -> future).get(timeoutInMS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             return null;
         }
@@ -89,6 +89,6 @@ public class WaitForTopicValue {
      */
     public CompletableFuture<String> waitForTopicValueAsync(ScheduledExecutorService scheduler, int timeoutInMS) {
         scheduler.schedule(this::timeout, timeoutInMS, TimeUnit.MILLISECONDS);
-        return subscripeFuture.thenCompose(b -> future);
+        return subscribeFuture.thenCompose(b -> future);
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.mqtt.generic.tools;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,17 +38,11 @@ public class WaitForTopicValue {
      *
      * @param connection A broker connection.
      * @param topic The topic
-     * @throws InterruptedException
-     * @throws ExecutionException
      */
     public WaitForTopicValue(MqttBrokerConnection connection, String topic) {
         final CompletableFuture<String> future = new CompletableFuture<>();
         final MqttMessageSubscriber mqttMessageSubscriber = (t, payload) -> {
-            try {
-                future.complete(new String(payload, "UTF-8"));
-            } catch (UnsupportedEncodingException e1) {
-                future.complete(new String(payload));
-            }
+            future.complete(new String(payload, StandardCharsets.UTF_8));
         };
         future.whenComplete((r, e) -> {
             connection.unsubscribe(topic, mqttMessageSubscriber);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/WaitForTopicValue.java
@@ -32,7 +32,6 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
 @NonNullByDefault
 public class WaitForTopicValue {
     private final CompletableFuture<String> future = new CompletableFuture<>();
-    private final CompletableFuture<Boolean> subscribeFuture;
     private final CompletableFuture<String> composeFuture;
 
     /**
@@ -56,16 +55,14 @@ public class WaitForTopicValue {
             connection.unsubscribe(topic, mqttMessageSubscriber);
         });
 
-        subscribeFuture = connection.subscribe(topic, mqttMessageSubscriber);
-
-        composeFuture = subscribeFuture.thenCompose(b -> future);
+        composeFuture = connection.subscribe(topic, mqttMessageSubscriber).thenCompose(b -> future);
     }
 
     /**
      * Free any resources
      */
     public void stop() {
-        future.completeExceptionally(new Exception("Stopped"));
+        composeFuture.completeExceptionally(new Exception("Stopped"));
     }
 
     /**
@@ -83,8 +80,8 @@ public class WaitForTopicValue {
     }
 
     private void timeout() {
-        if (!future.isDone()) {
-            future.completeExceptionally(new TimeoutException());
+        if (!composeFuture.isDone()) {
+            composeFuture.completeExceptionally(new TimeoutException());
         }
     }
 

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
@@ -16,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -94,16 +93,11 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
         }
 
         // Retrieve name and update found discovery
-        try {
-            WaitForTopicValue w = new WaitForTopicValue(connection, topic.replace("$homie", "$name"));
-            w.waitForTopicValueAsync(scheduler, 700).whenComplete((name, ex) -> {
-                String deviceName = ex == null ? name : deviceID;
-                publishDevice(connectionBridge, connection, deviceID, topic, deviceName);
-            });
-        } catch (InterruptedException | ExecutionException ignored) {
-            // The name is nice to have, but not required, use deviceId as fallback
-            publishDevice(connectionBridge, connection, deviceID, topic, deviceID);
-        }
+        WaitForTopicValue w = new WaitForTopicValue(connection, topic.replace("$homie", "$name"));
+        w.waitForTopicValueAsync(scheduler, 700).whenComplete((name, ex) -> {
+            String deviceName = ex == null ? name : deviceID;
+            publishDevice(connectionBridge, connection, deviceID, topic, deviceName);
+        });
     }
 
     void publishDevice(ThingUID connectionBridge, MqttBrokerConnection connection, String deviceID, String topic,

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
@@ -96,8 +96,9 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
         // Retrieve name and update found discovery
         try {
             WaitForTopicValue w = new WaitForTopicValue(connection, topic.replace("$homie", "$name"));
-            w.waitForTopicValueAsync(scheduler, 700).thenAccept(name -> {
-                publishDevice(connectionBridge, connection, deviceID, topic, name);
+            w.waitForTopicValueAsync(scheduler, 700).whenComplete((name, ex) -> {
+                String deviceName = ex == null ? name : deviceID;
+                publishDevice(connectionBridge, connection, deviceID, topic, deviceName);
             });
         } catch (InterruptedException | ExecutionException ignored) {
             // The name is nice to have, but not required, use deviceId as fallback


### PR DESCRIPTION
The ```future``` attribute was overwritten in the constructor and, as a consequence, the ```whenComplete``` lambda method was not called. This made it impossible to re-subscribe to the same topic from the same connection. This fix is critical for Homie users, as the extensions uses this function in the discovery process.

A couple of typos are also fixed.

Closes #6975 
Closes #7252

Reviewers: @jochen314, @J-N-K, @cpmeister 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>