### PR TITLE
[Deconz] add support for "last_seen" channel

### DIFF
--- a/bundles/org.openhab.binding.deconz/.classpath
+++ b/bundles/org.openhab.binding.deconz/.classpath
@@ -28,5 +28,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -110,6 +110,7 @@ The sensor devices support some of the following channels:
 |-----------------|--------------------------|:-----------:|-------------------------------------------------------------------------------------------|----------------------------------------------|
 | presence        | Switch                   |      R      | Status of presence: `ON` = presence; `OFF` = no-presence                                  | presencesensor                               |
 | last_updated    | DateTime                 |      R      | Timestamp when the sensor was last updated                                                | all, except daylightsensor                   |
+| last_seen       | DateTime                 |      R      | Timestamp when the sensor was last seen                                                   | all, except daylightsensor                   |
 | power           | Number:Power             |      R      | Current power usage in Watts                                                              | powersensor, sometimes for consumptionsensor |
 | consumption     | Number:Energy            |      R      | Current power usage in Watts/Hour                                                         | consumptionsensor                            |
 | voltage         | Number:ElectricPotential |      R      | Current voltage in V                                                                      | some powersensors                            |

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
@@ -64,6 +64,7 @@ public class BindingConstants {
     // List of all Channel ids
     public static final String CHANNEL_PRESENCE = "presence";
     public static final String CHANNEL_LAST_UPDATED = "last_updated";
+    public static final String CHANNEL_LAST_SEEN = "last_seen";
     public static final String CHANNEL_POWER = "power";
     public static final String CHANNEL_CONSUMPTION = "consumption";
     public static final String CHANNEL_VOLTAGE = "voltage";

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/DeconzBaseMessage.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/DeconzBaseMessage.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.deconz.internal.dto;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The REST interface and websocket connection are using the same fields.
@@ -36,6 +37,9 @@ public class DeconzBaseMessage {
 
     /** the API endpoint **/
     public String ep = "";
+
+    /** device last seen */
+    public @Nullable String lastseen;
 
     // websocket and rest api
     public String uniqueid = ""; // "00:0b:57:ff:fe:94:6b:dd-01-1000"

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBaseThingHandler.java
@@ -55,7 +55,8 @@ public abstract class DeconzBaseThingHandler<T extends DeconzBaseMessage> extend
     protected ThingConfig config = new ThingConfig();
     protected DeconzBridgeConfig bridgeConfig = new DeconzBridgeConfig();
     protected final Gson gson;
-    private @Nullable ScheduledFuture<?> scheduledFuture;
+    @Nullable
+    protected ScheduledFuture<?> scheduledFuture;
     protected @Nullable WebSocketConnection connection;
     protected @Nullable AsyncHttpClient http;
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorBaseThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorBaseThingHandler.java
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.measure.Unit;
 
@@ -78,6 +80,9 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler<Sens
      */
     private boolean ignoreConfigurationUpdate;
 
+    // Used to refresh the "last seen" status
+    private @Nullable ScheduledFuture<?> scheduledFuture;
+
     public SensorBaseThingHandler(Thing thing, Gson gson) {
         super(thing, gson);
     }
@@ -100,6 +105,9 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler<Sens
         WebSocketConnection conn = connection;
         if (conn != null) {
             conn.unregisterSensorListener(config.id);
+        }
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
         }
     }
 
@@ -156,6 +164,19 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler<Sens
         ignoreConfigurationUpdate = true;
         updateProperties(editProperties);
 
