### PR TITLE
[lutron] Fix auto-ignore for discovered devices

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -11,6 +11,8 @@
 			<property name="vendor">Lutron</property>
 		</properties>
 
+		<representation-property>serialNumber</representation-property>
+
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<context>network-address</context>
@@ -67,6 +69,8 @@
 			<channel id="lightlevel" typeId="lightDimmer"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -95,6 +99,8 @@
 			<channel id="shadelevel" typeId="shadeControl"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -116,6 +122,8 @@
 			<channel id="blindliftlevel" typeId="blindLift"/>
 			<channel id="blindtiltlevel" typeId="blindTilt"/>
 		</channels>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -146,6 +154,8 @@
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -165,6 +175,8 @@
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -201,6 +213,8 @@
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -226,6 +240,8 @@
 			<channel id="switchstatus" typeId="switchState"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -246,6 +262,8 @@
 			<channel id="occupancystatus" typeId="occupiedState"/>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -261,6 +279,8 @@
 
 		<label>seeTouch Keypad</label>
 		<description>Lutron seeTouch/Hybrid seeTouch wall keypad</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -316,6 +336,8 @@
 		<label>Tabletop seeTouch Keypad</label>
 		<description>Lutron wireless tabletop keypad</description>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -350,6 +372,8 @@
 
 		<label>International seeTouch Keypad</label>
 		<description>Lutron International seeTouch keypad (HomeWorks QS Only)</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -387,6 +411,8 @@
 
 		<label>Palladiom Keypad</label>
 		<description>Lutron Palladiom keypad (HomeWorks QS Only)</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -428,6 +454,8 @@
 		<label>Pico Keypad</label>
 		<description>Lutron wireless Pico keypad</description>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -462,6 +490,8 @@
 		<label>GRAFIK Eye QS</label>
 		<description>Lutron GRAFIK Eye QS for RadioRA 2/HomeWorks QS</description>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -494,6 +524,8 @@
 		<label>VCRX</label>
 		<description>Lutron visor control receiver</description>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -514,6 +546,8 @@
 
 		<label>WCI</label>
 		<description>QS Wallbox Closure Interface</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -536,6 +570,8 @@
 
 		<label>Virtual Keypad</label>
 		<description>Virtual integration keypad on repeater</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -566,6 +602,8 @@
 
 		<label>QS IO Interface</label>
 		<description>Lutron QS IO Interface</description>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
@@ -604,6 +642,8 @@
 			</channel>
 		</channels>
 
+		<representation-property>integrationId</representation-property>
+
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">
 				<label>Integration ID</label>
@@ -623,6 +663,8 @@
 		<channels>
 			<channel id="step" typeId="greenstep"/>
 		</channels>
+
+		<representation-property>integrationId</representation-property>
 
 		<config-description>
 			<parameter name="integrationId" type="integer" required="true">


### PR DESCRIPTION
Small update that adds representation-property tag to thing definitions. The appropriate representation properties were already being set in the discovery services, but were not defined in thing-types.xml.
