### PR TITLE
[lutron] Code clean-up to eliminate SCA warnings

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/GrafikEyeHandler.java
@@ -52,18 +52,18 @@ public class GrafikEyeHandler extends BaseThingHandler {
     /**
      * Cached instance of the {@link GrafikEyeConfig}. Will be null if disconnected.
      */
-    private GrafikEyeConfig _config = null;
+    private GrafikEyeConfig config = null;
 
     /**
      * The current fade for the grafik eye (only used when setting zone intensity). Will initially be set from
      * configuration.
      */
-    private int _fade = 0;
+    private int fade = 0;
 
     /**
      * The polling job to poll the actual state of the grafik eye
      */
-    private ScheduledFuture<?> _polling;
+    private ScheduledFuture<?> pollingJob;
 
     /**
      * Constructs the handler from the {@link org.eclipse.smarthome.core.thing.Thing}
@@ -109,28 +109,28 @@ public class GrafikEyeHandler extends BaseThingHandler {
         if (id.equals(PrgConstants.CHANNEL_SCENE)) {
             if (command instanceof DecimalType) {
                 final int scene = ((DecimalType) command).intValue();
-                getProtocolHandler().selectScene(_config.getControlUnit(), scene);
+                getProtocolHandler().selectScene(config.getControlUnit(), scene);
             } else {
                 logger.error("Received a SCENE command with a non DecimalType: {}", command);
             }
 
         } else if (id.equals(PrgConstants.CHANNEL_SCENELOCK)) {
             if (command instanceof OnOffType) {
-                getProtocolHandler().setSceneLock(_config.getControlUnit(), command == OnOffType.ON);
+                getProtocolHandler().setSceneLock(config.getControlUnit(), command == OnOffType.ON);
             } else {
                 logger.error("Received a SCENELOCK command with a non OnOffType: {}", command);
             }
 
         } else if (id.equals(PrgConstants.CHANNEL_SCENESEQ)) {
             if (command instanceof OnOffType) {
-                getProtocolHandler().setSceneSequence(_config.getControlUnit(), command == OnOffType.ON);
+                getProtocolHandler().setSceneSequence(config.getControlUnit(), command == OnOffType.ON);
             } else {
                 logger.error("Received a SCENESEQ command with a non OnOffType: {}", command);
             }
 
         } else if (id.equals(PrgConstants.CHANNEL_ZONELOCK)) {
             if (command instanceof OnOffType) {
-                getProtocolHandler().setZoneLock(_config.getControlUnit(), command == OnOffType.ON);
+                getProtocolHandler().setZoneLock(config.getControlUnit(), command == OnOffType.ON);
             } else {
                 logger.error("Received a ZONELOCK command with a non OnOffType: {}", command);
             }
@@ -139,20 +139,19 @@ public class GrafikEyeHandler extends BaseThingHandler {
             final Integer zone = getTrailingNbr(id, PrgConstants.CHANNEL_ZONELOWER);
 
             if (zone != null) {
-                getProtocolHandler().setZoneLower(_config.getControlUnit(), zone);
+                getProtocolHandler().setZoneLower(config.getControlUnit(), zone);
             }
 
         } else if (id.startsWith(PrgConstants.CHANNEL_ZONERAISE)) {
             final Integer zone = getTrailingNbr(id, PrgConstants.CHANNEL_ZONERAISE);
 
             if (zone != null) {
-                getProtocolHandler().setZoneRaise(_config.getControlUnit(), zone);
+                getProtocolHandler().setZoneRaise(config.getControlUnit(), zone);
             }
 
         } else if (id.equals(PrgConstants.CHANNEL_ZONEFADE)) {
             if (command instanceof DecimalType) {
-                final int fade = ((DecimalType) command).intValue();
-                setFade(fade);
+                setFade(((DecimalType) command).intValue());
             } else {
                 logger.error("Received a ZONEFADE command with a non DecimalType: {}", command);
             }
@@ -163,12 +162,12 @@ public class GrafikEyeHandler extends BaseThingHandler {
             if (zone != null) {
                 if (command instanceof PercentType) {
                     final int intensity = ((PercentType) command).intValue();
-                    getProtocolHandler().setZoneIntensity(_config.getControlUnit(), zone, _fade, intensity);
+                    getProtocolHandler().setZoneIntensity(config.getControlUnit(), zone, fade, intensity);
                 } else if (command instanceof OnOffType) {
-                    getProtocolHandler().setZoneIntensity(_config.getControlUnit(), zone, _fade,
+                    getProtocolHandler().setZoneIntensity(config.getControlUnit(), zone, fade,
                             command == OnOffType.ON ? 100 : 0);
                 } else if (command instanceof IncreaseDecreaseType) {
-                    getProtocolHandler().setZoneIntensity(_config.getControlUnit(), zone, _fade,
+                    getProtocolHandler().setZoneIntensity(config.getControlUnit(), zone, fade,
                             command == IncreaseDecreaseType.INCREASE);
                 } else {
                     logger.error("Received a ZONEINTENSITY command with a non DecimalType: {}", command);
@@ -184,9 +183,9 @@ public class GrafikEyeHandler extends BaseThingHandler {
                 } else if (command == StopMoveType.MOVE) {
                     logger.info("StopMoveType.Move is not suppored by QED shades");
                 } else if (command == StopMoveType.STOP) {
-                    getProtocolHandler().setZoneIntensity(_config.getControlUnit(), zone, _fade, 0);
+                    getProtocolHandler().setZoneIntensity(config.getControlUnit(), zone, fade, 0);
                 } else if (command instanceof UpDownType) {
-                    getProtocolHandler().setZoneIntensity(_config.getControlUnit(), zone, _fade,
+                    getProtocolHandler().setZoneIntensity(config.getControlUnit(), zone, fade,
                             command == UpDownType.UP ? 1 : 2);
                 } else {
                     logger.error("Received a ZONEINTENSITY command with a non DecimalType: {}", command);
@@ -213,9 +212,9 @@ public class GrafikEyeHandler extends BaseThingHandler {
             getProtocolHandler().refreshScene();
 
         } else if (id.equals(PrgConstants.CHANNEL_ZONEINTENSITY)) {
-            getProtocolHandler().refreshZoneIntensity(_config.getControlUnit());
+            getProtocolHandler().refreshZoneIntensity(config.getControlUnit());
         } else if (id.equals(PrgConstants.CHANNEL_ZONEFADE)) {
-            updateState(PrgConstants.CHANNEL_ZONEFADE, new DecimalType(_fade));
+            updateState(PrgConstants.CHANNEL_ZONEFADE, new DecimalType(fade));
         }
     }
 
@@ -274,14 +273,14 @@ public class GrafikEyeHandler extends BaseThingHandler {
      * starts a status refresh job
      */
     private void internalInitialize() {
-        _config = getThing().getConfiguration().as(GrafikEyeConfig.class);
+        config = getThing().getConfiguration().as(GrafikEyeConfig.class);
 
-        if (_config == null) {
+        if (config == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Configuration file missing");
             return;
         }
 
-        final String configErr = _config.validate();
+        final String configErr = config.validate();
         if (configErr != null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, configErr);
             return;
@@ -301,27 +300,27 @@ public class GrafikEyeHandler extends BaseThingHandler {
         }
 
         updateStatus(ThingStatus.ONLINE);
-        setFade(_config.getFade());
+        setFade(config.getFade());
 
         cancelPolling();
-        _polling = this.scheduler.scheduleWithFixedDelay(new Runnable() {
+        pollingJob = this.scheduler.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
                 final ThingStatus status = getThing().getStatus();
-                if (status == ThingStatus.ONLINE && _config != null) {
-                    getProtocolHandler().refreshState(_config.getControlUnit());
+                if (status == ThingStatus.ONLINE && config != null) {
+                    getProtocolHandler().refreshState(config.getControlUnit());
                 }
             }
-        }, 1, _config.getPolling(), TimeUnit.SECONDS);
+        }, 1, config.getPolling(), TimeUnit.SECONDS);
     }
 
     /**
      * Helper method to cancel our polling if we are currently polling
      */
     private void cancelPolling() {
-        if (_polling != null) {
-            _polling.cancel(true);
-            _polling = null;
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+            pollingJob = null;
         }
     }
 
