### PR TITLE
[alarmdecoder] additional message parsing for zone faults, and default the keypad mask

### DIFF
--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/KeypadHandler.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/handler/KeypadHandler.java
@@ -155,7 +155,9 @@ public class KeypadHandler extends ADThingHandler {
             return;
         }
         KeypadMessage kpMsg = (KeypadMessage) msg;
+
         int addressMask = kpMsg.getIntAddressMask();
+
         if (!(((config.addressMask & addressMask) != 0) || config.addressMask == 0 || addressMask == 0)) {
             return;
         }
@@ -167,7 +169,8 @@ public class KeypadHandler extends ADThingHandler {
 
         if (config.sendStar) {
             if (kpMsg.alphaMessage.contains("Hit * for faults") || kpMsg.alphaMessage.contains("Press * to show faults")
-                    || kpMsg.alphaMessage.contains("Press * Key")) {
+                    || kpMsg.alphaMessage.contains("Press * Key")
+                    || kpMsg.alphaMessage.contains("Press *  to show faults")) {
                 logger.debug("Sending * command to show faults.");
                 if (singleAddress) {
                     sendCommand(ADCommand.addressedMessage(config.addressMask, "*")); // send from keypad address

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -239,9 +239,10 @@
 		</channels>
 
 		<config-description>
-			<parameter name="addressMask" type="text" required="true">
+			<parameter name="addressMask" type="text">
 				<label>Address Mask</label>
-				<description>Keypad address mask</description>
+				<description>Receive and send messages from a specific keypad (0=any)</description>
+				<default>0</default>
 			</parameter>
 			<parameter name="sendCommands" type="boolean">
 				<label>Send Commands</label>


### PR DESCRIPTION
An additional keypad message needs to be checked for the sendStar option to work in some cases.
Default the keypad thing mask to 0 and clarify what it actually is.


Signed-off-by: bill <git@billforsyth.net>

