### PR TITLE
[melcloud] List devices on all levels

### DIFF
--- a/bundles/org.openhab.binding.melcloud/src/main/java/org/openhab/binding/melcloud/internal/api/MelCloudConnection.java
+++ b/bundles/org.openhab.binding.melcloud/src/main/java/org/openhab/binding/melcloud/internal/api/MelCloudConnection.java
@@ -106,6 +106,11 @@ public class MelCloudConnection {
                 if (building.getStructure().getDevices() != null) {
                     devices.addAll(building.getStructure().getDevices());
                 }
+                building.getStructure().getAreas().forEach(area -> {
+                    if (area.getDevices() != null) {
+                        devices.addAll(area.getDevices());
+                    }
+                });
                 building.getStructure().getFloors().forEach(floor -> {
                     if (floor.getDevices() != null) {
                         devices.addAll(floor.getDevices());


### PR DESCRIPTION
We weren't listing devices that where added to an Area which was not added to a Floor.
Now it lists all devices.

Signed-off-by: Wietse van Buitenen <thewiep@gmail.com>