### PR TITLE
[homekit] remove dependency on org.apache.commons

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -17,7 +17,6 @@ import static org.openhab.io.homekit.internal.HomekitAccessoryType.DUMMY;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GroupItem;
@@ -138,7 +137,8 @@ public class HomekitTaggedItem {
     }
 
     private int calculateId(Item item) {
-        int id = new HashCodeBuilder().append(item.getName()).hashCode();
+        // magic number 629 is the legacy from apache HashCodeBuilder (17*37)
+        int id = 629 + item.getName().hashCode();
         if (id < 0) {
             id += Integer.MAX_VALUE;
         }


### PR DESCRIPTION
remove dependency on org.apache.commons. (#7722)

the only usage was the HashCodeBuilder that can be easily replaced. the change is backwards compatible as it generates the same hash codes.

Signed-off-by: Eugen Freiter <freiter@gmx.de>
