### PR TITLE
[homekit] add support for motorized door and window

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -8,7 +8,6 @@ HomeKit organizes your home into "accessories" that are made up of a number of "
 Some accessory types require a specific set of characteristics.
 
 HomeKit integration supports following accessory types:
-- Window Covering/Blinds
 - Switchable 
 - Outlet
 - Lighting (simple, dimmable, color)
@@ -18,7 +17,11 @@ HomeKit integration supports following accessory types:
 - Lock
 - Security System
 - Garage Door Opener
+- Motorized Door
+- Motorized Window
+- Window Covering/Blinds
 - Valve
+- Air Quality Sensor
 - Contact Sensor
 - Leak Sensor
 - Motion Sensor
@@ -250,6 +253,20 @@ Switch light2 "Light 2" (gLight) {homekit="Lighting.OnState"}
 |                      |                             | FaultStatus                  | Switch, Contact          | Fault status                                                     |
 |                      |                             | TamperedStatus               | Switch, Contact          | Tampered status                                                  |
 |                      |                             | BatteryLowStatus             | Switch, Contact          | Battery status                                                   |
+| Door                 |                             |                              |                          | Motorized door. One Rollershutter item covers all mandatory characteristics. see examples below.                                                                                                                                                                                                |
+|                      | CurrentPosition             |                              | Rollershutter            | Current position of motorized door                                                                                                                                                                                                                                                                       |
+|                      | TargetPosition              |                              | Rollershutter            | Target position of motorized door                                                                                                                                                                                                                                                                       |
+|                      | PositionState               |                              | Rollershutter            | Position state. Supported states: DECREASING, INCREASING, STOPPED. Mapping can be redefined at item level, e.g. [DECREASING="Down", INCREASING="Up"]. If no state provided, "STOPPED" is used.                                                                                                |
+|                      |                             | Name                         | String                   | Name of the motorized door                                                                                                                                                                                                                                                                             |
+|                      |                             | HoldPosition                 | Switch                   | Motorized door should stop at its current position. A value of ON must hold the state of the accessory.  A value of OFF should be ignored.                                                                                                                                                               |
+|                      |                             | ObstructionStatus            | Switch, Contact          | Current status of obstruction sensor. ON-obstruction detected, OFF - no obstruction                                                                                                                                                                                                                       |
+| Window               |                             |                              |                          | Motorized window. One Rollershutter item covers all mandatory characteristics. see examples below.                                                                                                                                                                                                |
+|                      | CurrentPosition             |                              | Rollershutter            | Current position of motorized window                                                                                                                                                                                                                                                                       |
+|                      | TargetPosition              |                              | Rollershutter            | Target position of motorized window                                                                                                                                                                                                                                                                       |
+|                      | PositionState               |                              | Rollershutter            | Position state. Supported states: DECREASING, INCREASING, STOPPED. Mapping can be redefined at item level, e.g. [DECREASING="Down", INCREASING="Up"]. If no state provided, "STOPPED" is used.                                                                                                |
+|                      |                             | Name                         | String                   | Name of the motorized window                                                                                                                                                                                                                                                                             |
+|                      |                             | HoldPosition                 | Switch                   | Motorized door should stop at its current position. A value of ON must hold the state of the accessory.  A value of OFF should be ignored.                                                                                                                                                               |
+|                      |                             | ObstructionStatus            | Switch, Contact          | Current status of obstruction sensor. ON-obstruction detected, OFF - no obstruction                                                                                                                                                                                                                       |
 | WindowCovering       |                             |                              |                          | Window covering / blinds. One Rollershutter item covers all mandatory characteristics. see examples below.                                                                                                                                                                                                |
 |                      | CurrentPosition             |                              | Rollershutter            | Current position of window covering                                                                                                                                                                                                                                                                       |
 |                      | TargetPosition              |                              | Rollershutter            | Target position of window covering                                                                                                                                                                                                                                                                        |
@@ -461,7 +478,7 @@ Group           gSecuritySystem            "Security System Group"              
 String          security_current_state     "Security Current State"             (gSecuritySystem)    {homekit="SecuritySystem.CurrentSecuritySystemState"}
 String          security_target_state      "Security Target State"              (gSecuritySystem)    {homekit="SecuritySystem.TargetSecuritySystemState"}
 
