### PR TITLE
[homekit] bugfix 7491 / add support for merging several updates to one command

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -223,7 +223,7 @@
 /bundles/org.openhab.binding.zway/ @pathec
 /bundles/org.openhab.extensionservice.marketplace/ @kaikreuzer
 /bundles/org.openhab.extensionservice.marketplace.automation/ @kaikreuzer
-/bundles/org.openhab.io.homekit/ @beowulfe
+/bundles/org.openhab.io.homekit/ @beowulfe @yfre
 /bundles/org.openhab.io.hueemulation/ @davidgraeff @digitaldan
 /bundles/org.openhab.io.imperihome/ @pdegeus
 /bundles/org.openhab.io.javasound/ @kaikreuzer

--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -218,7 +218,7 @@ A full list of supported accessory types can be found in the table *below*.
 |                      |                             | Name                         | String                   | Name of the light                                                                                                                                                                                                                                                                                         |
 |                      |                             | Hue                          | Dimmer, Color            | Hue                                                                                                                                                                                                                                                                                                       |
 |                      |                             | Saturation                   | Dimmer, Color            | Saturation in % (1-100)                                                                                                                                                                                                                                                                                   |
-|                      |                             | Brightness                   | Dimmer, Color            | Brightness in % (1-100)                                                                                                                                                                                                                                                                                   |
+|                      |                             | Brightness                   | Dimmer, Color            | Brightness in % (1-100). See "Usage of dimmer modes" for configuration details.                                                                                                                                                                                                                                                                                  |
 |                      |                             | ColorTemperature             | Number                   | Color temperature which is represented in reciprocal megaKelvin, values - 50 to 400. should not be used in combination with hue, saturation and brightness                                                                                                                                                |
 | Fan                  |                             |                              |                          | Fan                                                                                                                                                                                                                                                                                                       |
 |                      | ActiveStatus                |                              | Switch                   | accessory current working status. A value of "ON"/"OPEN" indicate that the accessory is active and is functioning without any errors.                                                                                                                                                                     |
