### PR TITLE
[Seneye] fix errors when using Pond or Home sensors

### DIFF
--- a/addons/binding/org.openhab.binding.seneye/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.seneye/ESH-INF/binding/binding.xml
@@ -6,6 +6,6 @@
 
 	<name>Seneye Binding</name>
 	<description>The seneye binding polls the seneye API for your aquarium readings.</description>
-	<author>Niko Tanghe, Updated by Mick Ursell</author>
+	<author>Niko Tanghe</author>
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.seneye/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.seneye/ESH-INF/binding/binding.xml
@@ -6,6 +6,6 @@
 
 	<name>Seneye Binding</name>
 	<description>The seneye binding polls the seneye API for your aquarium readings.</description>
-	<author>Niko Tanghe</author>
+	<author>Niko Tanghe, Updated by Mick Ursell</author>
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
@@ -19,6 +19,10 @@
 			<channel id="kelvin" typeId="kelvin"/>
 			<channel id="lastreading" typeId="lastreading"/>
 			<channel id="slideexpires" typeId="slideexpires"/>
+			<channel id="wrongslide" typeId="wrongslide"/>
+			<channel id="slideserial" typeId="slideserial"/>
+			<channel id="outofwater" typeId="outofwater" />
+			<channel id="disconnected" typeId="disconnected" />
 		</channels>
 		<config-description>
 			<parameter name="aquarium_name" type="text" required="true">
@@ -106,5 +110,29 @@
 		<label>Slide expiration</label>
 		<description>The time your slide expires</description>
 		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="wrongslide">
+		<item-type>String</item-type>
+		<label>Wrong slide</label>
+		<description>The Wrong Slide is in use (becomes 1 when the slide has expired)</description>
+		<state readOnly="true" />
+	</channel-type>
+	<channel-type id="slideserial">
+	   <item-type>String</item-type>
+	   <label>Slide Serial Number</label>
+	   <description>The serial Number of the currently installed slide</description>
+	   <state readOnly="true" />
+	</channel-type>
+	<channel-type id="outofwater">
+	   <item-type>String</item-type>
+	   <label>Out of Water</label>
+	   <description>The Sensor is reporting being out of the water</description>
+	   <state readOnly="true" />
+	</channel-type>
+	<channel-type id="disconnected">
+	   <item-type>String</item-type>
+	   <label>Disconnected</label>
+	   <description>No readings have been uploaded for a while, check connection</description>
+	   <state readOnly="true" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
@@ -113,7 +113,7 @@
 	</channel-type>
 	<channel-type id="wrongslide">
 		<item-type>String</item-type>
-		<label>Wrong slide</label>
+		<label>Wrong Slide</label>
 		<description>The Wrong Slide is in use (becomes 1 when the slide has expired)</description>
 		<state readOnly="true" />
 	</channel-type>

--- a/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.seneye/ESH-INF/thing/thing-types.xml
@@ -118,21 +118,21 @@
 		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="slideserial">
-	   <item-type>String</item-type>
-	   <label>Slide Serial Number</label>
-	   <description>The serial Number of the currently installed slide</description>
-	   <state readOnly="true" />
+		<item-type>String</item-type>
+		<label>Slide Serial Number</label>
+		<description>The serial Number of the currently installed slide</description>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="outofwater">
-	   <item-type>String</item-type>
-	   <label>Out of Water</label>
-	   <description>The Sensor is reporting being out of the water</description>
-	   <state readOnly="true" />
+		<item-type>String</item-type>
+		<label>Out of Water</label>
+		<description>The Sensor is reporting being out of the water</description>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="disconnected">
-	   <item-type>String</item-type>
-	   <label>Disconnected</label>
-	   <description>No readings have been uploaded for a while, check connection</description>
-	   <state readOnly="true" />
+		<item-type>String</item-type>
+		<label>Disconnected</label>
+		<description>No readings have been uploaded for a while, check connection</description>
+		<state readOnly="true" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.seneye/README.md
+++ b/addons/binding/org.openhab.binding.seneye/README.md
@@ -17,7 +17,7 @@ You can have multiple seneye devices in your home, just make sure that your aqua
 
 ## Discovery
 
-Discovery is not supported, the seneye monitor must be configured manually; either through Paper or .items
+Discovery is not supported, the seneye monitor must be configured manually.
 
 ## Thing Configuration
 

--- a/addons/binding/org.openhab.binding.seneye/README.md
+++ b/addons/binding/org.openhab.binding.seneye/README.md
@@ -17,7 +17,7 @@ You can have multiple seneye devices in your home, just make sure that your aqua
 
 ## Discovery
 
-Discovery is not supported, the seneye monitor must be configured manually
+Discovery is not supported, the seneye monitor must be configured manually; either through Paper or .items
 
 ## Thing Configuration
 
@@ -47,21 +47,25 @@ The following channels are supported:
 | kelvin                  | String       | The kelvin level of your aquarium lightning, if available        |
 | lastreading             | DateTime     | The moment when the last readings are received from the monitor  |
 | slideexpires            | DateTime     | The moment when the current slide will expire                    |
