### PR TITLE
[miio] delayed sending of charge command

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -168,9 +168,15 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
             if (command instanceof OnOffType) {
                 if (command.equals(OnOffType.ON)) {
                     sendCommand(MiIoCommand.START_VACUUM);
+                    forceStatusUpdate();
+                    return;
                 } else {
                     sendCommand(MiIoCommand.STOP_VACUUM);
-                    sendCommand(MiIoCommand.CHARGE);
+                    scheduler.schedule(() -> {
+                        sendCommand(MiIoCommand.CHARGE);
+                        forceStatusUpdate();
+                    }, 2000, TimeUnit.MILLISECONDS);
+                    return;
                 }
             }
         }
@@ -183,7 +189,11 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
                 sendCommand(MiIoCommand.PAUSE);
             } else if (command.toString().equals("dock")) {
                 sendCommand(MiIoCommand.STOP_VACUUM);
-                sendCommand(MiIoCommand.CHARGE);
+                scheduler.schedule(() -> {
+                    sendCommand(MiIoCommand.CHARGE);
+                    forceStatusUpdate();
+                }, 2000, TimeUnit.MILLISECONDS);
+                return;
             } else {
                 logger.info("Command {} not recognised", command.toString());
             }


### PR DESCRIPTION
Delay sending charge command to avoid action locked response.

`2020-07-23 11:42:32.531 [DEBUG] [internal.handler.MiIoAbstractHandler] - Received response for 070A579C type: CHARGE, result: {}, fullresponse: {“error”:{“code”:-10003,“message”:“action locked”},“id”:1771}`

closes #7832
See also see also https://community.openhab.org/t/xiaomi-robot-vacuum-binding/31317/1612

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
