### PR TITLE
[homekit] fix 100% brightness for dimmer

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitOHItemProxy.java
@@ -85,6 +85,7 @@ public class HomekitOHItemProxy {
         final PercentType brightness = (PercentType) commandCache.remove(BRIGHTNESS_COMMAND);
         final DecimalType hue = (DecimalType) commandCache.remove(HUE_COMMAND);
         final PercentType saturation = (PercentType) commandCache.remove(SATURATION_COMMAND);
+        final @Nullable OnOffType currentOnState = ((DimmerItem) item).getStateAs(OnOffType.class);
         if (on != null) {
             // always sends OFF.
             // sends ON only if
@@ -93,7 +94,7 @@ public class HomekitOHItemProxy {
             // - DIMMER_MODE_FILTER_ON_EXCEPT100 is not enabled and brightness is null or below 100
             if ((on == OnOffType.OFF) || (dimmerMode == DIMMER_MODE_NORMAL)
                     || (dimmerMode == DIMMER_MODE_FILTER_BRIGHTNESS_100)
-                    || ((dimmerMode == DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100)
+                    || ((dimmerMode == DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100) && (currentOnState != OnOffType.ON)
                             && ((brightness == null) || (brightness.intValue() == 100)))) {
                 logger.trace("send OnOff command for item {} with value {}", item, on);
                 ((DimmerItem) item).send(on);
@@ -119,7 +120,7 @@ public class HomekitOHItemProxy {
             // - other modes (DIMMER_MODE_FILTER_BRIGHTNESS_100 or DIMMER_MODE_FILTER_ON_EXCEPT_BRIGHTNESS_100) and
             // <100%.
             if ((dimmerMode == DIMMER_MODE_NORMAL) || (dimmerMode == DIMMER_MODE_FILTER_ON)
-                    || (brightness.intValue() < 100)) {
+                    || (brightness.intValue() < 100) || (currentOnState == OnOffType.ON)) {
                 logger.trace("send Brightness command for item {} with value {}", item, brightness);
                 ((DimmerItem) item).send(brightness);
             }


### PR DESCRIPTION
### small fix for dimmer logic

with PR https://github.com/openhab/openhab-addons/pull/7825 a new logic for dimmer handling was introduced. 
the new logic suppress either ON state or brightness update depending on the dimmer state and selected dimmer mode. e.g. do not sends "brightness=100%" update on "ON" event. this helps to handle different dimmers behaviours, e.g. soft launch

however, it is not possible anymore to increase brightness to 100%. see https://community.openhab.org/t/homekit-homekit-sending-on-and-100-command/99485/28?u=yfre

This PR adapt logic as follow:
the rule 
`IF  "target state=ON" AND "target brightness=100" THEN do not update brightness
`
is changed to
`IF  "target state=ON" AND "target brightness=100" AND "current state = OFF" THEN do not update brightness
`

this means, if dimmer is already ON then it is possible to set brightness to 100%




Signed-off-by: Eugen Freiter <freiter@gmx.de>
