### PR TITLE
[telegram] allow access restrictions on chat ids

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -74,10 +74,17 @@ telegram.thing (no proxy):
 Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID", botToken="TOKEN" ]
 ```
 
-telegram.thing (multiple chat ids and markdown format):
+telegram.thing (multiple chat ids, one bi-directional chat (ID1), one outbound-only (ID2)):
 
 ```
-Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID1","ID2", botToken="TOKEN", parseMode ="Markdown" ]
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID1",">ID2", botToken="TOKEN" ]
+```
+
+
+telegram.thing (markdown format):
+
+```
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID", botToken="TOKEN", parseMode ="Markdown" ]
 ```
 
 telegram.thing (SOCKS5 proxy server is used): 

--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -62,29 +62,34 @@ In order to send a message, an action must be used instead.
 | `proxyPort`             |  None   | No       | Proxy port for telegram binding.                                                             |
 | `proxyType`             |  SOCKS5 | No       | Type of proxy server for telegram binding (SOCKS5 or HTTP). Default: SOCKS5                  |
 
+By default chat ids are bi-directionally, i.e. they can send and receive messages.
+They can be prefixed with an access modifier:
+- `<` restricts the chat to send only, i.e. this chat id can send messages to openHAB, but will never receive a notification.
+- `>` restricts the chat to receive only, i.e. this chat id will receive all notifications, but messages from this chat id will be discarded. 
+To use the reply function, chat ids need to be bi-directional.
 
 telegram.thing (no proxy):
 
 ```
-Thing telegram:telegramBot:Telegram_Bot [ chatIds="< ID >", botToken="< TOKEN >" ]
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID", botToken="TOKEN" ]
 ```
 
 telegram.thing (multiple chat ids and markdown format):
 
 ```
-Thing telegram:telegramBot:Telegram_Bot [ chatIds="< ID1 >","< ID2 >", botToken="< TOKEN >", parseMode ="Markdown" ]
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID1","ID2", botToken="TOKEN", parseMode ="Markdown" ]
 ```
 
 telegram.thing (SOCKS5 proxy server is used): 
 
 ```
-Thing telegram:telegramBot:Telegram_Bot [ chatIds="< ID >", botToken="< TOKEN >", proxyHost="< HOST >", proxyPort="< PORT >", proxyType="< TYPE >" ]
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID", botToken="TOKEN", proxyHost="HOST", proxyPort="PORT", proxyType="TYPE" ]
 ```
 
 or HTTP proxy server
 
 ```
