### PR TITLE
[amazonechocontrol] fix memory/thread leak and failing connection

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/WebSocketConnection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/WebSocketConnection.java
@@ -33,8 +33,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.UpgradeRequest;
-import org.eclipse.jetty.websocket.api.UpgradeResponse;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -42,7 +40,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.eclipse.jetty.websocket.client.io.UpgradeListener;
 import org.openhab.binding.amazonechocontrol.internal.jsons.JsonPushCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,8 +116,7 @@ public class WebSocketConnection {
 
             initPongTimeoutTimer();
 
-            sessionFuture = webSocketClient.connect(amazonEchoControlWebSocket, uri, request,
-                    amazonEchoControlWebSocket);
+            sessionFuture = webSocketClient.connect(amazonEchoControlWebSocket, uri, request);
         } catch (URISyntaxException e) {
             logger.debug("Initialize web socket failed", e);
         }


### PR DESCRIPTION
Fixes #7910 

This fixes the memory/thread leak resulting from incorrect shutdown handling. Because of the high re-connect rate of 60s this resulted in an OOM after some time. 

The requests failed because some headers were added twice which caused the server to discard the message.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>