### PR TITLE
[lutron] Deprecate ccopulsed and ccomaintained things

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -382,10 +382,8 @@ The `pulseLength` parameter sets the pulse length in seconds for a pulsed output
 It can range from 0.25 to 99.0 seconds and defaults to 0.5. It is ignored if `outputType="Maintained"`.
 Be aware that the Lutron controller may round the pulse length down to the nearest 0.25 seconds.
 
-The **ccopulsed** and **ccomaintained** things are just **cco** things with the `outputType` fixed.
-They are used by autodiscovery to automatically set the correct output type.
-You can also use them in manual configurations, if you prefer.
-This may be a good idea if you are interfacing to sensitive equipment where accidentally setting the wrong output type might cause equipment damage.
+**Note:** The **ccopulsed** and **ccomaintained** things are now deprecated.
+You should use the **cco** thing with the appropriate `outputType` setting instead.
 
 Each **cco** thing creates one switch channel called *switchstatus*.
 For pulsed CCOs, sending an ON command will close the output for the configured pulse time.
@@ -399,8 +397,7 @@ Thing configuration file example:
 
 ```
 Thing cco garage [ integrationId=5, outputType="Pulsed", pulseLength=0.5 ]
-Thing ccopulsed gate [ integrationId=6, pulseLength=0.25 ]
-Thing ccomaintained relay1 [ integrationId=7 ]
+Thing cco relay1 [ integrationId=7, outputType="Maintained"]
 ```
 
 ### Shades

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -80,9 +80,9 @@ public class LutronBindingConstants {
     public static final String INTEGRATION_ID = "integrationId";
 
     // CCO config properties
-    public static final String OUTPUT_TYPE = "outputType";
-    public static final String OUTPUT_TYPE_PULSED = "Pulsed";
-    public static final String OUTPUT_TYPE_MAINTAINED = "Maintained";
+    public static final String CCO_TYPE = "outputType";
+    public static final String CCO_TYPE_PULSED = "Pulsed";
+    public static final String CCO_TYPE_MAINTAINED = "Maintained";
     public static final String DEFAULT_PULSE = "pulseLength";
 
     // GreenMode config properties

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -85,23 +85,24 @@ import org.slf4j.LoggerFactory;
 public class LutronHandlerFactory extends BaseThingHandlerFactory {
 
     // Used by LutronDeviceDiscoveryService to discover these types
-    public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = Collections.unmodifiableSet(
-            Stream.of(THING_TYPE_DIMMER, THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR, THING_TYPE_KEYPAD,
-                    THING_TYPE_TTKEYPAD, THING_TYPE_INTLKEYPAD, THING_TYPE_PICO, THING_TYPE_VIRTUALKEYPAD,
-                    THING_TYPE_VCRX, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED, THING_TYPE_SHADE,
-                    THING_TYPE_TIMECLOCK, THING_TYPE_GREENMODE, THING_TYPE_QSIO, THING_TYPE_GRAFIKEYEKEYPAD,
-                    THING_TYPE_BLIND, THING_TYPE_PALLADIOMKEYPAD, THING_TYPE_WCI).collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_DIMMER, THING_TYPE_SWITCH, THING_TYPE_OCCUPANCYSENSOR,
+                    THING_TYPE_KEYPAD, THING_TYPE_TTKEYPAD, THING_TYPE_INTLKEYPAD, THING_TYPE_PICO,
+                    THING_TYPE_VIRTUALKEYPAD, THING_TYPE_VCRX, THING_TYPE_CCO, THING_TYPE_SHADE, THING_TYPE_TIMECLOCK,
+                    THING_TYPE_GREENMODE, THING_TYPE_QSIO, THING_TYPE_GRAFIKEYEKEYPAD, THING_TYPE_BLIND,
+                    THING_TYPE_PALLADIOMKEYPAD, THING_TYPE_WCI).collect(Collectors.toSet()));
 
     // Used by the HwDiscoveryService
     public static final Set<ThingTypeUID> HW_DISCOVERABLE_DEVICE_TYPES_UIDS = Collections
             .unmodifiableSet(Collections.singleton(HwConstants.THING_TYPE_HWDIMMER));
 
     // Other types that can be initiated but not discovered
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
-            Stream.of(THING_TYPE_IPBRIDGE, PrgConstants.THING_TYPE_PRGBRIDGE, PrgConstants.THING_TYPE_GRAFIKEYE,
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
+            .of(THING_TYPE_IPBRIDGE, PrgConstants.THING_TYPE_PRGBRIDGE, PrgConstants.THING_TYPE_GRAFIKEYE,
                     RadioRAConstants.THING_TYPE_RS232, RadioRAConstants.THING_TYPE_DIMMER,
                     RadioRAConstants.THING_TYPE_SWITCH, RadioRAConstants.THING_TYPE_PHANTOM,
-                    HwConstants.THING_TYPE_HWSERIALBRIDGE, THING_TYPE_CCO).collect(Collectors.toSet()));
+                    HwConstants.THING_TYPE_HWSERIALBRIDGE, THING_TYPE_CCO_PULSED, THING_TYPE_CCO_MAINTAINED)
+            .collect(Collectors.toSet()));
 
     private final Logger logger = LoggerFactory.getLogger(LutronHandlerFactory.class);
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -396,11 +396,11 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
                     break;
 
                 case CCO_PULSED:
