### PR TITLE
[netatmo] Mark the client secret configuration setting as a password

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/config/config.xml
@@ -16,6 +16,7 @@
 			<label>Client Secret</label>
 			<description>Client Secret provided for the application you created</description>
 			<required>true</required>
+			<context>password</context>
 		</parameter>
 
 		<parameter name="username" type="text">


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>
