### PR TITLE
[deconz] Add dynamic state descriptions and fix property updates

### DIFF
--- a/bundles/org.openhab.binding.deconz/pom.xml
+++ b/bundles/org.openhab.binding.deconz/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/DeconzHandlerFactory.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/DeconzHandlerFactory.java
@@ -59,12 +59,15 @@ public class DeconzHandlerFactory extends BaseThingHandlerFactory {
     private final Gson gson;
     private final WebSocketFactory webSocketFactory;
     private final HttpClientFactory httpClientFactory;
+    private final StateDescriptionProvider stateDescriptionProvider;
 
     @Activate
     public DeconzHandlerFactory(final @Reference WebSocketFactory webSocketFactory,
-            final @Reference HttpClientFactory httpClientFactory) {
+            final @Reference HttpClientFactory httpClientFactory,
+            final @Reference StateDescriptionProvider stateDescriptionProvider) {
         this.webSocketFactory = webSocketFactory;
         this.httpClientFactory = httpClientFactory;
+        this.stateDescriptionProvider = stateDescriptionProvider;
 
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(LightType.class, new LightTypeDeserializer());
@@ -85,7 +88,7 @@ public class DeconzHandlerFactory extends BaseThingHandlerFactory {
             return new DeconzBridgeHandler((Bridge) thing, webSocketFactory,
                     new AsyncHttpClient(httpClientFactory.getCommonHttpClient()), gson);
         } else if (LightThingHandler.SUPPORTED_THING_TYPE_UIDS.contains(thingTypeUID)) {
-            return new LightThingHandler(thing, gson);
+            return new LightThingHandler(thing, gson, stateDescriptionProvider);
         } else if (SensorThingHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             return new SensorThingHandler(thing, gson);
         } else if (SensorThermostatThingHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/StateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/StateDescriptionProvider.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.deconz.internal;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dynamic channel state description provider.
+ * Overrides the state description for the controls, which receive its configuration in the runtime.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { DynamicStateDescriptionProvider.class, StateDescriptionProvider.class }, immediate = true)
+public class StateDescriptionProvider implements DynamicStateDescriptionProvider {
+
+    private final Map<ChannelUID, StateDescription> descriptions = new ConcurrentHashMap<>();
+    private final Logger logger = LoggerFactory.getLogger(StateDescriptionProvider.class);
+
+    /**
+     * Set a state description for a channel. This description will be used when preparing the channel state by
+     * the framework for presentation. A previous description, if existed, will be replaced.
+     *
+     * @param channelUID
+     *            channel UID
+     * @param description
+     *            state description for the channel
+     */
+    public void setDescription(ChannelUID channelUID, StateDescription description) {
+        logger.trace("adding state description for channel {}", channelUID);
+        descriptions.put(channelUID, description);
+    }
+
+    /**
+     * remove all descriptions for a given thing
+     *
+     * @param thingUID the thing's UID
+     */
+    public void removeDescriptionsForThing(ThingUID thingUID) {
+        logger.trace("removing state description for thing {}", thingUID);
+        descriptions.entrySet().removeIf(entry -> entry.getKey().getThingUID().equals(thingUID));
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(Channel channel,
+            @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
+        if (descriptions.containsKey(channel.getUID())) {
+            logger.trace("returning new stateDescription for {}", channel.getUID());
+            return descriptions.get(channel.getUID());
+        } else {
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/Util.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/Util.java
@@ -47,15 +47,4 @@ public class Util {
     public static int constrainToRange(int intValue, int min, int max) {
         return Math.max(min, Math.min(intValue, max));
     }
-
-    public static int parseIntWithFallback(String text, int defaultValue) {
-        if (text == null || text.isEmpty()) {
-            return defaultValue;
-        }
-        try {
-            return Integer.parseInt(text);
-        } catch (NumberFormatException e) {
-            return defaultValue;
-        }        
-    }
 }

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerService;
+import org.openhab.binding.deconz.internal.Util;
 import org.openhab.binding.deconz.internal.dto.BridgeFullState;
 import org.openhab.binding.deconz.internal.dto.LightMessage;
 import org.openhab.binding.deconz.internal.dto.SensorMessage;
@@ -120,11 +121,10 @@ public class ThingDiscoveryService extends AbstractDiscoveryService implements D
         properties.put(Thing.PROPERTY_MODEL_ID, light.modelid);
 
         if (light.ctmax != null && light.ctmin != null) {
-            int ctmax = (light.ctmax > ZCL_CT_MAX) ? ZCL_CT_MAX : light.ctmax;
-            properties.put(PROPERTY_CT_MAX, Integer.toString(ctmax));
-
-            int ctmin = (light.ctmin < ZCL_CT_MIN) ? ZCL_CT_MIN : light.ctmin;
-            properties.put(PROPERTY_CT_MIN, Integer.toString(ctmin));
+            properties.put(PROPERTY_CT_MAX,
+                    Integer.toString(Util.constrainToRange(light.ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
+            properties.put(PROPERTY_CT_MIN,
+                    Integer.toString(Util.constrainToRange(light.ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
         }
 
         switch (lightType) {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBaseThingHandler.java
@@ -112,7 +112,7 @@ public abstract class DeconzBaseThingHandler<T extends DeconzBaseMessage> extend
         this.http = bridgeHandler.getHttp();
         this.bridgeConfig = bridgeHandler.getBridgeConfig();
 
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING);
+        updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE);
 
         // Real-time data
         registerListener();

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -15,6 +15,8 @@ package org.openhab.binding.deconz.internal.handler;
 import static org.openhab.binding.deconz.internal.BindingConstants.*;
 import static org.openhab.binding.deconz.internal.Util.*;
 
+import java.math.BigDecimal;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,6 +35,10 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
+import org.openhab.binding.deconz.internal.StateDescriptionProvider;
+import org.openhab.binding.deconz.internal.Util;
 import org.openhab.binding.deconz.internal.dto.DeconzBaseMessage;
 import org.openhab.binding.deconz.internal.dto.LightMessage;
 import org.openhab.binding.deconz.internal.dto.LightState;
@@ -70,7 +76,10 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
 
     private final Logger logger = LoggerFactory.getLogger(LightThingHandler.class);
 
+    private final StateDescriptionProvider stateDescriptionProvider;
+
     private long lastCommandExpireTimestamp = 0;
+    private boolean needsPropertyUpdate = false;
 
     /**
      * The light state. Contains all possible fields for all supported lights
@@ -78,13 +87,36 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
     private LightState lightStateCache = new LightState();
     private LightState lastCommand = new LightState();
 
-    private final int ct_max;
-    private final int ct_min;
+    // set defaults, we can override them later if we receive better values
+    private int ctMax = ZCL_CT_MAX;
+    private int ctMin = ZCL_CT_MIN;
 
-    public LightThingHandler(Thing thing, Gson gson) {
+    public LightThingHandler(Thing thing, Gson gson, StateDescriptionProvider stateDescriptionProvider) {
         super(thing, gson);
-        ct_max = parseIntWithFallback(thing.getProperties().get(PROPERTY_CT_MAX), ZCL_CT_MAX);
-        ct_min = parseIntWithFallback(thing.getProperties().get(PROPERTY_CT_MIN), ZCL_CT_MIN);
+
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    @Override
+    public void initialize() {
+        try {
+            Map<String, String> properties = thing.getProperties();
+            ctMax = Integer.parseInt(properties.get(PROPERTY_CT_MAX));
+            ctMin = Integer.parseInt(properties.get(PROPERTY_CT_MIN));
+
+            StateDescription stateDescription = StateDescriptionFragmentBuilder.create()
+                    .withMinimum(new BigDecimal(miredToKelvin(ctMin))).withMaximum(new BigDecimal(miredToKelvin(ctMax))).build().toStateDescription();
+            if (stateDescription != null) {
+                stateDescriptionProvider.setDescription(new ChannelUID(thing.getUID(), CHANNEL_COLOR_TEMPERATURE),
+                        stateDescription);
+            } else {
+                logger.warn("Failed to create state description in thing {}", thing.getUID());
+            }
+        } catch (NumberFormatException e) {
+            needsPropertyUpdate = true;
+        }
+
+        super.initialize();
     }
 
     @Override
@@ -174,8 +206,8 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
                 break;
             case CHANNEL_COLOR_TEMPERATURE:
                 if (command instanceof DecimalType) {
-                    int miredValue  = kelvinToMired(((DecimalType) command).intValue());
-                    newLightState.ct = constrainToRange(miredValue,ct_min, ct_max);
+                    int miredValue = kelvinToMired(((DecimalType) command).intValue());
+                    newLightState.ct = constrainToRange(miredValue, ctMin, ctMax);
 
                     if (currentOn != null && !currentOn) {
                         // sending new color temperature is only allowed when light is on
@@ -240,7 +272,22 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
         if (r.getResponseCode() == 403) {
             return null;
         } else if (r.getResponseCode() == 200) {
-            return gson.fromJson(r.getBody(), LightMessage.class);
+            LightMessage lightMessage = gson.fromJson(r.getBody(), LightMessage.class);
+            if (lightMessage != null && needsPropertyUpdate) {
+                // if we did not receive an ctmin/ctmax, then we probably don't need it
+                needsPropertyUpdate = false;
+
+                if (lightMessage.ctmin != null && lightMessage.ctmax != null) {
+
+                    Map<String, String> properties = thing.getProperties();
+                    properties.put(PROPERTY_CT_MAX,
+                            Integer.toString(Util.constrainToRange(lightMessage.ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
+                    properties.put(PROPERTY_CT_MIN,
+                            Integer.toString(Util.constrainToRange(lightMessage.ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
+                    updateProperties(properties);
+                }
+            }
+            return lightMessage;
         } else {
             throw new IllegalStateException("Unknown status code " + r.getResponseCode() + " for full state request");
         }
@@ -291,7 +338,7 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
                 break;
             case CHANNEL_COLOR_TEMPERATURE:
                 Integer ct = newState.ct;
-                if (ct != null && ct >= ct_min && ct <= ct_max) {
+                if (ct != null && ct >= ctMin && ct <= ctMax) {
                     updateState(channelId, new DecimalType(miredToKelvin(ct)));
                 }
                 break;

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/LightsTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/LightsTest.java
@@ -22,8 +22,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -35,7 +37,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.internal.creation.bytebuddy.MockAccess;
 import org.openhab.binding.deconz.internal.StateDescriptionProvider;
 import org.openhab.binding.deconz.internal.dto.LightMessage;
 import org.openhab.binding.deconz.internal.handler.LightThingHandler;
@@ -105,7 +106,14 @@ public class LightsTest {
         Thing light = ThingBuilder.create(THING_TYPE_COLOR_TEMPERATURE_LIGHT, thingUID).withProperties(properties)
                 .withChannel(ChannelBuilder.create(channelUID_bri, "Dimmer").build())
                 .withChannel(ChannelBuilder.create(channelUID_ct, "Number").build()).build();
-        LightThingHandler lightThingHandler = new LightThingHandler(light, gson, stateDescriptionProvider);
+        LightThingHandler lightThingHandler = new LightThingHandler(light, gson, stateDescriptionProvider) {
+            // avoid warning when initializing
+            @Override
+            public @Nullable Bridge getBridge() {
+                return null;
+            }
+        };
+
         lightThingHandler.initialize();
 
         Mockito.verify(stateDescriptionProvider).setDescription(eq(channelUID_ct), any());


### PR DESCRIPTION
This fixes the wrong ctmin/ctmax values for manually added things (both managed and unmanaged) and provides proper state descriptions for the color temperature.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
