### PR TITLE
[astro] - Fix tiny markdown syntax with bullets at top

### DIFF
--- a/bundles/org.openhab.binding.astro/README.md
+++ b/bundles/org.openhab.binding.astro/README.md
@@ -1,6 +1,7 @@
 # Astro Binding
 
 The Astro binding is used for calculating 
+
     * many DateTime and positional values for sun and moon.
     * Radiation levels (direct, diffuse and total) of the sun during the day
 

--- a/bundles/org.openhab.binding.astro/README.md
+++ b/bundles/org.openhab.binding.astro/README.md
@@ -2,8 +2,8 @@
 
 The Astro binding is used for calculating 
 
-    * many DateTime and positional values for sun and moon.
-    * Radiation levels (direct, diffuse and total) of the sun during the day
+* many DateTime and positional values for sun and moon.
+* Radiation levels (direct, diffuse and total) of the sun during the day
 
 ## Supported Things
 


### PR DESCRIPTION
Noticed the first two bullets under "The Astro binding is used for calculating" were not rendering properly. Added crlf.

Doc fix - markdown renders properly.