### PR TITLE
[tplinksmarthome] Added support for KP105

### DIFF
--- a/bundles/org.openhab.binding.tplinksmarthome/README.md
+++ b/bundles/org.openhab.binding.tplinksmarthome/README.md
@@ -99,6 +99,12 @@ Switching, Brightness and Color is done using the `color` channel.
 * LED On/Off
 * Wi-Fi signal strength (RSSI)
 
+### KP105 Kasa Wi-Fi Smart Plug - Slim Edition
+
+* Power On/Off
+* LED On/Off
+* Wi-Fi signal strength (RSSI)
+
 ### KP200 Smart Wi-Fi Power Outlet, 2-Sockets
 
 * Power On/Off Group
@@ -285,7 +291,7 @@ All devices support some of the following channels:
 
 | Channel Type ID     | Item Type                | Description                                    | Thing types supporting this channel                                                                |
 |---------------------|--------------------------|------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| switch              | Switch                   | Power the device on or off.                    | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP200, KP303, KP400, RE270K, RE370K |
+| switch              | Switch                   | Power the device on or off.                    | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP105, KP200, KP303, KP400, RE270K, RE370K |
 | brightness          | Dimmer                   | Set the brightness of device or dimmer.        | HS220, KB100, KL50, KL60, KL110, KL120, LB100, LB110, LB120, LB200                                 |
 | colorTemperature    | Dimmer                   | Set the color temperature in percentage.       | KB130, KL120, KL130, LB120, LB130, LB230                                                           |
 | colorTemperatureAbs | Number                   | Set the color temperature in Kelvin.           | KB130, KL120, KL130, LB120, LB130, LB230                                                           |

--- a/bundles/org.openhab.binding.tplinksmarthome/README.md
+++ b/bundles/org.openhab.binding.tplinksmarthome/README.md
@@ -300,7 +300,7 @@ All devices support some of the following channels:
 | eneryUsage          | Number:Energy            | Energy Usage in kWh.                           | HS110, HS300                                                                                       |
 | current             | Number:ElectricCurrent   | Actual current usage in Ampere.                | HS110, HS300                                                                                       |
 | voltage             | Number:ElectricPotential | Actual voltage usage in Volt.                  | HS110, HS300                                                                                       |
-| led                 | Switch                   | Switch the status LED on the device on or off. | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS220, HS300, KP100, KP303, KP200, KP400          |
+| led                 | Switch                   | Switch the status LED on the device on or off. | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS220, HS300, KP100, KP105, KP303, KP200, KP400          |
 | rssi                | Number:Power             | Wi-Fi signal strength indicator in dBm.        | All                                                                                                |
 
 The outlet devices (HS107, HS300, KP200, KP400) have group channels.

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -53,6 +53,7 @@ public enum TPLinkSmartHomeThingType {
     HS105("hs105", DeviceType.PLUG),
     HS110("hs110", DeviceType.PLUG),
     KP100("kp100", DeviceType.PLUG),
+    KP105("kp105", DeviceType.PLUG),
 
     // Switch Thing Type UIDs
     HS200("hs200", DeviceType.SWITCH),

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/ESH-INF/thing/KP105.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/ESH-INF/thing/KP105.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="kp105">
+		<label>KP105</label>
+		<description>TP-Link KP105 Kasa Wi-Fi Smart Plug - Slim Edition</description>
+		<category>PowerOutlet</category>
+
+		<channels>
+			<channel id="switch" typeId="system.power"/>
+			<channel id="led" typeId="led"/>
+			<channel id="rssi" typeId="rssi"/>
+		</channels>
+
+		<representation-property>deviceId</representation-property>
+
+		<config-description-ref uri="thing-type:device:plug"/>
+	</thing-type>
+</thing:thing-descriptions>


### PR DESCRIPTION
This adds support for the [KP105 slim smart plug](https://www.tp-link.com/uk/home-networking/smart-plug/kp105/#overview) (tested with the UK edition v1.0.5 Build 191209 Rel.094735).