### PR TITLE
[homekit] fix corrupt storage 

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/Homekit.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/Homekit.java
@@ -48,4 +48,9 @@ public interface Homekit {
      * returns list of HomeKit accessories registered at bridge.
      */
     List<HomekitAccessory> getAccessories();
+
+    /**
+     * clear all pairings with HomeKit clients
+     */
+    public void clearHomekitPairings();
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/Debouncer.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/Debouncer.java
@@ -84,6 +84,8 @@ class Debouncer {
         logger.trace("stop debouncer");
         if (feature != null) {
             feature.cancel(true);
+            calls.set(0);
+            pending.set(false);
         }
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import org.eclipse.smarthome.core.storage.Storage;
-import org.eclipse.smarthome.core.storage.StorageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +40,13 @@ public class HomekitAuthInfoImpl implements HomekitAuthInfo {
     private final byte[] privateKey;
     private final String pin;
 
-    public HomekitAuthInfoImpl(StorageService storageService, String pin) throws InvalidAlgorithmParameterException {
-        storage = storageService.getStorage("homekit");
-        initializeStorage();
+    public HomekitAuthInfoImpl(final Storage storage, final String pin) throws InvalidAlgorithmParameterException {
+        this.storage = storage;
         this.pin = pin;
-        mac = storage.get("mac");
-        salt = new BigInteger(storage.get("salt"));
-        privateKey = Base64.getDecoder().decode(storage.get("privateKey"));
+        initializeStorage();
+        mac = this.storage.get("mac");
+        salt = new BigInteger(this.storage.get("salt"));
+        privateKey = Base64.getDecoder().decode(this.storage.get("privateKey"));
     }
 
     @Override

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
@@ -18,6 +18,8 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,18 +37,15 @@ public class HomekitAuthInfoImpl implements HomekitAuthInfo {
     private final Logger logger = LoggerFactory.getLogger(HomekitAuthInfoImpl.class);
 
     private final Storage<String> storage;
-    private final String mac;
-    private final BigInteger salt;
-    private final byte[] privateKey;
+    private String mac;
+    private BigInteger salt;
+    private byte[] privateKey;
     private final String pin;
 
     public HomekitAuthInfoImpl(final Storage storage, final String pin) throws InvalidAlgorithmParameterException {
         this.storage = storage;
         this.pin = pin;
         initializeStorage();
-        mac = this.storage.get("mac");
-        salt = new BigInteger(this.storage.get("salt"));
-        privateKey = Base64.getDecoder().decode(this.storage.get("privateKey"));
     }
 
     @Override
@@ -76,7 +75,7 @@ public class HomekitAuthInfoImpl implements HomekitAuthInfo {
 
     @Override
     public byte[] getUserPublicKey(String username) {
-        String encodedKey = storage.get(createUserKey(username));
+        final String encodedKey = storage.get(createUserKey(username));
         if (encodedKey != null) {
             return Base64.getDecoder().decode(encodedKey);
         } else {
@@ -97,32 +96,39 @@ public class HomekitAuthInfoImpl implements HomekitAuthInfo {
 
     public void clear() {
         for (String key : new HashSet<>(storage.getKeys())) {
-            if (isUserKey("user_")) {
+            if (isUserKey(key)) {
                 storage.remove(key);
             }
         }
     }
 
-    private String createUserKey(String username) {
+    private String createUserKey(final String username) {
         return "user_" + username;
     }
 
-    private boolean isUserKey(String key) {
+    private boolean isUserKey(final String key) {
         return key.startsWith("user_");
     }
 
     private void initializeStorage() throws InvalidAlgorithmParameterException {
-        if (storage.get("mac") == null) {
+        mac = storage.get("mac");
+        salt = new BigInteger(storage.get("salt"));
+        privateKey = Base64.getDecoder().decode(storage.get("privateKey"));
+
+        if (mac == null) {
             logger.warn(
                     "Could not find existing MAC in {}. Generating new MAC. This will require re-pairing of iOS devices.",
                     storage.getClass().getName());
-            storage.put("mac", HomekitServer.generateMac());
+            mac = HomekitServer.generateMac();
+            storage.put("mac", mac);
         }
-        if (storage.get("salt") == null) {
-            storage.put("salt", HomekitServer.generateSalt().toString());
+        if (salt == null) {
+            salt = HomekitServer.generateSalt();
+            storage.put("salt", salt.toString());
         }
-        if (storage.get("privateKey") == null) {
-            storage.put("privateKey", Base64.getEncoder().encodeToString(HomekitServer.generateKey()));
+        if (privateKey == null) {
+            privateKey = HomekitServer.generateKey();
+            storage.put("privateKey", Base64.getEncoder().encodeToString(privateKey));
         }
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -149,8 +149,11 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
     }
 
     public void makeNewConfigurationRevision() {
-        storage.put(REVISION_CONFIG, "" + accessoryRegistry.makeNewConfigurationRevision());
+        final int newRevision = accessoryRegistry.makeNewConfigurationRevision();
         lastAccessoryCount = accessoryRegistry.getAllAccessories().size();
+        logger.trace("make new configuration revision. new revision number {}, number of accessories {}", newRevision,
+                lastAccessoryCount);
+        storage.put(REVISION_CONFIG, "" + newRevision);
         storage.put(ACCESSORY_COUNT, "" + lastAccessoryCount);
     }
 
@@ -189,6 +192,7 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
     }
 
     public synchronized void unsetBridge() {
+        applyUpdatesDebouncer.stop();
         accessoryRegistry.unsetBridge();
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.smarthome.core.storage.StorageService;
 import org.eclipse.smarthome.io.console.Console;
 import org.eclipse.smarthome.io.console.extensions.AbstractConsoleCommandExtension;
 import org.eclipse.smarthome.io.console.extensions.ConsoleCommandExtension;
@@ -43,7 +42,6 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
     private static final String LEGACY_SUBCMD_PRINT_ACCESSORY = "printAccessory";
 
     private final Logger logger = LoggerFactory.getLogger(HomekitCommandExtension.class);
-    private StorageService storageService;
     private Homekit homekit;
 
     public HomekitCommandExtension() {
@@ -108,15 +106,6 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
     }
 
     @Reference
-    public void setStorageService(StorageService storageService) {
-        this.storageService = storageService;
-    }
-
-    public void unsetStorageService(StorageService storageService) {
-        this.storageService = null;
-    }
-
-    @Reference
     public void setHomekit(Homekit homekit) {
         this.homekit = homekit;
     }
@@ -127,8 +116,7 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
 
     private void clearHomekitPairings(Console console) {
         try {
-            new HomekitAuthInfoImpl(storageService, null).clear();
-            homekit.refreshAuthInfo();
+            homekit.clearHomekitPairings();
             console.println("Cleared HomeKit pairings");
         } catch (Exception e) {
             logger.warn("Could not clear HomeKit pairings", e);

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitCommandExtension.java
@@ -115,12 +115,8 @@ public class HomekitCommandExtension extends AbstractConsoleCommandExtension {
     }
 
     private void clearHomekitPairings(Console console) {
-        try {
-            homekit.clearHomekitPairings();
-            console.println("Cleared HomeKit pairings");
-        } catch (Exception e) {
-            logger.warn("Could not clear HomeKit pairings", e);
-        }
+        homekit.clearHomekitPairings();
+        console.println("Cleared HomeKit pairings");
     }
 
     private void allowUnauthenticatedHomekitRequests(boolean allow, Console console) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -207,6 +207,7 @@ public class HomekitImpl implements Homekit {
         return new ArrayList<HomekitAccessory>(this.changeListener.getAccessories().values());
     }
 
+    @Override
     public void clearHomekitPairings() {
         try {
             if (authInfo != null) {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.items.MetadataRegistry;
 import org.eclipse.smarthome.core.net.NetworkAddressService;
+import org.eclipse.smarthome.core.storage.Storage;
 import org.eclipse.smarthome.core.storage.StorageService;
 import org.openhab.io.homekit.Homekit;
 import org.osgi.framework.Constants;
@@ -60,7 +61,7 @@ import io.github.hapjava.server.impl.HomekitServer;
 public class HomekitImpl implements Homekit {
 
     private final Logger logger = LoggerFactory.getLogger(HomekitImpl.class);
-    private final StorageService storageService;
+    private final Storage<String> storage;
     private final NetworkAddressService networkAddressService;
     private final HomekitChangeListener changeListener;
 
@@ -68,6 +69,7 @@ public class HomekitImpl implements Homekit {
     private @Nullable InetAddress networkInterface;
     private @Nullable HomekitServer homekitServer;
     private @Nullable HomekitRoot bridge;
+    private @Nullable HomekitAuthInfoImpl authInfo;
 
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
@@ -76,7 +78,7 @@ public class HomekitImpl implements Homekit {
     public HomekitImpl(@Reference StorageService storageService, @Reference ItemRegistry itemRegistry,
             @Reference NetworkAddressService networkAddressService, Map<String, Object> config,
             @Reference MetadataRegistry metadataRegistry) throws IOException, InvalidAlgorithmParameterException {
-        this.storageService = storageService;
+        this.storage = storageService.getStorage("homekit");
         this.networkAddressService = networkAddressService;
         this.settings = processConfig(config);
         this.changeListener = new HomekitChangeListener(itemRegistry, settings, metadataRegistry, storageService);
@@ -125,8 +127,9 @@ public class HomekitImpl implements Homekit {
     private void startBridge() throws InvalidAlgorithmParameterException, IOException {
         final HomekitServer homekitServer = this.homekitServer;
         if (homekitServer != null && bridge == null) {
-            final HomekitRoot bridge = homekitServer.createBridge(new HomekitAuthInfoImpl(storageService, settings.pin),
-                    settings.name, HomekitSettings.MANUFACTURER, HomekitSettings.MODEL, HomekitSettings.SERIAL_NUMBER,
+            authInfo = new HomekitAuthInfoImpl(storage, settings.pin);
+            final HomekitRoot bridge = homekitServer.createBridge(authInfo, settings.name, HomekitSettings.MANUFACTURER,
+                    HomekitSettings.MODEL, HomekitSettings.SERIAL_NUMBER,
                     FrameworkUtil.getBundle(getClass()).getVersion().toString(), HomekitSettings.HARDWARE_REVISION);
             changeListener.setBridge(bridge);
             this.bridge = bridge;
@@ -202,5 +205,16 @@ public class HomekitImpl implements Homekit {
     @Override
     public List<HomekitAccessory> getAccessories() {
         return new ArrayList<HomekitAccessory>(this.changeListener.getAccessories().values());
+    }
+
+    public void clearHomekitPairings() {
+        try {
+            if (authInfo != null) {
+                authInfo.clear();
+                refreshAuthInfo();
+            }
+        } catch (Exception e) {
+            logger.warn("Could not clear HomeKit pairings", e);
+        }
     }
 }


### PR DESCRIPTION
there are regular reports about "lost mac address" issue. 
https://community.openhab.org/t/homekit-could-not-find-existing-mac/100845/8
https://community.openhab.org/t/need-to-reset-homekit-pairing-at-every-launch/13542/32

sometimes the mac address disappears from homekit.json and one need to repair home clients with openhab. 

this issue is difficult to reproduce. there is no place in the source code where mac address gets removed from storage. there are only 2 places related to mac address: one is writing new mac to storage, another one is reading the mac from storage. 
so, must be something like race condition and inconsistent state of the storage object

this PR reduces number of class which have references to storage object. it also stops a runnable that could potential try to update storage at binding stop/shutdown event. 

changes:
- remove reference to storage object from HomekitCommandExtension, use a a call of HomekitImpl method instead
- stop Debouncer runnables on stop/shutdown event
- add some additional logging.

it is unclear whether it will fix the issue but imho it is at least an improvement of the storage handling and shutdown process 


Signed-off-by: Eugen Freiter <freiter@gmx.de>
