### PR TITLE
[nest] Fix possible memory leak and communication problems

### DIFF
--- a/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRequestFilter.java
+++ b/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/rest/NestStreamingRequestFilter.java
@@ -40,8 +40,8 @@ public class NestStreamingRequestFilter implements ClientRequestFilter {
     public void filter(@Nullable ClientRequestContext requestContext) throws IOException {
         if (requestContext != null) {
             MultivaluedMap<String, Object> headers = requestContext.getHeaders();
-            headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-            headers.add(HttpHeaders.CACHE_CONTROL, "no-cache");
+            headers.putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+            headers.putSingle(HttpHeaders.CACHE_CONTROL, "no-cache");
         }
     }
 }


### PR DESCRIPTION
It is possible the `NestStreamingRequestFilter` adds multiple of the same headers which may result in a memory leak and communication problems.

This is the same fix as added in #7811 for OH3 with CXF.