### PR TITLE
[mqtt] allow disabling discovery

### DIFF
--- a/bundles/org.openhab.binding.mqtt/README.md
+++ b/bundles/org.openhab.binding.mqtt/README.md
@@ -57,7 +57,7 @@ For more security, the following optional parameters can be altered:
 By default discovery services (like homie or homeassistant) are enabled on a broker.
 This behaviour can be controlled with a configuration parameter.
 
-* __enableDiscovery__:If set to true, enables discovery on this broker, if set to false, disables discovery services om this broker.
+* __enableDiscovery__:If set to true, enables discovery on this broker, if set to false, disables discovery services on this broker.
 
 ## Supported Channels
 

--- a/bundles/org.openhab.binding.mqtt/README.md
+++ b/bundles/org.openhab.binding.mqtt/README.md
@@ -54,6 +54,11 @@ For more security, the following optional parameters can be altered:
 * __certificate__: The certificate hash. If **certificatepin** is set this hash is used to verify the connection. Clear to allow a new certificate pinning on the next connection attempt. If empty will be filled automatically by the next successful connection. An example input would be `SHA-256:83F9171E06A313118889F7D79302BD1B7A2042EE0CFD029ABF8DD06FFA6CD9D3`.
 * __publickey__: The public key hash. If **publickeypin** is set this hash is used to verify the connection. Clear to allow a new public key pinning on the next connection attempt. If empty will be filled automatically by the next successful connection. An example input would be `SHA-256:83F9171E06A313118889F7D79302BD1B7A2042EE0CFD029ABF8DD06FFA6CD9D3`.
 
+By default discovery services (like homie or homeassistant) are enabled on a broker.
+This behaviour can be controlled with a configuration parameter.
+
+* __enableDiscovery__:If set to true, enables discovery on this broker, if set to false, disables discovery services om this broker.
+
 ## Supported Channels
 
 You can extend your broker connection bridges with a channel:

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/TopicSubscribe.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/TopicSubscribe.java
@@ -32,6 +32,8 @@ public class TopicSubscribe implements MqttMessageSubscriber {
     final String topic;
     final MQTTTopicDiscoveryParticipant topicDiscoveredListener;
 
+    private boolean isStarted = false;
+
     /**
      * Creates a {@link TopicSubscribe} object.
      *
@@ -66,7 +68,10 @@ public class TopicSubscribe implements MqttMessageSubscriber {
      * @return Completes with true if successful. Completes with false if not connected yet. Exceptionally otherwise.
      */
     public CompletableFuture<Boolean> start() {
-        return connection == null ? CompletableFuture.completedFuture(true) : connection.subscribe(topic, this);
+        CompletableFuture<Boolean> startFuture = connection == null ? CompletableFuture.completedFuture(true)
+                : connection.subscribe(topic, this);
+        isStarted = true;
+        return startFuture;
     }
 
     /**
@@ -75,6 +80,18 @@ public class TopicSubscribe implements MqttMessageSubscriber {
      * @return Completes with true if successful. Exceptionally otherwise.
      */
     public CompletableFuture<Boolean> stop() {
-        return connection == null ? CompletableFuture.completedFuture(true) : connection.unsubscribe(topic, this);
+        CompletableFuture<Boolean> stopFuture = connection == null ? CompletableFuture.completedFuture(true)
+                : connection.unsubscribe(topic, this);
+        isStarted = false;
+        return stopFuture;
+    }
+
+    /**
+     * status of this topic subscription
+     *
+     * @return true if started
+     */
+    public boolean isStarted() {
+        return isStarted;
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -123,7 +123,7 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
                 }
 
                 TopicSubscribe topicSubscribe = new TopicSubscribe(connection, topic, listener, thing.getUID());
-                if (!discoveryDisabled()) {
+                if (discoveryEnabled()) {
                     topicSubscribe.start().handle((result, ex) -> {
                         if (ex != null) {
                             logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
@@ -203,7 +203,7 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
             }
 
             TopicSubscribe topicSubscribe = new TopicSubscribe(connection, topic, listener, thing.getUID());
-            if (!discoveryDisabled()) {
+            if (discoveryEnabled()) {
                 topicSubscribe.start().handle((result, ex) -> {
                     if (ex != null) {
                         logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
@@ -255,5 +255,5 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
      *
      * @return true if discovery disabled
      */
-    public abstract boolean discoveryDisabled();
+    public abstract boolean discoveryEnabled();
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -118,17 +118,23 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
 
         discoveryTopics.forEach((topic, listenerMap) -> {
             listenerMap.replaceAll((listener, oldTopicSubscribe) -> {
+                if (oldTopicSubscribe.isStarted()) {
+                    oldTopicSubscribe.stop();
+                }
+
                 TopicSubscribe topicSubscribe = new TopicSubscribe(connection, topic, listener, thing.getUID());
-                topicSubscribe.start().handle((result, ex) -> {
-                    if (ex != null) {
-                        logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
-                                thing.getUID());
-                    } else {
-                        logger.trace("Subscribed {} to discovery topic {} on broker {}", listener, topic,
-                                thing.getUID());
-                    }
-                    return null;
-                });
+                if (!discoveryDisabled()) {
+                    topicSubscribe.start().handle((result, ex) -> {
+                        if (ex != null) {
+                            logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
+                                    thing.getUID());
+                        } else {
+                            logger.trace("Subscribed {} to discovery topic {} on broker {}", listener, topic,
+                                    thing.getUID());
+                        }
+                        return null;
+                    });
+                }
                 return topicSubscribe;
             });
         });
@@ -197,15 +203,18 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
             }
 
             TopicSubscribe topicSubscribe = new TopicSubscribe(connection, topic, listener, thing.getUID());
-            topicSubscribe.start().handle((result, ex) -> {
-                if (ex != null) {
-                    logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
-                            thing.getUID());
-                } else {
-                    logger.trace("Subscribed {} to discovery topic {} on broker {}", listener, topic, thing.getUID());
-                }
-                return null;
-            });
+            if (!discoveryDisabled()) {
+                topicSubscribe.start().handle((result, ex) -> {
+                    if (ex != null) {
+                        logger.warn("Failed to subscribe {} to discovery topic {} on broker {}", listener, topic,
+                                thing.getUID());
+                    } else {
+                        logger.trace("Subscribed {} to discovery topic {} on broker {}", listener, topic,
+                                thing.getUID());
+                    }
+                    return null;
+                });
+            }
             return topicSubscribe;
         });
     }
@@ -240,4 +249,11 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
                     return v.isEmpty() ? null : v;
                 });
     }
