### PR TITLE
[alarmdecoder] Add vzone thing for virtual zone control

### DIFF
--- a/bundles/org.openhab.binding.alarmdecoder/README.md
+++ b/bundles/org.openhab.binding.alarmdecoder/README.md
@@ -145,6 +145,7 @@ Thing config file example:
 The `vzone` thing sends open/close commands a virtual zone.
 After enabling zone expander emulation on both the alarm panel and the Alarm Decoder device, it can be used to control the state of a virtual zone.
 The `command` channel is write-only, and accepts either the string "OPEN" or the string "CLOSED".
+The `state` channel is a switch type channel that reflects the current state of the virtual zone (ON=closed/OFF=open).
 
 Parameters:
 
@@ -197,6 +198,7 @@ The alarmdecoder things expose the following channels:
 |  channel     | type    |RO/RW| description                  |
 |--------------|---------|-----|------------------------------|
 | command      | String  | WO  |"OPEN" or "CLOSED" command    |
+| state        | Switch  | RW  |Zone state (ON = closed)      |
 
 **keypad**
 

--- a/bundles/org.openhab.binding.alarmdecoder/README.md
+++ b/bundles/org.openhab.binding.alarmdecoder/README.md
@@ -23,6 +23,7 @@ The binding supports the following thing types:
 * `keypad` - Reports keypad status and optionally sends keypad messages.
 * `zone` - Reports status from zone expanders and relay expanders, and also from built-in zones via emulation.
 * `rfzone` - Reports status from RF zones.
+* `vzone` - Sends commands to virtual zones.
 * `lrr` - Reports messages sent from the panel to a Long Range Radio (LRR) or emulated LRR device.
 
 ## Discovery
@@ -86,6 +87,30 @@ Bridge alarmdecoder:serialbridge:ad1 [ serialPort="/dev/ttyS1", bitrate=115200, 
 }
 ```
 
+### keypad
+
+The `keypad` thing reports keypad status and optionally sends keypad messages.
+For panels that support multiple keypad addresses, it can be configured with an address mask of one or more keypad(s) for which it will receive messages.
+When sending messages, it will send from the configured keypad address if only one is configured.
+If a mask containing multiple addresses or 0 (all) is configured, it will send messages from the Alarm Decoder's configured address.
+
+Commands sent from the keypad thing are limited to the set of valid keypad command characters supported by the Alarm Decoder (0-9,*,#,<,>).
+In addition, the characters A-H will be translated to special keys 1-8.
+Command strings containing invalid characters will be ignored.
+
+Parameters:
+
+* `addressMask` (required) Keypad address mask (0 = All addresses)
+* `sendCommands` (default = false) Allow keypad commands to be sent to the alarm system from openHAB. Enabling this means the alarm system will be only as secure as your openHAB system.
+* `sendStar` (default = false) When disarmed/faulted, automatically send the * character to obtain zone fault information.
+* `commandMapping` (optional) Comma separated list of key/value pairs mapping integers to command strings for `intcommand` channel.
+
+Thing config file example:
+
+```
+  Thing keypad keypad1 [ addressMask=0, sendCommands=true ]
+```
+
 ### zone
 
 The `zone` thing reports status from zone expanders and relay expanders, and also from built-in zones via emulation.
@@ -115,28 +140,20 @@ Thing config file example:
   Thing rfzone motion1 [ serial=0180010 ]
 ```
 
-### keypad
+### vzone
 
