### PR TITLE
[solaredge] fixed percent channels

### DIFF
--- a/bundles/org.openhab.binding.solaredge/src/main/resources/ESH-INF/thing/generic-channel-types.xml
+++ b/bundles/org.openhab.binding.solaredge/src/main/resources/ESH-INF/thing/generic-channel-types.xml
@@ -53,7 +53,7 @@
 		</state>
 	</channel-type>
 	<channel-type id="live-type-battery_level">
-		<item-type>Number:Percent</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Battery Level</label>
 		<description>Current Charge Level</description>
 		<state pattern="%.0f %unit%" readOnly="true">
@@ -118,7 +118,7 @@
 		</state>
 	</channel-type>
 	<channel-type id="aggregate-type-selfConsumptionCoverage">
-		<item-type>Number:Percent</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Self Consumption Coverage</label>
 		<description>Self Consumption Coverage</description>
 		<state pattern="%.0f %unit%" readOnly="true">


### PR DESCRIPTION
fixed percent channels. Number:Percent is not valid, Number:Dimensionless must be used.


