### PR TITLE
[homekit] bugfix for #7695. allow root accessory have characteristics

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.io.homekit.internal;
 
-import static org.openhab.io.homekit.internal.HomekitCharacteristicType.EMPTY;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -229,10 +228,8 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         if (!accessoryTypes.isEmpty() && groups.isEmpty()) { // it has homekit accessory type and is not part of bigger
                                                              // homekit group item
             logger.trace("Item {} is a HomeKit accessory of types {}", item.getName(), accessoryTypes);
-            accessoryTypes.stream().filter(accessory -> accessory.getValue() == EMPTY) // no characteristic => root
-                                                                                       // accessory or group
-                    .forEach(rootAccessory -> createRootAccessory(new HomekitTaggedItem(item, rootAccessory.getKey(),
-                            HomekitAccessoryFactory.getItemConfiguration(item, metadataRegistry))));
+            accessoryTypes.stream().forEach(rootAccessory -> createRootAccessory(new HomekitTaggedItem(item,
+                    rootAccessory.getKey(), HomekitAccessoryFactory.getItemConfiguration(item, metadataRegistry))));
         }
     }
 


### PR DESCRIPTION
HomeKit integration was expecting that root accessories (e.g. group or single accessories) are tagged only with accessory type without any characteristics, e.g.

`Number humidity "Humidity Sensor" {homekit = "HumiditySensor"}`

however, following is also a valid definition but it was ignored as characteristic was not empty. 

`Number humidity "Humidity Sensor" {homekit = "HumiditySensor.RelativeHumidity"}`

this PR removes the filter on the "empty characteristic" for root accessories. 

Closes #7695 

Signed-off-by: Eugen Freiter <freiter@gmx.de>
