### PR TITLE
[mqtt][homie] Delete '$name' subscription in discovery service

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttBindingConstants.java
@@ -34,7 +34,7 @@ public class MqttBindingConstants {
     public static final String HOMIE_PROPERTY_VERSION = "homieversion";
     public static final String HOMIE_PROPERTY_HEARTBEAT_INTERVAL = "heartbeat_interval";
 
-    public static final int HOMIE_DEVICE_TIMEOUT = 5000;
-    public static final int HOMIE_SUBSCRIBE_TIMEOUT = 500;
-    public static final int HOMIE_ATTRIBUTE_TIMEOUT = 200;
+    public static final int HOMIE_DEVICE_TIMEOUT_MS = 15000;
+    public static final int HOMIE_SUBSCRIBE_TIMEOUT_MS = 500;
+    public static final int HOMIE_ATTRIBUTE_TIMEOUT_MS = 200;
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttBindingConstants.java
@@ -33,4 +33,8 @@ public class MqttBindingConstants {
 
     public static final String HOMIE_PROPERTY_VERSION = "homieversion";
     public static final String HOMIE_PROPERTY_HEARTBEAT_INTERVAL = "heartbeat_interval";
+
+    public static final int HOMIE_DEVICE_TIMEOUT = 5000;
+    public static final int HOMIE_SUBSCRIBE_TIMEOUT = 500;
+    public static final int HOMIE_ATTRIBUTE_TIMEOUT = 200;
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
@@ -89,8 +89,8 @@ public class MqttThingHandlerFactory extends BaseThingHandlerFactory implements 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(MqttBindingConstants.HOMIE300_MQTT_THING)) {
-            return new HomieThingHandler(thing, typeProvider, MqttBindingConstants.HOMIE_DEVICE_TIMEOUT,
-                    MqttBindingConstants.HOMIE_SUBSCRIBE_TIMEOUT, MqttBindingConstants.HOMIE_ATTRIBUTE_TIMEOUT);
+            return new HomieThingHandler(thing, typeProvider, MqttBindingConstants.HOMIE_DEVICE_TIMEOUT_MS,
+                    MqttBindingConstants.HOMIE_SUBSCRIBE_TIMEOUT_MS, MqttBindingConstants.HOMIE_ATTRIBUTE_TIMEOUT_MS);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/generic/internal/MqttThingHandlerFactory.java
@@ -89,7 +89,8 @@ public class MqttThingHandlerFactory extends BaseThingHandlerFactory implements 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(MqttBindingConstants.HOMIE300_MQTT_THING)) {
-            return new HomieThingHandler(thing, typeProvider, 1000, 500);
+            return new HomieThingHandler(thing, typeProvider, MqttBindingConstants.HOMIE_DEVICE_TIMEOUT,
+                    MqttBindingConstants.HOMIE_SUBSCRIBE_TIMEOUT, MqttBindingConstants.HOMIE_ATTRIBUTE_TIMEOUT);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/discovery/Homie300Discovery.java
@@ -25,7 +25,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.binding.mqtt.discovery.AbstractMQTTDiscovery;
 import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryService;
-import org.openhab.binding.mqtt.generic.tools.WaitForTopicValue;
 import org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -92,12 +91,7 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
             return;
         }
 
-        // Retrieve name and update found discovery
-        WaitForTopicValue w = new WaitForTopicValue(connection, topic.replace("$homie", "$name"));
-        w.waitForTopicValueAsync(scheduler, 700).whenComplete((name, ex) -> {
-            String deviceName = ex == null ? name : deviceID;
-            publishDevice(connectionBridge, connection, deviceID, topic, deviceName);
-        });
+        publishDevice(connectionBridge, connection, deviceID, topic, deviceID);
     }
 
     void publishDevice(ThingUID connectionBridge, MqttBrokerConnection connection, String deviceID, String topic,

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -55,6 +55,7 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
     /** The timeout per attribute field subscription */
     protected final int attributeReceiveTimeout;
     protected final int subscribeTimeout;
+    protected final int deviceTimeout;
     protected HandlerConfiguration config = new HandlerConfiguration();
     protected DelayedBatchProcessing<Object> delayedProcessing;
     private @Nullable ScheduledFuture<?> heartBeatTimer;
@@ -65,15 +66,17 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
      *
      * @param thing The thing of this handler
      * @param channelTypeProvider A channel type provider
+     * @param deviceTimeout Timeout for the entire device subscription. In milliseconds.
      * @param subscribeTimeout Timeout for an entire attribute class subscription and receive. In milliseconds.
      *            Even a slow remote device will publish a full node or property within 100ms.
      * @param attributeReceiveTimeout The timeout per attribute field subscription. In milliseconds.
      *            One attribute subscription and receiving should not take longer than 50ms.
      */
-    public HomieThingHandler(Thing thing, MqttChannelTypeProvider channelTypeProvider, int subscribeTimeout,
-            int attributeReceiveTimeout) {
-        super(thing, subscribeTimeout);
+    public HomieThingHandler(Thing thing, MqttChannelTypeProvider channelTypeProvider, int deviceTimeout,
+            int subscribeTimeout, int attributeReceiveTimeout) {
+        super(thing, deviceTimeout);
         this.channelTypeProvider = channelTypeProvider;
+        this.deviceTimeout = deviceTimeout;
         this.subscribeTimeout = subscribeTimeout;
         this.attributeReceiveTimeout = attributeReceiveTimeout;
         this.delayedProcessing = new DelayedBatchProcessing<>(subscribeTimeout, this, scheduler);

--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
@@ -132,7 +132,7 @@ public class HomieThingHandlerTests {
         doReturn(false).when(scheduledFuture).isDone();
         doReturn(scheduledFuture).when(scheduler).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
 
-        final HomieThingHandler handler = new HomieThingHandler(thing, channelTypeProvider, 30, 5);
+        final HomieThingHandler handler = new HomieThingHandler(thing, channelTypeProvider, 1000, 30, 5);
         thingHandler = spy(handler);
         thingHandler.setCallback(callback);
         final Device device = new Device(thing.getUID(), thingHandler, spy(new DeviceAttributes()),


### PR DESCRIPTION
Context:

Although we thought that https://github.com/openhab/openhab-addons/pull/7723 would solve #7252, the truth is that after the release of openHAB 2.5.6, new users started complaining that their Homie devices were not behaving correctly ($name message does not arrive). Taking into account that there are some problems with subscriptions and retained messages (in some circumstances the binding does not receive all the messages it should), it has been decided to remove the subscription to the "homie/xxx/$name" topic in the Homie300Discovery class. The only problem with this solution is that the name of the thing will be the same as the device id of Homie, but I think that this small loss of functionality will compensate for the advantage of fixing the bug. Also, the transport.io.mqtt library is already being improved to fix its bugs (https://github.com/openhab/openhab-core/commit/cc3f1407bd70912908087e1e8d62dd19fe8733ff, thanks @jochen314), although these changes are only valid for openHAB Core 3, so I think that, until openHAB3 is released, it is better to opt for this workaround.

Also, in the PR a new timeout has been added in the HomieThingHandler, which represents the maximum time the device can take to be completely processed. This timeout does have a high value (5000 milliseconds), although the other two timeouts still have values below 500 milliseconds. This improvement ends up defining the changes introduced in https://github.com/openhab/openhab-addons/pull/7760, since the previous code could fail in devices with many nodes and properties.

What do you think @jochen314, @cpmeister, @J-N-K?

Thanks!

Closes #7252 