### PR TITLE
[homekit] Use BigDecimal to ensure accurate rounding

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -18,12 +18,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
 import org.openhab.io.homekit.internal.HomekitSettings;
@@ -176,5 +183,18 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
 
     protected void addCharacteristic(HomekitTaggedItem characteristic) {
         characteristics.add(characteristic);
+    }
+
+    private <T extends Quantity<T>> double convertAndRound(double value, Unit<T> from, Unit<T> to) {
+      double rawValue = from == to ? value : from.getConverterTo(to).convert(value);
+      return new BigDecimal(rawValue).setScale(1, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    protected double convertToCelsius(double degrees){
+      return convertAndRound(degrees, getSettings().useFahrenheitTemperature ? ImperialUnits.FAHRENHEIT : SIUnits.CELSIUS, SIUnits.CELSIUS);
+    }
+
+    protected double convertFromCelsius(double degrees){
+      return convertAndRound(degrees, getSettings().useFahrenheitTemperature ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT, ImperialUnits.FAHRENHEIT);
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitTemperatureSensorImpl.java
@@ -55,20 +55,4 @@ class HomekitTemperatureSensorImpl extends AbstractHomekitAccessoryImpl implemen
     public void unsubscribeCurrentTemperature() {
         unsubscribe(HomekitCharacteristicType.CURRENT_TEMPERATURE);
     }
-
-    protected double convertToCelsius(double degrees) {
-        if (getSettings().useFahrenheitTemperature) {
-            return Math.round((5d / 9d) * (degrees - 32d) * 1000d) / 1000d;
-        } else {
-            return degrees;
-        }
-    }
-
-    protected double convertFromCelsius(double degrees) {
-        if (getSettings().useFahrenheitTemperature) {
-            return Math.round((((9d / 5d) * degrees) + 32d) * 10d) / 10d;
-        } else {
-            return degrees;
-        }
-    }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitThermostatImpl.java
@@ -236,20 +236,4 @@ class HomekitThermostatImpl extends AbstractHomekitAccessoryImpl implements Ther
     public void unsubscribeTargetTemperature() {
         unsubscribe(HomekitCharacteristicType.TARGET_TEMPERATURE);
     }
-
-    protected double convertToCelsius(double degrees) {
-        if (getSettings().useFahrenheitTemperature) {
-            return Math.round((5d / 9d) * (degrees - 32d) * 1000d) / 1000d;
-        } else {
-            return degrees;
-        }
-    }
-
-    protected double convertFromCelsius(double degrees) {
-        if (getSettings().useFahrenheitTemperature) {
-            return Math.round((((9d / 5d) * degrees) + 32d) * 10d) / 10d;
-        } else {
-            return degrees;
-        }
-    }
 }


### PR DESCRIPTION
Temperature values are often not reported correctly in HomeKit
especially when they are in Fahrenheit this also has the side effect of
having no decimal when using Fahrenheit temperatures.

This intends to fix this and allows for accurate rounding and reporting
of temperatures.

Signed-off-by: Ethan Dye <mrtops03@gmail.com>