### PR TITLE
[Robonect] Use global openHAB timezone for DateTime objects

### DIFF
--- a/bundles/org.openhab.binding.robonect/README.md
+++ b/bundles/org.openhab.binding.robonect/README.md
@@ -35,6 +35,7 @@ following configuration settings are supported for the `mower` thing.
 | offlineTimeout | no        | the maximum time, the mower can be offline before the binding triggers the offlineTrigger channel |
 | user           | no        | the username if authentication is enabled in the firmware.                                        |
 | password       | no        | the password if authenticaiton is enabled in the firmware.                                        |
+| timezone       | no        | the timezone as configured in Robonect on the robot (default: Europe/Berlin)                      |
 
 
 An example things configuration might look like

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectHandlerFactory.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/RobonectHandlerFactory.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.i18n.TimeZoneProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
@@ -25,6 +26,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.io.net.http.HttpClientFactory;
 import org.openhab.binding.robonect.internal.handler.RobonectHandler;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -40,6 +42,14 @@ public class RobonectHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_AUTOMOWER);
 
     private HttpClient httpClient;
+    private TimeZoneProvider timeZoneProvider;
+
+    @Activate
+    public RobonectHandlerFactory(@Reference HttpClientFactory httpClientFactory,
+            @Reference TimeZoneProvider timeZoneProvider) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.timeZoneProvider = timeZoneProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -51,18 +61,9 @@ public class RobonectHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_AUTOMOWER)) {
-            return new RobonectHandler(thing, httpClient);
+            return new RobonectHandler(thing, httpClient, timeZoneProvider);
         }
 
         return null;