@@ -349,7 +348,7 @@ public class GrafikEyeHandler extends BaseThingHandler {
      * @return the control unit
      */
     int getControlUnit() {
-        return _config.getControlUnit();
+        return config.getControlUnit();
     }
 
     /**
@@ -360,7 +359,7 @@ public class GrafikEyeHandler extends BaseThingHandler {
      * @return true if a shade zone, false otherwise
      */
     boolean isShade(int zone) {
-        return _config == null ? false : _config.isShadeZone(zone);
+        return config == null ? false : config.isShadeZone(zone);
     }
 
     /**
@@ -383,7 +382,7 @@ public class GrafikEyeHandler extends BaseThingHandler {
             throw new IllegalArgumentException("fade must be between 1-3600");
         }
 
-        _fade = fade;
-        updateState(PrgConstants.CHANNEL_ZONEFADE, new DecimalType(_fade));
+        this.fade = fade;
+        updateState(PrgConstants.CHANNEL_ZONEFADE, new DecimalType(this.fade));
     }
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgBridgeHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgBridgeHandler.java
@@ -45,17 +45,17 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
     /**
      * The {@link PrgProtocolHandler} that handles the actual protocol. Will never be null
      */
-    private PrgProtocolHandler _protocolHandler;
+    private PrgProtocolHandler protocolHandler;
 
     /**
      * The {@link SocketSession} to the physical devices. Will never be null
      */
-    private SocketSession _session;
+    private SocketSession session;
 
     /**
      * The retry connection event. Null if not retrying.
      */
-    private ScheduledFuture<?> _retryConnection;
+    private ScheduledFuture<?> retryConnectionJob;
 
     /**
      * Constructs the handler from the {@link Bridge}. Simply calls the super constructor with the {@link Bridge},
@@ -71,9 +71,9 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
         }
 
         final PrgBridgeConfig config = getPrgBridgeConfig();
-        _session = new SocketSession(config.getIpAddress(), 23);
+        session = new SocketSession(config.getIpAddress(), 23);
 
-        _protocolHandler = new PrgProtocolHandler(_session, new PrgHandlerCallback() {
+        protocolHandler = new PrgProtocolHandler(session, new PrgHandlerCallback() {
             @Override
             public void stateChanged(String channelId, State state) {
                 updateState(channelId, state);
@@ -106,7 +106,7 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
      * @return a non-null protocol handler to use
      */
     PrgProtocolHandler getProtocolHandler() {
-        return _protocolHandler;
+        return protocolHandler;
     }
 
     /**
@@ -161,33 +161,33 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
         }
 
         if (id.equals(PrgConstants.CHANNEL_ZONELOWERSTOP)) {
-            _protocolHandler.setZoneLowerStop();
+            protocolHandler.setZoneLowerStop();
 
         } else if (id.equals(PrgConstants.CHANNEL_ZONERAISESTOP)) {
-            _protocolHandler.setZoneRaiseStop();
+            protocolHandler.setZoneRaiseStop();
 
         } else if (id.equals(PrgConstants.CHANNEL_TIMECLOCK)) {
             if (command instanceof DateTimeType) {
                 final ZonedDateTime zdt = ((DateTimeType) command).getZonedDateTime();
-                _protocolHandler.setTime(GregorianCalendar.from(zdt));
+                protocolHandler.setTime(GregorianCalendar.from(zdt));
             } else {
                 logger.error("Received a TIMECLOCK channel command with a non DateTimeType: {}", command);
             }
         } else if (id.startsWith(PrgConstants.CHANNEL_SCHEDULE)) {
             if (command instanceof DecimalType) {
                 final int schedule = ((DecimalType) command).intValue();
-                _protocolHandler.selectSchedule(schedule);
+                protocolHandler.selectSchedule(schedule);
             } else {
                 logger.error("Received a SCHEDULE channel command with a non DecimalType: {}", command);
             }
 
         } else if (id.startsWith(PrgConstants.CHANNEL_SUPERSEQUENCESTART)) {
-            _protocolHandler.startSuperSequence();
+            protocolHandler.startSuperSequence();
 
         } else if (id.startsWith(PrgConstants.CHANNEL_SUPERSEQUENCEPAUSE)) {
-            _protocolHandler.pauseSuperSequence();
+            protocolHandler.pauseSuperSequence();
         } else if (id.startsWith(PrgConstants.CHANNEL_SUPERSEQUENCERESUME)) {
-            _protocolHandler.resumeSuperSequence();
+            protocolHandler.resumeSuperSequence();
 
         } else {
             logger.error("Unknown/Unsupported Channel id: {}", id);
@@ -206,25 +206,25 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
         }
 
         if (id.equals(PrgConstants.CHANNEL_TIMECLOCK)) {
-            _protocolHandler.refreshTime();
+            protocolHandler.refreshTime();
 
         } else if (id.equals(PrgConstants.CHANNEL_SCHEDULE)) {
-            _protocolHandler.refreshSchedule();
+            protocolHandler.refreshSchedule();
 
         } else if (id.equals(PrgConstants.CHANNEL_SUNRISE)) {
-            _protocolHandler.refreshSunriseSunset();
+            protocolHandler.refreshSunriseSunset();
 
         } else if (id.equals(PrgConstants.CHANNEL_SUNSET)) {
-            _protocolHandler.refreshSunriseSunset();
+            protocolHandler.refreshSunriseSunset();
 
         } else if (id.equals(PrgConstants.CHANNEL_SUPERSEQUENCESTATUS)) {
-            _protocolHandler.reportSuperSequenceStatus();
+            protocolHandler.reportSuperSequenceStatus();
         } else if (id.equals(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSTEP)) {
-            _protocolHandler.reportSuperSequenceStatus();
+            protocolHandler.reportSuperSequenceStatus();
         } else if (id.equals(PrgConstants.CHANNEL_SUPERSEQUENCENEXTMIN)) {
-            _protocolHandler.reportSuperSequenceStatus();
+            protocolHandler.reportSuperSequenceStatus();
         } else if (id.equals(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSEC)) {
-            _protocolHandler.reportSuperSequenceStatus();
+            protocolHandler.reportSuperSequenceStatus();
         }
     }
 
@@ -268,9 +268,9 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
         String response = "Server is offline - will try to reconnect later";
         try {
             logger.info("Attempting connection ...");
-            _session.connect();
+            session.connect();
 
-            response = _protocolHandler.login(config.getUserName());
+            response = protocolHandler.login(config.getUserName());
             if (response == null) {
                 if (config != null) {
                     updateStatus(ThingStatus.ONLINE);
@@ -293,7 +293,7 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
      */
     private void disconnect(boolean retryConnection) {
         try {
-            _session.disconnect();
+            session.disconnect();
         } catch (IOException e) {
             // ignore - we don't care
         }
@@ -308,14 +308,14 @@ public class PrgBridgeHandler extends BaseBridgeHandler {
      * call the {@link #connect()} method. If a retry attempt is pending, the request is ignored.
      */
     private void retryConnect() {
-        if (_retryConnection == null) {
+        if (retryConnectionJob == null) {
             final PrgBridgeConfig config = getPrgBridgeConfig();
             if (config != null) {
                 logger.info("Will try to reconnect in {} seconds", config.getRetryPolling());
-                _retryConnection = this.scheduler.schedule(new Runnable() {
+                retryConnectionJob = this.scheduler.schedule(new Runnable() {
                     @Override
                     public void run() {
-                        _retryConnection = null;
+                        retryConnectionJob = null;
                         connect();
                     }
                 }, config.getRetryPolling(), TimeUnit.SECONDS);

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgProtocolHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/PrgProtocolHandler.java
@@ -50,12 +50,12 @@ class PrgProtocolHandler {
     /**
      * The {@link SocketSession} used by this protocol handler
      */
-    private final SocketSession _session;
+    private final SocketSession session;
 
     /**
      * The {@link PrgBridgeHandler} to call back to update status and state
      */
-    private final PrgHandlerCallback _callback;
+    private final PrgHandlerCallback phCallback;
 
     // ------------------------------------------------------------------------------------------------
     // The following are the various command formats specified by the
@@ -106,17 +106,17 @@ class PrgProtocolHandler {
      * A lookup between a 0-100 percentage and corresponding hex value. Note: this specifically matches the liason
      * software setup
      */
-    private static final Map<Integer, String> intensityMap = new HashMap<>();
+    private static final Map<Integer, String> INTENSITY_MAP = new HashMap<>();
 
     /**
-     * The reverse lookup for the {{@link #intensityMap}
+     * The reverse lookup for the {{@link #INTENSITY_MAP}
      */
-    private static final Map<String, Integer> reverseIntensityMap = new HashMap<>();
+    private static final Map<String, Integer> REVERSE_INTENSITY_MAP = new HashMap<>();
 
     /**
      * A lookup between returned shade hex intensity to corresponding shade values
      */
-    private static final Map<String, Integer> shadeIntensityMap = new HashMap<>();
+    private static final Map<String, Integer> SHADE_INTENSITY_MAP = new HashMap<>();
 
     /**
      * Cache of current zone intensities
@@ -127,125 +127,125 @@ class PrgProtocolHandler {
      * Static method to setup the intensity lookup maps
      */
     static {
-        intensityMap.put(0, "0");
-        intensityMap.put(1, "2");
-        intensityMap.put(2, "3");
-        intensityMap.put(3, "4");
-        intensityMap.put(4, "6");
-        intensityMap.put(5, "7");
-        intensityMap.put(6, "8");
-        intensityMap.put(7, "9");
-        intensityMap.put(8, "B");
-        intensityMap.put(9, "C");
-        intensityMap.put(10, "D");
-        intensityMap.put(11, "F");
-        intensityMap.put(12, "10");
-        intensityMap.put(13, "11");
-        intensityMap.put(14, "12");
-        intensityMap.put(15, "14");
-        intensityMap.put(16, "15");
-        intensityMap.put(17, "16");
-        intensityMap.put(18, "18");
-        intensityMap.put(19, "19");
-        intensityMap.put(20, "1A");
-        intensityMap.put(21, "1B");
-        intensityMap.put(22, "1D");
-        intensityMap.put(23, "1E");
-        intensityMap.put(24, "1F");
-        intensityMap.put(25, "20");
-        intensityMap.put(26, "22");
-        intensityMap.put(27, "23");
-        intensityMap.put(28, "24");
-        intensityMap.put(29, "26");
-        intensityMap.put(30, "27");
-        intensityMap.put(31, "28");
-        intensityMap.put(32, "29");
-        intensityMap.put(33, "2B");
-        intensityMap.put(34, "2C");
-        intensityMap.put(35, "2D");
-        intensityMap.put(36, "2F");
-        intensityMap.put(37, "30");
-        intensityMap.put(38, "31");
-        intensityMap.put(39, "32");
-        intensityMap.put(40, "34");
-        intensityMap.put(41, "35");
-        intensityMap.put(42, "36");
-        intensityMap.put(43, "38");
-        intensityMap.put(44, "39");
-        intensityMap.put(45, "3A");
-        intensityMap.put(46, "3B");
-        intensityMap.put(47, "3D");
-        intensityMap.put(48, "3E");
-        intensityMap.put(49, "3F");
-        intensityMap.put(50, "40");
-        intensityMap.put(51, "42");
-        intensityMap.put(52, "43");
-        intensityMap.put(53, "44");
-        intensityMap.put(54, "46");
-        intensityMap.put(55, "47");
-        intensityMap.put(56, "48");
-        intensityMap.put(57, "49");
-        intensityMap.put(58, "4B");
-        intensityMap.put(59, "4C");
-        intensityMap.put(60, "4D");
-        intensityMap.put(61, "4F");
-        intensityMap.put(62, "50");
-        intensityMap.put(63, "51");
-        intensityMap.put(64, "52");
-        intensityMap.put(65, "54");
-        intensityMap.put(66, "55");
-        intensityMap.put(67, "56");
-        intensityMap.put(68, "58");
-        intensityMap.put(69, "59");
-        intensityMap.put(70, "5A");
-        intensityMap.put(71, "5B");
-        intensityMap.put(72, "5D");
-        intensityMap.put(73, "5E");
-        intensityMap.put(74, "5F");
-        intensityMap.put(75, "60");
-        intensityMap.put(76, "62");
-        intensityMap.put(77, "63");
-        intensityMap.put(78, "64");
-        intensityMap.put(79, "66");
-        intensityMap.put(80, "67");
-        intensityMap.put(81, "68");
-        intensityMap.put(82, "69");
-        intensityMap.put(83, "6B");
-        intensityMap.put(84, "6C");
-        intensityMap.put(85, "6D");
-        intensityMap.put(86, "6F");
-        intensityMap.put(87, "70");
-        intensityMap.put(88, "71");
-        intensityMap.put(89, "72");
-        intensityMap.put(90, "74");
-        intensityMap.put(91, "75");
-        intensityMap.put(92, "76");
-        intensityMap.put(93, "78");
-        intensityMap.put(94, "79");
-        intensityMap.put(95, "7A");
-        intensityMap.put(96, "7B");
-        intensityMap.put(97, "7D");
-        intensityMap.put(98, "7E");
-        intensityMap.put(99, "7F");
-        intensityMap.put(100, "7F");
+        INTENSITY_MAP.put(0, "0");
+        INTENSITY_MAP.put(1, "2");
+        INTENSITY_MAP.put(2, "3");
+        INTENSITY_MAP.put(3, "4");
+        INTENSITY_MAP.put(4, "6");
+        INTENSITY_MAP.put(5, "7");
+        INTENSITY_MAP.put(6, "8");
+        INTENSITY_MAP.put(7, "9");
+        INTENSITY_MAP.put(8, "B");
+        INTENSITY_MAP.put(9, "C");
+        INTENSITY_MAP.put(10, "D");
+        INTENSITY_MAP.put(11, "F");
+        INTENSITY_MAP.put(12, "10");
+        INTENSITY_MAP.put(13, "11");
+        INTENSITY_MAP.put(14, "12");
+        INTENSITY_MAP.put(15, "14");
+        INTENSITY_MAP.put(16, "15");
+        INTENSITY_MAP.put(17, "16");
+        INTENSITY_MAP.put(18, "18");
+        INTENSITY_MAP.put(19, "19");
+        INTENSITY_MAP.put(20, "1A");
+        INTENSITY_MAP.put(21, "1B");
+        INTENSITY_MAP.put(22, "1D");
+        INTENSITY_MAP.put(23, "1E");
+        INTENSITY_MAP.put(24, "1F");
+        INTENSITY_MAP.put(25, "20");
+        INTENSITY_MAP.put(26, "22");
+        INTENSITY_MAP.put(27, "23");
+        INTENSITY_MAP.put(28, "24");
+        INTENSITY_MAP.put(29, "26");
+        INTENSITY_MAP.put(30, "27");
+        INTENSITY_MAP.put(31, "28");
+        INTENSITY_MAP.put(32, "29");
+        INTENSITY_MAP.put(33, "2B");
+        INTENSITY_MAP.put(34, "2C");
+        INTENSITY_MAP.put(35, "2D");
+        INTENSITY_MAP.put(36, "2F");
+        INTENSITY_MAP.put(37, "30");
+        INTENSITY_MAP.put(38, "31");
+        INTENSITY_MAP.put(39, "32");
+        INTENSITY_MAP.put(40, "34");
+        INTENSITY_MAP.put(41, "35");
+        INTENSITY_MAP.put(42, "36");
+        INTENSITY_MAP.put(43, "38");
+        INTENSITY_MAP.put(44, "39");
+        INTENSITY_MAP.put(45, "3A");
+        INTENSITY_MAP.put(46, "3B");
+        INTENSITY_MAP.put(47, "3D");
+        INTENSITY_MAP.put(48, "3E");
+        INTENSITY_MAP.put(49, "3F");
+        INTENSITY_MAP.put(50, "40");
+        INTENSITY_MAP.put(51, "42");
+        INTENSITY_MAP.put(52, "43");
+        INTENSITY_MAP.put(53, "44");
+        INTENSITY_MAP.put(54, "46");
+        INTENSITY_MAP.put(55, "47");
+        INTENSITY_MAP.put(56, "48");
+        INTENSITY_MAP.put(57, "49");
+        INTENSITY_MAP.put(58, "4B");
+        INTENSITY_MAP.put(59, "4C");
+        INTENSITY_MAP.put(60, "4D");
+        INTENSITY_MAP.put(61, "4F");
+        INTENSITY_MAP.put(62, "50");
+        INTENSITY_MAP.put(63, "51");
+        INTENSITY_MAP.put(64, "52");
+        INTENSITY_MAP.put(65, "54");
+        INTENSITY_MAP.put(66, "55");
+        INTENSITY_MAP.put(67, "56");
+        INTENSITY_MAP.put(68, "58");
+        INTENSITY_MAP.put(69, "59");
+        INTENSITY_MAP.put(70, "5A");
+        INTENSITY_MAP.put(71, "5B");
+        INTENSITY_MAP.put(72, "5D");
+        INTENSITY_MAP.put(73, "5E");
+        INTENSITY_MAP.put(74, "5F");
+        INTENSITY_MAP.put(75, "60");
+        INTENSITY_MAP.put(76, "62");
+        INTENSITY_MAP.put(77, "63");
+        INTENSITY_MAP.put(78, "64");
+        INTENSITY_MAP.put(79, "66");
+        INTENSITY_MAP.put(80, "67");
+        INTENSITY_MAP.put(81, "68");
+        INTENSITY_MAP.put(82, "69");
+        INTENSITY_MAP.put(83, "6B");
+        INTENSITY_MAP.put(84, "6C");
+        INTENSITY_MAP.put(85, "6D");
+        INTENSITY_MAP.put(86, "6F");
+        INTENSITY_MAP.put(87, "70");
+        INTENSITY_MAP.put(88, "71");
+        INTENSITY_MAP.put(89, "72");
+        INTENSITY_MAP.put(90, "74");
+        INTENSITY_MAP.put(91, "75");
+        INTENSITY_MAP.put(92, "76");
+        INTENSITY_MAP.put(93, "78");
+        INTENSITY_MAP.put(94, "79");
+        INTENSITY_MAP.put(95, "7A");
+        INTENSITY_MAP.put(96, "7B");
+        INTENSITY_MAP.put(97, "7D");
+        INTENSITY_MAP.put(98, "7E");
+        INTENSITY_MAP.put(99, "7F");
+        INTENSITY_MAP.put(100, "7F");
 
-        for (int key : intensityMap.keySet()) {
-            String value = intensityMap.get(key);
-            reverseIntensityMap.put(value, key);
+        for (int key : INTENSITY_MAP.keySet()) {
+            String value = INTENSITY_MAP.get(key);
+            REVERSE_INTENSITY_MAP.put(value, key);
         }
 
-        shadeIntensityMap.put("0", 0);
-        shadeIntensityMap.put("5E", 0);
-        shadeIntensityMap.put("15", 1);
-        shadeIntensityMap.put("2D", 2);
-        shadeIntensityMap.put("71", 3);
-        shadeIntensityMap.put("72", 4);
-        shadeIntensityMap.put("73", 5);
-        shadeIntensityMap.put("5F", 1);
-        shadeIntensityMap.put("60", 2);
-        shadeIntensityMap.put("61", 3);
-        shadeIntensityMap.put("62", 4);
-        shadeIntensityMap.put("63", 5);
+        SHADE_INTENSITY_MAP.put("0", 0);
+        SHADE_INTENSITY_MAP.put("5E", 0);
+        SHADE_INTENSITY_MAP.put("15", 1);
+        SHADE_INTENSITY_MAP.put("2D", 2);
+        SHADE_INTENSITY_MAP.put("71", 3);
+        SHADE_INTENSITY_MAP.put("72", 4);
+        SHADE_INTENSITY_MAP.put("73", 5);
+        SHADE_INTENSITY_MAP.put("5F", 1);
+        SHADE_INTENSITY_MAP.put("60", 2);
+        SHADE_INTENSITY_MAP.put("61", 3);
+        SHADE_INTENSITY_MAP.put("62", 4);
+        SHADE_INTENSITY_MAP.put("63", 5);
     }
 
     /**
@@ -268,8 +268,8 @@ class PrgProtocolHandler {
             throw new IllegalArgumentException("callback cannot be null");
         }
 
-        _session = session;
-        _callback = callback;
+        this.session = session;
+        this.phCallback = callback;
     }
 
     /**
@@ -281,11 +281,11 @@ class PrgProtocolHandler {
     String login(String username) throws Exception {
         logger.info("Logging into the PRG interface");
         final NoDispatchingCallback callback = new NoDispatchingCallback();
-        _session.setCallback(callback);
+        session.setCallback(callback);
 
         String response = callback.getResponse();
         if (response.equals("login")) {
-            _session.sendCommand(username);
+            session.sendCommand(username);
         } else {
             return "Protocol violation - wasn't initially a command failure or login prompt: " + response;
         }
@@ -313,8 +313,8 @@ class PrgProtocolHandler {
      */
     private void postLogin() throws IOException {
         logger.info("PRG interface now connected");
-        _session.setCallback(new NormalResponseCallback());
-        _callback.statusChanged(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
+        session.setCallback(new NormalResponseCallback());
+        phCallback.statusChanged(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
     }
 
     /**
@@ -415,14 +415,14 @@ class PrgProtocolHandler {
             throw new IllegalArgumentException("Invalid intensity (must be between 0 and 100): " + intensity);
         }
 
-        final boolean isShade = _callback.isShade(controlUnit, zone);
+        final boolean isShade = phCallback.isShade(controlUnit, zone);
         if (isShade) {
             if (intensity > 5) {
                 throw new IllegalArgumentException("Invalid SHADE intensity (must be between 0 and 5): " + intensity);
             }
             return Integer.toString(intensity);
         } else {
-            final String hexNbr = intensityMap.get(intensity);
+            final String hexNbr = INTENSITY_MAP.get(intensity);
             if (hexNbr == null) { // this should be impossible as all 100 values are in table
                 logger.warn("Unknown zone intensity ({})", intensity);
                 return Integer.toHexString(intensity).toUpperCase();
@@ -444,17 +444,17 @@ class PrgProtocolHandler {
         validateControlUnit(controlUnit);
         validateZone(zone);
 
-        final boolean isShade = _callback.isShade(controlUnit, zone);
+        final boolean isShade = phCallback.isShade(controlUnit, zone);
 
         if (isShade) {
-            final Integer intNbr = shadeIntensityMap.get(intensity);
+            final Integer intNbr = SHADE_INTENSITY_MAP.get(intensity);
             if (intNbr == null) {
                 logger.warn("Unknown shade intensity ({})", intensity);
                 return Integer.parseInt(intensity, 16);
             }
             return intNbr;
         } else {
-            final Integer intNbr = reverseIntensityMap.get(intensity);
+            final Integer intNbr = REVERSE_INTENSITY_MAP.get(intensity);
             if (intNbr == null) {
                 logger.warn("Unknown zone intensity ({})", intensity);
                 return Integer.parseInt(intensity, 16);
@@ -570,7 +570,7 @@ class PrgProtocolHandler {
      * @throws IllegalArgumentException if controlUnit, zone or fade is invalid
      */
     void setZoneIntensity(int controlUnit, int zone, int fade, boolean increase) {
-        if (_callback.isShade(controlUnit, zone)) {
+        if (phCallback.isShade(controlUnit, zone)) {
             return;
         }
 
@@ -718,9 +718,9 @@ class PrgProtocolHandler {
         }
         try {
             logger.debug("SendCommand: {}", command);
-            _session.sendCommand(command);
+            session.sendCommand(command);
         } catch (IOException e) {
-            _callback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+            phCallback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Exception occurred sending to PRG: " + e);
         }
     }
@@ -853,7 +853,7 @@ class PrgProtocolHandler {
                     if (scene < 0) {
                         logger.warn("Unknown scene status returned for zone {}: {}", i, status);
                     } else {
-                        _callback.stateChanged(i, PrgConstants.CHANNEL_SCENE, new DecimalType(scene));
+                        phCallback.stateChanged(i, PrgConstants.CHANNEL_SCENE, new DecimalType(scene));
                         refreshZoneIntensity(i); // request to get new zone intensities
                     }
                 }
@@ -886,7 +886,7 @@ class PrgProtocolHandler {
                 final int yr = Integer.parseInt(m.group(5));
                 c.set(Calendar.YEAR, yr + (yr < 50 ? 1900 : 2000));
 
-                _callback.stateChanged(PrgConstants.CHANNEL_TIMECLOCK,
+                phCallback.stateChanged(PrgConstants.CHANNEL_TIMECLOCK,
                         new DateTimeType(ZonedDateTime.ofInstant(c.toInstant(), ZoneId.systemDefault())));
             } catch (NumberFormatException e) {
                 logger.error("Invalid time response (can't parse number): '{}'", resp);
@@ -909,7 +909,7 @@ class PrgProtocolHandler {
         if (m.groupCount() == 2) {
             try {
                 int schedule = Integer.parseInt(m.group(1));
-                _callback.stateChanged(PrgConstants.CHANNEL_SCHEDULE, new DecimalType(schedule));
+                phCallback.stateChanged(PrgConstants.CHANNEL_SCHEDULE, new DecimalType(schedule));
             } catch (NumberFormatException e) {
                 logger.error("Invalid schedule response (can't parse number): '{}'", resp);
             }
@@ -937,13 +937,13 @@ class PrgProtocolHandler {
                 final Calendar sunrise = Calendar.getInstance();
                 sunrise.set(Calendar.HOUR_OF_DAY, Integer.parseInt(m.group(1)));
                 sunrise.set(Calendar.MINUTE, Integer.parseInt(m.group(2)));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUNRISE,
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUNRISE,
                         new DateTimeType(ZonedDateTime.ofInstant(sunrise.toInstant(), ZoneId.systemDefault())));
 
                 final Calendar sunset = Calendar.getInstance();
                 sunset.set(Calendar.HOUR_OF_DAY, Integer.parseInt(m.group(3)));
                 sunset.set(Calendar.MINUTE, Integer.parseInt(m.group(4)));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUNSET,
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUNSET,
                         new DateTimeType(ZonedDateTime.ofInstant(sunset.toInstant(), ZoneId.systemDefault())));
             } catch (NumberFormatException e) {
                 logger.error("Invalid sunrise/sunset response (can't parse number): '{}'", resp);
@@ -968,10 +968,10 @@ class PrgProtocolHandler {
                 final int nextStep = Integer.parseInt(m.group(2));
                 final int nextMin = Integer.parseInt(m.group(3));
                 final int nextSec = Integer.parseInt(m.group(4));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCESTATUS, new StringType(m.group(1)));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSTEP, new DecimalType(nextStep));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTMIN, new DecimalType(nextMin));
-                _callback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSEC, new DecimalType(nextSec));
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCESTATUS, new StringType(m.group(1)));
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSTEP, new DecimalType(nextStep));
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTMIN, new DecimalType(nextMin));
+                phCallback.stateChanged(PrgConstants.CHANNEL_SUPERSEQUENCENEXTSEC, new DecimalType(nextSec));
             } catch (NumberFormatException e) {
                 logger.error("Invalid volume response (can't parse number): '{}'", resp);
             }
@@ -1001,7 +1001,7 @@ class PrgProtocolHandler {
                     }
                     final int zid = convertIntensity(controlUnit, z, zi);
 
-                    _callback.stateChanged(controlUnit, PrgConstants.CHANNEL_ZONEINTENSITY + z, new PercentType(zid));
+                    phCallback.stateChanged(controlUnit, PrgConstants.CHANNEL_ZONEINTENSITY + z, new PercentType(zid));
                 }
             } catch (NumberFormatException e) {
                 logger.error("Invalid volume response (can't parse number): '{}'", resp);
@@ -1034,11 +1034,11 @@ class PrgProtocolHandler {
                 final boolean zoneLock = (q4bits.length() > 2 ? q4bits.charAt(2) : '0') == '1';
                 final boolean sceneLock = (q4bits.length() > 3 ? q4bits.charAt(4) : '0') == '1';
 
-                _callback.stateChanged(controlUnit, PrgConstants.CHANNEL_SCENESEQ,
+                phCallback.stateChanged(controlUnit, PrgConstants.CHANNEL_SCENESEQ,
                         seqMode ? OnOffType.ON : OnOffType.OFF);
-                _callback.stateChanged(controlUnit, PrgConstants.CHANNEL_SCENELOCK,
+                phCallback.stateChanged(controlUnit, PrgConstants.CHANNEL_SCENELOCK,
                         sceneLock ? OnOffType.ON : OnOffType.OFF);
-                _callback.stateChanged(controlUnit, PrgConstants.CHANNEL_ZONELOCK,
+                phCallback.stateChanged(controlUnit, PrgConstants.CHANNEL_ZONELOCK,
                         zoneLock ? OnOffType.ON : OnOffType.OFF);
             } catch (NumberFormatException e) {
                 logger.error("Invalid controller information response: '{}'", resp);
@@ -1055,7 +1055,7 @@ class PrgProtocolHandler {
      * @param resp the possibly null, possibly empty actual response
      */
     private void handleResetting(Matcher m, String resp) {
-        _callback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE, "Device resetting");
+        phCallback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.DUTY_CYCLE, "Device resetting");
     }
 
     /**
@@ -1065,7 +1065,7 @@ class PrgProtocolHandler {
      * @param resp the possibly null, possibly empty actual response
      */
     private void handleButton(Matcher m, String resp) {
-        _callback.stateChanged(PrgConstants.CHANNEL_BUTTONPRESS, new StringType(resp));
+        phCallback.stateChanged(PrgConstants.CHANNEL_BUTTONPRESS, new StringType(resp));
     }
 
     /**
@@ -1169,7 +1169,7 @@ class PrgProtocolHandler {
 
         @Override
         public void responseException(Exception exception) {
-            _callback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+            phCallback.statusChanged(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Exception occurred reading from PRG: " + exception);
         }
     }
@@ -1186,17 +1186,17 @@ class PrgProtocolHandler {
         /**
          * Cache of responses that have occurred
          */
-        private BlockingQueue<Object> _responses = new ArrayBlockingQueue<>(5);
+        private BlockingQueue<Object> responses = new ArrayBlockingQueue<>(5);
 
         /**
-         * Will return the next response from {@link #_responses}. If the response is an exception, that exception will
+         * Will return the next response from {@link #responses}. If the response is an exception, that exception will
          * be thrown instead.
          *
          * @return a non-null, possibly empty response
          * @throws Exception an exception if one occurred during reading
          */
         String getResponse() throws Exception {
-            final Object lastResponse = _responses.poll(5, TimeUnit.SECONDS);
+            final Object lastResponse = responses.poll(5, TimeUnit.SECONDS);
             if (lastResponse instanceof String) {
                 return (String) lastResponse;
             } else if (lastResponse instanceof Exception) {
@@ -1211,7 +1211,7 @@ class PrgProtocolHandler {
         @Override
         public void responseReceived(String response) {
             try {
-                _responses.put(response);
+                responses.put(response);
             } catch (InterruptedException e) {
             }
         }
@@ -1219,7 +1219,7 @@ class PrgProtocolHandler {
         @Override
         public void responseException(Exception e) {
             try {
-                _responses.put(e);
+                responses.put(e);
             } catch (InterruptedException e1) {
             }
         }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/SocketSession.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/grxprg/SocketSession.java
@@ -42,47 +42,47 @@ public class SocketSession {
     /**
      * The host/ip address to connect to
      */
-    private final String _host;
+    private final String host;
 
     /**
      * The port to connect to
      */
-    private final int _port;
+    private final int port;
 
     /**
      * The actual socket being used. Will be null if not connected
      */
-    private Socket _client;
+    private Socket client;
 
     /**
-     * The writer to the {@link #_client}. Will be null if not connected
+     * The writer to the {@link #client}. Will be null if not connected
      */
-    private PrintStream _writer;
+    private PrintStream writer;
 
     /**
-     * The reader from the {@link #_client}. Will be null if not connected
+     * The reader from the {@link #client}. Will be null if not connected
      */
-    private BufferedReader _reader;
+    private BufferedReader reader;
 
     /**
-     * The {@link ResponseReader} that will be used to read from {@link #_reader}
+     * The {@link ResponseReader} that will be used to read from {@link #reader}
      */
-    private final ResponseReader _responseReader = new ResponseReader();
+    private final ResponseReader responseReader = new ResponseReader();
 
     /**
-     * The responses read from the {@link #_responseReader}
+     * The responses read from the {@link #responseReader}
      */
-    private final BlockingQueue<Object> _responses = new ArrayBlockingQueue<>(50);
+    private final BlockingQueue<Object> responsesQueue = new ArrayBlockingQueue<>(50);
 
     /**
-     * The dispatcher of responses from {@link #_responses}
+     * The dispatcher of responses from {@link #responsesQueue}
      */
-    private final Dispatcher _dispatcher = new Dispatcher();
+    private final Dispatcher dispatcher = new Dispatcher();
 
     /**
-     * The {@link SocketSessionCallback} that the {@link #_dispatcher} will call
+     * The {@link SocketSessionCallback} that the {@link #dispatcher} will call
      */
-    private AtomicReference<SocketSessionCallback> _callback = new AtomicReference<>(null);
+    private AtomicReference<SocketSessionCallback> callback = new AtomicReference<>(null);
 
     /**
      * Creates the socket session from the given host and port
@@ -98,12 +98,12 @@ public class SocketSession {
         if (port < 1 || port > 65535) {
             throw new IllegalArgumentException("Port must be between 1 and 65535");
         }
-        _host = host;
-        _port = port;
+        this.host = host;
+        this.port = port;
     }
 
     /**
-     * Set's the {@link SocketSessionCallback} to use when calling back the
+     * Sets the {@link SocketSessionCallback} to use when calling back the
      * responses that have been received.
      *
      * @param callback a non-null {@link SocketSessionCallback} to use
@@ -112,67 +112,67 @@ public class SocketSession {
         if (callback == null) {
             throw new IllegalArgumentException("callback cannot be null");
         }
-        _callback.set(callback);
+        this.callback.set(callback);
     }
 
     /**
-     * Will attempt to connect to the {@link #_host} on port {@link #_port}. If we are current connected, will
-     * {@link #disconnect()} first. Once connected, the {@link #_writer} and {@link #_reader} will be created, the
-     * {@link #_dispatcher} and {@link #_responseReader} will be started.
+     * Will attempt to connect to the {@link #host} on port {@link #port}. If we are current connected, will
+     * {@link #disconnect()} first. Once connected, the {@link #writer} and {@link #reader} will be created, the
+     * {@link #dispatcher} and {@link #responseReader} will be started.
      *
      * @throws java.io.IOException if an exception occurs during the connection attempt
      */
     public void connect() throws IOException {
         disconnect();
 
-        _client = new Socket(_host, _port);
-        _client.setKeepAlive(true);
-        _client.setSoTimeout(1000); // allow reader to check to see if it should stop every 1 second
+        client = new Socket(host, port);
+        client.setKeepAlive(true);
+        client.setSoTimeout(1000); // allow reader to check to see if it should stop every 1 second
 
-        logger.debug("Connecting to {}:{}", _host, _port);
-        _writer = new PrintStream(_client.getOutputStream());
-        _reader = new BufferedReader(new InputStreamReader(_client.getInputStream()));
+        logger.debug("Connecting to {}:{}", host, port);
+        writer = new PrintStream(client.getOutputStream());
+        reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
 
-        new Thread(_responseReader).start();
-        new Thread(_dispatcher).start();
+        new Thread(responseReader).start();
+        new Thread(dispatcher).start();
     }
 
     /**
-     * Disconnects from the {@link #_host} if we are {@link #isConnected()}. The {@link #_writer}, {@link #_reader} and
-     * {@link #_client}
-     * will be closed and set to null. The {@link #_dispatcher} and {@link #_responseReader} will be stopped, the
-     * {@link #_callback} will be nulled and the {@link #_responses} will be cleared.
+     * Disconnects from the {@link #host} if we are {@link #isConnected()}. The {@link #writer}, {@link #reader} and
+     * {@link #client}
+     * will be closed and set to null. The {@link #dispatcher} and {@link #responseReader} will be stopped, the
+     * {@link #callback} will be nulled and the {@link #responsesQueue} will be cleared.
      *
      * @throws java.io.IOException if an exception occurs during the disconnect attempt
      */
     public void disconnect() throws IOException {
         if (isConnected()) {
-            logger.debug("Disconnecting from {}:{}", _host, _port);
+            logger.debug("Disconnecting from {}:{}", host, port);
 
-            _dispatcher.stopRunning();
-            _responseReader.stopRunning();
+            dispatcher.stopRunning();
+            responseReader.stopRunning();
 
-            _writer.close();
-            _writer = null;
+            writer.close();
+            writer = null;
 
-            _reader.close();
-            _reader = null;
+            reader.close();
+            reader = null;
 
-            _client.close();
-            _client = null;
+            client.close();
+            client = null;
 
-            _callback.set(null);
-            _responses.clear();
+            callback.set(null);
+            responsesQueue.clear();
         }
     }
 
     /**
-     * Returns true if we are connected ({@link #_client} is not null and is connected)
+     * Returns true if we are connected ({@link #client} is not null and is connected)
      *
      * @return true if connected, false otherwise
      */
     public boolean isConnected() {
-        return _client != null && _client.isConnected();
+        return client != null && client.isConnected();
     }
 
     /**
@@ -191,8 +191,8 @@ public class SocketSession {
         }
 
         logger.debug("Sending Command: '{}'", command);
-        _writer.println(command + "\n"); // as pre spec - each command must have a newline
-        _writer.flush();
+        writer.println(command + "\n"); // as pre spec - each command must have a newline
+        writer.flush();
     }
 
     /**
@@ -205,37 +205,37 @@ public class SocketSession {
     private class ResponseReader implements Runnable {
 
         /**
-         * Whether the reader is currently running
+         * Whether the reader is currently rRunning
          */
-        private final AtomicBoolean _isRunning = new AtomicBoolean(false);
+        private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
         /**
          * Locking to allow proper shutdown of the reader
          */
-        private final Lock _lock = new ReentrantLock();
-        private final Condition _running = _lock.newCondition();
+        private final Lock rLock = new ReentrantLock();
+        private final Condition rRunning = rLock.newCondition();
 
         /**
          * Stops the reader. Will wait 5 seconds for the runnable to stop (should stop within 1 second based on the
          * setSOTimeout)
          */
         public void stopRunning() {
-            _lock.lock();
+            rLock.lock();
             try {
-                if (_isRunning.getAndSet(false)) {
-                    if (!_running.await(5, TimeUnit.SECONDS)) {
+                if (isRunning.getAndSet(false)) {
+                    if (!rRunning.await(5, TimeUnit.SECONDS)) {
                         logger.warn("Waited too long for dispatcher to finish");
                     }
                 }
             } catch (InterruptedException e) {
                 // shouldn't happen
             } finally {
-                _lock.unlock();
+                rLock.unlock();
             }
         }
 
         /**
-         * Runs the logic to read from the socket until {@link #_isRunning} is false. A 'response' is anything that ends
+         * Runs the logic to read from the socket until {@link #isRunning} is false. A 'response' is anything that ends
          * with a carriage-return/newline combo. Additionally, the special "login" prompts are
          * treated as responses for purposes of logging in.
          */
@@ -244,21 +244,21 @@ public class SocketSession {
             final StringBuilder sb = new StringBuilder(100);
             int c;
 
-            _isRunning.set(true);
-            _responses.clear();
+            isRunning.set(true);
+            responsesQueue.clear();
 
-            while (_isRunning.get()) {
+            while (isRunning.get()) {
                 try {
                     // if reader is null, sleep and try again
-                    if (_reader == null) {
+                    if (reader == null) {
                         Thread.sleep(250);
                         continue;
                     }
 
-                    c = _reader.read();
+                    c = reader.read();
                     if (c == -1) {
-                        _responses.put(new IOException("server closed connection"));
-                        _isRunning.set(false);
+                        responsesQueue.put(new IOException("server closed connection"));
+                        isRunning.set(false);
                         break;
                     }
                     final char ch = (char) c;
@@ -269,7 +269,7 @@ public class SocketSession {
                             sb.setLength(0);
                             final String response = str.substring(0, str.length() - 2);
                             logger.debug("Received response: {}", response);
-                            _responses.put(response);
+                            responsesQueue.put(response);
                         }
                     }
                     // logger.debug(">>> reading: " + sb + ":" + (int) ch);
@@ -279,19 +279,19 @@ public class SocketSession {
                     // Do nothing - probably shutting down
                 } catch (IOException e) {
                     try {
-                        _isRunning.set(false);
-                        _responses.put(e);
+                        isRunning.set(false);
+                        responsesQueue.put(e);
                     } catch (InterruptedException e1) {
                         // Do nothing - probably shutting down
                     }
                 }
             }
 
-            _lock.lock();
+            rLock.lock();
             try {
-                _running.signalAll();
+                rRunning.signalAll();
             } finally {
-                _lock.unlock();
+                rLock.unlock();
             }
         }
     }
@@ -307,64 +307,64 @@ public class SocketSession {
     private class Dispatcher implements Runnable {
 
         /**
-         * Whether the dispatcher is running or not
+         * Whether the dispatcher is rRunning or not
          */
-        private final AtomicBoolean _isRunning = new AtomicBoolean(false);
+        private final AtomicBoolean dispatcherRunning = new AtomicBoolean(false);
 
         /**
          * Locking to allow proper shutdown of the reader
          */
-        private final Lock _lock = new ReentrantLock();
-        private final Condition _running = _lock.newCondition();
+        private final Lock dLock = new ReentrantLock();
+        private final Condition dRunning = dLock.newCondition();
 
         /**
          * Stops the reader. Will wait 5 seconds for the runnable to stop (should stop within 1 second based on the poll
          * timeout below)
          */
         public void stopRunning() {
-            _lock.lock();
+            dLock.lock();
             try {
-                if (_isRunning.getAndSet(false)) {
-                    if (!_running.await(5, TimeUnit.SECONDS)) {
+                if (dispatcherRunning.getAndSet(false)) {
+                    if (!dRunning.await(5, TimeUnit.SECONDS)) {
                         logger.warn("Waited too long for dispatcher to finish");
                     }
                 }
             } catch (InterruptedException e) {
                 // do nothing
             } finally {
-                _lock.unlock();
+                dLock.unlock();
             }
         }
 
         /**
-         * Runs the logic to dispatch any responses to the current _callback until {@link #_isRunning} is false.
+         * Runs the logic to dispatch any responses to the current callback until {@link #isRunning} is false.
          */
         @Override
         public void run() {
-            _isRunning.set(true);
-            while (_isRunning.get()) {
+            dispatcherRunning.set(true);
+            while (dispatcherRunning.get()) {
                 try {
-                    final SocketSessionCallback callback = _callback.get();
+                    final SocketSessionCallback ssCallback = callback.get();
 
                     // if callback is null, we don't want to start dispatching yet.
-                    if (callback == null) {
+                    if (ssCallback == null) {
                         Thread.sleep(250);
                         continue;
                     }
 
-                    final Object response = _responses.poll(1, TimeUnit.SECONDS);
+                    final Object response = responsesQueue.poll(1, TimeUnit.SECONDS);
 
                     if (response != null) {
                         if (response instanceof String) {
                             try {
                                 logger.debug("Dispatching response: {}", response);
-                                callback.responseReceived((String) response);
+                                ssCallback.responseReceived((String) response);
                             } catch (Exception e) {
                                 logger.warn("Exception occurred processing the response '{}': ", response, e);
                             }
                         } else if (response instanceof Exception) {
                             logger.debug("Dispatching exception: {}", response);
-                            callback.responseException((Exception) response);
+                            ssCallback.responseException((Exception) response);
                         } else {
                             logger.error("Unknown response class: {}", response);
                         }
@@ -374,12 +374,12 @@ public class SocketSession {
                 }
             }
 
-            _lock.lock();
+            dLock.lock();
             try {
                 // Signal that we are done
-                _running.signalAll();
+                dRunning.signalAll();
             } finally {
-                _lock.unlock();
+                dLock.unlock();
             }
         }
     }


### PR DESCRIPTION
This commit consists entirely of changes to field names made in order to eliminate warnings from the code analysis tool. Mainly it involved removing leading underscores and de-conflicting the results. It's been an on-going project to try to eliminate all SCA warnings, although there is still a long way to go when it comes to null annotations.

@tmrobert8 - It looks like you are the original contributor of the modified files (for GRX-PRG), so I'd appreciate it if you could review and/or test it out. I don't have the hardware to test it myself.

