### PR TITLE
[mqtt.homie] Create PercentageValue only if attribute is settable

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
@@ -194,7 +194,7 @@ public class Property implements AttributeChanged {
                 if (step != null && !isDecimal && step.intValue() <= 0) {
                     step = new BigDecimal(1);
                 }
-                if (attributes.unit != null && attributes.unit.contains("%")) {
+                if (attributes.unit.contains("%") && attributes.settable) {
                     value = new PercentageValue(min, max, step, null, null);
                 } else {
                     value = new NumberValue(min, max, step, attributes.unit);


### PR DESCRIPTION
https://github.com/openhab/openhab-addons/pull/6845 added Dimmer functionallity to the Homie extension, but it was incomplete. As a consequence, now any attribute with the ```%``` unit is linked to a Dimmer item. This PR addresses that.

Fixes #7711

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>