### PR TITLE
[deconz] re-add battery channel

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
@@ -102,6 +102,9 @@ public class SensorThingHandler extends SensorBaseThingHandler {
     protected void valueUpdated(String channelID, SensorState newState, boolean initializing) {
         super.valueUpdated(channelID, newState, initializing);
         switch (channelID) {
+            case CHANNEL_BATTERY_LEVEL:
+                updateDecimalTypeChannel(channelID, newState.battery);
+                break;
             case CHANNEL_LIGHT:
                 Boolean dark = newState.dark;
                 if (dark != null) {


### PR DESCRIPTION
Fixes #7920 

The battery channel was accidentally removed during the refactoring in #7828.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
