### PR TITLE
[lutron] Add setLevel thing action to dimmer

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -103,7 +103,10 @@ Bridge lutron:ipbridge:radiora2 [ ipAddress="192.168.1.2", user="lutron", passwo
 
 ### Dimmers
 
-Dimmers can optionally be configured to specify a fade in and fade out time in seconds using the `fadeInTime` and `fadeOutTime` parameters.
+Dimmers can optionally be configured to specify a default fade in and fade out time in seconds using the `fadeInTime` and `fadeOutTime` parameters.
+These are used for ON and OFF commands, respectively, and default to 1 second if not set.
+Commands using a specific percent value will use a default fade time of 0.25 seconds.
+
 A **dimmer** thing has a single channel *lightlevel* with type Dimmer and category DimmableLight.
 
 Thing configuration file example:
@@ -111,6 +114,19 @@ Thing configuration file example:
 ```
 Thing dimmer livingroom [ integrationId=8, fadeInTime=0.5, fadeOutTime=5 ]
 ```
+
+The **dimmer** thing supports the thing action `setLevel(Double level, Double fadeTime, Double delayTime)` for automation rules.
+
+The parameters are:
+
+* `level` The new light level to set (0-100)
+* `fadeTime` The time in seconds over which the dimmer should fade to the new level
+* `delayTime` The time in seconds to delay before starting to fade to the new level
+
+The fadeTime and delayTime parameters are significant to 2 digits after the decimal point (i.e. to hundredths of a second), but some Lutron systems may round the time to the nearest 0.25 seconds when processing the command.
+Times of 100 seconds or more will be rounded to the nearest integer value.
+
+See below for an example rule using thing actions.
 
 ### Switches
 
@@ -578,7 +594,7 @@ The only exceptions are **greenmode** *step*, which is periodically polled and a
 Many other channels accept REFRESH commands to initiate a poll, but sending one should not normally be necessary.
 
 
-## RadioRA 2 Configuration File Example
+## RadioRA 2/HomeWorks QS Configuration File Examples:
 
 demo.things:
 
@@ -617,6 +633,19 @@ Number   Greenmode_Step      "Green Step"      { channel="lutron:greenmode:radio
 Rollershutter Lib_Shade1     "Shade 1"         { channel="lutron:shade:radiora2:libraryshade1:shadelevel" }
 
 ```
+
+dimmerAction.rules:
+
+```
+rule "Test dimmer action"
+when
+    Item TestSwitch received command ON
+then
+    val actions = getActions("lutron","lutron:dimmer:radiora2:lrtable")
+    actions.setLevel(100, 5.5, 0)
+end
+```
+
 
 # Lutron RadioRA (Classic) Binding
 

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/DimmerActions.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/DimmerActions.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.action;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.binding.ThingActions;
+import org.eclipse.smarthome.core.thing.binding.ThingActionsScope;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.lutron.internal.handler.DimmerHandler;
+import org.openhab.binding.lutron.internal.protocol.LutronDuration;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link DimmerActions} defines thing actions for DimmerHandler.
+ *
+ * @author Bob Adair - Initial contribution
+ */
+@ThingActionsScope(name = "lutron")
+@NonNullByDefault
+public class DimmerActions implements ThingActions {
+    private final Logger logger = LoggerFactory.getLogger(DimmerActions.class);
+
+    private @Nullable DimmerHandler handler;
+
+    public DimmerActions() {
+        logger.trace("Lutron Dimmer actions service created");
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof DimmerHandler) {
+            this.handler = (DimmerHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "setLightLevel", description = "Send light level command with fade and delay times")
+    public void setLightLevel(
+            @ActionInput(name = "level", label = "level", description = "Level") @Nullable DecimalType level,
+            @ActionInput(name = "fadeTime", label = "fadeTime", description = "Fade time") @Nullable DecimalType fadeTime,
+            @ActionInput(name = "delayTime", label = "delayTime", description = "Delay time") @Nullable DecimalType delayTime) {
+        // TODO - Allow null values for fade & delay
+        DimmerHandler dimmerHandler = handler;
+        if (dimmerHandler == null) {
+            logger.warn("Handler not set for Dimmer thing actions.");
+            return;
+        }
+
+        if (level == null) {
+            logger.debug("Ignoring setLightLevel command due to null value.");
+            return;
+        }
+        if (fadeTime == null) {
+            logger.debug("Ignoring setLightLevel command '{}' due to null value for fade time.", level);
+            return;
+        }
+        if (delayTime == null) {
+            logger.debug("Ignoring setLightLevel command '{}' due to null value for delay time.", level);
+            return;
+        }
+
+        dimmerHandler.setLightLevel(level, new LutronDuration(fadeTime.toBigDecimal()),
+                new LutronDuration(delayTime.toBigDecimal()));
+    }
+
+    // Static method for Rules DSL backward compatibility
+    public static void setLightLevel(@Nullable ThingActions actions, @Nullable DecimalType level,
+            @Nullable DecimalType fadeTime, @Nullable DecimalType delayTime) {
+        if (actions instanceof DimmerActions) {
+            ((DimmerActions) actions).setLightLevel(level, fadeTime, delayTime);
+        } else {
+            throw new IllegalArgumentException("Instance is not a DimmerActions class.");
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/IDimmerActions.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/IDimmerActions.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.action;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+
+/**
+ * The {@link IDimmerActions} interface defines the interface for all thing actions supported by the dimmer thing.
+ * This is only necessary to work around a bug in openhab-core (issue #1536). It should be removed once that is
+ * resolved.
+ *
+ * @author Bob Adair - Initial contribution
+ *
+ */
+@NonNullByDefault
+public interface IDimmerActions {
+
+    public void setLightLevel(@Nullable DecimalType level, @Nullable DecimalType fadeTime,
+            @Nullable DecimalType delayTime);
+
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/IDimmerActions.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/action/IDimmerActions.java
@@ -14,7 +14,6 @@ package org.openhab.binding.lutron.action;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 
 /**
  * The {@link IDimmerActions} interface defines the interface for all thing actions supported by the dimmer thing.
@@ -27,7 +26,6 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 @NonNullByDefault
 public interface IDimmerActions {
 
-    public void setLightLevel(@Nullable DecimalType level, @Nullable DecimalType fadeTime,
-            @Nullable DecimalType delayTime);
+    public void setLevel(@Nullable Double level, @Nullable Double fadeTime, @Nullable Double delayTime);
 
 }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
@@ -47,8 +47,8 @@ public class DimmerHandler extends LutronHandler {
     private final Logger logger = LoggerFactory.getLogger(DimmerHandler.class);
 
     private DimmerConfig config;
-    private LutronDuration fadeInTime = new LutronDuration(config.fadeInTime);
-    private LutronDuration fadeOutTime = new LutronDuration(config.fadeOutTime);
+    private LutronDuration fadeInTime;
+    private LutronDuration fadeOutTime;
 
     public DimmerHandler(Thing thing) {
         super(thing);
@@ -75,6 +75,8 @@ public class DimmerHandler extends LutronHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "No integrationId configured");
             return;
         }
+        fadeInTime = new LutronDuration(config.fadeInTime);
+        fadeOutTime = new LutronDuration(config.fadeOutTime);
         logger.debug("Initializing Dimmer handler for integration ID {}", getIntegrationId());
 
         initDeviceState();

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/handler/DimmerHandler.java
@@ -18,7 +18,6 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.Bridge;
@@ -118,7 +117,7 @@ public class DimmerHandler extends LutronHandler {
         }
     }
 
-    public void setLightLevel(DecimalType level, LutronDuration fade, LutronDuration delay) {
+    public void setLightLevel(BigDecimal level, LutronDuration fade, LutronDuration delay) {
         int intLevel = level.intValue();
         output(ACTION_ZONELEVEL, intLevel, fade, delay);
     }

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronDuration.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronDuration.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lutron.internal.protocol;
+
+import java.math.BigDecimal;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Holds time durations used by the Lutron protocols
+ *
+ * @author Bob Adair - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class LutronDuration {
+    public static final int MAX_SECONDS = 360000 - 1;
+    public static final int MAX_HUNDREDTHS = 99;
+
+    private static final Pattern PATTERN_SS = Pattern.compile("^(\\d{1,2})$");
+    private static final Pattern PATTERN_SSDEC = Pattern.compile("^(\\d{1,2})\\.(\\d{2})$");
+    private static final Pattern PATTERN_MMSS = Pattern.compile("^(\\d{1,2}):(\\d{2})$");
+    private static final Pattern PATTERN_HHMMSS = Pattern.compile("^(\\d{1,2}):(\\d{2}):(\\d{2})$");
+
+    // private final static Logger logger = LoggerFactory.getLogger(LutronDuration.class);
+
+    public final Integer seconds;
+    public final Integer hundredths;
+
+    /**
+     * Constructor accepting duration in seconds
+     */
+    public LutronDuration(Integer seconds) {
+        if (seconds < 0 || seconds > MAX_SECONDS) {
+            throw new IllegalArgumentException("Invalid duration");
+        }
+        this.seconds = seconds;
+        this.hundredths = 0;
+    }
+
+    /**
+     * Constructor accepting duration in seconds and hundredths of seconds
+     */
+    public LutronDuration(Integer seconds, Integer hundredths) {
+        if (seconds < 0 || seconds > MAX_SECONDS || hundredths < 0 || hundredths > MAX_HUNDREDTHS) {
+            throw new IllegalArgumentException("Invalid duration");
+        }
+        this.seconds = seconds;
+        this.hundredths = hundredths;
+    }
+
+    /**
+     * Constructor accepting duration in seconds as a BigDecimal
+     */
+    public LutronDuration(BigDecimal seconds) {
+        if (seconds.compareTo(BigDecimal.ZERO) == -1 || seconds.compareTo(new BigDecimal(MAX_SECONDS)) == 1) {
+            new IllegalArgumentException("Invalid duration");
+        }
+        this.seconds = seconds.intValue();
+        BigDecimal fractional = seconds.subtract(new BigDecimal(seconds.intValue()));
+        this.hundredths = fractional.movePointRight(2).intValue();
+    }
+
+    /**
+     * Constructor accepting duration string of the format: SS.ss, SS, MM:SS, or HH:MM:SS
+     */
+    public LutronDuration(String duration) {
+        Matcher matcherSS = PATTERN_SS.matcher(duration);
+        if (matcherSS.find()) {
+            Integer seconds = Integer.valueOf(matcherSS.group(1));
+            this.seconds = seconds;
+            this.hundredths = 0;
+            return;
+        }
+        Matcher matcherSSDec = PATTERN_SSDEC.matcher(duration);
+        if (matcherSSDec.find()) {
+            this.seconds = Integer.valueOf(matcherSSDec.group(1));
+            this.hundredths = Integer.valueOf(matcherSSDec.group(2));
+            return;
+        }
+        Matcher matcherMMSS = PATTERN_MMSS.matcher(duration);
+        if (matcherMMSS.find()) {
+            Integer minutes = Integer.valueOf(matcherMMSS.group(1));
+            Integer seconds = Integer.valueOf(matcherMMSS.group(2));
+            this.seconds = minutes * 60 + seconds;
+            this.hundredths = 0;
+            return;
+        }
+        Matcher matcherHHMMSS = PATTERN_HHMMSS.matcher(duration);
+        if (matcherHHMMSS.find()) {
+            Integer hours = Integer.valueOf(matcherHHMMSS.group(1));
+            Integer minutes = Integer.valueOf(matcherHHMMSS.group(2));
+            Integer seconds = Integer.valueOf(matcherHHMMSS.group(3));
+            this.seconds = hours * 60 * 60 + minutes * 60 + seconds;
+            this.hundredths = 0;
+            return;
+        }
+        throw new IllegalArgumentException("Invalid duration");
+    }
+
+    public String asLipString() {
+        if (seconds < 100) {
+            if (hundredths == 0) {
+                return String.valueOf(seconds);
+            } else {
+                return String.format("%d.%02d", seconds, hundredths);
+            }
+        } else if (seconds < 3600) {
+            return String.format("%d:%02d", seconds / 60, seconds % 60);
+        } else {
+            return String.format("%d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+        }
+    }
+
+    public String asLeapString() {
+        return ""; // TBD
+    }
+
+    @Override
+    public String toString() {
+        return asLipString();
+    }
+}

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronDuration.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/protocol/LutronDuration.java
@@ -34,8 +34,6 @@ public class LutronDuration {
     private static final Pattern PATTERN_MMSS = Pattern.compile("^(\\d{1,2}):(\\d{2})$");
     private static final Pattern PATTERN_HHMMSS = Pattern.compile("^(\\d{1,2}):(\\d{2}):(\\d{2})$");
 
-    // private final static Logger logger = LoggerFactory.getLogger(LutronDuration.class);
-
     public final Integer seconds;
     public final Integer hundredths;
 
@@ -71,6 +69,13 @@ public class LutronDuration {
         this.seconds = seconds.intValue();
         BigDecimal fractional = seconds.subtract(new BigDecimal(seconds.intValue()));
         this.hundredths = fractional.movePointRight(2).intValue();
+    }
+
+    /**
+     * Constructor accepting duration in seconds as a Double
+     */
+    public LutronDuration(Double seconds) {
+        this(new BigDecimal(seconds).setScale(2, BigDecimal.ROUND_HALF_UP));
     }
 
     /**


### PR DESCRIPTION
This update adds a setLevel(level, fadeTime, delayTime) thing action to the dimmer thing. This allows a level command to be sent with associated fade and delay times.

As discussed previously in openhab/openhab-core#1298, I think it is unfortunate that there isn't a more standard way to add this functionality. Even some attempt at defining a standard set of thing actions might be useful here, so that common actions across different things could be somewhat consistent. In the absence of that, I just picked an action name that I thought logical.

This update also includes a new LutronDuration class for time durations, which will eventually be useful for other coming improvements to the binding.

Signed-off-by: Bob Adair <bob.github@att.net>
Also-by: Austin Guiswite
