### PR TITLE
[somfytahoma] fixed bug when invalid percent value state received

### DIFF
--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBaseThingHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBaseThingHandler.java
@@ -20,16 +20,8 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.DecimalType;
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.PercentType;
-import org.eclipse.smarthome.core.library.types.StringType;
-import org.eclipse.smarthome.core.thing.Channel;
-import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.thing.Thing;
-import org.eclipse.smarthome.core.thing.ThingStatus;
-import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.library.types.*;
+import org.eclipse.smarthome.core.thing.*;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
@@ -205,7 +197,7 @@ public abstract class SomfyTahomaBaseThingHandler extends BaseThingHandler {
             switch (type) {
                 case TYPE_PERCENT:
                     Double valPct = Double.parseDouble(state.getValue().toString());
-                    return new PercentType(valPct.intValue());
+                    return new PercentType(normalizePercent(valPct));
                 case TYPE_DECIMAL:
                     Double valDec = Double.parseDouble(state.getValue().toString());
                     return new DecimalType(valDec);
@@ -220,10 +212,20 @@ public abstract class SomfyTahomaBaseThingHandler extends BaseThingHandler {
                 default:
                     return null;
             }
-        } catch (NumberFormatException ex) {
+        } catch (IllegalArgumentException ex) {
             logger.debug("{} Error while parsing Tahoma state! Value: {} type: {}", url, state.getValue(), type, ex);
         }
         return null;
+    }
+
+    private int normalizePercent(Double valPct) {
+        int value = valPct.intValue();
+        if (value < 0) {
+            value = 0;
+        } else if (value > 100) {
+            value = 100;
+        }
+        return value;
     }
 
     private State parseStringState(String value) {


### PR DESCRIPTION
Fixed a bug reported by the community https://community.openhab.org/t/tahoma-binding-compatible-with-oh2/27004/467
In some cases an invalid percent value is received from the Tahoma cloud (greater than 100 in this particular case, which cannot be converted to the PercentType)