@@ -380,6 +380,36 @@ String          security_current_state     "Security Current State"             
 String          security_target_state      "Security Target State"              (gSecuritySystem)    {homekit="SecuritySystem.TargetSecuritySystemState"}
 ```
 
+## Usage of dimmer modes
+
+The way HomeKit handles dimmer devices can be different to the actual dimmers' way of working.
+HomeKit home app sends following commands/update:
+
+- On brightness change home app sends "ON" event along with target brightness, e.g. "Brightness = 50%" + "State = ON". 
+- On "ON" event home app sends "ON" along with brightness 100%, i.e. "Brightness = 100%" + "State = ON"
+- On "OFF" event home app sends "OFF" without brightness information. 
+
+However, some dimmer devices for example do not expect brightness on "ON" event, some others do not expect "ON" upon brightness change. 
+In order to support different devices HomeKit binding can filter some events. Which events should be filtered is defined via dimmerMode configuration. 
+
+```xtend
+Dimmer dimmer_light	"Dimmer Light" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="<mode>"]}
+```
+
+Following modes are supported:
+
+- "normal" - no filtering. The commands will be sent to device as received from HomeKit. This is default mode.
+- "filterOn" - ON events are filtered out. only OFF events and brightness information are sent
+- "filterBrightness100" - only Brightness=100% is filtered out. everything else sent unchanged. This allows custom logic for soft launch in devices.
+- "filterOnExceptBrightness100"  - ON events are filtered out in all cases except of brightness = 100%.
+ 
+ Examples:
+ 
+ ```xtend
+ Dimmer dimmer_light_1	"Dimmer Light 1" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterOn"]}
+ Dimmer dimmer_light_2	"Dimmer Light 2" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterBrightness100"]}
+ Dimmer dimmer_light_3	"Dimmer Light 3" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterOnExceptBrightness100"]}
+ ```
 
 ## Usage of valve timer
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -227,7 +227,8 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         if (!accessoryTypes.isEmpty() && groups.isEmpty()) { // it has homekit accessory type and is not part of bigger
                                                              // homekit group item
             logger.trace("Item {} is a HomeKit accessory of types {}", item.getName(), accessoryTypes);
-            accessoryTypes.stream().forEach(rootAccessory -> createRootAccessory(new HomekitTaggedItem(item,
+            final HomekitOHItemProxy itemProxy = new HomekitOHItemProxy(item);
+            accessoryTypes.stream().forEach(rootAccessory -> createRootAccessory(new HomekitTaggedItem(itemProxy,
                     rootAccessory.getKey(), HomekitAccessoryFactory.getItemConfiguration(item, metadataRegistry))));
         }
     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandType.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandType.java
@@ -12,12 +12,16 @@
  */
 package org.openhab.io.homekit.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  *
  * Different command types supported by HomekitOHItemProxy.
  *
  * @author Eugen Freiter - Initial contribution
  */
+
+@NonNullByDefault
 public enum HomekitCommandType {
     HUE_COMMAND,
     SATURATION_COMMAND,

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandType.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandType.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.homekit.internal;
+
+/**
+ *
+ * Different command types supported by HomekitOHItemProxy.
+ *
+ * @author Eugen Freiter - Initial contribution
+ */
+public enum HomekitCommandType {
+    HUE_COMMAND,
+    SATURATION_COMMAND,
+    BRIGHTNESS_COMMAND,
+    ON_COMMAND;
+}

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
@@ -15,6 +15,7 @@ package org.openhab.io.homekit.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * Dimmer commands are handled differently by different devices.
@@ -30,6 +31,8 @@ import java.util.Optional;
  *
  * @author Eugen Freiter - Initial contribution
  */
+
+@NonNullByDefault
 public enum HomekitDimmerMode {
     DIMMER_MODE_NORMAL("normal"),
     DIMMER_MODE_FILTER_ON("filterOn"),

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
@@ -13,10 +13,10 @@
 package org.openhab.io.homekit.internal;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -42,7 +42,7 @@ public enum HomekitDimmerMode {
     DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100("filterOnExceptBrightness100");
 
     private static final Map<String, HomekitDimmerMode> TAG_MAP = Arrays.stream(HomekitDimmerMode.values())
-        .collect(Collectors.toMap(type -> type.tag.toUpperCase(), type -> type));
+            .collect(Collectors.toMap(type -> type.tag.toUpperCase(), type -> type));
 
     private final String tag;
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
@@ -12,9 +12,11 @@
  */
 package org.openhab.io.homekit.internal;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -23,11 +25,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * This enum describes different modes of dimmer handling in the context of HomeKit binding.
  *
  * Following modes are supported:
- * DIMMER_MODE_NORMAL - no filtering. The commands will be send to device as received from HomeKit.
+ * DIMMER_MODE_NORMAL - no filtering. The commands will be sent to device as received from HomeKit.
  * DIMMER_MODE_FILTER_ON - ON events are filtered out. only OFF and brightness information are sent
  * DIMMER_MODE_FILTER_BRIGHTNESS_100 - only Brightness=100% is filtered out. everything else unchanged. This allows
  * custom logic for soft launch in devices.
- * DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100 - ON events are filter out in all cases except of Brightness = 100%.
+ * DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100 - ON events are filtered out in all cases except of Brightness = 100%.
  *
  * @author Eugen Freiter - Initial contribution
  */
@@ -39,13 +41,8 @@ public enum HomekitDimmerMode {
     DIMMER_MODE_FILTER_BRIGHTNESS_100("filterBrightness100"),
     DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100("filterOnExceptBrightness100");
 
-    private static final Map<String, HomekitDimmerMode> TAG_MAP = new HashMap<>();
-
-    static {
-        for (HomekitDimmerMode type : HomekitDimmerMode.values()) {
-            TAG_MAP.put(type.tag.toUpperCase(), type);
-        }
-    }
+    private static final Map<String, HomekitDimmerMode> TAG_MAP = Arrays.stream(HomekitDimmerMode.values())
+        .collect(Collectors.toMap(type -> type.tag.toUpperCase(), type -> type));
 
     private final String tag;
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitDimmerMode.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.homekit.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Dimmer commands are handled differently by different devices.
+ * Some devices expect only the brightness updates, some other expect brightness as well as "On/Off" commands.
+ * This enum describes different modes of dimmer handling in the context of HomeKit binding.
+ *
+ * Following modes are supported:
+ * DIMMER_MODE_NORMAL - no filtering. The commands will be send to device as received from HomeKit.
+ * DIMMER_MODE_FILTER_ON - ON events are filtered out. only OFF and brightness information are sent
+ * DIMMER_MODE_FILTER_BRIGHTNESS_100 - only Brightness=100% is filtered out. everything else unchanged. This allows
+ * custom logic for soft launch in devices.
+ * DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100 - ON events are filter out in all cases except of Brightness = 100%.
+ *
+ * @author Eugen Freiter - Initial contribution
+ */
+public enum HomekitDimmerMode {
+    DIMMER_MODE_NORMAL("normal"),
+    DIMMER_MODE_FILTER_ON("filterOn"),
+    DIMMER_MODE_FILTER_BRIGHTNESS_100("filterBrightness100"),
+    DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100("filterOnExceptBrightness100");
+
+    private static final Map<String, HomekitDimmerMode> TAG_MAP = new HashMap<>();
+
+    static {
+        for (HomekitDimmerMode type : HomekitDimmerMode.values()) {
+            TAG_MAP.put(type.tag.toUpperCase(), type);
+        }
+    }
+
+    private final String tag;
+
+    private HomekitDimmerMode(String tag) {
+        this.tag = tag;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public static Optional<HomekitDimmerMode> valueOfTag(String tag) {
+        return Optional.ofNullable(TAG_MAP.get(tag.toUpperCase()));
+    }
+}

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -49,13 +49,13 @@ import org.slf4j.LoggerFactory;
 public class HomekitOHItemProxy {
     private final Logger logger = LoggerFactory.getLogger(HomekitOHItemProxy.class);
 
-    private static final int DEFAULT_DELAY = 50;
+    private static final int DEFAULT_DELAY = 50; // in ms
 
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
-    @Nullable
-    private ScheduledFuture<?> future;
+
+    private @Nullable ScheduledFuture<?> future;
 
     private final Item item;
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.io.homekit.internal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.common.ThreadPoolManager;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.library.items.ColorItem;
+import org.eclipse.smarthome.core.library.items.DimmerItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * Proxy class that can collect multiple commands for the same openHAB item and merge them to one command.
+ * e.g. Hue and Saturation update for Color Item
+ * 
+ * @author Eugen Freiter Initial contribution
+ *
+ */
+
+public class HomekitOHItemProxy {
+    private static final Logger logger = LoggerFactory.getLogger(HomekitOHItemProxy.class);
+    public static final String HUE_COMMAND = "hue";
+    public static final String SATURATION_COMMAND = "saturation";
+    public static final String BRIGHTNESS_COMMAND = "brightness";
+    public static final String ON_COMMAND = "on";
+
+    // delay, how long wait for further commands.
+    // TODO: make it configurable ?
+    private final int DELAY = 50;
+
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
+    private ScheduledFuture<?> future;
+
+    private final Item item;
+
+    @Nullable
+    private ConcurrentHashMap<String, State> commandCache;
+
+    public HomekitOHItemProxy(final Item item) {
+        this.item = item;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    private void sendCommand() {
+        if (item instanceof ColorItem) {
+            final State currentState = item.getState() instanceof UnDefType ? HSBType.BLACK : item.getState();
+            final State hue = commandCache.containsKey(HUE_COMMAND) ? commandCache.remove(HUE_COMMAND)
+                    : ((HSBType) currentState).getHue();
+            final State saturation = commandCache.containsKey(SATURATION_COMMAND)
+                    ? commandCache.remove(SATURATION_COMMAND)
+                    : ((HSBType) currentState).getSaturation();
+            final State brightness = commandCache.containsKey(BRIGHTNESS_COMMAND)
+                    ? commandCache.remove(BRIGHTNESS_COMMAND)
+                    : ((HSBType) currentState).getBrightness();
+            ((ColorItem) item).send(new HSBType((DecimalType) hue, (PercentType) saturation, (PercentType) brightness));
+            logger.trace("send HSB command for item {} with following values h {} s{} b{}", item, hue, saturation,
+                    brightness);
+        } else if (item instanceof DimmerItem) { // not ColorItem but DimmerItem
+            final State on = commandCache.remove(ON_COMMAND);
+            final State brightness = commandCache.remove(BRIGHTNESS_COMMAND);
+
+            // if "ON" command received we dont need to send brightness.
+            // TODO: make brightness suppression on "On" configurable.
+            if (on != null) {
+                logger.trace("send OnOff command for item {} with value {}", item, on);
+                ((DimmerItem) item).send((OnOffType) on);
+            } else {
+                if (brightness != null) {
+                    logger.trace("send brightness command for item {} with value {}", item, brightness);
+                    ((DimmerItem) item).send((PercentType) brightness);
+                }
+            }
+        }
+    }
+
+    public synchronized void sendCommandProxy(final String commandType, final State state) {
+        if (commandCache == null) {
+            // we dont need commandCache for all item types, therefore late instantiation here only for item we use
+            // commandProxy
+            commandCache = new ConcurrentHashMap<>();
+        }
+        commandCache.put(commandType, state);
+
+        logger.trace("add command to command cache: item {}, command type {}, command state {}. cache state after: {}",
+                this, commandType, state, commandCache);
+
+        // if cache has already HUE+SATURATION or BRIGTHNESS+ON then we dont expect any further relevant command
+        // send the command immediately
+        if ((commandCache.containsKey(HUE_COMMAND) && commandCache.containsKey(SATURATION_COMMAND))
+                || (commandCache.containsKey(BRIGHTNESS_COMMAND) && commandCache.containsKey(ON_COMMAND))) {
+            if (future != null)
+                future.cancel(true);
+            sendCommand();
+            return;
+        }
+
+        // it timer is not there create one. this will ensure that we will send command out even if no follow up
+        // commands were received.
+        if (future == null || future.isDone()) {
+            future = scheduler.schedule(() -> {
+                logger.trace("timer is over, sending the command");
+                sendCommand();
+            }, DELAY, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -48,22 +48,15 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HomekitOHItemProxy {
     private final Logger logger = LoggerFactory.getLogger(HomekitOHItemProxy.class);
-
     private static final int DEFAULT_DELAY = 50; // in ms
-
+    private final Item item;
+    private final Map<HomekitCommandType, State> commandCache = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
-
-
     private @Nullable ScheduledFuture<?> future;
-
-    private final Item item;
-
     private HomekitDimmerMode dimmerMode = DIMMER_MODE_NORMAL;
-
     // delay, how long wait for further commands. in ms.
     private int delay = DEFAULT_DELAY;
-    private Map<HomekitCommandType, State> commandCache = new ConcurrentHashMap<>();
 
     public HomekitOHItemProxy(final Item item) {
         this.item = item;

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -76,18 +76,15 @@ public class HomekitOHItemProxy {
 
     @SuppressWarnings("null")
     private void sendCommand() {
-
         if (!(item instanceof DimmerItem)) {
             // currently supports only DimmerItem and ColorItem (which extends DimmerItem)
             logger.debug("unexpected item type {}. Only DimmerItem and ColorItem are supported.", item);
             return;
         }
-
         final OnOffType on = (OnOffType) commandCache.remove(ON_COMMAND);
         final PercentType brightness = (PercentType) commandCache.remove(BRIGHTNESS_COMMAND);
         final DecimalType hue = (DecimalType) commandCache.remove(HUE_COMMAND);
         final PercentType saturation = (PercentType) commandCache.remove(SATURATION_COMMAND);
-
         if (on != null) {
             // always sends OFF.
             // sends ON only if
@@ -134,7 +131,6 @@ public class HomekitOHItemProxy {
         commandCache.put(commandType, state);
         logger.trace("add command to command cache: item {}, command type {}, command state {}. cache state after: {}",
                 this, commandType, state, commandCache);
-
         // if cache has already HUE+SATURATION or BRIGHTNESS+ON then we don't expect any further relevant command
         if (((item instanceof ColorItem) && commandCache.containsKey(HUE_COMMAND)
                 && commandCache.containsKey(SATURATION_COMMAND))
@@ -145,7 +141,6 @@ public class HomekitOHItemProxy {
             sendCommand();
             return;
         }
-
         // if timer is not already set, create a new one to ensure that the command command is send even if no follow up
         // commands are received.
         if (future == null || future.isDone()) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -14,6 +14,7 @@ package org.openhab.io.homekit.internal;
 
 import static org.openhab.io.homekit.internal.HomekitAccessoryType.DUMMY;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -38,11 +39,13 @@ public class HomekitTaggedItem {
     public final static String MIN_VALUE = "minValue";
     public final static String MAX_VALUE = "maxValue";
     public final static String STEP = "step";
+    public final static String DIMMER_MODE = "dimmerMode";
+    public final static String DELAY = "commandDelay";
 
     private static final Map<Integer, String> CREATED_ACCESSORY_IDS = new ConcurrentHashMap<>();
 
     // proxy item used to group commands for complex item types like Color or Dimmer
-    private final HomekitOHItemProxy item;
+    private final HomekitOHItemProxy proxyItem;
 
     // type of HomeKit accessory/service, e.g. TemperatureSensor
     private final HomekitAccessoryType homekitAccessoryType;
@@ -61,7 +64,7 @@ public class HomekitTaggedItem {
 
     public HomekitTaggedItem(HomekitOHItemProxy item, HomekitAccessoryType homekitAccessoryType,
             @Nullable Map<String, Object> configuration) {
-        this.item = item;
+        this.proxyItem = item;
         this.parentGroupItem = null;
         this.configuration = configuration;
         this.homekitAccessoryType = homekitAccessoryType;
@@ -71,6 +74,7 @@ public class HomekitTaggedItem {
         } else {
             this.id = 0;
         }
+        parseConfiguration();
     }
 
     public HomekitTaggedItem(HomekitOHItemProxy item, HomekitAccessoryType homekitAccessoryType,
@@ -88,7 +92,7 @@ public class HomekitTaggedItem {
     }
 
     public boolean isGroup() {
-        return (isAccessory() && (item.getItem() instanceof GroupItem));
+        return (isAccessory() && (proxyItem.getItem() instanceof GroupItem));
     }
 
     public HomekitAccessoryType getAccessoryType() {
@@ -127,7 +131,7 @@ public class HomekitTaggedItem {
      * @return openHAB item
      */
     public Item getItem() {
-        return item.getItem();
+        return proxyItem.getItem();
     }
 
     /**
@@ -136,7 +140,7 @@ public class HomekitTaggedItem {
      * @return proxy item
      */
     public HomekitOHItemProxy getProxyItem() {
-        return item;
+        return proxyItem;
     }
 
     /**
@@ -148,7 +152,7 @@ public class HomekitTaggedItem {
      * @param command command/state
      */
     public void sendCommandProxy(String commandType, State command) {
-        item.sendCommandProxy(commandType, command);
+        proxyItem.sendCommandProxy(commandType, command);
     }
 
     public int getId() {
@@ -156,7 +160,7 @@ public class HomekitTaggedItem {
     }
 
     public String getName() {
-        return item.getItem().getName();
+        return proxyItem.getItem().getName();
     }
 
     /**
@@ -174,6 +178,28 @@ public class HomekitTaggedItem {
      */
     public boolean isMemberOfAccessoryGroup() {
         return parentGroupItem != null;
+    }
+
+    private void parseConfiguration() {
+        if (configuration != null) {
+            Object dimmerModeConfig = configuration.get(DIMMER_MODE);
+            if (dimmerModeConfig instanceof String) {
+                final String dimmerModeConfigStr = (String) dimmerModeConfig;
+                if (dimmerModeConfigStr.equalsIgnoreCase("none")) {
+                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_NONE);
+                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterOn")) {
+                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_ON);
+                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterBrightness100")) {
+                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_BRIGHTNESS_100);
+                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterOnExceptBrightness100")) {
+                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100);
+                }
+            }
+            Object delayConfig = configuration.get(DELAY);
+            if (delayConfig instanceof BigDecimal) {
+                proxyItem.setDelay(((BigDecimal) delayConfig).intValue());
+            }
+        }
     }
 
     private int calculateId(Item item) {
@@ -199,7 +225,7 @@ public class HomekitTaggedItem {
     }
 
     public String toString() {
-        return "Item:" + item + "  HomeKit type:" + homekitAccessoryType + " HomeKit characteristic:"
+        return "Item:" + proxyItem + "  HomeKit type:" + homekitAccessoryType + " HomeKit characteristic:"
                 + homekitCharacteristicType;
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -14,7 +14,6 @@ package org.openhab.io.homekit.internal;
 
 import static org.openhab.io.homekit.internal.HomekitAccessoryType.DUMMY;
 
-import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -148,10 +147,10 @@ public class HomekitTaggedItem {
      * e.g. sendCommandProxy(hue), sendCommandProxy(brightness) would lead to one openHAB command that updates hue and
      * brightness at once
      *
-     * @param commandType type of the command, e.g. OHItemProxy.HUE_COMMAND
+     * @param commandType type of the command, e.g. HomekitCommandType.HUE_COMMAND
      * @param command command/state
      */
-    public void sendCommandProxy(String commandType, State command) {
+    public void sendCommandProxy(HomekitCommandType commandType, State command) {
         proxyItem.sendCommandProxy(commandType, command);
     }
 
@@ -184,20 +183,11 @@ public class HomekitTaggedItem {
         if (configuration != null) {
             Object dimmerModeConfig = configuration.get(DIMMER_MODE);
             if (dimmerModeConfig instanceof String) {
-                final String dimmerModeConfigStr = (String) dimmerModeConfig;
-                if (dimmerModeConfigStr.equalsIgnoreCase("none")) {
-                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_NONE);
-                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterOn")) {
-                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_ON);
-                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterBrightness100")) {
-                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_BRIGHTNESS_100);
-                } else if (dimmerModeConfigStr.equalsIgnoreCase("filterOnExceptBrightness100")) {
-                    proxyItem.setDimmerMode(HomekitOHItemProxy.DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100);
-                }
+                HomekitDimmerMode.valueOfTag((String) dimmerModeConfig).ifPresent(proxyItem::setDimmerMode);
             }
             Object delayConfig = configuration.get(DELAY);
-            if (delayConfig instanceof BigDecimal) {
-                proxyItem.setDelay(((BigDecimal) delayConfig).intValue());
+            if (delayConfig instanceof Number) {
+                proxyItem.setDelay(((Number) delayConfig).intValue());
             }
         }
     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.io.homekit.internal.accessories;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import javax.measure.Quantity;
 import javax.measure.Unit;
@@ -28,9 +28,9 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.types.State;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
 import org.openhab.io.homekit.internal.HomekitSettings;
@@ -218,15 +218,18 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
     }
 
     private <T extends Quantity<T>> double convertAndRound(double value, Unit<T> from, Unit<T> to) {
-      double rawValue = from == to ? value : from.getConverterTo(to).convert(value);
-      return new BigDecimal(rawValue).setScale(1, RoundingMode.HALF_UP).doubleValue();
+        double rawValue = from == to ? value : from.getConverterTo(to).convert(value);
+        return new BigDecimal(rawValue).setScale(1, RoundingMode.HALF_UP).doubleValue();
     }
 
-    protected double convertToCelsius(double degrees){
-      return convertAndRound(degrees, getSettings().useFahrenheitTemperature ? ImperialUnits.FAHRENHEIT : SIUnits.CELSIUS, SIUnits.CELSIUS);
+    protected double convertToCelsius(double degrees) {
+        return convertAndRound(degrees,
+                getSettings().useFahrenheitTemperature ? ImperialUnits.FAHRENHEIT : SIUnits.CELSIUS, SIUnits.CELSIUS);
     }
 
-    protected double convertFromCelsius(double degrees){
-      return convertAndRound(degrees, getSettings().useFahrenheitTemperature ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT, ImperialUnits.FAHRENHEIT);
+    protected double convertFromCelsius(double degrees) {
+        return convertAndRound(degrees,
+                getSettings().useFahrenheitTemperature ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT,
+                ImperialUnits.FAHRENHEIT);
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -39,8 +39,8 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
+import org.openhab.io.homekit.internal.HomekitCommandType;
 import org.openhab.io.homekit.internal.HomekitException;
-import org.openhab.io.homekit.internal.HomekitOHItemProxy;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -360,7 +360,7 @@ public class HomekitCharacteristicFactory {
             return CompletableFuture.completedFuture(value);
         }, (hue) -> {
             if (taggedItem.getItem() instanceof ColorItem) {
-                taggedItem.sendCommandProxy(HomekitOHItemProxy.HUE_COMMAND, new DecimalType(hue));
+                taggedItem.sendCommandProxy(HomekitCommandType.HUE_COMMAND, new DecimalType(hue));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Color type is supported.",
                         taggedItem.getItem().getType(), taggedItem.getName());
@@ -382,7 +382,7 @@ public class HomekitCharacteristicFactory {
         }, (brightness) -> {
             final Item item = taggedItem.getItem();
             if (item instanceof DimmerItem) {
-                taggedItem.sendCommandProxy(HomekitOHItemProxy.BRIGHTNESS_COMMAND, new PercentType(brightness));
+                taggedItem.sendCommandProxy(HomekitCommandType.BRIGHTNESS_COMMAND, new PercentType(brightness));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only ColorItem and DimmerItem are supported.",
                         item.getType(), taggedItem.getName());
@@ -403,7 +403,7 @@ public class HomekitCharacteristicFactory {
             return CompletableFuture.completedFuture(value);
         }, (saturation) -> {
             if (taggedItem.getItem() instanceof ColorItem) {
-                taggedItem.sendCommandProxy(HomekitOHItemProxy.SATURATION_COMMAND,
+                taggedItem.sendCommandProxy(HomekitCommandType.SATURATION_COMMAND,
                         new PercentType(saturation.intValue()));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Color type is supported.",

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitCharacteristicFactory.java
@@ -167,209 +167,212 @@ public class HomekitCharacteristicFactory {
         return CompletableFuture.completedFuture(defaultEnum);
     }
 
-    private static void setValueFromEnum(final HomekitTaggedItem item, CharacteristicEnum value,
+    private static void setValueFromEnum(final HomekitTaggedItem taggedItem, CharacteristicEnum value,
             CharacteristicEnum offEnum, CharacteristicEnum onEnum) {
-        if (item.getItem() instanceof SwitchItem) {
+        if (taggedItem.getItem() instanceof SwitchItem) {
             if (value.equals(offEnum)) {
-                ((SwitchItem) item.getItem()).send(OnOffType.OFF);
+                ((SwitchItem) taggedItem.getItem()).send(OnOffType.OFF);
             } else if (value.equals(onEnum)) {
-                ((SwitchItem) item.getItem()).send(OnOffType.ON);
+                ((SwitchItem) taggedItem.getItem()).send(OnOffType.ON);
             } else {
                 logger.warn("Enum value {} is not supported. Only following values are supported: {},{}", value,
                         offEnum, onEnum);
             }
-        } else if (item.getItem() instanceof NumberItem) {
-            ((NumberItem) item.getItem()).send(new DecimalType(value.getCode()));
+        } else if (taggedItem.getItem() instanceof NumberItem) {
+            ((NumberItem) taggedItem.getItem()).send(new DecimalType(value.getCode()));
         } else {
             logger.warn("Item type {} is not supported. Only Switch and Number item types are supported.",
-                    item.getItem().getType());
+                    taggedItem.getItem().getType());
         }
     }
 
     @SuppressWarnings("null")
-    private static int getIntFromItem(final HomekitTaggedItem item) {
+    private static int getIntFromItem(final HomekitTaggedItem taggedItem) {
         int value = 0;
-        final State state = item.getItem().getState();
+        final State state = taggedItem.getItem().getState();
         if (state instanceof PercentType) {
             value = state.as(PercentType.class).intValue();
         } else if (state instanceof DecimalType) {
             value = state.as(DecimalType.class).intValue();
         } else if (state instanceof UnDefType) {
-            logger.debug("Item state {} is UNDEF {}.", state, item.getName());
+            logger.debug("Item state {} is UNDEF {}.", state, taggedItem.getName());
         } else {
             logger.warn(
                     "Item state {} is not supported for {}. Only PercentType and DecimalType (0/100) are supported.",
-                    state, item.getName());
+                    state, taggedItem.getName());
         }
         return value;
     }
 
-    private static Supplier<CompletableFuture<Integer>> getIntSupplier(final HomekitTaggedItem item) {
-        return () -> CompletableFuture.completedFuture(getIntFromItem(item));
+    private static Supplier<CompletableFuture<Integer>> getIntSupplier(final HomekitTaggedItem taggedItem) {
+        return () -> CompletableFuture.completedFuture(getIntFromItem(taggedItem));
     }
 
-    private static ExceptionalConsumer<Integer> setIntConsumer(final HomekitTaggedItem item) {
+    private static ExceptionalConsumer<Integer> setIntConsumer(final HomekitTaggedItem taggedItem) {
         return (value) -> {
-            if (item.getItem() instanceof NumberItem) {
-                ((NumberItem) item.getItem()).send(new DecimalType(value));
+            if (taggedItem.getItem() instanceof NumberItem) {
+                ((NumberItem) taggedItem.getItem()).send(new DecimalType(value));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Number type is supported.",
-                        item.getItem().getType(), item.getName());
+                        taggedItem.getItem().getType(), taggedItem.getName());
             }
         };
     }
 
-    private static Supplier<CompletableFuture<Double>> getDoubleSupplier(final HomekitTaggedItem item) {
+    private static Supplier<CompletableFuture<Double>> getDoubleSupplier(final HomekitTaggedItem taggedItem) {
         return () -> {
-            final DecimalType value = item.getItem().getStateAs(DecimalType.class);
+            final DecimalType value = taggedItem.getItem().getStateAs(DecimalType.class);
             return CompletableFuture.completedFuture(value != null ? value.doubleValue() : 0.0);
         };
     }
 
-    protected static Consumer<HomekitCharacteristicChangeCallback> getSubscriber(final HomekitTaggedItem item,
+    protected static Consumer<HomekitCharacteristicChangeCallback> getSubscriber(final HomekitTaggedItem taggedItem,
             final HomekitCharacteristicType key, final HomekitAccessoryUpdater updater) {
-        return (callback) -> updater.subscribe((GenericItem) item.getItem(), key.getTag(), callback);
+        return (callback) -> updater.subscribe((GenericItem) taggedItem.getItem(), key.getTag(), callback);
     }
 
-    protected static Runnable getUnsubscriber(final HomekitTaggedItem item, final HomekitCharacteristicType key,
+    protected static Runnable getUnsubscriber(final HomekitTaggedItem taggedItem, final HomekitCharacteristicType key,
             final HomekitAccessoryUpdater updater) {
-        return () -> updater.unsubscribe((GenericItem) item.getItem(), key.getTag());
+        return () -> updater.unsubscribe((GenericItem) taggedItem.getItem(), key.getTag());
     }
 
     // create method for characteristic
-    private static StatusLowBatteryCharacteristic createStatusLowBatteryCharacteristic(final HomekitTaggedItem item,
-            final HomekitAccessoryUpdater updater) {
+    private static StatusLowBatteryCharacteristic createStatusLowBatteryCharacteristic(
+            final HomekitTaggedItem taggedItem, final HomekitAccessoryUpdater updater) {
         return new StatusLowBatteryCharacteristic(
-                () -> getEnumFromItem(item, StatusLowBatteryEnum.NORMAL, StatusLowBatteryEnum.LOW,
+                () -> getEnumFromItem(taggedItem, StatusLowBatteryEnum.NORMAL, StatusLowBatteryEnum.LOW,
                         StatusLowBatteryEnum.NORMAL),
-                getSubscriber(item, BATTERY_LOW_STATUS, updater), getUnsubscriber(item, BATTERY_LOW_STATUS, updater));
+                getSubscriber(taggedItem, BATTERY_LOW_STATUS, updater),
+                getUnsubscriber(taggedItem, BATTERY_LOW_STATUS, updater));
     }
 
-    private static StatusFaultCharacteristic createStatusFaultCharacteristic(final HomekitTaggedItem item,
+    private static StatusFaultCharacteristic createStatusFaultCharacteristic(final HomekitTaggedItem taggedItem,
             final HomekitAccessoryUpdater updater) {
         return new StatusFaultCharacteristic(
-                () -> getEnumFromItem(item, StatusFaultEnum.NO_FAULT, StatusFaultEnum.GENERAL_FAULT,
+                () -> getEnumFromItem(taggedItem, StatusFaultEnum.NO_FAULT, StatusFaultEnum.GENERAL_FAULT,
                         StatusFaultEnum.NO_FAULT),
-                getSubscriber(item, FAULT_STATUS, updater), getUnsubscriber(item, FAULT_STATUS, updater));
+                getSubscriber(taggedItem, FAULT_STATUS, updater), getUnsubscriber(taggedItem, FAULT_STATUS, updater));
     }
 
-    private static StatusTamperedCharacteristic createStatusTamperedCharacteristic(final HomekitTaggedItem item,
+    private static StatusTamperedCharacteristic createStatusTamperedCharacteristic(final HomekitTaggedItem taggedItem,
             final HomekitAccessoryUpdater updater) {
         return new StatusTamperedCharacteristic(
-                () -> getEnumFromItem(item, StatusTamperedEnum.NOT_TAMPERED, StatusTamperedEnum.TAMPERED,
+                () -> getEnumFromItem(taggedItem, StatusTamperedEnum.NOT_TAMPERED, StatusTamperedEnum.TAMPERED,
                         StatusTamperedEnum.NOT_TAMPERED),
-                getSubscriber(item, TAMPERED_STATUS, updater), getUnsubscriber(item, TAMPERED_STATUS, updater));
+                getSubscriber(taggedItem, TAMPERED_STATUS, updater),
+                getUnsubscriber(taggedItem, TAMPERED_STATUS, updater));
     }
 
     private static ObstructionDetectedCharacteristic createObstructionDetectedCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
         return new ObstructionDetectedCharacteristic(
-                () -> CompletableFuture.completedFuture(
-                        item.getItem().getState() == OnOffType.ON || item.getItem().getState() == OpenClosedType.OPEN),
-                getSubscriber(item, OBSTRUCTION_STATUS, updater), getUnsubscriber(item, OBSTRUCTION_STATUS, updater));
+                () -> CompletableFuture.completedFuture(taggedItem.getItem().getState() == OnOffType.ON
+                        || taggedItem.getItem().getState() == OpenClosedType.OPEN),
+                getSubscriber(taggedItem, OBSTRUCTION_STATUS, updater),
+                getUnsubscriber(taggedItem, OBSTRUCTION_STATUS, updater));
     }
 
-    private static StatusActiveCharacteristic createStatusActiveCharacteristic(final HomekitTaggedItem item,
+    private static StatusActiveCharacteristic createStatusActiveCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new StatusActiveCharacteristic(
-                () -> CompletableFuture.completedFuture(
-                        item.getItem().getState() == OnOffType.ON || item.getItem().getState() == OpenClosedType.OPEN),
-                getSubscriber(item, ACTIVE_STATUS, updater), getUnsubscriber(item, ACTIVE_STATUS, updater));
+                () -> CompletableFuture.completedFuture(taggedItem.getItem().getState() == OnOffType.ON
+                        || taggedItem.getItem().getState() == OpenClosedType.OPEN),
+                getSubscriber(taggedItem, ACTIVE_STATUS, updater), getUnsubscriber(taggedItem, ACTIVE_STATUS, updater));
     }
 
-    private static NameCharacteristic createNameCharacteristic(final HomekitTaggedItem item,
+    private static NameCharacteristic createNameCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new NameCharacteristic(() -> {
-            final State state = item.getItem().getState();
+            final State state = taggedItem.getItem().getState();
             return CompletableFuture.completedFuture(state instanceof UnDefType ? "" : state.toString());
         });
     }
 
-    private static HoldPositionCharacteristic createHoldPositionCharacteristic(final HomekitTaggedItem item,
+    private static HoldPositionCharacteristic createHoldPositionCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new HoldPositionCharacteristic(OnOffType::from);
     }
 
     private static CarbonMonoxideLevelCharacteristic createCarbonMonoxideLevelCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new CarbonMonoxideLevelCharacteristic(getDoubleSupplier(item),
-                getSubscriber(item, CARBON_DIOXIDE_LEVEL, updater),
-                getUnsubscriber(item, CARBON_DIOXIDE_LEVEL, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CarbonMonoxideLevelCharacteristic(getDoubleSupplier(taggedItem),
+                getSubscriber(taggedItem, CARBON_DIOXIDE_LEVEL, updater),
+                getUnsubscriber(taggedItem, CARBON_DIOXIDE_LEVEL, updater));
     }
 
     private static CarbonMonoxidePeakLevelCharacteristic createCarbonMonoxidePeakLevelCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new CarbonMonoxidePeakLevelCharacteristic(getDoubleSupplier(item),
-                getSubscriber(item, CARBON_DIOXIDE_PEAK_LEVEL, updater),
-                getUnsubscriber(item, CARBON_DIOXIDE_PEAK_LEVEL, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CarbonMonoxidePeakLevelCharacteristic(getDoubleSupplier(taggedItem),
+                getSubscriber(taggedItem, CARBON_DIOXIDE_PEAK_LEVEL, updater),
+                getUnsubscriber(taggedItem, CARBON_DIOXIDE_PEAK_LEVEL, updater));
     }
 
-    private static CarbonDioxideLevelCharacteristic createCarbonDioxideLevelCharacteristic(final HomekitTaggedItem item,
-            HomekitAccessoryUpdater updater) {
-        return new CarbonDioxideLevelCharacteristic(getDoubleSupplier(item),
-                getSubscriber(item, CARBON_MONOXIDE_LEVEL, updater),
-                getUnsubscriber(item, CARBON_MONOXIDE_LEVEL, updater));
+    private static CarbonDioxideLevelCharacteristic createCarbonDioxideLevelCharacteristic(
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CarbonDioxideLevelCharacteristic(getDoubleSupplier(taggedItem),
+                getSubscriber(taggedItem, CARBON_MONOXIDE_LEVEL, updater),
+                getUnsubscriber(taggedItem, CARBON_MONOXIDE_LEVEL, updater));
     }
 
     private static CarbonDioxidePeakLevelCharacteristic createCarbonDioxidePeakLevelCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new CarbonDioxidePeakLevelCharacteristic(getDoubleSupplier(item),
-                getSubscriber(item, CARBON_MONOXIDE_PEAK_LEVEL, updater),
-                getUnsubscriber(item, CARBON_MONOXIDE_PEAK_LEVEL, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CarbonDioxidePeakLevelCharacteristic(getDoubleSupplier(taggedItem),
+                getSubscriber(taggedItem, CARBON_MONOXIDE_PEAK_LEVEL, updater),
+                getUnsubscriber(taggedItem, CARBON_MONOXIDE_PEAK_LEVEL, updater));
     }
 
     private static CurrentHorizontalTiltAngleCharacteristic createCurrentHorizontalTiltAngleCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new CurrentHorizontalTiltAngleCharacteristic(getIntSupplier(item),
-                getSubscriber(item, CURRENT_HORIZONTAL_TILT_ANGLE, updater),
-                getUnsubscriber(item, CURRENT_HORIZONTAL_TILT_ANGLE, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CurrentHorizontalTiltAngleCharacteristic(getIntSupplier(taggedItem),
+                getSubscriber(taggedItem, CURRENT_HORIZONTAL_TILT_ANGLE, updater),
+                getUnsubscriber(taggedItem, CURRENT_HORIZONTAL_TILT_ANGLE, updater));
     }
 
     private static CurrentVerticalTiltAngleCharacteristic createCurrentVerticalTiltAngleCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new CurrentVerticalTiltAngleCharacteristic(getIntSupplier(item),
-                getSubscriber(item, CURRENT_VERTICAL_TILT_ANGLE, updater),
-                getUnsubscriber(item, CURRENT_VERTICAL_TILT_ANGLE, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new CurrentVerticalTiltAngleCharacteristic(getIntSupplier(taggedItem),
+                getSubscriber(taggedItem, CURRENT_VERTICAL_TILT_ANGLE, updater),
+                getUnsubscriber(taggedItem, CURRENT_VERTICAL_TILT_ANGLE, updater));
     }
 
     private static TargetHorizontalTiltAngleCharacteristic createTargetHorizontalTiltAngleCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new TargetHorizontalTiltAngleCharacteristic(getIntSupplier(item), setIntConsumer(item),
-                getSubscriber(item, TARGET_HORIZONTAL_TILT_ANGLE, updater),
-                getUnsubscriber(item, TARGET_HORIZONTAL_TILT_ANGLE, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new TargetHorizontalTiltAngleCharacteristic(getIntSupplier(taggedItem), setIntConsumer(taggedItem),
+                getSubscriber(taggedItem, TARGET_HORIZONTAL_TILT_ANGLE, updater),
+                getUnsubscriber(taggedItem, TARGET_HORIZONTAL_TILT_ANGLE, updater));
     }
 
     private static TargetVerticalTiltAngleCharacteristic createTargetVerticalTiltAngleCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
-        return new TargetVerticalTiltAngleCharacteristic(getIntSupplier(item), setIntConsumer(item),
-                getSubscriber(item, TARGET_HORIZONTAL_TILT_ANGLE, updater),
-                getUnsubscriber(item, TARGET_HORIZONTAL_TILT_ANGLE, updater));
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new TargetVerticalTiltAngleCharacteristic(getIntSupplier(taggedItem), setIntConsumer(taggedItem),
+                getSubscriber(taggedItem, TARGET_HORIZONTAL_TILT_ANGLE, updater),
+                getUnsubscriber(taggedItem, TARGET_HORIZONTAL_TILT_ANGLE, updater));
     }
 
-    private static HueCharacteristic createHueCharacteristic(final HomekitTaggedItem item,
+    private static HueCharacteristic createHueCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new HueCharacteristic(() -> {
             Double value = 0.0;
-            State state = item.getItem().getState();
+            State state = taggedItem.getItem().getState();
             if (state instanceof HSBType) {
                 value = ((HSBType) state).getHue().doubleValue();
             }
             return CompletableFuture.completedFuture(value);
         }, (hue) -> {
-            if (item.getItem() instanceof ColorItem) {
-                item.sendCommandProxy(HomekitOHItemProxy.HUE_COMMAND, new DecimalType(hue));
+            if (taggedItem.getItem() instanceof ColorItem) {
+                taggedItem.sendCommandProxy(HomekitOHItemProxy.HUE_COMMAND, new DecimalType(hue));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Color type is supported.",
-                        item.getItem().getType(), item.getName());
+                        taggedItem.getItem().getType(), taggedItem.getName());
             }
-        }, getSubscriber(item, HUE, updater), getUnsubscriber(item, HUE, updater));
+        }, getSubscriber(taggedItem, HUE, updater), getUnsubscriber(taggedItem, HUE, updater));
     }
 
-    private static BrightnessCharacteristic createBrightnessCharacteristic(final HomekitTaggedItem item,
+    private static BrightnessCharacteristic createBrightnessCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new BrightnessCharacteristic(() -> {
             int value = 0;
-            final State state = item.getItem().getState();
+            final State state = taggedItem.getItem().getState();
             if (state instanceof HSBType) {
                 value = ((HSBType) state).getBrightness().intValue();
             } else if (state instanceof PercentType) {
@@ -377,21 +380,21 @@ public class HomekitCharacteristicFactory {
             }
             return CompletableFuture.completedFuture(value);
         }, (brightness) -> {
-            final Item oItem = item.getItem();
-            if (oItem instanceof DimmerItem) {
-                item.sendCommandProxy(HomekitOHItemProxy.BRIGHTNESS_COMMAND, new PercentType(brightness));
+            final Item item = taggedItem.getItem();
+            if (item instanceof DimmerItem) {
+                taggedItem.sendCommandProxy(HomekitOHItemProxy.BRIGHTNESS_COMMAND, new PercentType(brightness));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only ColorItem and DimmerItem are supported.",
-                        oItem.getType(), item.getName());
+                        item.getType(), taggedItem.getName());
             }
-        }, getSubscriber(item, BRIGHTNESS, updater), getUnsubscriber(item, BRIGHTNESS, updater));
+        }, getSubscriber(taggedItem, BRIGHTNESS, updater), getUnsubscriber(taggedItem, BRIGHTNESS, updater));
     }
 
-    private static SaturationCharacteristic createSaturationCharacteristic(final HomekitTaggedItem item,
+    private static SaturationCharacteristic createSaturationCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new SaturationCharacteristic(() -> {
             Double value = 0.0;
-            State state = item.getItem().getState();
+            State state = taggedItem.getItem().getState();
             if (state instanceof HSBType) {
                 value = ((HSBType) state).getSaturation().doubleValue();
             } else if (state instanceof PercentType) {
@@ -399,38 +402,41 @@ public class HomekitCharacteristicFactory {
             }
             return CompletableFuture.completedFuture(value);
         }, (saturation) -> {
-            if (item.getItem() instanceof ColorItem) {
-                item.sendCommandProxy(HomekitOHItemProxy.SATURATION_COMMAND, new PercentType(saturation.intValue()));
+            if (taggedItem.getItem() instanceof ColorItem) {
+                taggedItem.sendCommandProxy(HomekitOHItemProxy.SATURATION_COMMAND,
+                        new PercentType(saturation.intValue()));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Color type is supported.",
-                        item.getItem().getType(), item.getName());
+                        taggedItem.getItem().getType(), taggedItem.getName());
             }
-        }, getSubscriber(item, SATURATION, updater), getUnsubscriber(item, SATURATION, updater));
+        }, getSubscriber(taggedItem, SATURATION, updater), getUnsubscriber(taggedItem, SATURATION, updater));
     }
 
-    private static ColorTemperatureCharacteristic createColorTemperatureCharacteristic(final HomekitTaggedItem item,
-            HomekitAccessoryUpdater updater) {
-        return new ColorTemperatureCharacteristic(getIntSupplier(item), setIntConsumer(item),
-                getSubscriber(item, COLOR_TEMPERATURE, updater), getUnsubscriber(item, COLOR_TEMPERATURE, updater));
+    private static ColorTemperatureCharacteristic createColorTemperatureCharacteristic(
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new ColorTemperatureCharacteristic(getIntSupplier(taggedItem), setIntConsumer(taggedItem),
+                getSubscriber(taggedItem, COLOR_TEMPERATURE, updater),
+                getUnsubscriber(taggedItem, COLOR_TEMPERATURE, updater));
     }
 
-    private static CurrentFanStateCharacteristic createCurrentFanStateCharacteristic(final HomekitTaggedItem item,
+    private static CurrentFanStateCharacteristic createCurrentFanStateCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new CurrentFanStateCharacteristic(() -> {
-            final DecimalType value = item.getItem().getStateAs(DecimalType.class);
+            final DecimalType value = taggedItem.getItem().getStateAs(DecimalType.class);
             CurrentFanStateEnum currentFanStateEnum = value != null ? CurrentFanStateEnum.fromCode(value.intValue())
                     : null;
             if (currentFanStateEnum == null) {
                 currentFanStateEnum = CurrentFanStateEnum.INACTIVE;
             }
             return CompletableFuture.completedFuture(currentFanStateEnum);
-        }, getSubscriber(item, CURRENT_FAN_STATE, updater), getUnsubscriber(item, CURRENT_FAN_STATE, updater));
+        }, getSubscriber(taggedItem, CURRENT_FAN_STATE, updater),
+                getUnsubscriber(taggedItem, CURRENT_FAN_STATE, updater));
     }
 
-    private static TargetFanStateCharacteristic createTargetFanStateCharacteristic(final HomekitTaggedItem item,
+    private static TargetFanStateCharacteristic createTargetFanStateCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new TargetFanStateCharacteristic(() -> {
-            final DecimalType value = item.getItem().getStateAs(DecimalType.class);
+            final DecimalType value = taggedItem.getItem().getStateAs(DecimalType.class);
             TargetFanStateEnum targetFanStateEnum = value != null ? TargetFanStateEnum.fromCode(value.intValue())
                     : null;
             if (targetFanStateEnum == null) {
@@ -438,42 +444,45 @@ public class HomekitCharacteristicFactory {
             }
             return CompletableFuture.completedFuture(targetFanStateEnum);
         }, (targetState) -> {
-            if (item.getItem() instanceof NumberItem) {
-                ((NumberItem) item.getItem()).send(new DecimalType(targetState.getCode()));
+            if (taggedItem.getItem() instanceof NumberItem) {
+                ((NumberItem) taggedItem.getItem()).send(new DecimalType(targetState.getCode()));
             } else {
                 logger.warn("Item type {} is not supported for {}. Only Number type is supported.",
-                        item.getItem().getType(), item.getName());
+                        taggedItem.getItem().getType(), taggedItem.getName());
             }
-        }, getSubscriber(item, TARGET_FAN_STATE, updater), getUnsubscriber(item, TARGET_FAN_STATE, updater));
+        }, getSubscriber(taggedItem, TARGET_FAN_STATE, updater),
+                getUnsubscriber(taggedItem, TARGET_FAN_STATE, updater));
     }
 
-    private static RotationDirectionCharacteristic createRotationDirectionCharacteristic(final HomekitTaggedItem item,
-            HomekitAccessoryUpdater updater) {
+    private static RotationDirectionCharacteristic createRotationDirectionCharacteristic(
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
         return new RotationDirectionCharacteristic(
-                () -> getEnumFromItem(item, RotationDirectionEnum.CLOCKWISE, RotationDirectionEnum.COUNTER_CLOCKWISE,
-                        RotationDirectionEnum.CLOCKWISE),
-                (value) -> setValueFromEnum(item, value, RotationDirectionEnum.CLOCKWISE,
+                () -> getEnumFromItem(taggedItem, RotationDirectionEnum.CLOCKWISE,
+                        RotationDirectionEnum.COUNTER_CLOCKWISE, RotationDirectionEnum.CLOCKWISE),
+                (value) -> setValueFromEnum(taggedItem, value, RotationDirectionEnum.CLOCKWISE,
                         RotationDirectionEnum.COUNTER_CLOCKWISE),
-                getSubscriber(item, ROTATION_DIRECTION, updater), getUnsubscriber(item, ROTATION_DIRECTION, updater));
+                getSubscriber(taggedItem, ROTATION_DIRECTION, updater),
+                getUnsubscriber(taggedItem, ROTATION_DIRECTION, updater));
     }
 
-    private static SwingModeCharacteristic createSwingModeCharacteristic(final HomekitTaggedItem item,
+    private static SwingModeCharacteristic createSwingModeCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new SwingModeCharacteristic(
-                () -> getEnumFromItem(item, SwingModeEnum.SWING_DISABLED, SwingModeEnum.SWING_ENABLED,
+                () -> getEnumFromItem(taggedItem, SwingModeEnum.SWING_DISABLED, SwingModeEnum.SWING_ENABLED,
                         SwingModeEnum.SWING_DISABLED),
-                (value) -> setValueFromEnum(item, value, SwingModeEnum.SWING_DISABLED, SwingModeEnum.SWING_ENABLED),
-                getSubscriber(item, SWING_MODE, updater), getUnsubscriber(item, SWING_MODE, updater));
+                (value) -> setValueFromEnum(taggedItem, value, SwingModeEnum.SWING_DISABLED,
+                        SwingModeEnum.SWING_ENABLED),
+                getSubscriber(taggedItem, SWING_MODE, updater), getUnsubscriber(taggedItem, SWING_MODE, updater));
     }
 
     private static LockPhysicalControlsCharacteristic createLockPhysicalControlsCharacteristic(
-            final HomekitTaggedItem item, HomekitAccessoryUpdater updater) {
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
         return new LockPhysicalControlsCharacteristic(
-                () -> getEnumFromItem(item, LockPhysicalControlsEnum.CONTROL_LOCK_DISABLED,
+                () -> getEnumFromItem(taggedItem, LockPhysicalControlsEnum.CONTROL_LOCK_DISABLED,
                         LockPhysicalControlsEnum.CONTROL_LOCK_ENABLED, LockPhysicalControlsEnum.CONTROL_LOCK_DISABLED),
-                (value) -> setValueFromEnum(item, value, LockPhysicalControlsEnum.CONTROL_LOCK_DISABLED,
+                (value) -> setValueFromEnum(taggedItem, value, LockPhysicalControlsEnum.CONTROL_LOCK_DISABLED,
                         LockPhysicalControlsEnum.CONTROL_LOCK_ENABLED),
-                getSubscriber(item, LOCK_CONTROL, updater), getUnsubscriber(item, LOCK_CONTROL, updater));
+                getSubscriber(taggedItem, LOCK_CONTROL, updater), getUnsubscriber(taggedItem, LOCK_CONTROL, updater));
     }
 
     private static RotationSpeedCharacteristic createRotationSpeedCharacteristic(final HomekitTaggedItem item,
@@ -482,33 +491,35 @@ public class HomekitCharacteristicFactory {
                 getSubscriber(item, ROTATION_SPEED, updater), getUnsubscriber(item, ROTATION_SPEED, updater));
     }
 
-    private static SetDurationCharacteristic createDurationCharacteristic(final HomekitTaggedItem item,
+    private static SetDurationCharacteristic createDurationCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
         return new SetDurationCharacteristic(() -> {
-            int value = getIntFromItem(item);
+            int value = getIntFromItem(taggedItem);
             if (value == 0) { // check for default duration
-                final Object duration = item.getConfiguration().get(HomekitValveImpl.CONFIG_DEFAULT_DURATION);
+                final Object duration = taggedItem.getConfiguration().get(HomekitValveImpl.CONFIG_DEFAULT_DURATION);
                 if (duration instanceof BigDecimal) {
                     value = ((BigDecimal) duration).intValue();
-                    if (item.getItem() instanceof NumberItem) {
-                        ((NumberItem) item.getItem()).setState(new DecimalType(value));
+                    if (taggedItem.getItem() instanceof NumberItem) {
+                        ((NumberItem) taggedItem.getItem()).setState(new DecimalType(value));
                     }
                 }
             }
             return CompletableFuture.completedFuture(value);
-        }, setIntConsumer(item), getSubscriber(item, DURATION, updater), getUnsubscriber(item, DURATION, updater));
+        }, setIntConsumer(taggedItem), getSubscriber(taggedItem, DURATION, updater),
+                getUnsubscriber(taggedItem, DURATION, updater));
     }
 
-    private static RemainingDurationCharacteristic createRemainingDurationCharacteristic(final HomekitTaggedItem item,
-            HomekitAccessoryUpdater updater) {
-        return new RemainingDurationCharacteristic(getIntSupplier(item),
-                getSubscriber(item, REMAINING_DURATION, updater), getUnsubscriber(item, REMAINING_DURATION, updater));
+    private static RemainingDurationCharacteristic createRemainingDurationCharacteristic(
+            final HomekitTaggedItem taggedItem, HomekitAccessoryUpdater updater) {
+        return new RemainingDurationCharacteristic(getIntSupplier(taggedItem),
+                getSubscriber(taggedItem, REMAINING_DURATION, updater),
+                getUnsubscriber(taggedItem, REMAINING_DURATION, updater));
     }
 
-    private static VolumeCharacteristic createVolumeCharacteristic(final HomekitTaggedItem item,
+    private static VolumeCharacteristic createVolumeCharacteristic(final HomekitTaggedItem taggedItem,
             HomekitAccessoryUpdater updater) {
-        return new VolumeCharacteristic(getIntSupplier(item),
-                (volume) -> ((NumberItem) item.getItem()).send(new DecimalType(volume)),
-                getSubscriber(item, DURATION, updater), getUnsubscriber(item, DURATION, updater));
+        return new VolumeCharacteristic(getIntSupplier(taggedItem),
+                (volume) -> ((NumberItem) taggedItem.getItem()).send(new DecimalType(volume)),
+                getSubscriber(taggedItem, DURATION, updater), getUnsubscriber(taggedItem, DURATION, updater));
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
@@ -13,7 +13,6 @@
 package org.openhab.io.homekit.internal.accessories;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.smarthome.core.items.GenericItem;
@@ -52,18 +51,17 @@ class HomekitLightbulbImpl extends AbstractHomekitAccessoryImpl implements Light
 
     @Override
     public CompletableFuture<Void> setLightbulbPowerState(boolean value) {
-        final Optional<HomekitTaggedItem> taggedItem = getCharacteristic(HomekitCharacteristicType.ON_STATE);
-        if (taggedItem.isPresent()) {
+        getCharacteristic(HomekitCharacteristicType.ON_STATE).ifPresent(tItem -> {
             final OnOffType onOffState = OnOffType.from(value);
-            final GenericItem item = (GenericItem) taggedItem.get().getItem();
+            final GenericItem item = (GenericItem) tItem.getItem();
             if (item instanceof DimmerItem) {
-                taggedItem.get().sendCommandProxy(HomekitOHItemProxy.ON_COMMAND, onOffState);
+                tItem.sendCommandProxy(HomekitOHItemProxy.ON_COMMAND, onOffState);
             } else if (item instanceof SwitchItem) {
                 ((SwitchItem) item).send(onOffState);
             } else if (item instanceof GroupItem) {
                 ((GroupItem) item).send(onOffState);
             }
-        }
+        });
         return CompletableFuture.completedFuture(null);
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
@@ -13,14 +13,17 @@
 package org.openhab.io.homekit.internal.accessories;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
+import org.eclipse.smarthome.core.library.items.DimmerItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
+import org.openhab.io.homekit.internal.HomekitOHItemProxy;
 import org.openhab.io.homekit.internal.HomekitSettings;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
@@ -49,11 +52,17 @@ class HomekitLightbulbImpl extends AbstractHomekitAccessoryImpl implements Light
 
     @Override
     public CompletableFuture<Void> setLightbulbPowerState(boolean value) {
-        GenericItem item = getItem(HomekitCharacteristicType.ON_STATE, GenericItem.class);
-        if (item instanceof SwitchItem) {
-            ((SwitchItem) item).send(OnOffType.from(value));
-        } else if (item instanceof GroupItem) {
-            ((GroupItem) item).send(OnOffType.from(value));
+        final Optional<HomekitTaggedItem> taggedItem = getCharacteristic(HomekitCharacteristicType.ON_STATE);
+        if (taggedItem.isPresent()) {
+            final OnOffType onOffState = OnOffType.from(value);
+            final GenericItem item = (GenericItem) taggedItem.get().getItem();
+            if (item instanceof DimmerItem) {
+                taggedItem.get().sendCommandProxy(HomekitOHItemProxy.ON_COMMAND, onOffState);
+            } else if (item instanceof SwitchItem) {
+                ((SwitchItem) item).send(onOffState);
+            } else if (item instanceof GroupItem) {
+                ((GroupItem) item).send(onOffState);
+            }
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitLightbulbImpl.java
@@ -22,7 +22,7 @@ import org.eclipse.smarthome.core.library.items.SwitchItem;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitCharacteristicType;
-import org.openhab.io.homekit.internal.HomekitOHItemProxy;
+import org.openhab.io.homekit.internal.HomekitCommandType;
 import org.openhab.io.homekit.internal.HomekitSettings;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
@@ -55,7 +55,7 @@ class HomekitLightbulbImpl extends AbstractHomekitAccessoryImpl implements Light
             final OnOffType onOffState = OnOffType.from(value);
             final GenericItem item = (GenericItem) tItem.getItem();
             if (item instanceof DimmerItem) {
-                tItem.sendCommandProxy(HomekitOHItemProxy.ON_COMMAND, onOffState);
+                tItem.sendCommandProxy(HomekitCommandType.ON_COMMAND, onOffState);
             } else if (item instanceof SwitchItem) {
                 ((SwitchItem) item).send(onOffState);
             } else if (item instanceof GroupItem) {


### PR DESCRIPTION
Issue:

complex openHAB items like Dimmer and Color have several characteristic. in case of Color all 3 characteristics are updated with one command/state - HSBType. 
in the same time, HomeKit home app sends updates for the characteristics independently of each other, e.g. update for hue, update for saturation and update for brightness. 
as results, characteristics can be get overwritten. 
see #7491 and https://community.openhab.org/t/coloritem-hue-and-saturation-updates/99468/4 
for more details. 

Solution:
as propose in https://community.openhab.org/t/coloritem-hue-and-saturation-updates/99468/4 this PR introduce a proxy for openHAB item, that collects commands/update first and then sends merged update - either wenn all relevant updates received or after 50ms after first update. 

in addition to HUE/Saturation issue, this update also solved Dimmer issue with "ON" and "Bightness" updates at the same time. see https://community.openhab.org/t/homekit-homekit-sending-on-and-100-command/99485


Signed-off-by: Eugen Freiter <freiter@gmx.de>