+
+    /**
+     * check whether discovery is disabled on this broker
+     *
+     * @return true if discovery disabled
+     */
+    public abstract boolean discoveryDisabled();
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -123,6 +123,11 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
         super.dispose();
     }
 
+    @Override
+    public boolean discoveryDisabled() {
+        return config.disableDiscovery;
+    }
+
     /**
      * Reads the thing configuration related to public key or certificate pinning, creates an appropriate a
      * {@link PinningSSLContextProvider} and assigns it to the {@link MqttBrokerConnection} instance.

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandler.java
@@ -124,8 +124,8 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
     }
 
     @Override
-    public boolean discoveryDisabled() {
-        return config.disableDiscovery;
+    public boolean discoveryEnabled() {
+        return config.enableDiscovery;
     }
 
     /**

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandlerConfig.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandlerConfig.java
@@ -35,5 +35,5 @@ public class BrokerHandlerConfig extends MqttBrokerConnectionConfig {
     public String certificate = "";
     public String publickey = "";
 
-    public boolean disableDiscovery = false;
+    public boolean enableDiscovery = true;
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandlerConfig.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/BrokerHandlerConfig.java
@@ -34,4 +34,6 @@ public class BrokerHandlerConfig extends MqttBrokerConnectionConfig {
     public boolean publickeypin = false;
     public String certificate = "";
     public String publickey = "";
+
+    public boolean disableDiscovery = false;
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
@@ -50,6 +50,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     protected final MqttService service;
 
     protected String brokerID = "";
+    protected boolean discoveryDisabled = false;
 
     public SystemBrokerHandler(Bridge thing, MqttService service) {
         super(thing);
@@ -116,6 +117,8 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     @Override
     public void initialize() {
         this.brokerID = getThing().getConfiguration().get("brokerid").toString();
+        this.discoveryDisabled = (Boolean) getThing().getConfiguration().get("disableDiscovery");
+
         service.addBrokersListener(this);
 
         connection = service.getBrokerConnection(brokerID);
@@ -131,5 +134,10 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     public void dispose() {
         service.removeBrokersListener(this);
         super.dispose();
+    }
+
+    @Override
+    public boolean discoveryDisabled() {
+        return discoveryDisabled;
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
@@ -50,7 +50,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     protected final MqttService service;
 
     protected String brokerID = "";
-    protected boolean discoveryDisabled = false;
+    protected boolean discoveryEnabled = true;
 
     public SystemBrokerHandler(Bridge thing, MqttService service) {
         super(thing);
@@ -117,7 +117,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     @Override
     public void initialize() {
         this.brokerID = getThing().getConfiguration().get("brokerid").toString();
-        this.discoveryDisabled = (Boolean) getThing().getConfiguration().get("disableDiscovery");
+        this.discoveryEnabled = (Boolean) getThing().getConfiguration().get("enableDiscovery");
 
         service.addBrokersListener(this);
 
@@ -138,6 +138,6 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
 
     @Override
     public boolean discoveryEnabled() {
-        return discoveryDisabled;
+        return discoveryEnabled;
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/handler/SystemBrokerHandler.java
@@ -137,7 +137,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     }
 
     @Override
-    public boolean discoveryDisabled() {
+    public boolean discoveryEnabled() {
         return discoveryDisabled;
     }
 }

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -155,11 +155,11 @@
 					`SHA-256:83F9171E06A313118889F7D79302BD1B7A2042EE0CFD029ABF8DD06FFA6CD9D3`</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="disableDiscovery" type="boolean">
-				<label>Disable Discovery</label>
-				<description>If set to true disables this broker for all discovery services</description>
+			<parameter name="enableDiscovery" type="boolean">
+				<label>Enable Discovery</label>
+				<description>If set to true enables this broker for all discovery services.</description>
 				<advanced>true</advanced>
-				<default>false</default>
+				<default>true</default>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -187,11 +187,11 @@
 				<label>Broker ID</label>
 				<description>Each system wide configured MQTT broker has a unique broker ID.</description>
 			</parameter>
-			<parameter name="disableDiscovery" type="boolean">
-				<label>Disable Discovery</label>
-				<description>If set to true disables this broker for all discovery services</description>
+			<parameter name="enableDiscovery" type="boolean">
+				<label>Enable Discovery</label>
+				<description>If set to true enables this broker for all discovery services.</description>
 				<advanced>true</advanced>
-				<default>false</default>
+				<default>true</default>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -155,6 +155,12 @@
 					`SHA-256:83F9171E06A313118889F7D79302BD1B7A2042EE0CFD029ABF8DD06FFA6CD9D3`</description>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="disableDiscovery" type="boolean">
+				<label>Disable Discovery</label>
+				<description>If set to true disables this broker for all discovery services</description>
+				<advanced>true</advanced>
+				<default>false</default>
+			</parameter>
 		</config-description>
 	</bridge-type>
 
@@ -180,6 +186,12 @@
 			<parameter name="brokerid" type="text" required="true">
 				<label>Broker ID</label>
 				<description>Each system wide configured MQTT broker has a unique broker ID.</description>
+			</parameter>
+			<parameter name="disableDiscovery" type="boolean">
+				<label>Disable Discovery</label>
+				<description>If set to true disables this broker for all discovery services</description>
+				<advanced>true</advanced>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/MQTTTopicDiscoveryServiceTest.java
@@ -104,7 +104,7 @@ public class MQTTTopicDiscoveryServiceTest {
     }
 
     @Test
-    public void firstHandlerThanSubscribe() {
+    public void firstHandlerThenSubscribe() {
         handler.initialize();
         BrokerHandlerEx.verifyCreateBrokerConnection(handler, 1);
 


### PR DESCRIPTION
Fixes #8056 

This adds a parameter to the broker to disable discovery. By default this is set to false (so discovery is enabled), which is the same behaviour like before.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>