-                    notifyDiscovery(THING_TYPE_CCO_PULSED, output.getIntegrationId(), label);
+                    notifyDiscovery(THING_TYPE_CCO, output.getIntegrationId(), label, CCO_TYPE, CCO_TYPE_PULSED);
                     break;
 
                 case CCO_MAINTAINED:
-                    notifyDiscovery(THING_TYPE_CCO_MAINTAINED, output.getIntegrationId(), label);
+                    notifyDiscovery(THING_TYPE_CCO, output.getIntegrationId(), label, CCO_TYPE, CCO_TYPE_MAINTAINED);
                     break;
 
                 case SYSTEM_SHADE:

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/CcoHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/CcoHandler.java
@@ -82,12 +82,12 @@ public class CcoHandler extends LutronHandler {
 
         // Determine output type from configuration if not pre-defined by subclass
         if (outputType == null) {
-            String oType = (String) getThing().getConfiguration().get(OUTPUT_TYPE);
+            String oType = (String) getThing().getConfiguration().get(CCO_TYPE);
 
-            if (oType == null || oType == OUTPUT_TYPE_PULSED) {
+            if (oType == null || oType == CCO_TYPE_PULSED) {
                 logger.debug("Setting CCO type Pulsed for device {}.", integrationId);
                 outputType = CcoOutputType.PULSED;
-            } else if (oType == OUTPUT_TYPE_MAINTAINED) {
+            } else if (oType == CCO_TYPE_MAINTAINED) {
                 logger.debug("Setting CCO type Maintained for device {}.", integrationId);
                 outputType = CcoOutputType.MAINTAINED;
             } else {

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -201,13 +201,13 @@
 		</config-description>
 	</thing-type>
 
-	<thing-type id="ccopulsed">
+	<thing-type id="ccopulsed" listed="false">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>
 		</supported-bridge-type-refs>
 
-		<label>Pulsed CCO</label>
-		<description>Pulsed Contact Closure Output</description>
+		<label>Pulsed CCO (Deprecated)</label>
+		<description>Pulsed Contact Closure Output (Deprecated)</description>
 
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>
@@ -228,13 +228,13 @@
 		</config-description>
 	</thing-type>
 
-	<thing-type id="ccomaintained">
+	<thing-type id="ccomaintained" listed="false">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="ipbridge"/>
 		</supported-bridge-type-refs>
 
-		<label>Maintained CCO</label>
-		<description>Maintained Contact Closure Output</description>
+		<label>Maintained CCO (Deprecated)</label>
+		<description>Maintained Contact Closure Output (Deprecated)</description>
 
 		<channels>
 			<channel id="switchstatus" typeId="switchState"/>


### PR DESCRIPTION
This commit deprecates the ccopulsed and ccomaintained things. Users should use the cco thing instead. There is no loss or change in functionality.

* Discovery will now create cco instead of ccopulsed and ccomaintained things.
* The ccopulsed and ccomaintained thing types are now defined with listed=false.
* The thing descriptions are marked with "Deprecated".
* Docs have been updates with the change.

Looking back, I should not have created separate cco, ccopulsed, and ccomaintained things. I did it based on some mistaken assumptions about discovery. So now is as good a time as any to clean this up. The deprecated things will continue to work for now, but I would like to remove them in or after the OH 3.0 release.