+        // "Last seen" is the last "ping" from the device, whereas "last update" is the last status changed.
+        // For example, for a fire sensor, the device pings regularly, without necessarily updating channels.
+        // So to monitor a sensor is still alive, the "last seen" is necessary.
+        if (stateResponse.lastseen != null) {
+            updateState(CHANNEL_LAST_SEEN,
+                    new DateTimeType(ZonedDateTime.ofInstant(
+                            LocalDateTime.parse(stateResponse.lastseen, DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                            ZoneOffset.UTC, ZoneId.systemDefault())));
+            // Because "last seen" is never updated by the WebSocket API - if this is supported, then we have to
+            // manually poll it time to time (every 5 minutes by default)
+            scheduledFuture = scheduler.scheduleAtFixedRate((Runnable) this::requestState, 5, 5, TimeUnit.MINUTES);
+        }
+
         // Some sensors support optional channels
         // (see https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices#sensors)
         // any battery-powered sensor
@@ -198,7 +219,7 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler<Sens
 
     /**
      * Update channel value from {@link SensorConfig} object - override to include further channels
-     * 
+     *
      * @param channelUID
      * @param newConfig
      */
@@ -222,7 +243,7 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler<Sens
 
     /**
      * Update channel value from {@link SensorState} object - override to include further channels
-     * 
+     *
      * @param channelID
      * @param newState
      * @param initializing

--- a/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
@@ -13,6 +13,7 @@
 		<channels>
 			<channel typeId="presence" id="presence"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>			
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -34,6 +35,14 @@
 		<category>Time</category>
 		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
 	</channel-type>
+	
+	<channel-type id="last_seen">
+        <item-type>DateTime</item-type>
+        <label>Last Seen</label>
+        <description>The date and time when the sensor was last seen.</description>
+        <category>Time</category>
+        <state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+    </channel-type>
 
 	<thing-type id="powersensor">
 		<supported-bridge-type-refs>
@@ -44,6 +53,7 @@
 		<channels>
 			<channel typeId="power" id="power"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -84,6 +94,7 @@
 		<channels>
 			<channel typeId="consumption" id="consumption"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -108,6 +119,7 @@
 			<channel typeId="buttonevent" id="buttonevent"/>
 			<channel typeId="button" id="button"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -168,6 +180,7 @@
 			<channel typeId="dark" id="dark"/>
 			<channel typeId="daylight" id="daylight"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -212,6 +225,7 @@
 		<channels>
 			<channel typeId="temperature" id="temperature"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -235,6 +249,7 @@
 		<channels>
 			<channel typeId="humidity" id="humidity"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -258,6 +273,7 @@
 		<channels>
 			<channel typeId="pressure" id="pressure"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -317,6 +333,7 @@
 		<channels>
 			<channel typeId="open" id="open"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -340,6 +357,7 @@
 		<channels>
 			<channel typeId="waterleakage" id="waterleakage"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -363,6 +381,7 @@
 		<channels>
 			<channel typeId="fire" id="fire"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -386,6 +405,7 @@
 		<channels>
 			<channel typeId="alarm" id="alarm"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -416,6 +436,7 @@
 		<channels>
 			<channel typeId="vibration" id="vibration"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -439,6 +460,7 @@
 		<channels>
 			<channel typeId="battery" id="battery_level"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -461,6 +483,7 @@
 		<channels>
 			<channel typeId="carbonmonoxide" id="carbonmonoxide"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -488,6 +511,7 @@
 			<channel typeId="offset" id="offset"/>
 			<channel typeId="valve" id="valve"/>
 			<channel typeId="last_updated" id="last_updated"/>
+            <channel typeId="last_seen" id="last_seen"/>
 		</channels>
 		<representation-property>uid</representation-property>
 		<config-description-ref uri="thing-type:deconz:sensor"/>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
@@ -38,11 +38,11 @@
 
 	<channel-type id="last_seen">
 		<item-type>DateTime</item-type>
-    <label>Last Seen</label>
-    <description>The date and time when the sensor was last seen.</description>
-    <category>Time</category>
-    <state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
-  </channel-type>
+		<label>Last Seen</label>
+		<description>The date and time when the sensor was last seen.</description>
+		<category>Time</category>
+		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+	</channel-type>
 
 	<thing-type id="powersensor">
 		<supported-bridge-type-refs>
@@ -53,7 +53,7 @@
 		<channels>
 			<channel typeId="power" id="power"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -94,7 +94,7 @@
 		<channels>
 			<channel typeId="consumption" id="consumption"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -119,7 +119,7 @@
 			<channel typeId="buttonevent" id="buttonevent"/>
 			<channel typeId="button" id="button"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/ESH-INF/thing/sensor-thing-types.xml
@@ -13,7 +13,7 @@
 		<channels>
 			<channel typeId="presence" id="presence"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>			
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -35,14 +35,14 @@
 		<category>Time</category>
 		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
 	</channel-type>
-	
+
 	<channel-type id="last_seen">
-        <item-type>DateTime</item-type>
-        <label>Last Seen</label>
-        <description>The date and time when the sensor was last seen.</description>
-        <category>Time</category>
-        <state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
-    </channel-type>
+		<item-type>DateTime</item-type>
+    <label>Last Seen</label>
+    <description>The date and time when the sensor was last seen.</description>
+    <category>Time</category>
+    <state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+  </channel-type>
 
 	<thing-type id="powersensor">
 		<supported-bridge-type-refs>
@@ -180,7 +180,7 @@
 			<channel typeId="dark" id="dark"/>
 			<channel typeId="daylight" id="daylight"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -225,7 +225,7 @@
 		<channels>
 			<channel typeId="temperature" id="temperature"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -249,7 +249,7 @@
 		<channels>
 			<channel typeId="humidity" id="humidity"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -273,7 +273,7 @@
 		<channels>
 			<channel typeId="pressure" id="pressure"></channel>
 			<channel typeId="last_updated" id="last_updated"></channel>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -333,7 +333,7 @@
 		<channels>
 			<channel typeId="open" id="open"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -357,7 +357,7 @@
 		<channels>
 			<channel typeId="waterleakage" id="waterleakage"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -381,7 +381,7 @@
 		<channels>
 			<channel typeId="fire" id="fire"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -405,7 +405,7 @@
 		<channels>
 			<channel typeId="alarm" id="alarm"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -436,7 +436,7 @@
 		<channels>
 			<channel typeId="vibration" id="vibration"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -460,7 +460,7 @@
 		<channels>
 			<channel typeId="battery" id="battery_level"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -483,7 +483,7 @@
 		<channels>
 			<channel typeId="carbonmonoxide" id="carbonmonoxide"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 
 		<representation-property>uid</representation-property>
@@ -511,7 +511,7 @@
 			<channel typeId="offset" id="offset"/>
 			<channel typeId="valve" id="valve"/>
 			<channel typeId="last_updated" id="last_updated"/>
-            <channel typeId="last_seen" id="last_seen"/>
+			<channel typeId="last_seen" id="last_seen"/>
 		</channels>
 		<representation-property>uid</representation-property>
 		<config-description-ref uri="thing-type:deconz:sensor"/>


### PR DESCRIPTION

The current binding provides support for "last_update" channel but not "last_seen". Last_update is updated when a device changes his state (battery status, or in my case of a smoke detector - when then is fire!).

Because I want to monitor if my smoke detectors are still alive, I need to check the "last_seen" value.

As last_seen is not in the WebSocket messages, it needs a refresh of the sensor:

![image](https://user-images.githubusercontent.com/13451066/85432046-a9f4f380-b582-11ea-82a6-63d69f677d6b.png)

