### PR TITLE
Fix jdbc and mapdb persistence build errors

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/org.openhab.persistence.jdbc/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Persistence Service :: JDBC</name>
 
   <properties>
-    <bnd.importpackage>!org.osgi.service.jdbc.*,!sun.security.*,!org.apache.lucene.*,!org.apache.logging.log4j,!waffle.windows.auth.*,!org.hibernate.*,!org.jboss.*,!org.codehaus.groovy.*,!com.codahale.metrics.*,!com.google.protobuf.*,!com.ibm.icu.*,!com.ibm.jvm.*,!com.mchange.*,!com.sun.*,!com.vividsolutions.*,!io.prometheus.*,com.mysql.jdbc;resolution:=optional,org.apache.derby.*;resolution:=optional,org.h2;resolution:=optional,org.h2.jdbcx;resolution:=optional,org.hsqldb;resolution:=optional,org.hsqldb.jdbc;resolution:=optional,org.mariadb.jdbc;resolution:=optional,org.postgresql;resolution:=optional,org.sqlite;resolution:=optional,org.sqlite.jdbc4;resolution:=optional</bnd.importpackage>
+    <bnd.importpackage>!org.osgi.service.jdbc.*,!sun.security.*,!org.apache.lucene.*,!org.apache.logging.log4j,!waffle.windows.auth.*,!org.hibernate.*,!org.jboss.*,!org.codehaus.groovy.*,!com.codahale.metrics.*,!com.google.protobuf.*,!com.ibm.icu.*,!com.ibm.jvm.*,!com.mchange.*,!com.sun.*,!com.vividsolutions.*,!io.prometheus.*,com.mysql.jdbc;resolution:=optional,org.apache.derby.*;resolution:=optional,org.h2;resolution:=optional,org.h2.jdbcx;resolution:=optional,org.hsqldb;resolution:=optional,org.hsqldb.jdbc;resolution:=optional,org.mariadb.jdbc;resolution:=optional,org.postgresql;resolution:=optional,org.sqlite;resolution:=optional,org.sqlite.jdbc4;resolution:=optional,javassist*;resolution:=optional</bnd.importpackage>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/bundles/org.openhab.persistence.mapdb/pom.xml
+++ b/bundles/org.openhab.persistence.mapdb/pom.xml
@@ -14,4 +14,12 @@
 
   <name>openHAB Add-ons :: Bundles :: Persistence Service :: MapDB</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.mapdb</groupId>
+      <artifactId>mapdb</artifactId>
+      <version>1.0.9</version>
+    </dependency>
+  </dependencies>
+
 </project>


### PR DESCRIPTION
The javassist dependency previously provided by the jetty-all bundle is no longer available causing the openhab-persistence-jdbc-derby feature verification to fail. It is unknown to me if it is really required so I've made it an optional import for now:

`[ERROR] Message: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=openhab-persistence-jdbc-derby; type=karaf.feature; version=3.0.0.SNAPSHOT; filter:="(&(osgi.identity=openhab-persistence-jdbc-derby)(type=karaf.feature)(version>=3.0.0.SNAPSHOT))" [caused by: Unable to resolve openhab-persistence-jdbc-derby/3.0.0.SNAPSHOT: missing requirement [openhab-persistence-jdbc-derby/3.0.0.SNAPSHOT] osgi.identity; osgi.identity=org.openhab.persistence.jdbc; type=osgi.bundle; version="[3.0.0.202005240847,3.0.0.202005240847]"; resolution:=mandatory [caused by: Unable to resolve org.openhab.persistence.jdbc/3.0.0.202005240847: missing requirement [org.openhab.persistence.jdbc/3.0.0.202005240847] osgi.wiring.package; filter:="(osgi.wiring.package=javassist)"]]`

---

The mapdb build failed because mapdb is no longer provided by openhab-core since the MapDB Storage got removed.

Related to:
* https://github.com/openhab/openhab-core/pull/1443
* https://github.com/openhab/openhab-core/pull/1493
