### PR TITLE
[keba] Don't use selector if it has been closed

### DIFF
--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -219,9 +219,6 @@ class KeContactTransceiver {
         while (true) {
             try {
                 synchronized (selector) {
-                    if (!selector.isOpen()) {
-                        return;
-                    }
                     try {
                         selector.selectNow();
                     } catch (IOException e) {
@@ -401,7 +398,7 @@ class KeContactTransceiver {
                 } else {
                     return;
                 }
-            } catch (InterruptedException e) {
+            } catch (InterruptedException | ClosedSelectorException e) {
                 Thread.currentThread().interrupt();
                 return;
             }

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -219,6 +219,9 @@ class KeContactTransceiver {
         while (true) {
             try {
                 synchronized (selector) {
+                    if (!selector.isOpen()) {
+                        return;
+                    }
                     try {
                         selector.selectNow();
                     } catch (IOException e) {


### PR DESCRIPTION
On bundle shutdown, I have seen errors like:
```
Exception in thread "openHAB-Keba-Transceiver" java.nio.channels.ClosedSelectorException
        at java.base/sun.nio.ch.SelectorImpl.ensureOpen(SelectorImpl.java:75)
        at java.base/sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:118)
        at java.base/sun.nio.ch.SelectorImpl.selectNow(SelectorImpl.java:146)
        at org.openhab.binding.keba.internal.handler.KeContactTransceiver.lambda$0(KeContactTransceiver.java:223)
        at java.base/java.lang.Thread.run(Thread.java:834)
```
We hence must make sure to only use the selector if it hasn't yet been closed.

Signed-off-by: Kai Kreuzer <kai@openhab.org>