### PR TITLE
[mqtt.homie] Improve Homie discovery time

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
@@ -62,12 +62,13 @@ public class DelayedBatchProcessing<T> implements Consumer<T> {
      * @param t An object
      */
     @Override
-    public void accept(T t) {
+    synchronized public void accept(T t) {
         queue.add(t);
         final ScheduledFuture<?> scheduledFuture = this.future;
-        if (scheduledFuture == null || scheduledFuture.isDone()) {
-            this.future = executor.schedule(this::run, delay, TimeUnit.MILLISECONDS);
+        if (scheduledFuture != null && !scheduledFuture.isDone()) {
+            scheduledFuture.cancel(true);
         }
+        this.future = executor.schedule(this::run, delay, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
@@ -63,12 +63,8 @@ public class DelayedBatchProcessing<T> implements Consumer<T> {
      * @param t An object
      */
     @Override
-    synchronized public void accept(T t) {
+    public void accept(T t) {
         queue.add(t);
-        final ScheduledFuture<?> scheduledFuture = this.futureRef.get();
-        if (scheduledFuture != null && !scheduledFuture.isDone()) {
-            cancel(futureRef.getAndSet(null));
-        }
         cancel(futureRef.getAndSet(executor.schedule(this::run, delay, TimeUnit.MILLISECONDS)));
     }
 
@@ -78,10 +74,7 @@ public class DelayedBatchProcessing<T> implements Consumer<T> {
      * @return A list of accumulated objects
      */
     public List<T> join() {
-        ScheduledFuture<?> scheduledFuture = this.futureRef.get();
-        if (scheduledFuture != null && !scheduledFuture.isDone()) {
-            cancel(futureRef.getAndSet(null));
-        }
+        cancel(futureRef.getAndSet(null));
         List<T> lqueue = new ArrayList<>();
         synchronized (queue) {
             lqueue.addAll(queue);
@@ -102,10 +95,7 @@ public class DelayedBatchProcessing<T> implements Consumer<T> {
      * Deliver queued items now to the target consumer.
      */
     public void forceProcessNow() {
-        ScheduledFuture<?> scheduledFuture = this.futureRef.get();
-        if (scheduledFuture != null && !scheduledFuture.isDone()) {
-            cancel(futureRef.getAndSet(null));
-        }
+        cancel(futureRef.getAndSet(null));
         run();
     }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/tools/DelayedBatchProcessing.java
@@ -56,8 +56,8 @@ public class DelayedBatchProcessing<T> implements Consumer<T> {
     }
 
     /**
-     * Add new object to the batch process list. If the list was empty, the delay timer
-     * is armed and all successive objects are accumulated from here on.
+     * Add new object to the batch process list. Every time a new object is received,
+     * the delay timer is rescheduled.
      *
      * @param t An object
      */

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
@@ -89,7 +89,7 @@ public class MqttThingHandlerFactory extends BaseThingHandlerFactory implements 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(MqttBindingConstants.HOMIE300_MQTT_THING)) {
-            return new HomieThingHandler(thing, typeProvider, 15000, 2000);
+            return new HomieThingHandler(thing, typeProvider, 1000, 500);
         }
         return null;
     }


### PR DESCRIPTION
As expressed in https://github.com/openhab/openhab-addons/pull/5963#issuecomment-523585015, the best way to improve the Homie discovery time was to decrease the timeout values, while also resetting the timer everytime a new value is received. This are the changes done:

- Reschedule the batch processing service when a new value is added. This makes the service more reliable, because the ```run``` function will only be called after the last message is received, and it doesn't matter how long it takes, as long as there is a constant flow of messages.
- Make the ```accept``` function synchronized, so that no new schedules are created when multiple threads are involved.
- Decrease Homie device timeout values to smaller ones. I am 'ok' if you want to increase them, but in my tests they have work great, because MQTT messages are delivered within milliseconds. Having a one second delay between two MQTT messages seems safe :wink:

As the DelayedBatchProccesing class is also used in the Home Assistant extension, I would really like to hear @jochen314's opinion about the proposed changes :+1: A review is also requested for @cpmeister, @J-N-K and @cweitkamp.

Closes #5958

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>