-Group  			gCooler    				"Cooler Group"       				 	                {homekit="HeaterCooler"}
+Group  			gCooler    			        "Cooler Group"       				 	                {homekit="HeaterCooler"}
 Switch          cooler_active 				"Cooler Active" 				    (gCooler) 		    {homekit="ActiveStatus"}
 Number 			cooler_current_temp     	"Cooler Current Temp [%.1f C]"  	(gCooler)  	        {homekit="CurrentTemperature"}
 String 			cooler_current_mode  	    "Cooler Current Mode" 		        (gCooler) 			{homekit="CurrentHeaterCoolerState" [HEATING="HEAT", COOLING="COOL"]}          
@@ -502,18 +519,20 @@ Following modes are supported:
  Dimmer dimmer_light_2	"Dimmer Light 2" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterBrightness100"]}
  Dimmer dimmer_light_3	"Dimmer Light 3" 	 {homekit="Lighting, Lighting.Brightness" [dimmerMode="filterOnExceptBrightness100"]}
  ```
-### Windows Covering / Blinds
+### Windows Covering (Blinds) / Window / Door
 
-HomeKit Windows Covering accessory type has following mandatory characteristics: 
+HomeKit Windows Covering, Window and Door accessory types have following mandatory characteristics: 
 
 - CurrentPosition (0-100% of current window covering position)
 - TargetPosition (0-100% of target position)
-- PositionState (DECREASING,INCREASING or STOPPED as state. HomeKit integration currently supports only STOPPED)
+- PositionState (DECREASING,INCREASING or STOPPED as state). If no state provided, HomeKit will send STOPPED
 
-These characteristics can be mapped to a single openHAB rollershutter item. In such case currentPosition will always equal target position, means if you request to close a blind, HomeKit will immediately report that the blind is closed.
+These characteristics can be mapped to a single openHAB rollershutter item. In such case currentPosition will always equal target position, means if you request to close a blind/window/door, HomeKit will immediately report that the blind/window/door is closed.
 As discussed above, one can use full or shorthand definition. Following two definitions are equal:
 
 ```xtend
+Rollershutter 	window 		            "Window"  	                {homekit = "Window"}
+Rollershutter 	door		            "Door"  	                {homekit = "Door"}
 Rollershutter   window_covering         "Window Rollershutter"      {homekit = "WindowCovering"}
 Rollershutter 	window_covering_long 	"Window Rollershutter long" {homekit = "WindowCovering, WindowCovering.CurrentPosition, WindowCovering.TargetPosition, WindowCovering.PositionState"}
  ```
@@ -523,7 +542,7 @@ openHAB Rollershutter is defined by default as:
 - OPEN if position is 0%,
 - CLOSED if position is 100%.
 
-In contrast, HomeKit window covering has inverted mapping
+In contrast, HomeKit window covering/door/window have inverted mapping
 - OPEN if position 100%
 - CLOSED if position is 0%
 
@@ -532,6 +551,9 @@ In case you need to disable this logic you can do it with configuration paramete
 
 ```xtend
 Rollershutter window_covering "Window Rollershutter" {homekit = "WindowCovering"  [inverted="false"]}
