### PR TITLE
[phc] Fix duplicate id in JRM channel definition

### DIFF
--- a/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/channel-types.xml
@@ -42,6 +42,37 @@
 		</channels>
 	</channel-group-type>
 
+	<channel-group-type id="jrmChannels">
+		<label>JRM Channels</label>
+		<description>Outgoing shutter channels (relay).</description>
+		<channels>
+			<channel id="00" typeId="jrm-channel"/>
+			<channel id="01" typeId="jrm-channel"/>
+			<channel id="02" typeId="jrm-channel"/>
+			<channel id="03" typeId="jrm-channel"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="jrmTimeChannels" advanced="true">
+		<label>JRM time Channels</label>
+		<description>Time for shutter channels in seconds with an accuracy of 1/10 seconds.</description>
+		<channels>
+			<channel id="00" typeId="jrmTime-channel"/>
+			<channel id="01" typeId="jrmTime-channel"/>
+			<channel id="02" typeId="jrmTime-channel"/>
+			<channel id="03" typeId="jrmTime-channel"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="dimChannels">
+		<label>DIM Channels</label>
+		<description>Outgoing dimmer channels.</description>
+		<channels>
+			<channel id="00" typeId="dim-channel"/>
+			<channel id="01" typeId="dim-channel"/>
+		</channels>
+	</channel-group-type>
+
 	<!-- Channel Types -->
 	<channel-type id="am-channel">
 		<item-type>Switch</item-type>

--- a/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.phc/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -74,16 +74,10 @@
 		<label>PHC JRM</label>
 		<description>Thing for an shutter module (JRM).</description>
 
-		<channels>
-			<channel id="00" typeId="jrm-channel"/>
-			<channel id="01" typeId="jrm-channel"/>
-			<channel id="02" typeId="jrm-channel"/>
-			<channel id="03" typeId="jrm-channel"/>
-			<channel id="00" typeId="jrmTime-channel"/>
-			<channel id="01" typeId="jrmTime-channel"/>
-			<channel id="02" typeId="jrmTime-channel"/>
-			<channel id="03" typeId="jrmTime-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="jrm" typeId="jrmChannels"/>
+			<channel-group id="jrmT" typeId="jrmTimeChannels"/>
+		</channel-groups>
 
 		<config-description>
 			<parameter name="address" type="text" pattern="[0-1]{5}" min="5" max="5">
@@ -94,25 +88,25 @@
 			<parameter name="upDownTime1" type="integer" min="1" max="65535">
 				<advanced>true</advanced>
 				<label>Time Shutter 1</label>
-				<description>The Time which the first shutter needs to move up/down.</description>
+				<description>The time (in seconds) which the first shutter needs to move up/down.</description>
 				<default>30</default>
 			</parameter>
 			<parameter name="upDownTime2" type="integer" min="1" max="65535">
 				<advanced>true</advanced>
 				<label>Time Shutter 2</label>
-				<description>The Time which the second shutter needs to move up/down.</description>
+				<description>The time (in seconds) which the second shutter needs to move up/down.</description>
 				<default>30</default>
 			</parameter>
 			<parameter name="upDownTime3" type="integer" min="1" max="65535">
 				<advanced>true</advanced>
 				<label>Time Shutter 3</label>
-				<description>The Time which the third shutter needs to move up/down.</description>
+				<description>The time (in seconds) which the third shutter needs to move up/down.</description>
 				<default>30</default>
 			</parameter>
 			<parameter name="upDownTime4" type="integer" min="1" max="65535">
 				<advanced>true</advanced>
 				<label>Time Shutter 4</label>
-				<description>The Time which the fourth shutter needs to move up/down.</description>
+				<description>The time (in seconds) which the fourth shutter needs to move up/down.</description>
 				<default>30</default>
 			</parameter>
 		</config-description>
@@ -126,10 +120,9 @@
 		<label>PHC DIM</label>
 		<description>Thing for a dimmer module (DM).</description>
 
-		<channels>
-			<channel id="00" typeId="dim-channel"/>
-			<channel id="01" typeId="dim-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="dim" typeId="dimChannels"/>
+		</channel-groups>
 
 		<config-description>
 			<parameter name="address" type="text" pattern="[0-1]{5}" min="5" max="5">


### PR DESCRIPTION
Fix a bug in the thing type definition, that has crept in #6447.

While I removed the channel groups for JRM and DIM thing types I forgot that goup id is used in the Binding.
Aditionally I didn't change the channel ids so we have duplicate ids in the JRM type definition.

So we have to use the channel-groups for all thing-types again.

The bug was found in this thread: https://community.openhab.org/t/switch-from-peha-phc-to-new-automation-with-openhab2/61154/36 

Signed-off-by: Jonas Hohaus <jh@gnlpf.net>

