### PR TITLE
[adorne] Add https for website (otherwise the link is not recognized)

### DIFF
--- a/bundles/org.openhab.binding.adorne/README.md
+++ b/bundles/org.openhab.binding.adorne/README.md
@@ -1,6 +1,6 @@
 # Adorne Binding 
 
-The Adorne Binding integrates [Adorne Wi-Fi ready devices](https://www.legrand.us/adorne/products/wireless-whole-house-lighting-controls.aspx) (switches, dimmers, outlets) from [Legrand](legrand.com).
+The Adorne Binding integrates [Adorne Wi-Fi ready devices](https://www.legrand.us/adorne/products/wireless-whole-house-lighting-controls.aspx) (switches, dimmers, outlets) from [Legrand](https://legrand.com/).
 
 Legrand attempted to provide a public API based on Samsung's ARTIK Cloud and the initial version of this binding was based on that API.
 However, Samsung shut down ARTIK Cloud shortly after the release and Legrand has not offered a public API replacement since.


### PR DESCRIPTION
Legrand website was just used as name, however in Markup syntax. This results in an invalid link:

```
https://www.openhab.org/addons/bindings/adorne/legrand.com
```
