### PR TITLE
[innogysmarthome] Fix Battery Warnings (Bug 

### DIFF
--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/InnogyClient.java
@@ -446,8 +446,8 @@ public class InnogyClient {
         final List<Message> messageList = getMessages();
         final Map<String, List<Message>> deviceMessageMap = new HashMap<>();
         for (final Message m : messageList) {
-            if (m.getDeviceLinkList() != null && !m.getDeviceLinkList().isEmpty()) {
-                final String deviceId = m.getDeviceLinkList().get(0).replace("/device/", "");
+            if (m.getDevices() != null && !m.getDevices().isEmpty()) {
+                final String deviceId = m.getDevices().get(0).replace("/device/", "");
                 List<Message> ml;
                 if (deviceMessageMap.containsKey(deviceId)) {
                     ml = deviceMessageMap.get(deviceId);
@@ -544,8 +544,8 @@ public class InnogyClient {
 
         for (final Message m : messageList) {
             logger.trace("Message Type {} with ID {}", m.getType(), m.getId());
-            if (m.getDeviceLinkList() != null && !m.getDeviceLinkList().isEmpty()) {
-                for (final String li : m.getDeviceLinkList()) {
+            if (m.getDevices() != null && !m.getDevices().isEmpty()) {
+                for (final String li : m.getDevices()) {
                     if (deviceIdPath.equals(li)) {
                         ml.add(m);
                     }

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/message/Message.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/message/Message.java
@@ -103,7 +103,7 @@ public class Message {
      *
      * Optional.
      */
-    private List<String> deviceLinkList;
+    private List<String> devices;
 
     /**
      * Container for all parameters of the message. The parameters are contained in Property entities.
@@ -190,15 +190,15 @@ public class Message {
     /**
      * @return the deviceLinkList
      */
-    public List<String> getDeviceLinkList() {
-        return deviceLinkList;
+    public List<String> getDevices() {
+        return devices;
     }
 
     /**
      * @param deviceLinkList the deviceLinkList to set
      */
-    public void setDeviceLinkList(List<String> deviceLinkList) {
-        this.deviceLinkList = deviceLinkList;
+    public void setDevices(List<String> deviceLinkList) {
+        this.devices = deviceLinkList;
     }
 
     /**

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/message/Message.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/client/entity/message/Message.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.innogysmarthome.internal.client.entity.message;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
 /**
@@ -85,11 +87,13 @@ public class Message {
     /**
      * Defines whether the message has been viewed by a user.
      */
+    @SerializedName("read")
     private boolean isRead;
 
     /**
      * Defines whether it is an alert or a message, default is message.
      */
+    @SerializedName("class")
     private String messageClass;
     /**
      * Timestamp when the message was created.
@@ -188,17 +192,17 @@ public class Message {
     }
 
     /**
-     * @return the deviceLinkList
+     * @return the devices
      */
     public List<String> getDevices() {
         return devices;
     }
 
     /**
-     * @param deviceLinkList the deviceLinkList to set
+     * @param devices the devices to set
      */
-    public void setDevices(List<String> deviceLinkList) {
-        this.devices = deviceLinkList;
+    public void setDevices(List<String> devices) {
+        this.devices = devices;
     }
 
     /**
@@ -209,7 +213,7 @@ public class Message {
     }
 
     /**
-     * @param dataPropertyList the dataPropertyList to set
+     * @param properties the dataPropertyList to set
      */
     public void setProperties(MessageProperties properties) {
         this.properties = properties;

--- a/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/main/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandler.java
@@ -650,8 +650,8 @@ public class InnogyBridgeHandler extends BaseBridgeHandler
             logger.trace("Message: {}", gson.toJson(message));
             logger.trace("Messagetype: {}", message.getType());
         }
-        if (Message.TYPE_DEVICE_LOW_BATTERY.equals(message.getType()) && message.getDeviceLinkList() != null) {
-            for (final String link : message.getDeviceLinkList()) {
+        if (Message.TYPE_DEVICE_LOW_BATTERY.equals(message.getType()) && message.getDevices() != null) {
+            for (final String link : message.getDevices()) {
                 deviceStructMan.refreshDevice(Link.getId(link));
                 final Device device = deviceStructMan.getDeviceById(Link.getId(link));
                 if (device != null) {


### PR DESCRIPTION
This PR fixes low battery messages.
Closes: #6932 

Root cause: Json field "DeviceLinkList" of a "Message" is renamed (by Innogy) to "Devices". 