-The `keypad` thing reports keypad status and optionally sends keypad messages.
-For panels that support multiple keypad addresses, it can be configured with an address mask of one or more keypad(s) for which it will receive messages.
-When sending messages, it will send from the configured keypad address if only one is configured.
-If a mask containing multiple addresses or 0 (all) is configured, it will send messages from the Alarm Decoder's configured address.
-
-Commands sent from the keypad thing are limited to the set of valid keypad command characters supported by the Alarm Decoder (0-9,*,#,<,>).
-In addition, the characters A-H will be translated to special keys 1-8.
-Command strings containing invalid characters will be ignored.
+The `vzone` thing sends open/close commands a virtual zone.
+After enabling zone expander emulation on both the alarm panel and the Alarm Decoder device, it can be used to control the state of a virtual zone.
+The `command` channel is write-only, and accepts either the string "OPEN" or the string "CLOSED".
 
 Parameters:
 
-* `addressMask` (required) Keypad address mask (0 = All addresses)
-* `sendCommands` (default = false) Allow keypad commands to be sent to the alarm system from openHAB. Enabling this means the alarm system will be only as secure as your openHAB system.
-* `sendStar` (default = false) When disarmed/faulted, automatically send the * character to obtain zone fault information.
-* `commandMapping` (optional) Comma separated list of key/value pairs mapping integers to command strings for `intcommand` channel.
+* `address` (required) Virtual zone number (0-99)
 
 Thing config file example:
 
 ```
-  Thing keypad keypad1 [ addressMask=0, sendCommands=true ]
+  Thing vzone watersensor [ address=41 ]
 ```
 
 ### lrr
@@ -174,6 +191,12 @@ The alarmdecoder things expose the following channels:
 | loop2        | Contact | RO  |Loop 2 state                  |
 | loop3        | Contact | RO  |Loop 3 state                  |
 | loop4        | Contact | RO  |Loop 4 state                  |
+
+**vzone**
+
+|  channel     | type    |RO/RW| description                  |
+|--------------|---------|-----|------------------------------|
+| command      | String  | WO  |"OPEN" or "CLOSED" command    |
 
 **keypad**
 
@@ -222,6 +245,7 @@ Bridge alarmdecoder:ipbridge:ad1 [ hostname="cerberus.home", tcpPort=10000, disc
     Thing zone frontdoor [ address=10, channel=1 ]
     Thing zone backdoor [ address=11, channel=1 ]
     Thing rfzone motion1 [ serial=0180010 ]
+    Thing vzone watersensor [ address=41 ]
     Thing keypad keypad1 [ addressMask=0, sendCommands=true ]
     Thing lrr lrr [ partition=0 ]
 }
@@ -246,6 +270,8 @@ Contact Motion1Loop1 "Loop 1" {channel="alarmdecoder:rfzone:ad1:motion1:loop1"}
 Contact Motion1Loop2 "Loop 2" {channel="alarmdecoder:rfzone:ad1:motion1:loop2"}
 Contact Motion1Loop3 "Loop 3" {channel="alarmdecoder:rfzone:ad1:motion1:loop3"}
 Contact Motion1Loop4 "Loop 4" {channel="alarmdecoder:rfzone:ad1:motion1:loop4"}
+
+String WaterSensorCmd "Virtual Zone Command" {channel="alarmdecoder:vzone:ad1:watersensor:command"}
 
 Number LrrPartition "Partition Number [%d]" {channel="alarmdecoder:lrr:ad1:lrr:partition"}
 Number LrrEventData "CID Event Data [%d]" {channel="alarmdecoder:lrr:ad1:lrr:eventdata"}

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBindingConstants.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBindingConstants.java
@@ -37,6 +37,7 @@ public class AlarmDecoderBindingConstants {
     public static final ThingTypeUID THING_TYPE_SERIALBRIDGE = new ThingTypeUID(BINDING_ID, "serialbridge");
     public static final ThingTypeUID THING_TYPE_ZONE = new ThingTypeUID(BINDING_ID, "zone");
     public static final ThingTypeUID THING_TYPE_RFZONE = new ThingTypeUID(BINDING_ID, "rfzone");
+    public static final ThingTypeUID THING_TYPE_VZONE = new ThingTypeUID(BINDING_ID, "vzone");
     public static final ThingTypeUID THING_TYPE_KEYPAD = new ThingTypeUID(BINDING_ID, "keypad");
     public static final ThingTypeUID THING_TYPE_LRR = new ThingTypeUID(BINDING_ID, "lrr");
 
@@ -54,6 +55,9 @@ public class AlarmDecoderBindingConstants {
     public static final String PROPERTY_ID = "id";
 
     public static final String CHANNEL_CONTACT = "contact";
+
+    // Channel IDs for VZoneHandler
+    public static final String CHANNEL_COMMAND = "command";
 
     // Channel IDs for RFZoneHandler
     public static final String PROPERTY_SERIAL = "serial";

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBindingConstants.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBindingConstants.java
@@ -55,6 +55,7 @@ public class AlarmDecoderBindingConstants {
     public static final String PROPERTY_ID = "id";
 
     public static final String CHANNEL_CONTACT = "contact";
+    public static final String CHANNEL_STATE = "state";
 
     // Channel IDs for VZoneHandler
     public static final String CHANNEL_COMMAND = "command";

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderHandlerFactory.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderHandlerFactory.java
@@ -38,6 +38,7 @@ import org.openhab.binding.alarmdecoder.internal.handler.KeypadHandler;
 import org.openhab.binding.alarmdecoder.internal.handler.LRRHandler;
 import org.openhab.binding.alarmdecoder.internal.handler.RFZoneHandler;
 import org.openhab.binding.alarmdecoder.internal.handler.SerialBridgeHandler;
+import org.openhab.binding.alarmdecoder.internal.handler.VZoneHandler;
 import org.openhab.binding.alarmdecoder.internal.handler.ZoneHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -58,7 +59,7 @@ public class AlarmDecoderHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(THING_TYPE_IPBRIDGE, THING_TYPE_SERIALBRIDGE, THING_TYPE_ZONE, THING_TYPE_RFZONE,
-                    THING_TYPE_KEYPAD, THING_TYPE_LRR).collect(Collectors.toSet()));
+                    THING_TYPE_VZONE, THING_TYPE_KEYPAD, THING_TYPE_LRR).collect(Collectors.toSet()));
 
     private final Logger logger = LoggerFactory.getLogger(AlarmDecoderHandlerFactory.class);
 
@@ -94,6 +95,8 @@ public class AlarmDecoderHandlerFactory extends BaseThingHandlerFactory {
             return new ZoneHandler(thing);
         } else if (THING_TYPE_RFZONE.equals(thingTypeUID)) {
             return new RFZoneHandler(thing);
+        } else if (THING_TYPE_VZONE.equals(thingTypeUID)) {
+            return new VZoneHandler(thing);
         } else if (THING_TYPE_KEYPAD.equals(thingTypeUID)) {
             return new KeypadHandler(thing);
         } else if (THING_TYPE_LRR.equals(thingTypeUID)) {

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/config/VZoneConfig.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/config/VZoneConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.alarmdecoder.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VZoneConfig} class contains fields mapping thing configuration parameters for VZoneHandler.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public class VZoneConfig {
+    public int address = -1;
+}

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/ADBridgeHandler.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/ADBridgeHandler.java
@@ -312,7 +312,8 @@ public abstract class ADBridgeHandler extends BaseBridgeHandler {
             throw new MessageParseException(e.getMessage());
         }
 
-        logger.trace("Processing version message sn:{} ver:{} cap:{}", verMsg.serial, verMsg.version, verMsg.capabilities);
+        logger.trace("Processing version message sn:{} ver:{} cap:{}", verMsg.serial, verMsg.version,
+                verMsg.capabilities);
         Map<String, String> properties = editProperties();
         properties.put(PROPERTY_SERIALNUM, verMsg.serial);
         properties.put(PROPERTY_VERSION, verMsg.version);
@@ -354,7 +355,8 @@ public abstract class ADBridgeHandler extends BaseBridgeHandler {
             // Notify child zone handlers by calling notifyPanelReady() for each
             for (Thing thing : getThing().getThings()) {
                 ADThingHandler handler = (ADThingHandler) thing.getHandler();
-                if (handler != null && (handler instanceof ZoneHandler || handler instanceof RFZoneHandler)) {
+                if (handler != null && (handler instanceof ZoneHandler || handler instanceof RFZoneHandler
+                        || handler instanceof VZoneHandler)) {
                     handler.notifyPanelReady();
                 }
             }

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/ADBridgeHandler.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/ADBridgeHandler.java
@@ -345,7 +345,7 @@ public abstract class ADBridgeHandler extends BaseBridgeHandler {
      * contact channels are initialized into the UNDEF state. This method is called when there is reason to assume that
      * there are no faulted zones, because the alarm panel is in state READY. Zone handlers that have not yet received
      * updates can then set their contact states to CLOSED. Only executes the first time panel is ready after bridge
-     * connect/reconnect. Currently only notifies ZoneHandler and RFZoneHandler things.
+     * connect/reconnect.
      */
     private void notifyChildHandlersPanelReady() {
         if (!panelReadyReceived) {
@@ -355,8 +355,7 @@ public abstract class ADBridgeHandler extends BaseBridgeHandler {
             // Notify child zone handlers by calling notifyPanelReady() for each
             for (Thing thing : getThing().getThings()) {
                 ADThingHandler handler = (ADThingHandler) thing.getHandler();
-                if (handler != null && (handler instanceof ZoneHandler || handler instanceof RFZoneHandler
-                        || handler instanceof VZoneHandler)) {
+                if (handler != null) {
                     handler.notifyPanelReady();
                 }
             }

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/VZoneHandler.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/VZoneHandler.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.alarmdecoder.internal.handler;
+
+import static org.openhab.binding.alarmdecoder.internal.AlarmDecoderBindingConstants.CHANNEL_COMMAND;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.alarmdecoder.internal.config.VZoneConfig;
+import org.openhab.binding.alarmdecoder.internal.protocol.ADCommand;
+import org.openhab.binding.alarmdecoder.internal.protocol.ADMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link VZoneHandler} is responsible for sending state commands to virtual zones.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@NonNullByDefault
+public class VZoneHandler extends ADThingHandler {
+
+    public static final String CMD_OPEN = "OPEN";
+    public static final String CMD_CLOSED = "CLOSED";
+
+    private final Logger logger = LoggerFactory.getLogger(VZoneHandler.class);
+
+    private VZoneConfig config = new VZoneConfig();
+
+    public VZoneHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(VZoneConfig.class);
+
+        if (config.address < 0 || config.address > 99) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid address setting");
+            return;
+        }
+        logger.debug("Virtual zone handler initializing for address {}", config.address);
+        initDeviceState();
+    }
+
+    @Override
+    public void initChannelState() {
+        // Do nothing
+    }
+
+    @Override
+    public void notifyPanelReady() {
+        // Do nothing
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_COMMAND)) {
+            if (command instanceof StringType) {
+                String cmd = ((StringType) command).toString();
+                if (CMD_OPEN.equalsIgnoreCase(cmd)) {
+                    sendCommand(ADCommand.setZone(config.address, ADCommand.ZONE_OPEN));
+                } else if (CMD_CLOSED.equalsIgnoreCase(cmd)) {
+                    sendCommand(ADCommand.setZone(config.address, ADCommand.ZONE_CLOSED));
+                } else {
+                    logger.debug("Virtual zone handler {} received invalid command: {}", config.address, cmd);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleUpdate(ADMessage msg) {
+        // Ignore update requests
+    }
+}

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADCommand.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADCommand.java
@@ -33,6 +33,9 @@ public final class ADCommand {
     public static final String SPECIAL_KEY_7 = "\u0007\u0007\u0007";
     public static final String SPECIAL_KEY_8 = "\u0008\u0008\u0008";
 
+    public static final int ZONE_OPEN = 1;
+    public static final int ZONE_CLOSED = 0;
+
     // public static final String KEYPAD_COMMAND_CHARACTERS = "0123456789*#<>";
     public static final String KEYPAD_COMMAND_REGEX = "^[0-9A-H*#<>]+$";
 

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -140,6 +140,27 @@
 		</config-description>
 	</thing-type>
 
+	<!-- Virtual Zone Thing Type -->
+	<thing-type id="vzone">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="ipbridge" />
+			<bridge-type-ref id="serialbridge" />
+		</supported-bridge-type-refs>
+
+		<label>Virtual Zone</label>
+		<description>Alarm Decoder virtual zone</description>
+
+		<channels>
+			<channel id="command" typeId="contact-command-channel" />
+		</channels>
+
+		<config-description>
+			<parameter name="address" type="integer" required="true">
+				<label>Virtual Zone Number</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<!-- Keypad Thing Type -->
 	<thing-type id="keypad">
 		<supported-bridge-type-refs>
@@ -323,5 +344,17 @@
 	<channel-type id="int-command-channel" advanced="true">
 		<item-type>Number</item-type>
 		<label>Integer Command Channel</label>
+	</channel-type>
+
+	<!-- Contact command channel type -->
+	<channel-type id="contact-command-channel">
+		<item-type>String</item-type>
+		<label>Contact Command</label>
+		<command>
+			<options>
+				<option value="OPEN">Open</option>
+				<option value="CLOSED">Closed</option>
+			</options>
+		</command>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -152,6 +152,7 @@
 
 		<channels>
 			<channel id="command" typeId="contact-command-channel" />
+			<channel id="state" typeId="switch-channel" />
 		</channels>
 
 		<config-description>
@@ -317,6 +318,14 @@
 		<label>Indicator State</label>
 		<category>Switch</category>
 		<state readOnly="true" />
+	</channel-type>
+
+	<!-- Switch Channel Type -->
+	<channel-type id="switch-channel">
+		<item-type>Switch</item-type>
+		<label>Switch State</label>
+		<category>Switch</category>
+		<state readOnly="false" />
 	</channel-type>
 
 	<!-- Number Channel Type -->


### PR DESCRIPTION
This PR adds support for a new vzone thing for control of AD virtual zones. This allows users to open and close the virtual zones from openHAB.

