### PR TITLE
[modbus][sunspec] Fixed type and scale errors on acc32 fields

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -119,6 +119,7 @@
 /bundles/org.openhab.binding.milight/ @davidgraeff
 /bundles/org.openhab.binding.minecraft/ @ibaton
 /bundles/org.openhab.binding.modbus/ @ssalonen
+/bundles/org.openhab.binding.modbus.sunspec/ @mrbig
 /bundles/org.openhab.binding.mqtt/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.generic/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.homeassistant/ @davidgraeff
@@ -191,7 +192,6 @@
 /bundles/org.openhab.binding.sonyprojector/ @lolodomo
 /bundles/org.openhab.binding.spotify/ @Hilbrand
 /bundles/org.openhab.binding.squeezebox/ @digitaldan @mhilbush
-/bundles/org.openhab.binding.modbus.sunspec/ @mrbig
 /bundles/org.openhab.binding.synopanalyzer/ @clinique
 /bundles/org.openhab.binding.systeminfo/ @svilenvul
 /bundles/org.openhab.binding.tado/ @dfrommi

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -497,7 +497,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
      * @return the scaled value as a DecimalType
      */
     protected State getScaled(Number value, Short scaleFactor, Unit<?> unit) {
-        if (scaleFactor == 1) {
+        if (scaleFactor == 0) {
             return new QuantityType<>(value.longValue(), unit);
         }
         return new QuantityType<>(BigDecimal.valueOf(value.longValue(), scaleFactor * -1), unit);

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/parser/AbstractBaseParser.java
@@ -85,7 +85,7 @@ public class AbstractBaseParser {
      * @return the parsed value or empty if the field is not implemented
      */
     protected Optional<Long> extractOptionalAcc32(ModbusRegisterArray raw, int index) {
-        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.UINT32).map(DecimalType::longValue)
+        return ModbusBitUtilities.extractStateFromRegisters(raw, index, ValueType.INT32).map(DecimalType::longValue)
                 .filter(value -> value != 0);
     }
 
@@ -121,6 +121,6 @@ public class AbstractBaseParser {
      * @return the parsed value or 1 if the field is not implemented
      */
     protected Short extractSunSSF(ModbusRegisterArray raw, int index) {
-        return extractOptionalSunSSF(raw, index).orElse((short) 1);
+        return extractOptionalSunSSF(raw, index).orElse((short) 0);
     }
 }


### PR DESCRIPTION
This PR fixes some scaling errors in the modbus.sunspec bundle:

- ACC32 fields were mistakenly parsed as unsigned int instead of signed
- default scale value changed to 1
- scaling was missing for 10^1 fields

