### PR TITLE
[wemo] Do http (not port) ping to determine if wemo port is alive

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -481,7 +481,7 @@ public class WemoHandler extends AbstractWemoHandler implements UpnpIOParticipan
         return wemoURL;
     }
 
-    public boolean servicePing(String host, int port) throws IOException {
+    public boolean servicePing(String host, int port) {
         logger.trace("Ping WeMo device at '{}:{}'", host, port);
         try {
             HttpUtil.executeUrl("GET", "http://" + host + ":" + port, 250);

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoHandler.java
@@ -17,12 +17,6 @@ import static org.openhab.binding.wemo.internal.WemoBindingConstants.*;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -49,6 +43,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant;
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
 import org.openhab.binding.wemo.internal.http.WemoHttpCall;
@@ -480,20 +475,20 @@ public class WemoHandler extends AbstractWemoHandler implements UpnpIOParticipan
                 }
             }
             wemoURL = "http://" + host + ":" + port + "/upnp/control/" + actionService + "1";
+            logger.trace("WeMo url {}", wemoURL);
             return wemoURL;
         }
         return wemoURL;
     }
 
     public boolean servicePing(String host, int port) throws IOException {
-        SocketAddress socketAddress = new InetSocketAddress(host, port);
-        try (Socket socket = new Socket()) {
-            logger.trace("Ping WeMo device at '{}'", socketAddress);
-            socket.connect(socketAddress, 250);
-            return true;
-        } catch (ConnectException | SocketTimeoutException | NoRouteToHostException ignored) {
+        logger.trace("Ping WeMo device at '{}:{}'", host, port);
+        try {
+            HttpUtil.executeUrl("GET", "http://" + host + ":" + port, 250);
+        } catch (IOException e) {
             return false;
         }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
When the wemo changes its service port, it sometimes doesn't close the old one. The wemo binding relied on a simple connect() to figure out if the service was available.  Since the wemo tends to increase the port number upon changing, the first port that the binding would hit was inactive, and this would never correct itself even when the binding was restarted since the problem is on the wemo side (the lower numbered port would still not be valid)

This changes the logic to use a real http request that forces the wemo to respond with something. The bad port will not reply with anything other than just accepting.

Old behavior would look something like the following:
```
07-Jun-2020 21:27:04.210 [TRACE] [.openhab.binding.wemo.internal.handler.WemoHandler] - Ping WeMo device at '/192.168.1.200:49151'
07-Jun-2020 21:27:04.217 [TRACE] [.openhab.binding.wemo.internal.handler.WemoHandler] - Ping WeMo device at '/192.168.1.200:49152'
07-Jun-2020 21:27:04.222 [TRACE] [.openhab.binding.wemo.internal.handler.WemoHandler] - Ping WeMo device at '/192.168.1.200:49153'
07-Jun-2020 21:27:04.227 [TRACE] [.openhab.binding.wemo.internal.handler.WemoHandler] - WeMo device Lightswitch-1_0-221413K13013CB responded at Port 49153
07-Jun-2020 21:27:06.235 [DEBUG] [rg.openhab.binding.wemo.internal.http.WemoHttpCall] - Could not make HTTP call to WeMo
```
However if an SSDP was issued it would show the correct port:
```
HTTP/1.1 200 OK
CACHE-CONTROL: max-age=86400
DATE: Mon, 08 Jun 2020 01:31:34 GMT
EXT:
LOCATION: http://192.168.1.200:49154/setup.xml
OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
01-NLS: c8a56a96-1dd1-11b2-befd-9672c2c999e0
SERVER: Unspecified, UPnP/1.0, Unspecified
X-User-Agent: redsonic
ST: upnp:rootdevice
USN: uuid:Lightswitch-1_0-221413K13013CB::upnp:rootdevice
```

The new behavior will correctly determine the port:
```
23:57:20.668 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:497 - Ping WeMo device at '192.168.1.200:49151'
23:57:20.919 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:497 - Ping WeMo device at '192.168.1.200:49152'
23:57:21.171 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:497 - Ping WeMo device at '192.168.1.200:49153'
23:57:21.422 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:497 - Ping WeMo device at '192.168.1.200:49154'
23:57:21.430 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:470 - WeMo device Lightswitch-1_0-221413K13013CB responded at Port 49154
23:57:21.430 [thingHandler-42] TRACE o.o.b.w.internal.handler.WemoHandler:478 - WeMo url http://192.168.1.200:49154/upnp/control/basicevent1
```