### PR TITLE
[homekit] add support for group switches

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitChangeListener.java
@@ -227,9 +227,9 @@ public class HomekitChangeListener implements ItemRegistryChangeListener {
         final List<Entry<HomekitAccessoryType, HomekitCharacteristicType>> accessoryTypes = HomekitAccessoryFactory
                 .getAccessoryTypes(item, metadataRegistry);
         final List<GroupItem> groups = HomekitAccessoryFactory.getAccessoryGroups(item, itemRegistry, metadataRegistry);
-        logger.trace("Item {} has groups {}", item.getName(), groups);
-        if (!accessoryTypes.isEmpty() && groups.isEmpty()) { // it has homekit accessory type and is not part of bigger
-                                                             // homekit group item
+        if (!accessoryTypes.isEmpty() && groups.stream().noneMatch(g -> g.getBaseItem() != null)) {
+            // it has homekit accessory type and is not part of bigger homekit group item without baseItem, i.e. not
+            // Group:Switch
             logger.trace("Item {} is a HomeKit accessory of types {}", item.getName(), accessoryTypes);
             final HomekitOHItemProxy itemProxy = new HomekitOHItemProxy(item);
             accessoryTypes.stream().forEach(rootAccessory -> createRootAccessory(new HomekitTaggedItem(itemProxy,

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -92,7 +92,8 @@ public class HomekitTaggedItem {
     }
 
     public boolean isGroup() {
-        return (isAccessory() && (proxyItem.getItem() instanceof GroupItem));
+        return (isAccessory() && (proxyItem.getItem() instanceof GroupItem)
+                && ((GroupItem) proxyItem.getItem()).getBaseItem() == null);
     }
 
     public HomekitAccessoryType getAccessoryType() {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -262,7 +262,7 @@ public class HomekitAccessoryFactory {
             MetadataRegistry metadataRegistry) {
         return item.getGroupNames().stream().flatMap(name -> {
             Item groupItem = itemRegistry.get(name);
-            if (groupItem instanceof GroupItem) {
+            if ((groupItem instanceof GroupItem) && ((GroupItem) groupItem).getBaseItem() == null) {
                 return Stream.of((GroupItem) groupItem);
             } else {
                 return Stream.empty();


### PR DESCRIPTION
as discussed here 
https://community.openhab.org/t/problems-with-homekit-switchable-feature-on-switch-groups/100702
and here
https://community.openhab.org/t/homekit-could-not-find-existing-mac/100845/26

current HomeKit binding does not support groups with a base item, eg.
```
Group:Switch:OR(ON,OFF) gLights "ALL Lights [%s]"	{homekit="Lighting"}
Switch Light_1 "Light 1 [%s]"  (gLights,) {homekit="Lighting"}
Switch Light_2 "Light 2 [%s]"  (gLights,) {homekit="Lighting"}
```
it would create only one accessory - for the group but not for light_1 and light_2. the logic is following: if an item is part of bigger group with homekit tag, then the item is a characteristic of this homekit accessory/group. 

this PR fix this issue by ignoring groups with base item.


Signed-off-by: Eugen Freiter <freiter@gmx.de>