+| wrongslide              | String       | The Slide is not valid (normally expired)                        | 
+| slideserial             | String       | The serial number of the Slide                                   | 
+| outofwater              | String       | The Slide is reporting being out of the water                    | 
+| disconnected            | String       | The Seneye has not uploaded any updates recently                 | 
 
 ## Full example
 
 A manual configuration through a `things/seneye.things` file could look like this:
 
 ```
-Thing seneye:seneye:mySeneye "Seneye" @ "Living Room" [aquarium_name="MyAquarium", username="mail@example.com", password="xxx", poll_time=5]
+Thing seneye:monitor:mySeneye "Seneye" @ "Living Room" [aquarium_name="MyAquarium", username="mail@example.com", password="xxx", poll_time=5]
 ```
 
 A manual configuration through a `demo.items` file could look like this:
 
 ```
-String mySeneye_Temperature  "Temp [%s] C"        { channel="seneye:seneye:mySeneye:temperature" }
-String mySeneye_PH           "PH [%s]"            { channel="seneye:seneye:mySeneye:ph" }
-String mySeneye_NH3          "NH3 [%s]"           { channel="seneye:seneye:mySeneye:nh3" }
+String mySeneye_Temperature  "Temp [%s] C"        { channel="seneye:monitor:mySeneye:temperature" }
+String mySeneye_PH           "PH [%s]"            { channel="seneye:monitor:mySeneye:ph" }
+String mySeneye_NH3          "NH3 [%s]"           { channel="seneye:monitor:mySeneye:nh3" }
 ```
 
 The sitemap could look like this:

--- a/addons/binding/org.openhab.binding.seneye/build.properties
+++ b/addons/binding/org.openhab.binding.seneye/build.properties
@@ -4,5 +4,6 @@ bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
                ESH-INF/,\
-               about.html
+               about.html,\
+               README.md
 

--- a/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/SeneyeBindingConstants.java
+++ b/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/SeneyeBindingConstants.java
@@ -39,6 +39,10 @@ public class SeneyeBindingConstants {
     public final static String CHANNEL_KELVIN = "kelvin";
     public final static String CHANNEL_LASTREADING = "lastreading";
     public final static String CHANNEL_SLIDEEXPIRES = "slideexpires";
+    public final static String CHANNEL_WRONGSLIDE = "wrongslide";
+    public final static String CHANNEL_SLIDESERIAL = "slideserial";
+    public final static String CHANNEL_OUTOFWATER = "outofwater";
+    public final static String CHANNEL_DISCONNECTED = "disconnected";
 
     // List of all Parameters
     public final static String PARAMETER_AQUARIUMNAME = "aquariumname";

--- a/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/handler/SeneyeHandler.java
+++ b/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/handler/SeneyeHandler.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.smarthome.core.cache.ExpiringCache;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -74,6 +75,10 @@ public final class SeneyeHandler extends BaseThingHandler implements ReadingsUpd
             updateState(CHANNEL_KELVIN, new DecimalType(readings.kelvin.curr));
             updateState(CHANNEL_LASTREADING, new DateTimeType(readings.status.getLast_experimentDate()));
             updateState(CHANNEL_SLIDEEXPIRES, new DateTimeType(readings.status.getSlide_expiresDate()));
+            updateState(CHANNEL_WRONGSLIDE, new StringType(readings.status.getWrong_slideString()));
+            updateState(CHANNEL_SLIDESERIAL, new StringType(readings.status.getSlide_serialString()));
+            updateState(CHANNEL_OUTOFWATER, new StringType(readings.status.getOut_of_waterString()));
+            updateState(CHANNEL_DISCONNECTED, new StringType(readings.status.getDisconnectedString()));
         }
     }
 

--- a/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/internal/SeneyeStatus.java
+++ b/addons/binding/org.openhab.binding.seneye/src/main/java/org/openhab/binding/seneye/internal/SeneyeStatus.java
@@ -17,11 +17,11 @@ import org.eclipse.smarthome.core.library.types.DateTimeType;
  */
 
 public class SeneyeStatus {
-    public boolean disconnected;
+    public String disconnected;
     public String slide_serial;
     public String slide_expires;
-    public boolean out_of_water;
-    public boolean wrong_slide;
+    public String out_of_water;
+    public String wrong_slide;
     public String last_experiment;
 
     public String getLast_experimentDate() {
@@ -37,4 +37,21 @@ public class SeneyeStatus {
                 .format(new java.util.Date(Long.parseLong(tick) * 1000));
         return date;
     }
+
+    public String getWrong_slideString() {
+        return wrong_slide;
+    }
+
+    public String getSlide_serialString() {
+        return slide_serial;
+    }
+
+    public String getOut_of_waterString() {
+        return out_of_water;
+    }
+
+    public String getDisconnectedString() {
+        return disconnected;
+    }
+
 }


### PR DESCRIPTION
This is a bug fix for Seneye binding when using Pond or Home Sensors.
Previously the binding would fail as it would try and pull readings for Channels that didn't exist on these sensors.

Mick Ursell <bindings@mru-photography.co.uk>