+Rollershutter window		   "Window"  	         {homekit = "Window" [inverted="false"]}
+Rollershutter door		       "Door"  	         {homekit = "Door" [inverted="false"]}
+
  ```
 
 Window covering can have a number of optional characteristics like horizontal & vertical tilt, obstruction status and hold position trigger. 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryType.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAccessoryType.java
@@ -34,6 +34,8 @@ public enum HomekitAccessoryType {
     MOTION_SENSOR("MotionSensor"),
     OCCUPANCY_SENSOR("OccupancySensor"),
     WINDOW_COVERING("WindowCovering"),
+    DOOR("Door"),
+    WINDOW("Window"),
     SMOKE_SENSOR("SmokeSensor"),
     CARBON_MONOXIDE_SENSOR("CarbonMonoxideSensor"),
     CARBON_DIOXIDE_SENSOR("CarbonDioxideSensor"),

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -29,10 +29,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
@@ -297,37 +295,5 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
                 getItem(characteristicType, GenericItem.class)
                         .orElseThrow(() -> new IncompleteAccessoryException(characteristicType)),
                 trueOnOffValue, trueOpenClosedValue);
-    }
-
-    /**
-     * convert/invert position of door/window/blinds.
-     * openHAB Rollershutter is:
-     * - completely open if position is 0%,
-     * - completely closed if position is 100%.
-     * HomeKit mapping has inverted mapping
-     * From Specification: "For blinds/shades/awnings, a value of 0 indicates a position that permits the least light
-     * and a value
-     * of 100 indicates a position that allows most light.", i.e.
-     * HomeKit Blinds is
-     * - completely open if position is 100%,
-     * - completely closed if position is 0%.
-     *
-     * As openHAB rollershutter item is typically used for window covering, the binding has by default inverting
-     * mapping.
-     * One can override this default behaviour with inverted="false/no" flag. in this cases, openHAB item value will be
-     * sent to HomeKit with no changes.
-     *
-     * @param value source value
-     * @return target value
-     */
-    @NonNullByDefault
-    protected int convertPosition(int value, int openPosition) {
-        return Math.abs(openPosition - value);
-    }
-
-    @NonNullByDefault
-    protected int convertPositionState(HomekitCharacteristicType type, int openPosition, int closedPosition) {
-        final @Nullable DecimalType value = getStateAs(type, PercentType.class);
-        return value != null ? convertPosition(value.intValue(), openPosition) : closedPosition;
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -29,8 +29,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
@@ -295,5 +297,37 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
                 getItem(characteristicType, GenericItem.class)
                         .orElseThrow(() -> new IncompleteAccessoryException(characteristicType)),
                 trueOnOffValue, trueOpenClosedValue);
+    }
+
+    /**
+     * convert/invert position of door/window/blinds.
+     * openHAB Rollershutter is:
+     * - completely open if position is 0%,
+     * - completely closed if position is 100%.
+     * HomeKit mapping has inverted mapping
+     * From Specification: "For blinds/shades/awnings, a value of 0 indicates a position that permits the least light
+     * and a value
+     * of 100 indicates a position that allows most light.", i.e.
+     * HomeKit Blinds is
+     * - completely open if position is 100%,
+     * - completely closed if position is 0%.
+     *
+     * As openHAB rollershutter item is typically used for window covering, the binding has by default inverting
+     * mapping.
+     * One can override this default behaviour with inverted="false/no" flag. in this cases, openHAB item value will be
+     * sent to HomeKit with no changes.
+     *
+     * @param value source value
+     * @return target value
+     */
+    @NonNullByDefault
+    protected int convertPosition(int value, int openPosition) {
+        return Math.abs(openPosition - value);
+    }
+
+    @NonNullByDefault
+    protected int convertPositionState(HomekitCharacteristicType type, int openPosition, int closedPosition) {
+        final @Nullable DecimalType value = getStateAs(type, PercentType.class);
+        return value != null ? convertPosition(value.intValue(), openPosition) : closedPosition;
     }
 }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitPositionAccessoryImpl.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.io.homekit.internal.accessories;
+
+import static org.openhab.io.homekit.internal.HomekitCharacteristicType.CURRENT_POSITION;
+import static org.openhab.io.homekit.internal.HomekitCharacteristicType.POSITION_STATE;
+import static org.openhab.io.homekit.internal.HomekitCharacteristicType.TARGET_POSITION;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.items.RollershutterItem;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
+import org.openhab.io.homekit.internal.HomekitSettings;
+import org.openhab.io.homekit.internal.HomekitTaggedItem;
+
+import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.windowcovering.PositionStateEnum;
+
+/**
+ * Common methods for Door, Window and WindowCovering.
+ * 
+ * @author Eugen Freiter - Initial contribution
+ */
+@NonNullByDefault
+abstract class AbstractHomekitPositionAccessoryImpl extends AbstractHomekitAccessoryImpl {
+    protected int closedPosition;
+    protected int openPosition;
+    private final Map<PositionStateEnum, String> positionStateMapping;
+
+    public AbstractHomekitPositionAccessoryImpl(HomekitTaggedItem taggedItem,
+            List<HomekitTaggedItem> mandatoryCharacteristics, HomekitAccessoryUpdater updater,
+            HomekitSettings settings) {
+        super(taggedItem, mandatoryCharacteristics, updater, settings);
+        final String invertedConfig = getAccessoryConfiguration(HomekitTaggedItem.INVERTED, "true");
+        final boolean inverted = invertedConfig.equalsIgnoreCase("yes") || invertedConfig.equalsIgnoreCase("true");
+        closedPosition = inverted ? 0 : 100;
+        openPosition = inverted ? 100 : 0;
+        positionStateMapping = new EnumMap<>(PositionStateEnum.class);
+        positionStateMapping.put(PositionStateEnum.DECREASING, "DECREASING");
+        positionStateMapping.put(PositionStateEnum.INCREASING, "INCREASING");
+        positionStateMapping.put(PositionStateEnum.STOPPED, "STOPPED");
+        updateMapping(POSITION_STATE, positionStateMapping);
+    }
+
+    public CompletableFuture<Integer> getCurrentPosition() {
+        return CompletableFuture.completedFuture(convertPositionState(CURRENT_POSITION, openPosition, closedPosition));
+    }
+
+    public CompletableFuture<PositionStateEnum> getPositionState() {
+        return CompletableFuture
+                .completedFuture(getKeyFromMapping(POSITION_STATE, positionStateMapping, PositionStateEnum.STOPPED));
+    }
+
+    public CompletableFuture<Integer> getTargetPosition() {
+        return CompletableFuture.completedFuture(convertPositionState(TARGET_POSITION, openPosition, closedPosition));
+    }
+
+    @NonNullByDefault({})
+    public CompletableFuture<Void> setTargetPosition(int value) {
+        getItem(TARGET_POSITION, RollershutterItem.class)
+                .ifPresent(item -> item.send(new PercentType(convertPosition(value, openPosition))));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public void subscribeCurrentPosition(HomekitCharacteristicChangeCallback callback) {
+        subscribe(CURRENT_POSITION, callback);
+    }
+
+    public void subscribePositionState(HomekitCharacteristicChangeCallback callback) {
+        subscribe(POSITION_STATE, callback);
+    }
+
+    public void subscribeTargetPosition(HomekitCharacteristicChangeCallback callback) {
+        subscribe(TARGET_POSITION, callback);
+    }
+
+    public void unsubscribeCurrentPosition() {
+        unsubscribe(CURRENT_POSITION);
+    }
+
+    public void unsubscribePositionState() {
+        unsubscribe(POSITION_STATE);
+    }
+
+    public void unsubscribeTargetPosition() {
+        unsubscribe(TARGET_POSITION);
+    }
+}

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitAccessoryFactory.java
@@ -97,6 +97,9 @@ public class HomekitAccessoryFactory {
                     TARGET_HEATER_COOLER_STATE, CURRENT_TEMPERATURE });
             // LEGACY
             put(BLINDS, new HomekitCharacteristicType[] { TARGET_POSITION, CURRENT_POSITION, POSITION_STATE });
+            put(WINDOW, new HomekitCharacteristicType[] { CURRENT_POSITION, TARGET_POSITION, POSITION_STATE });
+            put(DOOR, new HomekitCharacteristicType[] { CURRENT_POSITION, TARGET_POSITION, POSITION_STATE });
+
             put(OLD_HUMIDITY_SENSOR, new HomekitCharacteristicType[] { RELATIVE_HUMIDITY });
             put(OLD_DIMMABLE_LIGHTBULB, new HomekitCharacteristicType[] { ON_STATE });
             put(OLD_COLORFUL_LIGHTBULB, new HomekitCharacteristicType[] { ON_STATE });
@@ -129,6 +132,8 @@ public class HomekitAccessoryFactory {
             put(SPEAKER, HomekitSpeakerImpl.class);
             put(GARAGE_DOOR_OPENER, HomekitGarageDoorOpenerImpl.class);
             put(BLINDS, HomekitWindowCoveringImpl.class);
+            put(DOOR, HomekitDoorImpl.class);
+            put(WINDOW, HomekitWindowImpl.class);
             put(HEATER_COOLER, HomekitHeaterCoolerImpl.class);
             put(OLD_HUMIDITY_SENSOR, HomekitHumiditySensorImpl.class);
             put(OLD_DIMMABLE_LIGHTBULB, HomekitLightbulbImpl.class);

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDoorImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitDoorImpl.java
@@ -20,22 +20,22 @@ import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitSettings;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
-import io.github.hapjava.accessories.WindowCoveringAccessory;
+import io.github.hapjava.accessories.DoorAccessory;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.characteristics.impl.windowcovering.PositionStateEnum;
-import io.github.hapjava.services.impl.WindowCoveringService;
+import io.github.hapjava.services.impl.DoorService;
 
 /**
  *
- * @author epike - Initial contribution
+ * @author Eugen Freiter - Initial contribution
  */
 @NonNullByDefault
-public class HomekitWindowCoveringImpl extends AbstractHomekitPositionAccessoryImpl implements WindowCoveringAccessory {
+public class HomekitDoorImpl extends AbstractHomekitPositionAccessoryImpl implements DoorAccessory {
 
-    public HomekitWindowCoveringImpl(HomekitTaggedItem taggedItem, List<HomekitTaggedItem> mandatoryCharacteristics,
+    public HomekitDoorImpl(HomekitTaggedItem taggedItem, List<HomekitTaggedItem> mandatoryCharacteristics,
             HomekitAccessoryUpdater updater, HomekitSettings settings) {
         super(taggedItem, mandatoryCharacteristics, updater, settings);
-        getServices().add(new WindowCoveringService(this));
+        getServices().add(new DoorService(this));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class HomekitWindowCoveringImpl extends AbstractHomekitPositionAccessoryI
 
     @Override
     @NonNullByDefault({})
-    public CompletableFuture<Void> setTargetPosition(int value) {
+    public CompletableFuture<Void> setTargetPosition(Integer value) {
         return super.setTargetPosition(value);
     }
 

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/HomekitWindowImpl.java
@@ -20,22 +20,22 @@ import org.openhab.io.homekit.internal.HomekitAccessoryUpdater;
 import org.openhab.io.homekit.internal.HomekitSettings;
 import org.openhab.io.homekit.internal.HomekitTaggedItem;
 
-import io.github.hapjava.accessories.WindowCoveringAccessory;
+import io.github.hapjava.accessories.WindowAccessory;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.characteristics.impl.windowcovering.PositionStateEnum;
-import io.github.hapjava.services.impl.WindowCoveringService;
+import io.github.hapjava.services.impl.WindowService;
 
 /**
  *
- * @author epike - Initial contribution
+ * @author Eugen Freiter - Initial contribution
  */
 @NonNullByDefault
-public class HomekitWindowCoveringImpl extends AbstractHomekitPositionAccessoryImpl implements WindowCoveringAccessory {
+public class HomekitWindowImpl extends AbstractHomekitPositionAccessoryImpl implements WindowAccessory {
 
-    public HomekitWindowCoveringImpl(HomekitTaggedItem taggedItem, List<HomekitTaggedItem> mandatoryCharacteristics,
+    public HomekitWindowImpl(HomekitTaggedItem taggedItem, List<HomekitTaggedItem> mandatoryCharacteristics,
             HomekitAccessoryUpdater updater, HomekitSettings settings) {
         super(taggedItem, mandatoryCharacteristics, updater, settings);
-        getServices().add(new WindowCoveringService(this));
+        getServices().add(new WindowService(this));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class HomekitWindowCoveringImpl extends AbstractHomekitPositionAccessoryI
 
     @Override
     @NonNullByDefault({})
-    public CompletableFuture<Void> setTargetPosition(int value) {
+    public CompletableFuture<Void> setTargetPosition(Integer value) {
         return super.setTargetPosition(value);
     }
 


### PR DESCRIPTION
this PR adds support for motorized door and window to HomeKit integration. 
As door & window have vary similar methods to window covering, a common class AbstractHomekitPositionAccessoryImpl is added.

Added @NonNullByDefault but not sure how useful it is, as it has to be deactivated for @override methods

Signed-off-by: Eugen Freiter <freiter@gmx.de>
