### PR TITLE
[netatmo] Add support for Presence camera events (#3059)

### DIFF
--- a/bundles/org.openhab.binding.netatmo/NOTICE
+++ b/bundles/org.openhab.binding.netatmo/NOTICE
@@ -39,10 +39,10 @@ oltu.oauth2
 * Project: https://oltu.apache.org
 * Source:  https://svn.apache.org/viewvc/oltu/trunk
 
-netatmo-java-retrofit
-* License: Apache 2.0 License
+netatmo-swagger-decl
+* License: MIT License
 * Project: https://dev.netatmo.com
-* Source:  https://github.com/cbornet/netatmo-swagger-api
+* Source:  https://github.com/cbornet/netatmo-swagger-decl
 
 retrofit
 * License: Apache 2.0 License

--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -448,24 +448,27 @@ All these channels except Sp_Temperature, SetpointMode and Planning are read onl
 
 **Supported channels for the Home thing:**
 
-| Channel ID              | Item Type | Description                                              |
-|-------------------------|-----------|----------------------------------------------------------|
-| welcomeHomeCity         | String    | City of the home                                         |
-| welcomeHomeCountry      | String    | Country of the home                                      |
-| welcomeHomeTimezone     | String    | Timezone of the home                                     |
-| welcomeHomePersonCount  | Number    | Total number of Persons that are at home                 |
-| welcomeHomeUnknownCount | Number    | Count how many Unknown Persons are at home               |
-| welcomeEventType        | String    | Type of event                                            |
-| welcomeEventTime        | DateTime  | Time of occurrence of event                               |
-| welcomeEventCameraId    | String    | Camera that detected the event                           |
-| welcomeEventPersonId    | String    | Id of the person the event is about (if any)             |
-| welcomeEventSnapshot    | Image     | picture of the last event, if it applies                 |
-| welcomeEventSnapshotURL | String    | if the last event (depending upon event type) in the home lead a snapshot picture, the picture URL will be available here |
-| welcomeEventVideoURL    | String    | if the last event (depending upon event type) in the home lead a snapshot picture, the corresponding video URL will be available here |
-| welcomeEventVideoStatus | String    | Status of the video (recording, deleted or available)    |
-| welcomeEventIsArrival   | Switch    | If person was considered "away" before being seen during this event |
-| welcomeEventMessage     | String    | Message sent by Netatmo corresponding to given event     |
-| welcomeEventSubType     | String    | Sub-type of SD and Alim events                           |
+| Channel ID               | Item Type | Description                                              |
+|--------------------------|-----------|----------------------------------------------------------|
+| welcomeHomeCity          | String    | City of the home                                         |
+| welcomeHomeCountry       | String    | Country of the home                                      |
+| welcomeHomeTimezone      | String    | Timezone of the home                                     |
+| welcomeHomePersonCount   | Number    | Total number of Persons that are at home                 |
+| welcomeHomeUnknownCount  | Number    | Count how many Unknown Persons are at home               |
+| welcomeEventType         | String    | Type of event                                            |
+| welcomeEventTime         | DateTime  | Time of occurrence of event                               |
+| welcomeEventCameraId     | String    | Camera that detected the event                           |
+| welcomeEventPersonId     | String    | Id of the person the event is about (if any)             |
+| welcomeEventSnapshot     | Image     | picture of the last event, if it applies                 |
+| welcomeEventSnapshotURL  | String    | if the last event (depending upon event type) in the home lead a snapshot picture, the picture URL will be available here |
+| welcomeEventVideoURL     | String    | if the last event (depending upon event type) in the home lead a snapshot picture, the corresponding video URL will be available here |
+| welcomeEventVideoStatus  | String    | Status of the video (recording, deleted or available)    |
+| welcomeEventIsArrival    | Switch    | If person was considered "away" before being seen during this event |
+| welcomeEventMessage      | String    | Message sent by Netatmo corresponding to given event     |
+| welcomeEventSubType      | String    | Sub-type of SD and Alim events                           |
+| homeEventHumanDetected   | Switch    | If the last event recorded a human                       |
+| homeEventAnimalDetected  | Switch    | If the last event recorded an animal                     |
+| homeEventVehicleDetected | Switch    | If the last event recorded a vehicle                     |
 
 All these channels are read only.
 

--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -42,6 +42,7 @@ Bridge netatmo:netatmoapi:home [ clientId="<CLIENT_ID>", clientSecret="<CLIENT_S
     Thing NATherm1  thermostat [ id="xx:xx:xx:xx:xx:xx", parentId="bb:bb:bb:bb:bb:bb" ]
     Thing NAWelcomeHome home   [ id="58yyacaaexxxebca99x999x", refreshInterval=600000 ]
     Thing NACamera camera [ id="cc:cc:cc:cc:cc:cc", parentId="58yyacaaexxxebca99x999x" ]
+    Thing NOC presenceOutdoorCamera [ id="dd:dd:dd:dd:dd:dd", parentId="58yyacaaexxxebca99x999x" ]
     Thing NAWelcomePerson sysadmin [ id="aaaaaaaa-bbbb-cccc-eeee-zzzzzzzzzzzz", parentId="58yyacaaexxxebca99x999x" ]
     ...
 }

--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -475,10 +475,10 @@ All these channels are read only.
 | Channel Type ID  | Options                | Description                                           |
 |------------------|------------------------|-------------------------------------------------------|
 | cameraEvent      |                        | A camera event is triggered with a short delay but without requiring a webhook. The information of the event can get retrieved from the other "welcomeEvent" home thing channels |
-|                  | HUMAN_DETECTED         | Triggered when a human (or person) was detected       |
-|                  | ANIMAL_DETECTED        | Triggered when an animal was detected                 |
-|                  | MOVEMENT_DETECTED      | Triggered when an unspecified movement was detected   |
-|                  | VEHICLE_DETECTED       | Triggered when a vehicle was detected                 |
+|                  | HUMAN                  | Triggered when a human (or person) was detected       |
+|                  | ANIMAL                 | Triggered when an animal was detected                 |
+|                  | MOVEMENT               | Triggered when an unspecified movement was detected   |
+|                  | VEHICLE                | Triggered when a vehicle was detected                 |
 | welcomeHomeEvent |                        | A welcome home event is triggered directly via a configured webhook |
 |                  | PERSON                 | Triggered when a concrete person was detected         |
 |                  | PERSON_AWAY            | Triggered when a concrete person leaves               |

--- a/bundles/org.openhab.binding.netatmo/README.md
+++ b/bundles/org.openhab.binding.netatmo/README.md
@@ -447,6 +447,8 @@ All these channels except Sp_Temperature, SetpointMode and Planning are read onl
 
 ### Welcome Home
 
+All these channels are read only.
+
 **Supported channels for the Home thing:**
 
 | Channel ID               | Item Type | Description                                              |
@@ -467,12 +469,36 @@ All these channels except Sp_Temperature, SetpointMode and Planning are read onl
 | welcomeEventIsArrival    | Switch    | If person was considered "away" before being seen during this event |
 | welcomeEventMessage      | String    | Message sent by Netatmo corresponding to given event     |
 | welcomeEventSubType      | String    | Sub-type of SD and Alim events                           |
-| homeEventHumanDetected   | Switch    | If the last event recorded a human                       |
-| homeEventAnimalDetected  | Switch    | If the last event recorded an animal                     |
-| homeEventVehicleDetected | Switch    | If the last event recorded a vehicle                     |
 
-All these channels are read only.
+**Supported trigger channels for the Home thing:**
 
+| Channel Type ID  | Options                | Description                                           |
+|------------------|------------------------|-------------------------------------------------------|
+| cameraEvent      |                        | A camera event is triggered with a short delay but without requiring a webhook. The information of the event can get retrieved from the other "welcomeEvent" home thing channels |
+|                  | HUMAN_DETECTED         | Triggered when a human (or person) was detected       |
+|                  | ANIMAL_DETECTED        | Triggered when an animal was detected                 |
+|                  | MOVEMENT_DETECTED      | Triggered when an unspecified movement was detected   |
+|                  | VEHICLE_DETECTED       | Triggered when a vehicle was detected                 |
+| welcomeHomeEvent |                        | A welcome home event is triggered directly via a configured webhook |
+|                  | PERSON                 | Triggered when a concrete person was detected         |
+|                  | PERSON_AWAY            | Triggered when a concrete person leaves               |
+|                  | MOVEMENT               | Triggered when a movement was detected                |
+|                  | CONNECTION             | Triggered when a camera connection gets created       |
+|                  | DISCONNECTION          | Triggered when a camera connection got lost           |
+|                  | ON                     | Triggered when camera monitoring is switched on       |
+|                  | OFF                    | Triggered when camera monitoring is switched off      |
+|                  | BOOT                   | Triggered when a camera is booting                    |
+|                  | SD                     | Triggered when a camera SD card status was changed    |
+|                  | ALIM                   | Triggered when a power supply status was changed      |
+|                  | NEW_MODULE             | Triggered when a new module was discovered            |
+|                  | MODULE_CONNECT         | Triggered when a module gets connected                |
+|                  | MODULE_DISCONNECT      | Triggered when a module gets disconnected             |
+|                  | MODULE_LOW_BATTERY     | Triggered when the battery of a module gets low       |
+|                  | MODULE_END_UPDATE      | Triggered when a firmware update of a module is done  |
+|                  | TAG_BIG_MOVE           | Triggered when a big movement of a tag was detected   |
+|                  | TAG_SMALL_MOVE         | Triggered when a small movement of a tag was detected |
+|                  | TAG_UNINSTALLED        | Triggered when a tag gets uninstalled                 |
+|                  | TAG_OPEN               | Triggered when an open event of a tag was detected    |
 
 ### Welcome and Presence Camera
 

--- a/bundles/org.openhab.binding.netatmo/pom.xml
+++ b/bundles/org.openhab.binding.netatmo/pom.xml
@@ -20,12 +20,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.cbornet.netatmo-swagger-api</groupId>
-      <artifactId>netatmo-java-retrofit</artifactId>
-      <version>1.1.3</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>org.json.json</artifactId>
       <version>20131018</version>
@@ -62,5 +56,30 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-codegen-maven-plugin</artifactId>
+        <version>2.1.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>https://raw.githubusercontent.com/cbornet/netatmo-swagger-decl/master/spec/swagger.yaml</inputSpec>
+              <language>java</language>
+              <library>retrofit</library>
+              <configOptions>
+                <sourceFolder>src/main/java</sourceFolder>
+              </configOptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
@@ -227,6 +227,10 @@ public class NetatmoBindingConstants {
 
     public static final String CHANNEL_WELCOME_HOME_EVENT = "welcomeHomeEvent";
 
+    public static final String CHANNEL_HOME_EVENT_HUMAN_DETECTED = "homeEventHumanDetected";
+    public static final String CHANNEL_HOME_EVENT_ANIMAL_DETECTED = "homeEventAnimalDetected";
+    public static final String CHANNEL_HOME_EVENT_VEHICLE_DETECTED = "homeEventVehicleDetected";
+
     public static final String CHANNEL_WELCOME_PERSON_LASTSEEN = "welcomePersonLastSeen";
     public static final String CHANNEL_WELCOME_PERSON_ATHOME = "welcomePersonAtHome";
     public static final String CHANNEL_WELCOME_PERSON_AVATAR_URL = "welcomePersonAvatarUrl";

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
@@ -74,12 +74,6 @@ public class NetatmoBindingConstants {
     public static final String MAX_TEMP = "max_temp";
     public static final String SUM_RAIN = "sum_rain";
 
-    // Camera event options
-    public static final String CAMERA_EVENT_OPTION_ANIMAL_DETECTED = "ANIMAL_DETECTED";
-    public static final String CAMERA_EVENT_OPTION_HUMAN_DETECTED = "HUMAN_DETECTED";
-    public static final String CAMERA_EVENT_OPTION_MOVEMENT_DETECTED = "MOVEMENT_DETECTED";
-    public static final String CAMERA_EVENT_OPTION_VEHICLE_DETECTED = "VEHICLE_DETECTED";
-
     // List of Bridge Type UIDs
     public static final ThingTypeUID APIBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, "netatmoapi");
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBindingConstants.java
@@ -74,6 +74,12 @@ public class NetatmoBindingConstants {
     public static final String MAX_TEMP = "max_temp";
     public static final String SUM_RAIN = "sum_rain";
 
+    // Camera event options
+    public static final String CAMERA_EVENT_OPTION_ANIMAL_DETECTED = "ANIMAL_DETECTED";
+    public static final String CAMERA_EVENT_OPTION_HUMAN_DETECTED = "HUMAN_DETECTED";
+    public static final String CAMERA_EVENT_OPTION_MOVEMENT_DETECTED = "MOVEMENT_DETECTED";
+    public static final String CAMERA_EVENT_OPTION_VEHICLE_DETECTED = "VEHICLE_DETECTED";
+
     // List of Bridge Type UIDs
     public static final ThingTypeUID APIBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, "netatmoapi");
 
@@ -227,9 +233,7 @@ public class NetatmoBindingConstants {
 
     public static final String CHANNEL_WELCOME_HOME_EVENT = "welcomeHomeEvent";
 
-    public static final String CHANNEL_HOME_EVENT_HUMAN_DETECTED = "homeEventHumanDetected";
-    public static final String CHANNEL_HOME_EVENT_ANIMAL_DETECTED = "homeEventAnimalDetected";
-    public static final String CHANNEL_HOME_EVENT_VEHICLE_DETECTED = "homeEventVehicleDetected";
+    public static final String CHANNEL_CAMERA_EVENT = "cameraEvent";
 
     public static final String CHANNEL_WELCOME_PERSON_LASTSEEN = "welcomePersonLastSeen";
     public static final String CHANNEL_WELCOME_PERSON_ATHOME = "welcomePersonAtHome";

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/camera/CameraHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/camera/CameraHandler.java
@@ -48,7 +48,7 @@ public class CameraHandler extends NetatmoModuleHandler<NAWelcomeCamera> {
 
     @SuppressWarnings("null")
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         switch (channelId) {
             case CHANNEL_CAMERA_STATUS:
                 return getStatusState();

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
@@ -132,12 +132,12 @@ public abstract class AbstractNetatmoThingHandler extends BaseThingHandler {
     }
 
     protected void updateChannels() {
-        updateNonTriggerChannels();
+        updateDataChannels();
 
-        triggerTriggerChannels();
+        triggerEventChannels();
     }
 
-    private void updateNonTriggerChannels() {
+    private void updateDataChannels() {
         getThing().getChannels().stream().filter(channel -> !channel.getKind().equals(ChannelKind.TRIGGER))
                 .forEach(channel -> {
 
@@ -152,10 +152,10 @@ public abstract class AbstractNetatmoThingHandler extends BaseThingHandler {
     }
 
     /**
-     * Triggers all trigger channels
+     * Triggers all event/trigger channels
      * (when a channel is triggered, a rule can get all other information from the updated non-trigger channels)
      */
-    private void triggerTriggerChannels() {
+    private void triggerEventChannels() {
         getThing().getChannels().stream().filter(channel -> channel.getKind().equals(ChannelKind.TRIGGER))
                 .forEach(channel -> triggerChannelIfRequired(channel.getUID().getId()));
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
@@ -115,7 +115,7 @@ public abstract class AbstractNetatmoThingHandler extends BaseThingHandler {
 
     protected abstract void initializeThing();
 
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         Optional<State> result;
 
         result = batteryHelper.flatMap(helper -> helper.getNAThingProperty(channelId));

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/AbstractNetatmoThingHandler.java
@@ -32,12 +32,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
-import org.eclipse.smarthome.core.thing.Bridge;
-import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.thing.Thing;
-import org.eclipse.smarthome.core.thing.ThingStatus;
-import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.*;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
@@ -137,16 +132,39 @@ public abstract class AbstractNetatmoThingHandler extends BaseThingHandler {
     }
 
     protected void updateChannels() {
-        getThing().getChannels().stream().filter(channel -> channel.getKind() != ChannelKind.TRIGGER)
+        updateNonTriggerChannels();
+
+        triggerTriggerChannels();
+    }
+
+    private void updateNonTriggerChannels() {
+        getThing().getChannels().stream().filter(channel -> !channel.getKind().equals(ChannelKind.TRIGGER))
                 .forEach(channel -> {
-                    String channelId = channel.getUID().getId();
-                    if (isLinked(channelId)) {
-                        State state = getNAThingProperty(channelId);
-                        if (state != null) {
-                            updateState(channel.getUID(), state);
-                        }
-                    }
-                });
+
+            String channelId = channel.getUID().getId();
+            if (isLinked(channelId)) {
+                State state = getNAThingProperty(channelId);
+                if (state != null) {
+                    updateState(channel.getUID(), state);
+                }
+            }
+        });
+    }
+
+    /**
+     * Triggers all trigger channels
+     * (when a channel is triggered, a rule can get all other information from the updated non-trigger channels)
+     */
+    private void triggerTriggerChannels() {
+        getThing().getChannels().stream().filter(channel -> channel.getKind().equals(ChannelKind.TRIGGER))
+                .forEach(channel -> triggerChannelIfRequired(channel.getUID().getId()));
+    }
+
+    /**
+     * Triggers the trigger channel with the given channel id when required (when an update is available)
+     * @param channelId channel id
+     */
+    protected void triggerChannelIfRequired(@NonNull String channelId) {
     }
 
     @Override

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoDeviceHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoDeviceHandler.java
@@ -89,7 +89,7 @@ public abstract class NetatmoDeviceHandler<DEVICE> extends AbstractNetatmoThingH
         }
     }
 
-    protected abstract DEVICE updateReadings();
+    protected abstract @Nullable DEVICE updateReadings();
 
     protected void updateProperties(DEVICE deviceData) {
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoDeviceHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoDeviceHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PointType;
@@ -148,7 +149,7 @@ public abstract class NetatmoDeviceHandler<DEVICE> extends AbstractNetatmoThingH
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         try {
             switch (channelId) {
                 case CHANNEL_LAST_STATUS_STORE:

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoModuleHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoModuleHandler.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -71,7 +72,7 @@ public class NetatmoModuleHandler<MODULE> extends AbstractNetatmoThingHandler {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         try {
             if (channelId.equalsIgnoreCase(CHANNEL_LAST_MESSAGE) && module != null) {
                 Method getLastMessage = module.getClass().getMethod("getLastMessage");

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/homecoach/NAHealthyHomeCoachHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/homecoach/NAHealthyHomeCoachHandler.java
@@ -53,7 +53,7 @@ public class NAHealthyHomeCoachHandler extends NetatmoDeviceHandler<NAHealthyHom
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (device != null) {
             NADashboardData dashboardData = device.getDashboardData();
             switch (channelId) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAMainHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAMainHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
@@ -165,7 +166,7 @@ public class NAMainHandler extends NetatmoDeviceHandler<NAMain> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (device != null) {
             NADashboardData dashboardData = device.getDashboardData();
             if (dashboardData != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule1Handler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule1Handler.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.internal.WeatherUtils;
@@ -101,7 +102,7 @@ public class NAModule1Handler extends NetatmoModuleHandler<NAStationModule> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (module != null) {
             NADashboardData dashboardData = module.getDashboardData();
             if (dashboardData != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule2Handler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule2Handler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.netatmo.internal.station;
 import static org.openhab.binding.netatmo.internal.ChannelTypeUtils.*;
 import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.internal.handler.NetatmoModuleHandler;
@@ -40,7 +41,7 @@ public class NAModule2Handler extends NetatmoModuleHandler<NAStationModule> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (module != null) {
             NADashboardData dashboardData = module.getDashboardData();
             if (dashboardData != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule3Handler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule3Handler.java
@@ -64,7 +64,7 @@ public class NAModule3Handler extends NetatmoModuleHandler<NAStationModule> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (module != null) {
             NADashboardData dashboardData = module.getDashboardData();
             if (dashboardData != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule4Handler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/station/NAModule4Handler.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.types.State;
 import org.openhab.binding.netatmo.internal.WeatherUtils;
@@ -113,7 +114,7 @@ public class NAModule4Handler extends NetatmoModuleHandler<NAStationModule> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         if (module != null) {
             NADashboardData dashboardData = module.getDashboardData();
             if (dashboardData != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/thermostat/NAPlugHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/thermostat/NAPlugHandler.java
@@ -62,7 +62,7 @@ public class NAPlugHandler extends NetatmoDeviceHandler<NAPlug> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         switch (channelId) {
             case CHANNEL_CONNECTED_BOILER:
                 return device != null ? toOnOffType(device.getPlugConnectedBoiler()) : UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/thermostat/NATherm1Handler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/thermostat/NATherm1Handler.java
@@ -100,7 +100,7 @@ public class NATherm1Handler extends NetatmoModuleHandler<NAThermostat> {
 
     @SuppressWarnings("null")
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         switch (channelId) {
             case CHANNEL_THERM_ORIENTATION:
                 return module != null ? toDecimalType(module.getThermOrientation()) : UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeCameraHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeCameraHandler.java
@@ -33,7 +33,7 @@ public class NAWelcomeCameraHandler extends CameraHandler {
 
     @SuppressWarnings("null")
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         switch (channelId) {
             case CHANNEL_WELCOME_CAMERA_STATUS:
                 return getStatusState();

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -83,12 +83,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
                 });
 
                 Optional<NAWelcomeEvent> previousLastEvent = lastEvent;
-                result.getEvents().forEach(event -> {
-                    if (!lastEvent.isPresent() || lastEvent.get().getTime() < event.getTime()) {
-                        lastEvent = Optional.of(event);
-                    }
-                });
-
+                lastEvent = result.getEvents().stream().min(Comparator.comparingInt(NAWelcomeEvent::getTime));
                 isNewLastEvent = previousLastEvent.isPresent() && !previousLastEvent.equals(lastEvent);
             }
         }
@@ -238,12 +233,6 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     }
 
     private static Optional<NAWelcomeSubEvent> findFirstSubEvent(Optional<NAWelcomeEvent> event) {
-        if (event.isPresent()) {
-            List<NAWelcomeSubEvent> subEvents = event.get().getEventList();
-            if (subEvents != null && !subEvents.isEmpty()) {
-                return Optional.of(subEvents.get(0));
-            }
-        }
-        return Optional.empty();
+        return event.map(NAWelcomeEvent::getEventList).flatMap(subEvents -> subEvents.stream().findFirst());
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import io.swagger.client.model.*;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -41,12 +42,15 @@ import org.slf4j.LoggerFactory;
  * @author Ing. Peter Weiss - Welcome camera implementation
  *
  */
+@NonNullByDefault
 public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
-    private Logger logger = LoggerFactory.getLogger(NAWelcomeHomeHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(NAWelcomeHomeHandler.class);
 
     private int iPersons = -1;
     private int iUnknowns = -1;
+    @Nullable
     private NAWelcomeEvent lastEvent;
+    @Nullable
     private Integer dataTimeStamp;
 
     public NAWelcomeHomeHandler(@NonNull Thing thing) {
@@ -54,8 +58,8 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     }
 
     @Override
-    protected NAWelcomeHome updateReadings() {
-        NAWelcomeHome result = null;
+    protected @Nullable NAWelcomeHome updateReadings() {
+        @Nullable NAWelcomeHome result = null;
         NAWelcomeHomeData homeDataBody = getBridgeHandler().getWelcomeDataBody(getId());
         if (homeDataBody != null) {
             // data time stamp is updated to now as WelcomeDataBody does not provide any information according to this
@@ -124,13 +128,13 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
                     return UnDefType.UNDEF;
                 }
             case CHANNEL_WELCOME_EVENT_SNAPSHOT:
-                String url = findSnapshotURL();
+                @Nullable String url = findSnapshotURL();
                 if(url != null) {
                     return HttpUtil.downloadImage(url);
                 }
                 return UnDefType.UNDEF;
             case CHANNEL_WELCOME_EVENT_SNAPSHOT_URL:
-                String snapshotURL = findSnapshotURL();
+                @Nullable String snapshotURL = findSnapshotURL();
                 if(snapshotURL != null) {
                     return toStringType(snapshotURL);
                 }
@@ -154,7 +158,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
                 return lastEvent != null ? lastEvent.getIsArrival() != null ? OnOffType.ON : OnOffType.OFF
                         : UnDefType.UNDEF;
             case CHANNEL_WELCOME_EVENT_MESSAGE:
-                String eventMessage = findEventMessage();
+                @Nullable String eventMessage = findEventMessage();
                 return eventMessage != null
                         ? new StringType(eventMessage.replace("<b>", "").replace("</b>", ""))
                         : UnDefType.UNDEF;
@@ -170,11 +174,11 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         return super.getNAThingProperty(channelId);
     }
 
-    private String findEventMessage() {
+    private @Nullable String findEventMessage() {
         if(lastEvent != null) {
-            String message = lastEvent.getMessage();
+            @Nullable String message = lastEvent.getMessage();
             if(message == null) {
-                NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
+                @Nullable NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
                 if(firstSubEvent != null) {
                     message = firstSubEvent.getMessage();
                 }
@@ -189,11 +193,11 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
      *
      * @return Url of the picture or null
      */
-    protected String findSnapshotURL() {
+    protected @Nullable String findSnapshotURL() {
         if(lastEvent != null) {
             NAWelcomeSnapshot snapshot = lastEvent.getSnapshot();
             if (snapshot == null) {
-                NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
+                @Nullable NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
                 if (firstSubEvent != null) {
                     snapshot = firstSubEvent.getSnapshot();
                 }
@@ -225,7 +229,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         return OnOffType.OFF;
     }
 
-    private static NAWelcomeSubEvent findFirstSubEvent(NAWelcomeEvent event) {
+    private static @Nullable NAWelcomeSubEvent findFirstSubEvent(NAWelcomeEvent event) {
         List<NAWelcomeSubEvent> subEvents = event.getEventList();
         if(subEvents != null && !subEvents.isEmpty()) {
             return subEvents.get(0);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.netatmo.internal.ChannelTypeUtils.*;
 import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 
 import java.util.*;
+import java.util.function.Function;
 
 import io.swagger.client.model.*;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -98,11 +99,11 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     protected State getNAThingProperty(String channelId) {
         switch (channelId) {
             case CHANNEL_WELCOME_HOME_CITY:
-                return device != null ? toStringType(device.getPlace().getCity()) : UnDefType.UNDEF;
+                return getPlaceInfo(NAWelcomePlace::getCity);
             case CHANNEL_WELCOME_HOME_COUNTRY:
-                return device != null ? toStringType(device.getPlace().getCountry()) : UnDefType.UNDEF;
+                return getPlaceInfo(NAWelcomePlace::getCountry);
             case CHANNEL_WELCOME_HOME_TIMEZONE:
-                return device != null ? toStringType(device.getPlace().getTimezone()) : UnDefType.UNDEF;
+                return getPlaceInfo(NAWelcomePlace::getTimezone);
             case CHANNEL_WELCOME_HOME_PERSONCOUNT:
                 return iPersons != -1 ? new DecimalType(iPersons) : UnDefType.UNDEF;
             case CHANNEL_WELCOME_HOME_UNKNOWNCOUNT:
@@ -256,6 +257,12 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     @Override
     protected @Nullable Integer getDataTimestamp() {
         return dataTimeStamp;
+    }
+
+    private State getPlaceInfo(Function<NAWelcomePlace, String> infoGetFunction) {
+        return Optional.ofNullable(device).map(
+                d -> toStringType(infoGetFunction.apply(d.getPlace()))
+        ).orElse(UnDefType.UNDEF);
     }
 
     private static @Nullable NAWelcomeSubEvent findFirstSubEvent(Optional<NAWelcomeEvent> event) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -95,7 +95,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     }
 
     @Override
-    protected State getNAThingProperty(@Nullable String channelId) {
+    protected State getNAThingProperty(String channelId) {
         switch (channelId) {
             case CHANNEL_WELCOME_HOME_CITY:
                 return device != null ? toStringType(device.getPlace().getCity()) : UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -18,7 +18,6 @@ import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 import java.util.*;
 
 import io.swagger.client.model.*;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
@@ -47,11 +46,11 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
 
     private int iPersons = -1;
     private int iUnknowns = -1;
-    @Nullable private NAWelcomeEvent lastEvent;
+    private @Nullable NAWelcomeEvent lastEvent;
     private boolean isNewLastEvent;
-    @Nullable private Integer dataTimeStamp;
+    private @Nullable Integer dataTimeStamp;
 
-    public NAWelcomeHomeHandler(@NonNull Thing thing) {
+    public NAWelcomeHomeHandler(Thing thing) {
         super(thing);
     }
 
@@ -234,7 +233,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
      */
     protected @Nullable String findSnapshotURL() {
         if(lastEvent != null) {
-            NAWelcomeSnapshot snapshot = lastEvent.getSnapshot();
+            @Nullable NAWelcomeSnapshot snapshot = lastEvent.getSnapshot();
             if (snapshot == null) {
                 @Nullable NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
                 if (firstSubEvent != null) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -47,11 +47,9 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
 
     private int iPersons = -1;
     private int iUnknowns = -1;
-    @Nullable
-    private NAWelcomeEvent lastEvent;
+    @Nullable private NAWelcomeEvent lastEvent;
     private boolean isNewLastEvent;
-    @Nullable
-    private Integer dataTimeStamp;
+    @Nullable private Integer dataTimeStamp;
 
     public NAWelcomeHomeHandler(@NonNull Thing thing) {
         super(thing);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -213,10 +213,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
                 return Optional.of(message);
             }
 
-            @Nullable NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
-            if (firstSubEvent != null) {
-                return Optional.ofNullable(firstSubEvent.getMessage());
-            }
+            return findFirstSubEvent(lastEvent).map(NAWelcomeSubEvent::getMessage);
         }
         return Optional.empty();
     }
@@ -230,10 +227,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         if(lastEvent.isPresent()) {
             @Nullable NAWelcomeSnapshot snapshot = lastEvent.get().getSnapshot();
             if (snapshot == null) {
-                @Nullable NAWelcomeSubEvent firstSubEvent = findFirstSubEvent(lastEvent);
-                if (firstSubEvent != null) {
-                    snapshot = firstSubEvent.getSnapshot();
-                }
+                snapshot = findFirstSubEvent(lastEvent).map(NAWelcomeSubEvent::getSnapshot).orElse(null);
             }
 
             if (snapshot != null && snapshot.getId() != null && snapshot.getKey() != null) {
@@ -257,13 +251,13 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         ).orElse(UnDefType.UNDEF);
     }
 
-    private static @Nullable NAWelcomeSubEvent findFirstSubEvent(Optional<NAWelcomeEvent> event) {
+    private static Optional<NAWelcomeSubEvent> findFirstSubEvent(Optional<NAWelcomeEvent> event) {
         if(event.isPresent()) {
             List<NAWelcomeSubEvent> subEvents = event.get().getEventList();
             if (subEvents != null && !subEvents.isEmpty()) {
-                return subEvents.get(0);
+                return Optional.of(subEvents.get(0));
             }
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -178,27 +178,18 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         NAWelcomeEvent event = eventOptional.get();
 
         if (event.getPersonId() != null) {
-            detectedObjectTypes.add(CAMERA_EVENT_OPTION_HUMAN_DETECTED);
+            detectedObjectTypes.add(NAWelcomeSubEvent.TypeEnum.HUMAN.name());
         }
 
         if (NAWebhookCameraEvent.EventTypeEnum.MOVEMENT.toString().equals(event.getType())) {
-            detectedObjectTypes.add(CAMERA_EVENT_OPTION_MOVEMENT_DETECTED);
+            detectedObjectTypes.add(NAWebhookCameraEvent.EventTypeEnum.MOVEMENT.name());
         }
 
         event.getEventList().forEach(subEvent -> {
-            String detectedObjectType = translateDetectedObjectType(subEvent.getType());
+            String detectedObjectType = subEvent.getType().name();
             detectedObjectTypes.add(detectedObjectType);
         });
         return detectedObjectTypes;
-    }
-
-    private static String translateDetectedObjectType(NAWelcomeSubEvent.TypeEnum type) {
-        switch (type) {
-            case HUMAN: return CAMERA_EVENT_OPTION_HUMAN_DETECTED;
-            case ANIMAL: return CAMERA_EVENT_OPTION_ANIMAL_DETECTED;
-            case VEHICLE: return CAMERA_EVENT_OPTION_VEHICLE_DETECTED;
-            default: throw new IllegalArgumentException("Unknown detected object type!");
-        }
     }
 
     private Optional<String> findEventMessage() {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandler.java
@@ -95,7 +95,7 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@Nullable String channelId) {
         switch (channelId) {
             case CHANNEL_WELCOME_HOME_CITY:
                 return device != null ? toStringType(device.getPlace().getCity()) : UnDefType.UNDEF;
@@ -229,10 +229,12 @@ public class NAWelcomeHomeHandler extends NetatmoDeviceHandler<NAWelcomeHome> {
         return OnOffType.OFF;
     }
 
-    private static @Nullable NAWelcomeSubEvent findFirstSubEvent(NAWelcomeEvent event) {
-        List<NAWelcomeSubEvent> subEvents = event.getEventList();
-        if(subEvents != null && !subEvents.isEmpty()) {
-            return subEvents.get(0);
+    private static @Nullable NAWelcomeSubEvent findFirstSubEvent(@Nullable NAWelcomeEvent event) {
+        if(event != null) {
+            List<NAWelcomeSubEvent> subEvents = event.getEventList();
+            if (subEvents != null && !subEvents.isEmpty()) {
+                return subEvents.get(0);
+            }
         }
         return null;
     }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomePersonHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomePersonHandler.java
@@ -68,7 +68,7 @@ public class NAWelcomePersonHandler extends NetatmoModuleHandler<NAWelcomePerson
     }
 
     @Override
-    protected State getNAThingProperty(String channelId) {
+    protected State getNAThingProperty(@NonNull String channelId) {
         switch (channelId) {
             case CHANNEL_WELCOME_PERSON_LASTSEEN:
                 return module != null ? toDateTimeType(module.getLastSeen()) : UnDefType.UNDEF;

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
@@ -32,6 +32,10 @@
 			<channel id="welcomeEventMessage" typeId="message"></channel>
 			<channel id="welcomeEventSubType" typeId="sub_type"></channel>
 			<channel id="welcomeHomeEvent" typeId="homeEvent"></channel>
+			
+			<channel id="homeEventHumanDetected" typeId="humanDetected"/>
+			<channel id="homeEventAnimalDetected" typeId="animalDetected"/>
+			<channel id="homeEventVehicleDetected" typeId="vehicleDetected"/>
 		</channels>
 
 		<representation-property>id</representation-property>
@@ -135,6 +139,25 @@
 		<item-type>String</item-type>
 		<label>Sub Type</label>
 		<description>Sub-type of SD and Alim events. Go to Welcome page for further details.</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	
+	<channel-type id="humanDetected" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Human detected</label>
+		<description>Switched to true/on when the camera detects a person/human.</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="animalDetected" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Animal detected</label>
+		<description>Switched to true/on when the camera detects an animal.</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="vehicleDetected" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Vehicle detected</label>
+		<description>Switched to true/on when the camera detects a vehicle.</description>
 		<state readOnly="true"></state>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
@@ -33,9 +33,7 @@
 			<channel id="welcomeEventSubType" typeId="sub_type"></channel>
 			<channel id="welcomeHomeEvent" typeId="homeEvent"></channel>
 			
-			<channel id="homeEventHumanDetected" typeId="humanDetected"/>
-			<channel id="homeEventAnimalDetected" typeId="animalDetected"/>
-			<channel id="homeEventVehicleDetected" typeId="vehicleDetected"/>
+			<channel id="cameraEvent" typeId="cameraEvent"/>
 		</channels>
 
 		<representation-property>id</representation-property>
@@ -141,24 +139,18 @@
 		<description>Sub-type of SD and Alim events. Go to Welcome page for further details.</description>
 		<state readOnly="true"></state>
 	</channel-type>
-	
-	<channel-type id="humanDetected" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Human detected</label>
-		<description>Switched to true/on when the camera detects a person/human.</description>
-		<state readOnly="true"></state>
-	</channel-type>
-	<channel-type id="animalDetected" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Animal detected</label>
-		<description>Switched to true/on when the camera detects an animal.</description>
-		<state readOnly="true"></state>
-	</channel-type>
-	<channel-type id="vehicleDetected" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Vehicle detected</label>
-		<description>Switched to true/on when the camera detects a vehicle.</description>
-		<state readOnly="true"></state>
+
+	<channel-type id="cameraEvent">
+		<kind>trigger</kind>
+		<label>Camera Event</label>
+		<event>
+			<options>
+				<option value="ANIMAL_DETECTED">Animal detected</option>
+				<option value="HUMAN_DETECTED">Human detected</option>
+				<option value="MOVEMENT_DETECTED">Unspecified movement detected</option>
+				<option value="VEHICLE_DETECTED">Vehicle detected</option>
+			</options>
+		</event>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/ESH-INF/thing/welcomehome.xml
@@ -145,10 +145,10 @@
 		<label>Camera Event</label>
 		<event>
 			<options>
-				<option value="ANIMAL_DETECTED">Animal detected</option>
-				<option value="HUMAN_DETECTED">Human detected</option>
-				<option value="MOVEMENT_DETECTED">Unspecified movement detected</option>
-				<option value="VEHICLE_DETECTED">Vehicle detected</option>
+				<option value="ANIMAL">Animal detected</option>
+				<option value="HUMAN">Human detected</option>
+				<option value="MOVEMENT">Unspecified movement detected</option>
+				<option value="VEHICLE">Vehicle detected</option>
 			</options>
 		</event>
 	</channel-type>


### PR DESCRIPTION
This pull-request adds support for the events of the Netatmo Presence camera.

It ...
- uses the updated Netatmo API (to support the sub-event structure which is used by the Presence events)
- delivers all information of the Presence events to the home thing (the message and snapshot is now available/set)
- adds new channels to the home thing to report if a human, animal or vehicle was detected
- simplifies the process of updating the Netatmo API (the retrofit code generation is now embedded within the Maven build)

Please see issue 3059 for more information: #3059