### PR TITLE
[lutron] Added a feature to override dimmer Thing configuration fade in/out times

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -531,6 +531,8 @@ The following is a summary of channels for all RadioRA 2 binding things:
 | Thing               | Channel           | Item Type     | Description                                  |
 |---------------------|-------------------|---------------|--------------------------------------------- |
 | dimmer              | lightlevel        | Dimmer        | Increase/decrease the light level            |
+| dimmer              | enablefadetime    | Switch        | Override default fade in/out time            |
+| dimmer              | fadetime          | Number        | Fade time when changing light level          |
 | switch              | switchstatus      | Switch        | On/off status of the switch                  |
 | occupancysensor     | occupancystatus   | Switch        | Occupancy status                             |
 | cco                 | switchstatus      | Switch        | On/off status of the CCO                     |
@@ -556,6 +558,8 @@ Appropriate channels will be created automatically by the keypad, ttkeypad, intl
 | Thing     | Channel       | Native Type  | Accepts                                               |
 |-----------|---------------|--------------|-------------------------------------------------------|
 |dimmer     |lightlevel     |PercentType   |OnOffType, PercentType                                 |
+|dimmer     |enablefadetime |OnOffType     |OnOffType                                              |
+|dimmer     |fadetime       |DecimalType   |DecimalType                                            |
 |switch     |switchstatus   |OnOffType     |OnOffType                                              |
 |occ. sensor|occupancystatus|OnOffType     |(*readonly*)                                           |
 |cco        |switchstatus   |OnOffType     |OnOffType, RefreshType                                 |

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronBindingConstants.java
@@ -65,6 +65,8 @@ public class LutronBindingConstants {
     public static final String CHANNEL_STEP = "step";
     public static final String CHANNEL_BLINDLIFTLEVEL = "blindliftlevel";
     public static final String CHANNEL_BLINDTILTLEVEL = "blindtiltlevel";
+    public static final String CHANNEL_ENABLEFADETIME = "enablefadetime";
+    public static final String CHANNEL_FADETIME = "fadetime";
 
     // Bridge config properties (used by discovery service)
     public static final String HOST = "ipAddress";

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -67,6 +67,8 @@
 
 		<channels>
 			<channel id="lightlevel" typeId="lightDimmer"/>
+			<channel id="enablefadetime" typeId="enableFadeTime"/>
+			<channel id="fadetime" typeId="fadeTime"/>
 		</channels>
 
 		<representation-property>integrationId</representation-property>
@@ -1098,6 +1100,20 @@
 		<description>Increase/decrease the light level</description>
 		<category>DimmableLight</category>
 		<state min="0" max="100" pattern="%d %%"/>
+	</channel-type>
+
+	<channel-type id="enableFadeTime">
+		<item-type>Switch</item-type>
+		<label>Enable Fade Time</label>
+		<description>Allows config fade in/out time to be overridden</description>
+	</channel-type>
+
+	<channel-type id="fadeTime">
+		<item-type>Number</item-type>
+		<label>Fade In/Out Time</label>
+		<description>Sets time in seconds to increase/decrease light level</description>
+		<category>Number</category>
+		<state min="0"/>
 	</channel-type>
 
 	<channel-type id="shadeControl">


### PR DESCRIPTION
When feature is enabled, the specified Item fade time will be used as light level changes. When disabled, dimmer fading will be set according to the preconfigured default. Useful for changing lighting behavior in rules or on sitemap via UI.

Signed-off-by: Austin Guiswite <austin@guiswitehome.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
