### PR TITLE
[telegram] Added support for long polling #7043

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -19,6 +19,7 @@ As described in the Telegram Bot API, this is the manual procedure needed in ord
 
 - Open a browser and invoke `https://api.telegram.org/bot<token>/getUpdates` (where `<token>` is the authentication token previously obtained)
 - Look at the JSON result to find the value of `id`: that's the chatID.
+
 Note that if using a Telegram group chat, the group chatIDs are prefixed with a dash that must be included in the config (e.g. `-22334455`).
 If this does not work for you (the JSON response may be empty), or you want to send to *more* than one recipient (= another chatID), the alternative is to contact (= open a chat with) a Telegram bot to respond with the chatID.
 There's a number of them such as `@myidbot` or `@chatid_echo_bot` - open a chat, eventually tap `/start` and it will return the chatID you're looking for.
@@ -61,11 +62,14 @@ In order to send a message, an action must be used instead.
 | `proxyHost`             |  None   | No       | Proxy host for telegram binding.                                                             |
 | `proxyPort`             |  None   | No       | Proxy port for telegram binding.                                                             |
 | `proxyType`             |  SOCKS5 | No       | Type of proxy server for telegram binding (SOCKS5 or HTTP). Default: SOCKS5                  |
+| `longPollingTime`       |  25     | Yes      | TimeSpan for long polling the telegram API                                                   |
 
 By default chat ids are bi-directionally, i.e. they can send and receive messages.
 They can be prefixed with an access modifier:
+
 - `<` restricts the chat to send only, i.e. this chat id can send messages to openHAB, but will never receive a notification.
-- `>` restricts the chat to receive only, i.e. this chat id will receive all notifications, but messages from this chat id will be discarded. 
+- `>` restricts the chat to receive only, i.e. this chat id will receive all notifications, but messages from this chat id will be discarded.
+ 
 To use the reply function, chat ids need to be bi-directional.
 
 telegram.thing (no proxy):

--- a/bundles/org.openhab.binding.telegram/pom.xml
+++ b/bundles/org.openhab.binding.telegram/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramBindingConstants.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramBindingConstants.java
@@ -37,4 +37,5 @@ public class TelegramBindingConstants {
     public static final String LASTMESSAGEUSERNAME = "lastMessageUsername";
     public static final String CHATID = "chatId";
     public static final String REPLYID = "replyId";
+    public static final String LONGPOLLINGTIME = "longPollingTime";
 }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramConfiguration.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramConfiguration.java
@@ -35,6 +35,7 @@ public class TelegramConfiguration {
     private @Nullable Integer proxyPort;
     private @Nullable String proxyType;
     private String parseMode = "";
+    private int longPollingTime;
 
     public @Nullable String getBotUsername() {
         return botUsername;
@@ -62,5 +63,9 @@ public class TelegramConfiguration {
 
     public @Nullable String getProxyType() {
         return proxyType;
+    }
+
+    public int getLongPollingTime() {
+        return longPollingTime;
     }
 }

--- a/bundles/org.openhab.binding.telegram/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -25,7 +25,8 @@
 			</parameter>
 			<parameter name="chatIds" type="text" required="true" multiple="true">
 				<label>Chat Id(s)</label>
-				<description>One or more chat id(s). Access modifiers ("&lt;" for inbound only, "&gt;" for outbound only) can be used as prefix (optional).</description>
+				<description>One or more chat id(s). Access modifiers ("&lt;" for inbound only, "&gt;" for outbound only) can be
+					used as prefix (optional).</description>
 			</parameter>
 			<parameter name="parseMode" type="text" required="false">
 				<label>Parse Mode</label>
@@ -54,6 +55,11 @@
 				</options>
 				<default>SOCKS5</default>
 				<description>Enter your proxy type. Default: SOCKS5</description>
+			</parameter>
+			<parameter name="longPollingTime" type="integer" required="true" min="0" max="50" unit="s">
+				<label>Long Polling Time</label>
+				<description>Enter the long polling time in seconds.</description>
+				<default>25</default>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
I added a new parameter for long polling. There is a new parameter with default value 25 seconds. The Telegram WebApp uses 25 seconds. Maximal value is 50 seconds. After this time the telegram api interups the connection.

Additional i fixed some warnings.