### PR TITLE
[nzwateralerts] New Zealand Water Alerts Binding initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -154,6 +154,7 @@
 /bundles/org.openhab.binding.ntp/ @marcelrv
 /bundles/org.openhab.binding.nuki/ @mkatter
 /bundles/org.openhab.binding.nuvo/ @mlobstein
+/bundles/org.openhab.binding.nzwateralerts/ @cossey
 /bundles/org.openhab.binding.oceanic/ @kgoderis
 /bundles/org.openhab.binding.ojelectronics/ @EvilPingu
 /bundles/org.openhab.binding.omnikinverter/ @hansbogert

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -758,6 +758,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.nzwateralerts</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.oceanic</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.nzwateralerts/.classpath
+++ b/bundles/org.openhab.binding.nzwateralerts/.classpath
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.nzwateralerts/.project
+++ b/bundles/org.openhab.binding.nzwateralerts/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.nzwateralerts</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.nzwateralerts/NOTICE
+++ b/bundles/org.openhab.binding.nzwateralerts/NOTICE
@@ -10,4 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/openhab/openhab2-addons
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.nzwateralerts/NOTICE
+++ b/bundles/org.openhab.binding.nzwateralerts/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab2-addons

--- a/bundles/org.openhab.binding.nzwateralerts/README.md
+++ b/bundles/org.openhab.binding.nzwateralerts/README.md
@@ -1,0 +1,56 @@
+# NZ Water Alerts Binding
+
+Get Water Alert Levels for cities in New Zealand. Getting this alert level can help you script and automate smarter tasks. 
+
+> Example: Disable automated spinklers based on a level 3 or 4 water alert level
+
+_This Binding scrapes the [Smart Water](http://www.smartwater.org.nz/) and [Be Water Wise](https://bewaterwise.org.nz/) websites for Water Alert Levels._
+
+## Thing Configuration
+
+You can configure this Binding through _PaperUI_ or manually.
+
+```
+Thing nzwateralerts:wateralert "HCC" [ location="smartwater:hamilton:hamilton", refreshInterval="4" ]
+```
+
+The above gets the Water Alert level for Hamilton and refreshes this data every 4 hours.
+
+Supported city/area list:
+
+| City                     | Config Value                               |
+| ------------------------ | ------------------------------------------ |
+| Bream Bay                | bewaterwise:whangarei:breambay             |
+| Dargaville & Baylys      | bewaterwise:kaipara:dargavilleampbaylys    |
+| Glinks Gully             | bewaterwise:kaipara:glinksgully            |
+| Hamilton City            | smartwater:hamilton:hamilton               |
+| Kaikohe / Ngawha         | bewaterwise:farnorth:kaikohengawha         |
+| Kaitaia                  | bewaterwise:farnorth:kaitaia               |
+| Kerikeri / Waipapa       | bewaterwise:farnorth:kerikeriwaipapa       |
+| Mangapai                 | bewaterwise:whangarei:mangapai             |
+| Mangawhai                | bewaterwise:kaipara:mangawhai              |
+| Maungakaramea            | bewaterwise:whangarei:maungakaramea        |
+| Maungaturoto             | bewaterwise:kaipara:maungaturoto           |
+| Moerewa / Kawakawa       | bewaterwise:farnorth:moerewakawakawa       |
+| Napier                   | napiercitycouncil:napier:napier            |
+| Okaihau                  | bewaterwise:farnorth:okaihau               |
+| Opononi / Omapere        | bewaterwise:farnorth:opononiomapere        |
+| Rawene                   | bewaterwise:farnorth:rawene                |
+| Ruawai                   | bewaterwise:kaipara:ruawai                 |
+| Russell                  | bewaterwise:farnorth:russell               |
+| Waipa District           | smartwater:waipa:waipa                     |
+| Waikato District         | smartwater:waikato:waikato                 |
+| Waitangi / Paihia / Opua | bewaterwise:farnorth:waitangipaihiaopua    |
+| Whangarei                | bewaterwise:whangarei:whangarei            |
+
+## Channels
+
+There is only one channel with this binding labelled `alertlevel` which contains a Number 0-4 to represent the alert level.
+
+> Water Alert Level 0 represents _No Water Restrictions_ in some cities.
+
+## Other Cities
+
+At present the supported cities were implemented by scraping the web page on the respective website which contains the restriction information. 
+
+**No councils have this data in a programmatic format easily accessible to software.** Most won't have pages which contain the current alert level and only offer alerts via twitter or text. If you can convince your council to always have a page displaying the current alert level (even if none is in effect) then I can attempt to parse the page for inclusion in this Binding.

--- a/bundles/org.openhab.binding.nzwateralerts/README.md
+++ b/bundles/org.openhab.binding.nzwateralerts/README.md
@@ -1,22 +1,25 @@
 # NZ Water Alerts Binding
 
-Get Water Alert Levels for cities in New Zealand. Getting this alert level can help you script and automate smarter tasks. 
+Get Water Alert Levels for cities in New Zealand. Getting this alert level can help you script and automate smarter tasks for water and avoid getting penalized from your distract or local council. 
 
 > Example: Disable automated spinklers based on a level 3 or 4 water alert level
 
-_This Binding scrapes the [Smart Water](http://www.smartwater.org.nz/) and [Be Water Wise](https://bewaterwise.org.nz/) websites for Water Alert Levels._
+This Binding scrapes multiple websites for Water Levels:
+* Northland's [BeWaterWise Website](https://bewaterwise.org.nz/)
+* Waikato's [Smart Water Website](https://www.smartwater.org.nz/)
+* Napier's [Council Website](https://www.napier.govt.nz)
 
 ## Thing Configuration
 
 You can configure this Binding through _PaperUI_ or manually.
 
-```
-Thing nzwateralerts:wateralert "HCC" [ location="smartwater:hamilton:hamilton", refreshInterval="4" ]
-```
+### Configuration Values
+| Value           | Type         | Description                            |
+| --------------- | ------------ | -------------------------------------- |
+| location        | string       | The location to get water data from. Refer to the list below for values. |
+| refreshInterval | number       | The time interval (in hours) to refresh the data.
 
-The above gets the Water Alert level for Hamilton and refreshes this data every 4 hours.
-
-Supported city/area list:
+### Supported city/area list
 
 | City                     | Config Value                               |
 | ------------------------ | ------------------------------------------ |
@@ -43,11 +46,19 @@ Supported city/area list:
 | Waitangi / Paihia / Opua | bewaterwise:farnorth:waitangipaihiaopua    |
 | Whangarei                | bewaterwise:whangarei:whangarei            |
 
+### Example
+
+```
+Thing nzwateralerts:wateralert "HCC" [ location="smartwater:hamilton:hamilton", refreshInterval="4" ]
+```
+
+The above gets the Water Alert level for Hamilton and refreshes this data every 4 hours.
+
 ## Channels
 
 There is only one channel with this binding labelled `alertlevel` which contains a Number 0-4 to represent the alert level.
 
-> Water Alert Level 0 represents _No Water Restrictions_ in some cities.
+Depending on your region, either Alert Level 0 or 1 can represent _No Water Restrictions_. Check with your regional council for further details.
 
 ## Other Cities
 

--- a/bundles/org.openhab.binding.nzwateralerts/README.md
+++ b/bundles/org.openhab.binding.nzwateralerts/README.md
@@ -12,7 +12,7 @@ This Binding scrapes multiple websites for Water Levels:
 
 ## Thing Configuration
 
-You can configure this Binding through _PaperUI_ or manually.
+The binding and thing ID is `nzwateralerts:wateralert`.
 
 ### Configuration Values
 

--- a/bundles/org.openhab.binding.nzwateralerts/README.md
+++ b/bundles/org.openhab.binding.nzwateralerts/README.md
@@ -5,6 +5,7 @@ Get Water Alert Levels for cities in New Zealand. Getting this alert level can h
 > Example: Disable automated spinklers based on a level 3 or 4 water alert level
 
 This Binding scrapes multiple websites for Water Levels:
+
 * Northland's [BeWaterWise Website](https://bewaterwise.org.nz/)
 * Waikato's [Smart Water Website](https://www.smartwater.org.nz/)
 * Napier's [Council Website](https://www.napier.govt.nz)
@@ -14,6 +15,7 @@ This Binding scrapes multiple websites for Water Levels:
 You can configure this Binding through _PaperUI_ or manually.
 
 ### Configuration Values
+
 | Value           | Type         | Description                            |
 | --------------- | ------------ | -------------------------------------- |
 | location        | string       | The location to get water data from. Refer to the list below for values. |

--- a/bundles/org.openhab.binding.nzwateralerts/README.md
+++ b/bundles/org.openhab.binding.nzwateralerts/README.md
@@ -1,6 +1,7 @@
 # NZ Water Alerts Binding
 
-Get Water Alert Levels for cities in New Zealand. Getting this alert level can help you script and automate smarter tasks for water and avoid getting penalized from your distract or local council. 
+Get Water Alert Levels for cities in New Zealand.
+Getting this alert level can help you script and automate smarter tasks for water and avoid getting penalized from your distract or local council. 
 
 > Example: Disable automated spinklers based on a level 3 or 4 water alert level
 
@@ -60,10 +61,13 @@ The above gets the Water Alert level for Hamilton and refreshes this data every 
 
 There is only one channel with this binding labelled `alertlevel` which contains a Number 0-4 to represent the alert level.
 
-Depending on your region, either Alert Level 0 or 1 can represent _No Water Restrictions_. Check with your regional council for further details.
+Depending on your region, either Alert Level 0 or 1 can represent _No Water Restrictions_.
+Check with your regional council for further details.
 
 ## Other Cities
 
 At present the supported cities were implemented by scraping the web page on the respective website which contains the restriction information. 
 
-**No councils have this data in a programmatic format easily accessible to software.** Most won't have pages which contain the current alert level and only offer alerts via twitter or text. If you can convince your council to always have a page displaying the current alert level (even if none is in effect) then I can attempt to parse the page for inclusion in this Binding.
+**No councils have this data in a programmatic format easily accessible to software.**
+Most won't have pages which contain the current alert level and only offer alerts via twitter or text.
+If you can convince your council to always have a page displaying the current alert level (even if none is in effect) then I can attempt to parse the page for inclusion in this Binding.

--- a/bundles/org.openhab.binding.nzwateralerts/pom.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.nzwateralerts/pom.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.6-SNAPSHOT</version>
+    <version>2.5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.nzwateralerts</artifactId>

--- a/bundles/org.openhab.binding.nzwateralerts/pom.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.nzwateralerts</artifactId>

--- a/bundles/org.openhab.binding.nzwateralerts/pom.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.nzwateralerts</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: NZ Water Alerts Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.nzwateralerts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+
+    <feature name="openhab-binding-nzwateralerts" description="NZWaterAlerts Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nzwateralerts/${project.version}</bundle>
+    </feature>
+</features>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding. nzwateralerts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-    
-    <feature name="openhab-binding-nzwateralerts" description="NZ Water Alerts Binding" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nzwateralerts/${project.version}</bundle>
-    </feature>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-nzwateralerts" description="NZ Water Alerts Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nzwateralerts/${project.version}</bundle>
+	</feature>
 </features>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.nzwateralerts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
-
-    <feature name="openhab-binding-nzwateralerts" description="NZWaterAlerts Binding" version="${project.version}">
+<features name="org.openhab.binding. nzwateralerts-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+    
+    <feature name="openhab-binding-nzwateralerts" description="NZ Water Alerts Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.nzwateralerts/${project.version}</bundle>
     </feature>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
@@ -39,6 +39,7 @@ public class NZWaterAlertsBindingConstants {
     // List of all Channel ids
     public static final String CHANNEL_ALERTLEVEL = "alertlevel";
 
-    //List of all supported services
-    public static final List<WaterWebService> WATER_WEB_SERVICES = Arrays.asList(new WaterWebService[]{new SmartWater(), new BeWaterWise(), new NapierCityCouncil()});
+    // List of all supported services
+    public static final List<WaterWebService> WATER_WEB_SERVICES = Arrays
+            .asList(new WaterWebService[] { new SmartWater(), new BeWaterWise(), new NapierCityCouncil() });
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsBindingConstants.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.openhab.binding.nzwateralerts.internal.api.BeWaterWise;
+import org.openhab.binding.nzwateralerts.internal.api.NapierCityCouncil;
+import org.openhab.binding.nzwateralerts.internal.api.SmartWater;
+import org.openhab.binding.nzwateralerts.internal.api.WaterWebService;
+
+/**
+ * The {@link NZWaterAlertsBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class NZWaterAlertsBindingConstants {
+
+    private static final String BINDING_ID = "nzwateralerts";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_WATERALERT = new ThingTypeUID(BINDING_ID, "wateralert");
+
+    // List of all Channel ids
+    public static final String CHANNEL_ALERTLEVEL = "alertlevel";
+
+    //List of all supported services
+    public static final List<WaterWebService> WATER_WEB_SERVICES = Arrays.asList(new WaterWebService[]{new SmartWater(), new BeWaterWise(), new NapierCityCouncil()});
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
@@ -22,10 +22,6 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class NZWaterAlertsConfiguration {
-
-    /**
-     * Sample configuration parameter. Replace with your own.
-     */
     public @Nullable String location;
     public int refreshInterval;
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
@@ -12,16 +12,20 @@
  */
 package org.openhab.binding.nzwateralerts.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link NZWaterAlertsConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author Stewart Cossey - Initial contribution
  */
+@NonNullByDefault
 public class NZWaterAlertsConfiguration {
 
     /**
      * Sample configuration parameter. Replace with your own.
      */
-    public String location;
+    public @Nullable String location;
     public int refreshInterval;
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/NZWaterAlertsConfiguration.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal;
+
+/**
+ * The {@link NZWaterAlertsConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+public class NZWaterAlertsConfiguration {
+
+    /**
+     * Sample configuration parameter. Replace with your own.
+     */
+    public String location;
+    public int refreshInterval;
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BeWaterWise} class contains the logic to get data the SmartWater.org.nz website.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class BeWaterWise implements WaterWebService {
+    private final Logger logger = LoggerFactory.getLogger(BeWaterWise.class);
+
+    private static final String HOSTNAME = "https://bewaterwise.org.nz";
+    private static final String REGION_FARNORTH = "/current-water-levels_far-north/";
+    private static final String REGION_WHANGAREI = "/current-water-levels_whangarei/";
+    private static final String REGION_KAIPARA = "/current-water-levels_kaipara/";
+
+    private String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
+    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+
+    @Override
+    public String service() {
+        return "bewaterwise";
+    }
+
+    @Override
+    public String endpoint(String region) {
+        switch (region.toLowerCase()) {
+            case "farnorth":
+                return HOSTNAME + REGION_FARNORTH;
+            
+            case "whangarei":
+                return HOSTNAME + REGION_WHANGAREI;
+
+            case "kaipara":
+                return HOSTNAME + REGION_KAIPARA;
+        }
+        return "";
+    }
+
+    @Override
+    public int findWaterLevel(String data, String area) {
+        Matcher matches = regex.matcher(data);
+        
+        while (matches.find()) {
+            String dataArea = matches.group(1).replaceAll("\\W", "");
+            String level = matches.group(2);
+            logger.debug("Data Area {} Level {}", dataArea, level);
+            if (dataArea.equalsIgnoreCase(area)) {
+                return Integer.valueOf(level);
+            }
+        }
+        return -1;
+    }
+
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -20,7 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link BeWaterWise} class contains the logic to get data the SmartWater.org.nz website.
+ * The {@link BeWaterWise} class contains the logic to get data the
+ * SmartWater.org.nz website.
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -33,8 +34,9 @@ public class BeWaterWise implements WaterWebService {
     private static final String REGION_WHANGAREI = "/current-water-levels_whangarei/";
     private static final String REGION_KAIPARA = "/current-water-levels_kaipara/";
 
-    private String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
-    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+    private final String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
+    private final Pattern regex = Pattern.compile(pattern,
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
     public String service() {
@@ -42,11 +44,11 @@ public class BeWaterWise implements WaterWebService {
     }
 
     @Override
-    public String endpoint(String region) {
+    public String endpoint(final String region) {
         switch (region.toLowerCase()) {
             case "farnorth":
                 return HOSTNAME + REGION_FARNORTH;
-            
+
             case "whangarei":
                 return HOSTNAME + REGION_WHANGAREI;
 
@@ -57,12 +59,12 @@ public class BeWaterWise implements WaterWebService {
     }
 
     @Override
-    public int findWaterLevel(String data, String area) {
-        Matcher matches = regex.matcher(data);
-        
+    public int findWaterLevel(final String data, final String area) {
+        final Matcher matches = regex.matcher(data);
+
         while (matches.find()) {
-            String dataArea = matches.group(1).replaceAll("\\W", "");
-            String level = matches.group(2);
+            final String dataArea = matches.group(1).replaceAll("\\W", "");
+            final String level = matches.group(2);
             logger.debug("Data Area {} Level {}", dataArea, level);
             if (dataArea.equalsIgnoreCase(area)) {
                 return Integer.valueOf(level);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -21,7 +21,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link BeWaterWise} class contains the logic to get data the
- * SmartWater.org.nz website.
+ * bewaterwise.org.nz website.
+ * 
+ * Northland Regional Council
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -34,8 +36,8 @@ public class BeWaterWise implements WaterWebService {
     private static final String REGION_WHANGAREI = "/current-water-levels_whangarei/";
     private static final String REGION_KAIPARA = "/current-water-levels_kaipara/";
 
-    private final String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
-    private final Pattern regex = Pattern.compile(pattern,
+    private static final String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
+    private static final Pattern regex = Pattern.compile(pattern,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -36,8 +36,8 @@ public class BeWaterWise implements WaterWebService {
     private static final String REGION_WHANGAREI = "/current-water-levels_whangarei/";
     private static final String REGION_KAIPARA = "/current-water-levels_kaipara/";
 
-    private static final String pattern = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
-    private static final Pattern regex = Pattern.compile(pattern,
+    private static final String PATTERN = "vc_text_separator.*?<span>(.*?)<\\/span>.*?water-level-([0-4]).*?";
+    private static final Pattern REGEX = Pattern.compile(PATTERN,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
@@ -62,7 +62,7 @@ public class BeWaterWise implements WaterWebService {
 
     @Override
     public int findWaterLevel(final String data, final String area) {
-        final Matcher matches = regex.matcher(data);
+        final Matcher matches = REGEX.matcher(data);
 
         while (matches.find()) {
             final String dataArea = matches.group(1).replaceAll("\\W", "");

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/BeWaterWise.java
@@ -74,5 +74,4 @@ public class BeWaterWise implements WaterWebService {
         }
         return -1;
     }
-
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link NapierCityCouncil} class contains the logic to get data the
  * www.napier.govt.nz website.
+ * 
+ * Napier City Council
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -32,8 +34,8 @@ public class NapierCityCouncil implements WaterWebService {
     private static final String HOSTNAME = "https://www.napier.govt.nz";
     private static final String REGION_NAPIER = "/services/water/water-restrictions/";
 
-    private final String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
-    private final Pattern regex = Pattern.compile(pattern,
+    private static final String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
+    private static final Pattern regex = Pattern.compile(pattern,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -20,7 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link NapierCityCouncil} class contains the logic to get data the www.napier.govt.nz website.
+ * The {@link NapierCityCouncil} class contains the logic to get data the
+ * www.napier.govt.nz website.
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -31,8 +32,9 @@ public class NapierCityCouncil implements WaterWebService {
     private static final String HOSTNAME = "https://www.napier.govt.nz";
     private static final String REGION_NAPIER = "/services/water/water-restrictions/";
 
-    private String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
-    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+    private final String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
+    private final Pattern regex = Pattern.compile(pattern,
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
     public String service() {
@@ -40,24 +42,24 @@ public class NapierCityCouncil implements WaterWebService {
     }
 
     @Override
-    public String endpoint(String region) {
+    public String endpoint(final String region) {
         switch (region.toLowerCase()) {
             case "napier":
                 return HOSTNAME + REGION_NAPIER;
-            
+
         }
         return "";
     }
 
     @Override
-    public int findWaterLevel(String data, String area) {
-        Matcher matches = regex.matcher(data);
-        
+    public int findWaterLevel(final String data, final String area) {
+        final Matcher matches = regex.matcher(data);
+
         while (matches.find()) {
-            String level = matches.group(1);
+            final String level = matches.group(1);
             logger.debug("Data Level {}", level);
 
-            switch(level.toLowerCase()) {
+            switch (level.toLowerCase()) {
                 case "no":
                     return 0;
 

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link NapierCityCouncil} class contains the logic to get data the www.napier.govt.nz website.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class NapierCityCouncil implements WaterWebService {
+    private final Logger logger = LoggerFactory.getLogger(NapierCityCouncil.class);
+
+    private static final String HOSTNAME = "https://www.napier.govt.nz";
+    private static final String REGION_NAPIER = "/services/water/water-restrictions/";
+
+    private String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
+    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+
+    @Override
+    public String service() {
+        return "napiercitycouncil";
+    }
+
+    @Override
+    public String endpoint(String region) {
+        switch (region.toLowerCase()) {
+            case "napier":
+                return HOSTNAME + REGION_NAPIER;
+            
+        }
+        return "";
+    }
+
+    @Override
+    public int findWaterLevel(String data, String area) {
+        Matcher matches = regex.matcher(data);
+        
+        while (matches.find()) {
+            String level = matches.group(1);
+            logger.debug("Data Level {}", level);
+
+            switch(level.toLowerCase()) {
+                case "no":
+                    return 0;
+
+                case "level one":
+                    return 1;
+
+                case "level two":
+                    return 2;
+
+                case "level three":
+                    return 3;
+
+                case "level four":
+                    return 4;
+            }
+
+        }
+        return -1;
+    }
+
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -34,8 +34,8 @@ public class NapierCityCouncil implements WaterWebService {
     private static final String HOSTNAME = "https://www.napier.govt.nz";
     private static final String REGION_NAPIER = "/services/water/water-restrictions/";
 
-    private static final String pattern = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
-    private static final Pattern regex = Pattern.compile(pattern,
+    private static final String PATTERN = "\"waterstat\".*?<p>.*?at (.*?) Restrictions.*?</div>";
+    private static final Pattern REGEX = Pattern.compile(PATTERN,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
@@ -55,7 +55,7 @@ public class NapierCityCouncil implements WaterWebService {
 
     @Override
     public int findWaterLevel(final String data, final String area) {
-        final Matcher matches = regex.matcher(data);
+        final Matcher matches = REGEX.matcher(data);
 
         while (matches.find()) {
             final String level = matches.group(1);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/NapierCityCouncil.java
@@ -81,5 +81,4 @@ public class NapierCityCouncil implements WaterWebService {
         }
         return -1;
     }
-
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -20,7 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link SmartWater} class contains the logic to get data the SmartWater.org.nz website.
+ * The {@link SmartWater} class contains the logic to get data the
+ * SmartWater.org.nz website.
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -33,8 +34,9 @@ public class SmartWater implements WaterWebService {
     private static final String REGION_WAIKATO = "/alert-levels/waikato-district-council";
     private static final String REGION_WAIPA = "/alert-levels/waipa-district-council";
 
-    private String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
-    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+    private final String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
+    private final Pattern regex = Pattern.compile(pattern,
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
     public String service() {
@@ -42,11 +44,11 @@ public class SmartWater implements WaterWebService {
     }
 
     @Override
-    public String endpoint(String region) {
+    public String endpoint(final String region) {
         switch (region.toLowerCase()) {
             case "hamilton":
                 return HOSTNAME + REGION_HAMILTON;
-            
+
             case "waikato":
                 return HOSTNAME + REGION_WAIKATO;
 
@@ -57,9 +59,9 @@ public class SmartWater implements WaterWebService {
     }
 
     @Override
-    public int findWaterLevel(String data, String area) {
-        Matcher matches = regex.matcher(data);
-        
+    public int findWaterLevel(final String data, final String area) {
+        final Matcher matches = regex.matcher(data);
+
         while (matches.find()) {
             String level = matches.group(1);
             logger.debug("Data Level {}", level);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link SmartWater} class contains the logic to get data the
  * SmartWater.org.nz website.
+ * 
+ * Waikato Regional Council
  *
  * @author Stewart Cossey - Initial contribution
  */
@@ -34,8 +36,8 @@ public class SmartWater implements WaterWebService {
     private static final String REGION_WAIKATO = "/alert-levels/waikato-district-council";
     private static final String REGION_WAIPA = "/alert-levels/waipa-district-council";
 
-    private final String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
-    private final Pattern regex = Pattern.compile(pattern,
+    private static final String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
+    private static final Pattern regex = Pattern.compile(pattern,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SmartWater} class contains the logic to get data the SmartWater.org.nz website.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class SmartWater implements WaterWebService {
+    private final Logger logger = LoggerFactory.getLogger(SmartWater.class);
+
+    private static final String HOSTNAME = "http://www.smartwater.org.nz";
+    private static final String REGION_HAMILTON = "/alert-levels/hamilton-city";
+    private static final String REGION_WAIKATO = "/alert-levels/waikato-district-council";
+    private static final String REGION_WAIPA = "/alert-levels/waipa-district-council";
+
+    private String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
+    private Pattern regex = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+
+    @Override
+    public String service() {
+        return "smartwater";
+    }
+
+    @Override
+    public String endpoint(String region) {
+        switch (region.toLowerCase()) {
+            case "hamilton":
+                return HOSTNAME + REGION_HAMILTON;
+            
+            case "waikato":
+                return HOSTNAME + REGION_WAIKATO;
+
+            case "waipa":
+                return HOSTNAME + REGION_WAIPA;
+        }
+        return "";
+    }
+
+    @Override
+    public int findWaterLevel(String data, String area) {
+        Matcher matches = regex.matcher(data);
+        
+        while (matches.find()) {
+            String level = matches.group(1);
+            logger.debug("Data Level {}", level);
+            if (level.equalsIgnoreCase("no")) {
+                logger.debug("Convert Data Level to 0");
+                level = "0";
+            }
+            return Integer.valueOf(level);
+        }
+        return -1;
+    }
+
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -36,8 +36,8 @@ public class SmartWater implements WaterWebService {
     private static final String REGION_WAIKATO = "/alert-levels/waikato-district-council";
     private static final String REGION_WAIPA = "/alert-levels/waipa-district-council";
 
-    private static final String pattern = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
-    private static final Pattern regex = Pattern.compile(pattern,
+    private static final String PATTERN = "/assets/Alert-Level-Images/water-alert-([1-4]|no)-large.svg.*?";
+    private static final Pattern REGEX = Pattern.compile(PATTERN,
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
 
     @Override
@@ -62,7 +62,7 @@ public class SmartWater implements WaterWebService {
 
     @Override
     public int findWaterLevel(final String data, final String area) {
-        final Matcher matches = regex.matcher(data);
+        final Matcher matches = REGEX.matcher(data);
 
         while (matches.find()) {
             String level = matches.group(1);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/SmartWater.java
@@ -75,5 +75,4 @@ public class SmartWater implements WaterWebService {
         }
         return -1;
     }
-
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/TaupoDistrictCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/TaupoDistrictCouncil.java
@@ -88,5 +88,4 @@ public class TaupoDistrictCouncil implements WaterWebService {
         }
         return -1;
     }
-
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/TaupoDistrictCouncil.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/TaupoDistrictCouncil.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link TaupoDistrictCouncil} class contains the logic to get data the
+ * www.taupodc.govt.nz website.
+ * 
+ * Taupo District Council
+ * 
+ * NOTE: This is currently a placeholder. This region needs to go into restrictions
+ * first so I can parse the correct output. -Stewart Cossey
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class TaupoDistrictCouncil implements WaterWebService {
+    private final Logger logger = LoggerFactory.getLogger(TaupoDistrictCouncil.class);
+
+    private static final String HOSTNAME = "https://www.taupodc.govt.nz";
+    private static final String REGION_TAUPO = "/transport-and-water/water-conservation";
+
+    private static final String PATTERN = "div class=\"rc\".*?<tbody>.*?<strong>.*?<strong>(.*?) restrictions</strong>";
+    private static final Pattern REGEX = Pattern.compile(PATTERN,
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+
+    @Override
+    public String service() {
+        return "taupodistrictcouncil";
+    }
+
+    @Override
+    public String endpoint(final String region) {
+        switch (region.toLowerCase()) {
+            case "taupo":
+                return HOSTNAME + REGION_TAUPO;
+
+        }
+        return "";
+    }
+
+    @Override
+    public int findWaterLevel(final String data, final String area) {
+        final Matcher matches = REGEX.matcher(data);
+
+        while (matches.find()) {
+            final String level = matches.group(1);
+            logger.debug("Data Level {}", level);
+
+            switch (level.toLowerCase()) {
+                case "no":
+                    return 0;
+
+                case "level one":
+                case "level 1":
+                    return 1;
+
+                case "level two":
+                case "level 2":
+                    return 2;
+
+                case "level three":
+                case "level 3":
+                    return 3;
+
+                case "level four":
+                case "level 4":
+                    return 4;
+            }
+
+        }
+        return -1;
+    }
+
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -12,17 +12,17 @@
  */
 package org.openhab.binding.nzwateralerts.internal.api;
 
+import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * The {@link WebClient} class contains the logic to get data from a URL.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The {@link WebClient} class contains the logic to get data from a URL.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class WaterAlertWebClient {
+    private final Logger logger = LoggerFactory.getLogger(WaterAlertWebClient.class);
+
+    private @Nullable HttpClient httpClient = null;
+    private @Nullable WaterWebService service = null;
+    
+    private String webService = "";
+    private String region = "";
+    private String area = "";
+
+    public WaterAlertWebClient(HttpClient httpClient, String location) {
+        this.httpClient = httpClient;
+
+        String[] locationSegmented = location.split(":", 3);
+        webService = locationSegmented[0];
+        region = locationSegmented[1];
+        area = locationSegmented[2];
+
+        for (WaterWebService srv : WATER_WEB_SERVICES) {
+            logger.trace("Checking service {}", srv.service());
+            if (locationSegmented[0].equalsIgnoreCase(srv.service())) {
+                logger.trace("Found service {}", srv.service());
+                service = srv;
+            }
+        }
+
+        if (service == null) {
+            logger.debug("Service could not be found for {}", locationSegmented[0]);
+        }
+    }
+
+    public @Nullable Integer getLevel() {
+        ContentResponse response;
+        try {
+            if (service != null) {
+                logger.debug("Getting Water Level from service {} region {} area {}", webService,
+                region, area);
+                String endpoint = service.endpoint(region);
+                logger.trace("Getting data from endpoint {}", endpoint);
+                response = httpClient.GET(endpoint);
+
+                int waterLevel = service.findWaterLevel(response.getContentAsString(), area);
+                logger.debug("Got water level {}", waterLevel);
+                return waterLevel;
+            } else {
+                logger.debug("Service is null");
+                return null;
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            logger.debug("Error when attempting to get Water Level {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -15,6 +15,7 @@ package org.openhab.binding.nzwateralerts.internal.api;
 import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -33,6 +34,8 @@ import org.slf4j.LoggerFactory;
 public class WaterAlertWebClient {
     private final Logger logger = LoggerFactory.getLogger(WaterAlertWebClient.class);
 
+    private static final int REQUEST_TIMEOUT = 10;
+
     private final HttpClient httpClient;
     private final String webService;
     private final String region;
@@ -40,7 +43,7 @@ public class WaterAlertWebClient {
 
     private @Nullable WaterWebService service = null;
 
-    public WaterAlertWebClient(final HttpClient httpClient, final String location) throws Exception {
+    public WaterAlertWebClient(final HttpClient httpClient, final String location) {
         this.httpClient = httpClient;
 
         final String[] locationSegmented = location.split(":", 3);
@@ -69,8 +72,8 @@ public class WaterAlertWebClient {
                 logger.debug("Getting Water Level from service {} region {} area {}", webService, region, area);
 
                 final String endpoint = localService.endpoint(region);
-                logger.trace("Getting data from endpoint {}", endpoint);
-                response = httpClient.GET(endpoint);
+                logger.trace("Getting data from endpoint {} with timeout {}", endpoint, REQUEST_TIMEOUT);
+                response = httpClient.newRequest(endpoint).timeout(REQUEST_TIMEOUT, TimeUnit.SECONDS).send();
 
                 final int waterLevel = localService.findWaterLevel(response.getContentAsString(), area);
                 logger.debug("Got water level {}", waterLevel);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -17,7 +17,6 @@ import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingCon
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.commons.lang.NullArgumentException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
@@ -41,28 +40,24 @@ public class WaterAlertWebClient {
 
     private @Nullable WaterWebService service = null;
 
-    public WaterAlertWebClient(final HttpClient httpClient, @Nullable final String location) {
+    public WaterAlertWebClient(final HttpClient httpClient, final String location) throws Exception {
         this.httpClient = httpClient;
 
-        if (location != null) {
-            final String[] locationSegmented = location.split(":", 3);
-            webService = locationSegmented[0];
-            region = locationSegmented[1];
-            area = locationSegmented[2];
+        final String[] locationSegmented = location.split(":", 3);
+        webService = locationSegmented[0];
+        region = locationSegmented[1];
+        area = locationSegmented[2];
 
-            for (final WaterWebService srv : WATER_WEB_SERVICES) {
-                logger.trace("Checking service {}", srv.service());
-                if (locationSegmented[0].equalsIgnoreCase(srv.service())) {
-                    logger.trace("Found service {}", srv.service());
-                    service = srv;
-                }
+        for (final WaterWebService srv : WATER_WEB_SERVICES) {
+            logger.trace("Checking service {}", srv.service());
+            if (locationSegmented[0].equalsIgnoreCase(srv.service())) {
+                logger.trace("Found service {}", srv.service());
+                service = srv;
             }
+        }
 
-            if (service == null) {
-                logger.debug("Service could not be found for {}", locationSegmented[0]);
-            }
-        } else {
-            throw new NullArgumentException("The location is empty.");
+        if (service == null) {
+            logger.debug("Service could not be found for {}", locationSegmented[0]);
         }
     }
 

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -33,14 +33,14 @@ import java.util.concurrent.TimeoutException;
 public class WaterAlertWebClient {
     private final Logger logger = LoggerFactory.getLogger(WaterAlertWebClient.class);
 
-    private @Nullable HttpClient httpClient = null;
-    private @Nullable WaterWebService service = null;
-
+    private final HttpClient httpClient;
     private final String webService;
     private final String region;
     private final String area;
 
-    public WaterAlertWebClient(final HttpClient httpClient, final String location) {
+    private @Nullable WaterWebService service = null;
+
+    public WaterAlertWebClient(final HttpClient httpClient, @Nullable final String location) {
         this.httpClient = httpClient;
 
         final String[] locationSegmented = location.split(":", 3);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterAlertWebClient.java
@@ -35,20 +35,20 @@ public class WaterAlertWebClient {
 
     private @Nullable HttpClient httpClient = null;
     private @Nullable WaterWebService service = null;
-    
-    private String webService = "";
-    private String region = "";
-    private String area = "";
 
-    public WaterAlertWebClient(HttpClient httpClient, String location) {
+    private final String webService;
+    private final String region;
+    private final String area;
+
+    public WaterAlertWebClient(final HttpClient httpClient, final String location) {
         this.httpClient = httpClient;
 
-        String[] locationSegmented = location.split(":", 3);
+        final String[] locationSegmented = location.split(":", 3);
         webService = locationSegmented[0];
         region = locationSegmented[1];
         area = locationSegmented[2];
 
-        for (WaterWebService srv : WATER_WEB_SERVICES) {
+        for (final WaterWebService srv : WATER_WEB_SERVICES) {
             logger.trace("Checking service {}", srv.service());
             if (locationSegmented[0].equalsIgnoreCase(srv.service())) {
                 logger.trace("Found service {}", srv.service());
@@ -65,13 +65,12 @@ public class WaterAlertWebClient {
         ContentResponse response;
         try {
             if (service != null) {
-                logger.debug("Getting Water Level from service {} region {} area {}", webService,
-                region, area);
-                String endpoint = service.endpoint(region);
+                logger.debug("Getting Water Level from service {} region {} area {}", webService, region, area);
+                final String endpoint = service.endpoint(region);
                 logger.trace("Getting data from endpoint {}", endpoint);
                 response = httpClient.GET(endpoint);
 
-                int waterLevel = service.findWaterLevel(response.getContentAsString(), area);
+                final int waterLevel = service.findWaterLevel(response.getContentAsString(), area);
                 logger.debug("Got water level {}", waterLevel);
                 return waterLevel;
             } else {

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
@@ -15,13 +15,16 @@ package org.openhab.binding.nzwateralerts.internal.api;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link WebService} class contains the common interfaces for the different services.
+ * The {@link WebService} class contains the common interfaces for the different
+ * services.
  *
  * @author Stewart Cossey - Initial contribution
  */
 @NonNullByDefault
 public interface WaterWebService {
     String service();
+
     String endpoint(String region);
+
     int findWaterLevel(String data, String area);
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/api/WaterWebService.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.api;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link WebService} class contains the common interfaces for the different services.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public interface WaterWebService {
+    String service();
+    String endpoint(String region);
+    int findWaterLevel(String data, String area);
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.binder;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.openhab.binding.nzwateralerts.internal.NZWaterAlertsConfiguration;
+import org.openhab.binding.nzwateralerts.internal.api.WaterAlertWebClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link NZWaterAlertsController} is responsible for handling the connection
+ * between the handler and API.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class NZWaterAlertsBinder {
+    private @Nullable WaterAlertWebClient webClient;
+
+    private final Logger logger = LoggerFactory.getLogger(NZWaterAlertsBinder.class);
+
+    private final Set<NZWaterAlertsBinderListener> listeners = new CopyOnWriteArraySet<>();
+    private @Nullable ScheduledFuture<?> future;
+    private @Nullable ScheduledExecutorService scheduler;
+
+    private int refreshInterval = 5;
+
+    public NZWaterAlertsBinder(@Nullable HttpClient httpClient, @Nullable NZWaterAlertsConfiguration config, @Nullable
+            ScheduledExecutorService scheduler) {
+        if (httpClient != null && config != null && scheduler != null) {
+            this.webClient = new WaterAlertWebClient(httpClient, config.location);
+            this.scheduler = scheduler;
+            refreshInterval = config.refreshInterval;
+        } else {
+            for (NZWaterAlertsBinderListener listener : listeners) {
+                listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Could not create webClient, a parameter is null");
+            }
+            logger.debug("Create Binder failed due to null item; httpClient {} config {} scheduler {}", httpClient != null, config != null, scheduler != null);
+        }
+    }
+
+    public void update() {
+        if (webClient != null) {
+            Integer waterLevel = webClient.getLevel();
+
+            for (NZWaterAlertsBinderListener listener : listeners) {
+                if (waterLevel == null) {
+                    listener.updateBindingStatus(ThingStatus.OFFLINE);
+                } else {
+                    listener.updateBindingStatus(ThingStatus.ONLINE);
+                    listener.updateWaterLevel(waterLevel);
+                }
+            }
+        }
+    }
+
+    /**
+     * Registers the given {@link NZWaterAlertsBinderListener}. If it is already
+     * registered, this method returns immediately.
+     *
+     * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
+     *                              registered.
+     */
+    public void registerListener(NZWaterAlertsBinderListener alertsBinderInterface) {
+        final boolean isAdded = listeners.add(alertsBinderInterface);
+        if (isAdded) {
+            updatePollingState();
+        }
+    }
+
+    /**
+     * Unregisters the given {@link NZWaterAlertsBinderListener}. If it is already
+     * unregistered, this method returns immediately.
+     *
+     * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
+     *                              unregistered.
+     */
+    public void unregisterListener(NZWaterAlertsBinderListener alertsBinderInterface) {
+        final boolean isRemoved = listeners.remove(alertsBinderInterface);
+        if (isRemoved) {
+            updatePollingState();
+        }
+    }
+
+    private void updatePollingState() {
+        boolean isPolling = future != null;
+        if (isPolling && listeners.isEmpty()) {
+            if (future != null)
+            future.cancel(true);
+            future = null;
+            return;
+        }
+
+        if (!isPolling && !listeners.isEmpty()) {
+            future = scheduler.scheduleWithFixedDelay(() -> {
+                update();
+            }, 0, refreshInterval, TimeUnit.HOURS);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -60,18 +60,20 @@ public class NZWaterAlertsBinder {
                 refreshInterval = config.refreshInterval;
             }
         } else {
-            for (NZWaterAlertsBinderListener listener : listeners) {
-                listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Could not create webClient, a parameter is null");
+            for (final NZWaterAlertsBinderListener listener : listeners) {
+                listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Could not create webClient, a parameter is null");
             }
-            logger.debug("Create Binder failed due to null item; httpClient {} config {} scheduler {}", httpClient != null, config != null, scheduler != null);
+            logger.debug("Create Binder failed due to null item; httpClient {} config {} scheduler {}",
+                    httpClient != null, config != null, scheduler != null);
         }
     }
 
     public void update() {
         if (webClient != null) {
-            Integer waterLevel = webClient.getLevel();
+            final Integer waterLevel = webClient.getLevel();
 
-            for (NZWaterAlertsBinderListener listener : listeners) {
+            for (final NZWaterAlertsBinderListener listener : listeners) {
                 if (waterLevel == null) {
                     listener.updateBindingStatus(ThingStatus.OFFLINE);
                 } else {
@@ -89,7 +91,7 @@ public class NZWaterAlertsBinder {
      * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
      *                              registered.
      */
-    public void registerListener(NZWaterAlertsBinderListener alertsBinderInterface) {
+    public void registerListener(final NZWaterAlertsBinderListener alertsBinderInterface) {
         final boolean isAdded = listeners.add(alertsBinderInterface);
         if (isAdded) {
             updatePollingState();
@@ -103,7 +105,7 @@ public class NZWaterAlertsBinder {
      * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
      *                              unregistered.
      */
-    public void unregisterListener(NZWaterAlertsBinderListener alertsBinderInterface) {
+    public void unregisterListener(final NZWaterAlertsBinderListener alertsBinderInterface) {
         final boolean isRemoved = listeners.remove(alertsBinderInterface);
         if (isRemoved) {
             updatePollingState();
@@ -111,7 +113,7 @@ public class NZWaterAlertsBinder {
     }
 
     private void updatePollingState() {
-        boolean isPolling = future != null;
+        final boolean isPolling = future != null;
         if (isPolling && listeners.isEmpty()) {
             if (future != null)
             future.cancel(true);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -58,15 +58,8 @@ public class NZWaterAlertsBinder {
                             "Location is not set.");
                 }
             } else {
-                try {
-                    this.webClient = new WaterAlertWebClient(httpClient, localLocation);
-                    refreshInterval = config.refreshInterval;
-                } catch (Exception ex) {
-                    for (final NZWaterAlertsBinderListener listener : listeners) {
-                        listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                                "Location is not valid.");
-                    }
-                }
+                this.webClient = new WaterAlertWebClient(httpClient, localLocation);
+                refreshInterval = config.refreshInterval;
             }
         } else {
             for (final NZWaterAlertsBinderListener listener : listeners) {

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -51,14 +51,22 @@ public class NZWaterAlertsBinder {
         this.scheduler = scheduler;
 
         if (config != null) {
-            if (config.location == null) {
+            final String localLocation = config.location;
+            if (localLocation == null) {
                 for (final NZWaterAlertsBinderListener listener : listeners) {
                     listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                             "Location is not set.");
                 }
             } else {
-                this.webClient = new WaterAlertWebClient(httpClient, config.location);
-                refreshInterval = config.refreshInterval;
+                try {
+                    this.webClient = new WaterAlertWebClient(httpClient, localLocation);
+                    refreshInterval = config.refreshInterval;
+                } catch (Exception ex) {
+                    for (final NZWaterAlertsBinderListener listener : listeners) {
+                        listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                                "Location is not valid.");
+                    }
+                }
             }
         } else {
             for (final NZWaterAlertsBinderListener listener : listeners) {

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -89,7 +89,7 @@ public class NZWaterAlertsBinder {
      * registered, this method returns immediately.
      *
      * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
-     *                              registered.
+     *            registered.
      */
     public void registerListener(final NZWaterAlertsBinderListener alertsBinderInterface) {
         final boolean isAdded = listeners.add(alertsBinderInterface);
@@ -103,7 +103,7 @@ public class NZWaterAlertsBinder {
      * unregistered, this method returns immediately.
      *
      * @param alertsBinderInterface The {@link NZWaterAlertsBinderListener} to be
-     *                              unregistered.
+     *            unregistered.
      */
     public void unregisterListener(final NZWaterAlertsBinderListener alertsBinderInterface) {
         final boolean isRemoved = listeners.remove(alertsBinderInterface);
@@ -116,7 +116,7 @@ public class NZWaterAlertsBinder {
         final boolean isPolling = future != null;
         if (isPolling && listeners.isEmpty()) {
             if (future != null)
-            future.cancel(true);
+                future.cancel(true);
             future = null;
             return;
         }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -48,10 +48,17 @@ public class NZWaterAlertsBinder {
 
     public NZWaterAlertsBinder(@Nullable HttpClient httpClient, @Nullable NZWaterAlertsConfiguration config, @Nullable
             ScheduledExecutorService scheduler) {
+
         if (httpClient != null && config != null && scheduler != null) {
-            this.webClient = new WaterAlertWebClient(httpClient, config.location);
-            this.scheduler = scheduler;
-            refreshInterval = config.refreshInterval;
+            if (config.location == null) {
+                for (NZWaterAlertsBinderListener listener : listeners) {
+                    listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Location is not set.");
+                }
+            } else {
+                this.webClient = new WaterAlertWebClient(httpClient, config.location);
+                this.scheduler = scheduler;
+                refreshInterval = config.refreshInterval;
+            }
         } else {
             for (NZWaterAlertsBinderListener listener : listeners) {
                 listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Could not create webClient, a parameter is null");

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinder.java
@@ -46,13 +46,13 @@ public class NZWaterAlertsBinder {
 
     private int refreshInterval = 5;
 
-    public NZWaterAlertsBinder(@Nullable HttpClient httpClient, @Nullable NZWaterAlertsConfiguration config, @Nullable
-            ScheduledExecutorService scheduler) {
-
+    public NZWaterAlertsBinder(final HttpClient httpClient, @Nullable final NZWaterAlertsConfiguration config,
+            @Nullable final ScheduledExecutorService scheduler) {
         if (httpClient != null && config != null && scheduler != null) {
             if (config.location == null) {
-                for (NZWaterAlertsBinderListener listener : listeners) {
-                    listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Location is not set.");
+                for (final NZWaterAlertsBinderListener listener : listeners) {
+                    listener.updateBindingStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                            "Location is not set.");
                 }
             } else {
                 this.webClient = new WaterAlertWebClient(httpClient, config.location);

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
@@ -23,9 +23,9 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
  */
 @NonNullByDefault
 public interface NZWaterAlertsBinderListener {
-    public void updateWaterLevel(int level);
+    void updateWaterLevel(int level);
 
-    public void updateBindingStatus(ThingStatus thingStatus);
+    void updateBindingStatus(ThingStatus thingStatus);
 
-    public void updateBindingStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String description);
+    void updateBindingStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String description);
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.binder;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+
+/**
+ * The {@link NZWaterAlertsControllerListener} is responsible for handling the events from the WebClient and Handler.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public interface NZWaterAlertsBinderListener {
+    public void updateWaterLevel(int level);
+    public void updateBindingStatus(ThingStatus thingStatus);
+    public void updateBindingStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String description);
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/binder/NZWaterAlertsBinderListener.java
@@ -24,6 +24,8 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 @NonNullByDefault
 public interface NZWaterAlertsBinderListener {
     public void updateWaterLevel(int level);
+
     public void updateBindingStatus(ThingStatus thingStatus);
+
     public void updateBindingStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String description);
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -51,10 +51,11 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        final NZWaterAlertsBinder localBinder = binder;
         if (CHANNEL_ALERTLEVEL.equals(channelUID.getId())) {
             if (command instanceof RefreshType) {
-                if (binder != null)
-                    binder.update();
+                if (localBinder != null)
+                    localBinder.update();
             }
         }
     }
@@ -63,22 +64,26 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
     public void initialize() {
         config = getConfigAs(NZWaterAlertsConfiguration.class);
 
-        binder = new NZWaterAlertsBinder(httpClient, config, scheduler);
+        NZWaterAlertsBinder localBinder = binder = new NZWaterAlertsBinder(httpClient, config, scheduler);
 
         updateStatus(ThingStatus.UNKNOWN);
-        binder.registerListener(this);
+        localBinder.registerListener(this);
     }
 
     @Override
     public void dispose() {
-        binder.unregisterListener(this);
+        NZWaterAlertsBinder localBinder = binder;
+        if (localBinder != null)
+            localBinder.unregisterListener(this);
 
         super.dispose();
     }
 
     @Override
     public void handleRemoval() {
-        binder.unregisterListener(this);
+        NZWaterAlertsBinder localBinder = binder;
+        if (localBinder != null)
+            localBinder.unregisterListener(this);
 
         super.handleRemoval();
     }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -47,7 +47,6 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
         super(thing);
 
         this.httpClient = httpClient;
-        
     }
 
     @Override
@@ -55,7 +54,7 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
         if (CHANNEL_ALERTLEVEL.equals(channelUID.getId())) {
             if (command instanceof RefreshType) {
                 if (binder != null)
-                binder.update();
+                    binder.update();
             }
         }
     }
@@ -68,7 +67,6 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
 
         updateStatus(ThingStatus.UNKNOWN);
         binder.registerListener(this);
-
     }
 
     @Override

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.handler;
+
+import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.nzwateralerts.internal.NZWaterAlertsConfiguration;
+import org.openhab.binding.nzwateralerts.internal.binder.NZWaterAlertsBinder;
+import org.openhab.binding.nzwateralerts.internal.binder.NZWaterAlertsBinderListener;
+
+/**
+ * The {@link NZWaterAlertsHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAlertsBinderListener {
+
+    private @Nullable NZWaterAlertsConfiguration config = null;
+    private @Nullable HttpClient httpClient = null;
+    private @Nullable NZWaterAlertsBinder binder = null;
+
+    public NZWaterAlertsHandler(Thing thing, @Nullable HttpClient httpClient) {
+        super(thing);
+
+        this.httpClient = httpClient;
+        
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (CHANNEL_ALERTLEVEL.equals(channelUID.getId())) {
+            if (command instanceof RefreshType) {
+                if (binder != null)
+                binder.update();
+            }
+        }
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(NZWaterAlertsConfiguration.class);
+
+        binder = new NZWaterAlertsBinder(httpClient, config, scheduler);
+
+        updateStatus(ThingStatus.UNKNOWN);
+        binder.registerListener(this);
+
+    }
+
+    @Override
+    public void dispose() {
+        binder.unregisterListener(this);
+
+        super.dispose();
+    }
+
+    @Override
+    public void handleRemoval() {
+        binder.unregisterListener(this);
+
+        super.handleRemoval();
+    }
+
+    @Override
+    public void updateWaterLevel(int level) {
+        if (level == -1) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_ALERTLEVEL), UnDefType.UNDEF);
+        } else {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_ALERTLEVEL), new DecimalType(level));
+        }
+    }
+
+    @Override
+    public void updateBindingStatus(ThingStatus thingStatus) {
+        updateStatus(thingStatus);
+    }
+
+    @Override
+    public void updateBindingStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String description) {
+        updateStatus(thingStatus, thingStatusDetail, description);
+    }
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -40,10 +40,10 @@ import org.openhab.binding.nzwateralerts.internal.binder.NZWaterAlertsBinderList
 public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAlertsBinderListener {
 
     private @Nullable NZWaterAlertsConfiguration config = null;
-    private @Nullable HttpClient httpClient = null;
+    private HttpClient httpClient;
     private @Nullable NZWaterAlertsBinder binder = null;
 
-    public NZWaterAlertsHandler(Thing thing, @Nullable HttpClient httpClient) {
+    public NZWaterAlertsHandler(Thing thing, HttpClient httpClient) {
         super(thing);
 
         this.httpClient = httpClient;

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandler.java
@@ -73,8 +73,9 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
     @Override
     public void dispose() {
         NZWaterAlertsBinder localBinder = binder;
-        if (localBinder != null)
+        if (localBinder != null) {
             localBinder.unregisterListener(this);
+        }
 
         super.dispose();
     }
@@ -82,8 +83,9 @@ public class NZWaterAlertsHandler extends BaseThingHandler implements NZWaterAle
     @Override
     public void handleRemoval() {
         NZWaterAlertsBinder localBinder = binder;
-        if (localBinder != null)
+        if (localBinder != null) {
             localBinder.unregisterListener(this);
+        }
 
         super.handleRemoval();
     }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
@@ -63,5 +63,4 @@ public class NZWaterAlertsHandlerFactory extends BaseThingHandlerFactory {
 
         return null;
     }
-
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.net.http.HttpClientFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -38,9 +39,14 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 @Component(configurationPid = "binding.nzwateralerts", service = ThingHandlerFactory.class)
 public class NZWaterAlertsHandlerFactory extends BaseThingHandlerFactory {
-    @Nullable HttpClient httpClient = null;
+    private final HttpClient httpClient;
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WATERALERT);
+
+    @Activate
+    public NZWaterAlertsHandlerFactory(final @Reference HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -58,12 +64,4 @@ public class NZWaterAlertsHandlerFactory extends BaseThingHandlerFactory {
         return null;
     }
 
-    @Reference
-    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.getCommonHttpClient();
-    }
-
-    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
-        this.httpClient = null;
-    }
 }

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/java/org/openhab/binding/nzwateralerts/internal/handler/NZWaterAlertsHandlerFactory.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nzwateralerts.internal.handler;
+
+import static org.openhab.binding.nzwateralerts.internal.NZWaterAlertsBindingConstants.*;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.io.net.http.HttpClientFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link NZWaterAlertsHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Stewart Cossey - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.nzwateralerts", service = ThingHandlerFactory.class)
+public class NZWaterAlertsHandlerFactory extends BaseThingHandlerFactory {
+    @Nullable HttpClient httpClient = null;
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_WATERALERT);
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_WATERALERT.equals(thingTypeUID)) {
+            return new NZWaterAlertsHandler(thing, httpClient);
+        }
+
+        return null;
+    }
+
+    @Reference
+    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
+        this.httpClient = null;
+    }
+}

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="nzwateralerts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>NZ Water Alerts Binding</name>
+	<description>Water Alert Levels for New Zealand water supply.</description>
+	<author>Stewart Cossey</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -16,7 +16,6 @@
 			<parameter name="location" type="text" required="true">
 				<label>Location</label>
 				<description>The location to get the Water Alert level for.</description>
-				<required>true</required>
 				<limitToOptions>true</limitToOptions>
 				<options>
 					<option value="bewaterwise:whangarei:breambay">Bream Bay</option>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -45,7 +45,7 @@
 					<option value="bewaterwise:whangarei:whangarei">Whangarei</option>
 				</options>
 			</parameter>
-			<parameter name="refreshInterval" type="integer" required="true">
+			<parameter name="refreshInterval" type="integer" required="true" min="1" unit="h">
 				<label>Refresh Interval</label>
 				<default>5</default>
 				<description>The interval (in hours) to refresh the data.</description>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="nzwateralerts"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="wateralert">
+		<label>Alert</label>
+		<description>Water Alert Levels for New Zealand water supply.</description>
+
+		<channels>
+			<channel id="alertlevel" typeId="alertlevel" />
+		</channels>
+
+		<config-description>
+			<parameter name="location" type="text" required="true">
+				<label>Location</label>
+				<description>The location to get the Water Alert level for.</description>
+				<required>true</required>
+				<limitToOptions>true</limitToOptions>
+				<options>
+					<option value="bewaterwise:whangarei:breambay">Bream Bay</option>
+					<option value="bewaterwise:kaipara:dargavilleampbaylys">Dargaville &amp; Baylys</option>
+					<option value="bewaterwise:kaipara:glinksgully">Glinks Gully</option>
+					<option value="smartwater:hamilton:hamilton">Hamilton City</option>
+					<option value="bewaterwise:farnorth:kaikohengawha">Kaikohe / Ngawha</option>
+					<option value="bewaterwise:farnorth:kaitaia">Kaitaia</option>
+					<option value="bewaterwise:farnorth:kerikeriwaipapa">Kerikeri / Waipapa</option>
+					<option value="smartwater:waipa:kihikihi">Kihikihi</option>
+					<option value="bewaterwise:whangarei:mangapai">Mangapai</option>
+					<option value="bewaterwise:kaipara:mangawhai">Mangawhai</option>
+					<option value="bewaterwise:whangarei:maungakaramea">Maungakaramea</option>
+					<option value="bewaterwise:kaipara:maungaturoto">Maungaturoto</option>
+					<option value="bewaterwise:farnorth:moerewakawakawa">Moerewa / Kawakawa</option>
+					<option value="napiercitycouncil:napier:napier">Napier</option>
+					<option value="bewaterwise:farnorth:okaihau">Okaihau</option>
+					<option value="bewaterwise:farnorth:opononiomapere">Opononi / Omapere</option>
+					<option value="smartwater:waipa:pukerimu">Pukerimu</option>
+					<option value="bewaterwise:farnorth:rawene">Rawene</option>
+					<option value="bewaterwise:kaipara:ruawai">Ruawai</option>
+					<option value="bewaterwise:farnorth:russell">Russell</option>
+					<option value="smartwater:waipa:waipa">Waipa District</option>
+					<option value="smartwater:waikato:waikato">Waikato District</option>
+					<option value="bewaterwise:farnorth:waitangipaihiaopua">Waitangi / Paihia / Opua</option>
+					<option value="bewaterwise:whangarei:whangarei">Whangarei</option>
+				</options>
+			</parameter>
+			<parameter name="refreshInterval" type="integer" required="true">
+				<label>Refresh Interval</label>
+				<default>5</default>
+				<description>The interval (in hours) to refresh the data.</description>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<channel-type id="alertlevel">
+		<item-type>Number</item-type>
+		<label>Alert Level</label>
+		<description>The alert level for the location.</description>
+		<state readOnly="true"></state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nzwateralerts/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -9,7 +9,7 @@
 		<description>Water Alert Levels for New Zealand water supply.</description>
 
 		<channels>
-			<channel id="alertlevel" typeId="alertlevel" />
+			<channel id="alertlevel" typeId="alertlevel"/>
 		</channels>
 
 		<config-description>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -192,6 +192,7 @@
     <module>org.openhab.binding.ntp</module>
     <module>org.openhab.binding.nuki</module>
     <module>org.openhab.binding.nuvo</module>
+    <module>org.openhab.binding.nzwateralerts</module>
     <module>org.openhab.binding.oceanic</module>
     <module>org.openhab.binding.ojelectronics</module>
     <module>org.openhab.binding.omnikinverter</module>


### PR DESCRIPTION
New Zealand Water Alerts Binding

__*New Pull Request due to the original being open for 693 commits and unable to rebase.*__

This is a new binding which gives the Water Alert Level in some regions in New Zealand.

There is only a single channel which returns the water alert level, a range of `0-4` or `1-4` depending on region. This is intended to be used with automated sprinkler systems in openHAB as restriction levels usually dictate the days where you are allowed to use sprinklers, if at all.

Works by page scraping associated regional council websites. Unfortunately cannot use a Web API as none exists. 