### PR TITLE
[Gardena] Update Watering_Timer unit in Doc

### DIFF
--- a/bundles/org.openhab.binding.gardena/README.md
+++ b/bundles/org.openhab.binding.gardena/README.md
@@ -111,7 +111,7 @@ Number  Watering_Duration   "Duration [%d min]" { channel="gardena:watering_comp
 String Power_Timer          "Power Timer [%s]"  { channel="gardena:power:home:myPowerplug:power#power_timer" }
 
 // smart Irrigation Control
-Number Watering_Timer_1     "Watering Timer 1 [%d min]  { channel="gardena:ic24:home:myIrrigationController:watering#watering_timer_1" }
+Number Watering_Timer_1     "Watering Timer 1 [%s s]  { channel="gardena:ic24:home:myIrrigationController:watering#watering_timer_1" }
 
 // smart Pressure Pump
 Number Pump_Timer           "Pump Timer [%d min]        { channel="gardena:electronic_pressure_pump:home:myPressurePump:manual_watering#manual_watering_timer" }
@@ -126,7 +126,7 @@ Power_Timer.sendCommand("off")
 Power_Timer.sendCommand("180") // on for 180 seconds
 
 Watering_Timer_1.sendCommand(0) // turn off watering
-Watering_Timer_1.sendCommand(30) // turn on for 30 minutes
+Watering_Timer_1.sendCommand(300) // turn on for 300 seconds (5 minutes)
 
 Pump_Timer.sendCommand(0) // turn the pump off
 Pump_Timer.sendCommand(30) // turn the pump on for 30 minutes

--- a/bundles/org.openhab.binding.gardena/README.md
+++ b/bundles/org.openhab.binding.gardena/README.md
@@ -111,7 +111,7 @@ Number  Watering_Duration   "Duration [%d min]" { channel="gardena:watering_comp
 String Power_Timer          "Power Timer [%s]"  { channel="gardena:power:home:myPowerplug:power#power_timer" }
 
 // smart Irrigation Control
-Number Watering_Timer_1     "Watering Timer 1 [%s s]  { channel="gardena:ic24:home:myIrrigationController:watering#watering_timer_1" }
+Number Watering_Timer_1     "Watering Timer 1 [%d s]  { channel="gardena:ic24:home:myIrrigationController:watering#watering_timer_1" }
 
 // smart Pressure Pump
 Number Pump_Timer           "Pump Timer [%d min]        { channel="gardena:electronic_pressure_pump:home:myPressurePump:manual_watering#manual_watering_timer" }


### PR DESCRIPTION
The unit of the watering timer of the ic24 is now in seconds and not in minutes anymore.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