-Thing telegram:telegramBot:Telegram_Bot [ chatIds="< ID >", botToken="< TOKEN >", proxyHost="localhost", proxyPort="8123", proxyType="HTTP" ]
+Thing telegram:telegramBot:Telegram_Bot [ chatIds="ID", botToken="TOKEN", proxyHost="localhost", proxyPort="8123", proxyType="HTTP" ]
 ```
 
 
@@ -97,7 +102,7 @@ Thing telegram:telegramBot:Telegram_Bot [ chatIds="< ID >", botToken="< TOKEN >"
 | lastMessageDate                      | DateTime  | The date of the last received message (UTC)                     |
 | lastMessageName                      | String    | The full name of the sender of the last received message        |
 | lastMessageUsername                  | String    | The username of the sender of the last received message         |
-| chatId                               | String    | The id of the chat of the last received meesage                 |
+| chatId                               | String    | The id of the chat of the last received message                 |
 | replyId                              | String    | The id of the reply which was passed to sendTelegram() as replyId argument. This id can be used to have an unambiguous assignment of the users reply to the message which was sent by the bot             |
 
 All channels are read-only.

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/bot/TelegramActions.java
@@ -151,7 +151,7 @@ public class TelegramActions implements ThingActions {
             @ActionInput(name = "message") @Nullable String message) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            for (Long chatId : localHandler.getChatIds()) {
+            for (Long chatId : localHandler.getReceiverChatIds()) {
                 if (!sendTelegramAnswer(chatId, replyId, message)) {
                     return false;
                 }
@@ -170,7 +170,7 @@ public class TelegramActions implements ThingActions {
     public boolean sendTelegram(@ActionInput(name = "message") @Nullable String message) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            for (Long chatId : localHandler.getChatIds()) {
+            for (Long chatId : localHandler.getReceiverChatIds()) {
                 if (!sendTelegram(chatId, message)) {
                     return false;
                 }
@@ -193,7 +193,7 @@ public class TelegramActions implements ThingActions {
             @ActionInput(name = "buttons") @Nullable String... buttons) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            for (Long chatId : localHandler.getChatIds()) {
+            for (Long chatId : localHandler.getReceiverChatIds()) {
                 if (!sendTelegramQuery(chatId, message, replyId, buttons)) {
                     return false;
                 }
@@ -264,7 +264,7 @@ public class TelegramActions implements ThingActions {
             @ActionInput(name = "args") @Nullable Object... args) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            for (Long chatId : localHandler.getChatIds()) {
+            for (Long chatId : localHandler.getReceiverChatIds()) {
                 if (!sendTelegram(chatId, message, args)) {
                     return false;
                 }
@@ -377,7 +377,7 @@ public class TelegramActions implements ThingActions {
             @ActionInput(name = "password") @Nullable String password) {
         TelegramHandler localHandler = handler;
         if (localHandler != null) {
-            for (Long chatId : localHandler.getChatIds()) {
+            for (Long chatId : localHandler.getReceiverChatIds()) {
                 if (!sendTelegramPhoto(chatId, photoURL, caption, username, password)) {
                     return false;
                 }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -144,16 +144,17 @@ public class TelegramHandler extends BaseThingHandler {
         receiverChatId.clear();
 
         for (String chatIdStr : config.getChatIds()) {
+            String trimmedChatId = chatIdStr.trim();
             try {
-                if (chatIdStr.trim().startsWith("<")) {
+                if (trimmedChatId.startsWith("<")) {
                     // inbound only
-                    authorizedSenderChatId.add(Long.valueOf(chatIdStr.substring(1)));
-                } else if (chatIdStr.trim().startsWith(">")) {
+                    authorizedSenderChatId.add(Long.valueOf(trimmedChatId.substring(1)));
+                } else if (trimmedChatId.startsWith(">")) {
                     // outbound only
-                    receiverChatId.add(Long.valueOf(chatIdStr.substring(1)));
+                    receiverChatId.add(Long.valueOf(trimmedChatId.substring(1)));
                 } else {
                     // bi-directional (default)
-                    Long chatId = Long.valueOf(chatIdStr);
+                    Long chatId = Long.valueOf(trimmedChatId);
                     authorizedSenderChatId.add(chatId);
                     receiverChatId.add(chatId);
                 }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -105,7 +105,9 @@ public class TelegramHandler extends BaseThingHandler {
         }
     }
 
-    private final List<Long> chatIds = new ArrayList<>();
+    private final List<Long> authorizedSenderChatId = new ArrayList<>();
+    private final List<Long> receiverChatId = new ArrayList<>();
+
     private final Logger logger = LoggerFactory.getLogger(TelegramHandler.class);
     private @Nullable ScheduledFuture<?> thingOnlineStatusJob;
 
@@ -138,10 +140,23 @@ public class TelegramHandler extends BaseThingHandler {
         TelegramConfiguration config = getConfigAs(TelegramConfiguration.class);
 
         String botToken = config.getBotToken();
-        chatIds.clear();
+        authorizedSenderChatId.clear();
+        receiverChatId.clear();
+
         for (String chatIdStr : config.getChatIds()) {
             try {
-                chatIds.add(Long.valueOf(chatIdStr));
+                if (chatIdStr.startsWith("<")) {
+                    // inbound only
+                    authorizedSenderChatId.add(Long.valueOf(chatIdStr.replace("<", "")));
+                } else if (chatIdStr.startsWith(">")) {
+                    // outbound only
+                    receiverChatId.add(Long.valueOf(chatIdStr.replace(">", "")));
+                } else {
+                    // bi-directional (default)
+                    Long chatId = Long.valueOf(chatIdStr);
+                    authorizedSenderChatId.add(chatId);
+                    receiverChatId.add(chatId);
+                }
             } catch (NumberFormatException e) {
                 logger.warn("The chat id {} is not a number and will be ignored", chatIdStr);
             }
@@ -233,7 +248,7 @@ public class TelegramHandler extends BaseThingHandler {
 
             if (message != null) {
                 chatId = message.chat().id();
-                if (!chatIds.contains(chatId)) {
+                if (!authorizedSenderChatId.contains(chatId)) {
                     logger.warn(
                             "Ignored message from unknown chat id {}. If you know the sender of that chat, add it to the list of chat ids in the thing configuration to authorize it",
                             chatId);
@@ -344,8 +359,22 @@ public class TelegramHandler extends BaseThingHandler {
         return Collections.singleton(TelegramActions.class);
     }
 
-    public List<Long> getChatIds() {
-        return chatIds;
+    /**
+     * get the list of all authorized senders
+     *
+     * @return list of chatIds
+     */
+    public List<Long> getAuthorizedSenderChatIds() {
+        return authorizedSenderChatId;
+    }
+
+    /**
+     * get the list of all receivers
+     *
+     * @return list of chatIds
+     */
+    public List<Long> getReceiverChatIds() {
+        return receiverChatId;
     }
 
     public void addMessageId(Long chatId, String replyId, Integer messageId) {

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -145,12 +145,12 @@ public class TelegramHandler extends BaseThingHandler {
 
         for (String chatIdStr : config.getChatIds()) {
             try {
-                if (chatIdStr.startsWith("<")) {
+                if (chatIdStr.trim().startsWith("<")) {
                     // inbound only
-                    authorizedSenderChatId.add(Long.valueOf(chatIdStr.replace("<", "")));
-                } else if (chatIdStr.startsWith(">")) {
+                    authorizedSenderChatId.add(Long.valueOf(chatIdStr.substring(1)));
+                } else if (chatIdStr.trim().startsWith(">")) {
                     // outbound only
-                    receiverChatId.add(Long.valueOf(chatIdStr.replace(">", "")));
+                    receiverChatId.add(Long.valueOf(chatIdStr.substring(1)));
                 } else {
                     // bi-directional (default)
                     Long chatId = Long.valueOf(chatIdStr);

--- a/bundles/org.openhab.binding.telegram/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -25,7 +25,7 @@
 			</parameter>
 			<parameter name="chatIds" type="text" required="true" multiple="true">
 				<label>Chat Id(s)</label>
-				<description>Enter your chat id(s). Only messages from this id(s) will be send to openHAB.</description>
+				<description>One or more chat id(s). Access modifiers ("&lt;" for inbound only, "&gt;" for outbound only) can be used as prefix (optional).</description>
 			</parameter>
 			<parameter name="parseMode" type="text" required="false">
 				<label>Parse Mode</label>


### PR DESCRIPTION
Adds the ability to use access modifiers on chat is. Use-case: Some chat ids (e.g. children) should receive notifications but should not be allowed to send commands. 

Fully backward compatible, no modifier = sending and receiving

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>