-    }
-
-    @Reference
-    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
-        this.httpClient = httpClientFactory.getCommonHttpClient();
-    }
-
-    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
-        this.httpClient = null;
     }
 }

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/config/RobonectConfig.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/config/RobonectConfig.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.robonect.internal.config;
 
 /**
- * 
+ *
  * This class acts simply a structure for holding the thing configuration.
- * 
+ *
  * @author Marco Meyer - Initial contribution
  */
 public class RobonectConfig {
@@ -29,6 +29,8 @@ public class RobonectConfig {
     private int pollInterval;
 
     private int offlineTimeout;
+
+    private String timezone;
 
     public String getHost() {
         return host;
@@ -48,5 +50,9 @@ public class RobonectConfig {
 
     public int getOfflineTimeout() {
         return offlineTimeout;
+    }
+
+    public String getTimezone() {
+        return timezone;
     }
 }

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -350,8 +350,9 @@ public class RobonectHandler extends BaseThingHandler {
         try {
             timeZone = ZoneId.of(timeZoneString);
         } catch (DateTimeException e) {
-            logger.warn("Error setting time zone '{}', falling back to the default 'Europe/Berlin' time zone:",
-                    timeZoneString, e);
+            logger.warn("Error setting timezone '{}', falling back to the default timezone configured in openHAB: '{}'",
+                    timeZoneString, timeZoneProvider.getTimeZone(), e);
+            timeZone = timeZoneProvider.getTimeZone();
         }
 
         try {

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -348,7 +348,13 @@ public class RobonectHandler extends BaseThingHandler {
 
         String timeZoneString = robonectConfig.getTimezone();
         try {
-            timeZone = ZoneId.of(timeZoneString);
+            if (timeZoneString != null) {
+                timeZone = ZoneId.of(timeZoneString);
+            } else {
+                logger.warn("No timezone provided, falling back to the default timezone configured in openHAB: '{}'",
+                        timeZoneProvider.getTimeZone());
+                timeZone = timeZoneProvider.getTimeZone();
+            }
         } catch (DateTimeException e) {
             logger.warn("Error setting timezone '{}', falling back to the default timezone configured in openHAB: '{}'",
                     timeZoneString, timeZoneProvider.getTimeZone(), e);

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -76,7 +76,7 @@ public class RobonectHandler extends BaseThingHandler {
     private HttpClient httpClient;
     private TimeZoneProvider timeZoneProvider;
 
-    private ZoneId timeZone = ZoneId.of("Europe/Berlin");
+    private ZoneId timeZone;
 
     private RobonectClient robonectClient;
 
@@ -289,7 +289,11 @@ public class RobonectHandler extends BaseThingHandler {
         // provide correct results.
         Instant rawInstant = Instant.ofEpochMilli(Long.valueOf(unixTimeSec) * 1000);
 
-        ZoneOffset offsetToConfiguredZone = timeZone.getRules().getOffset(rawInstant);
+        ZoneId timeZoneOfThing = timeZone;
+        if (timeZoneOfThing == null) {
+            timeZoneOfThing = timeZoneProvider.getTimeZone();
+        }
+        ZoneOffset offsetToConfiguredZone = timeZoneOfThing.getRules().getOffset(rawInstant);
         long adjustedTime = rawInstant.getEpochSecond() - offsetToConfiguredZone.getTotalSeconds();
         Instant adjustedInstant = Instant.ofEpochMilli(adjustedTime * 1000);
 
@@ -353,12 +357,10 @@ public class RobonectHandler extends BaseThingHandler {
             } else {
                 logger.warn("No timezone provided, falling back to the default timezone configured in openHAB: '{}'",
                         timeZoneProvider.getTimeZone());
-                timeZone = timeZoneProvider.getTimeZone();
             }
         } catch (DateTimeException e) {
             logger.warn("Error setting timezone '{}', falling back to the default timezone configured in openHAB: '{}'",
                     timeZoneString, timeZoneProvider.getTimeZone(), e);
-            timeZone = timeZoneProvider.getTimeZone();
         }
 
         try {

--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -15,7 +15,6 @@ package org.openhab.binding.robonect.internal.handler;
 import static org.openhab.binding.robonect.internal.RobonectBindingConstants.*;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.i18n.TimeZoneProvider;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -71,12 +71,14 @@ public class RobonectHandler extends BaseThingHandler {
     private ScheduledFuture<?> pollingJob;
 
     private HttpClient httpClient;
+    private TimeZoneProvider timeZoneProvider;
 
     private RobonectClient robonectClient;
 
-    public RobonectHandler(Thing thing, HttpClient httpClient) {
+    public RobonectHandler(Thing thing, HttpClient httpClient, TimeZoneProvider timeZoneProvider) {
         super(thing);
         this.httpClient = httpClient;
+        this.timeZoneProvider = timeZoneProvider;
     }
 
     @Override
@@ -278,7 +280,7 @@ public class RobonectHandler extends BaseThingHandler {
 
     private State convertUnixToDateTimeType(String unixTimeSec) {
         Instant ns = Instant.ofEpochMilli(Long.valueOf(unixTimeSec) * 1000);
-        ZonedDateTime zdt = ZonedDateTime.ofInstant(ns, ZoneId.of("UTC"));
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(ns, timeZoneProvider.getTimeZone());
         return new DateTimeType(zdt);
     }
 

--- a/bundles/org.openhab.binding.robonect/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.robonect/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -80,6 +80,11 @@
 				<description>The maximum time the mower may be offline before the offline trigger is triggered.
 				</description>
 			</parameter>
+			<parameter name="timezone" type="text" required="false">
+				<label>Timezone</label>
+				<default>Europe/Berlin</default>
+				<description>The timezone configured on the robot (e.g. Europe/Berlin).</description>
+			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
@@ -82,7 +82,7 @@ public class RobonectHandlerTest {
         subject.setCallback(callbackMock);
         subject.setRobonectClient(robonectClientMock);
 
-        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("UTC"));
+        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("Europe/Berlin"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
@@ -12,16 +12,15 @@
  */
 package org.openhab.binding.robonect.internal.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
+import java.time.ZoneId;
 import java.util.Calendar;
 
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.i18n.TimeZoneProvider;
 import org.eclipse.smarthome.core.library.types.DateTimeType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -38,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.openhab.binding.robonect.internal.RobonectBindingConstants;
 import org.openhab.binding.robonect.internal.RobonectClient;
@@ -53,7 +53,7 @@ import org.openhab.binding.robonect.internal.model.Wlan;
 
 /**
  * The goal of this class is to test RobonectHandler in isolation.
- * 
+ *
  * @author Marco Meyer - Initial contribution
  */
 public class RobonectHandlerTest {
@@ -72,12 +72,17 @@ public class RobonectHandlerTest {
     @Mock
     private HttpClient httpClientMock;
 
+    @Mock
+    private TimeZoneProvider timezoneProvider;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        subject = new RobonectHandler(robonectThingMock, httpClientMock);
+        subject = new RobonectHandler(robonectThingMock, httpClientMock, timezoneProvider);
         subject.setCallback(callbackMock);
         subject.setRobonectClient(robonectClientMock);
+
+        Mockito.when(timezoneProvider.getTimeZone()).thenReturn(ZoneId.of("UTC"));
     }
 
     @Test


### PR DESCRIPTION
Use the timezone that has been configured by the user in openHAB settings
for all robonect messages instead of UTC.

Fixes #7848

Signed-off-by: Stefan Triller <github@stefantriller.de>