### PR TITLE
[amazonechocontrol] improve login handling

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -688,6 +688,11 @@ E.g. to read out the history call from an installation on openhab:8080 with an a
 
 http://openhab:8080/amazonechocontrol/account1/PROXY/api/activities?startTime=&size=50&offset=1
 
+To resolve login problems the connection settings of an `account` thing can be reset via the karaf console.
+The command `amazonechocontrol listAccounts` shows a list of all available `account` things.
+The command `amazonechocontrol resetAccount <id>` resets the device id and all other connection settings.
+After resetting a connection, a new login as described above is necessary.
+
 ## Note
 
 This binding uses the same API as the Web-Browser-Based Alexa site (alexa.amazon.de).

--- a/bundles/org.openhab.binding.amazonechocontrol/pom.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountServlet.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountServlet.java
@@ -177,7 +177,7 @@ public class AccountServlet extends HttpServlet {
         // handle post of login page
         connection = this.connectionToInitialize;
         if (connection == null) {
-            returnError(resp, "Connection not in intialize mode.");
+            returnError(resp, "Connection not in initialize mode.");
             return;
         }
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/ConsoleCommandExtension.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/ConsoleCommandExtension.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.io.console.Console;
+import org.eclipse.smarthome.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.binding.amazonechocontrol.internal.handler.AccountHandler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link ConsoleCommandExtension} class
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@Component(service = org.eclipse.smarthome.io.console.extensions.ConsoleCommandExtension.class)
+@NonNullByDefault
+public class ConsoleCommandExtension extends AbstractConsoleCommandExtension {
+    private static final String LIST_ACCOUNTS = "listAccounts";
+    private static final String RESET_ACCOUNT = "resetAccount";
+
+    private final AmazonEchoControlHandlerFactory handlerFactory;
+
+    @Activate
+    public ConsoleCommandExtension(@Reference AmazonEchoControlHandlerFactory handlerFactory) {
+        super("amazonechocontrol", "Manage the AmazonEchoControl account");
+
+        this.handlerFactory = handlerFactory;
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length > 0) {
+            String command = args[0];
+            switch (command) {
+                case LIST_ACCOUNTS:
+                    listAccounts(console);
+                    break;
+                case RESET_ACCOUNT:
+                    if (args.length == 2) {
+                        resetAccount(console, args[1]);
+                    } else {
+                        console.println("Invalid use of command '" + command + "'");
+                        printUsage(console);
+                    }
+                    break;
+                default:
+                    console.println("Unknown command '" + command + "'");
+                    printUsage(console);
+                    break;
+            }
+        } else {
+            printUsage(console);
+        }
+    }
+
+    private void listAccounts(Console console) {
+        Set<AccountHandler> accountHandlers = handlerFactory.getAccountHandlers();
+
+        accountHandlers.forEach(handler -> console.println(
+                "Thing-Id: " + handler.getThing().getUID().getId() + " ('" + handler.getThing().getLabel() + "')"));
+    }
+
+    private void resetAccount(Console console, String accountId) {
+        Optional<AccountHandler> accountHandler = handlerFactory.getAccountHandlers().stream()
+                .filter(handler -> handler.getThing().getUID().getId().equals(accountId)).findAny();
+        if (accountHandler.isPresent()) {
+            console.println("Resetting account '" + accountId + "'");
+            accountHandler.get().setConnection(null);
+        } else {
+            console.println("Account '" + accountId + "' not found.");
+        }
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays.asList(buildCommandUsage(LIST_ACCOUNTS, "list all AmazonEchoControl accounts"), buildCommandUsage(
+                RESET_ACCOUNT + " <account_id>",
+                "resets the account connection (clears all authentication data) for the thing with the given id"));
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author Michael Geramb - Initial contribution
  */
 @NonNullByDefault
-public class AmazonEchoDiscovery extends AbstractDiscoveryService  {
+public class AmazonEchoDiscovery extends AbstractDiscoveryService {
 
     AccountHandler accountHandler;
     private final Logger logger = LoggerFactory.getLogger(AmazonEchoDiscovery.class);
@@ -185,7 +185,8 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService  {
 
         if (!discoveredFlashBriefings.contains(currentFlashBriefingJson)) {
             ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
-            ThingUID freeThingUID =  new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, brigdeThingUID, Integer.toString(currentFlashBriefingJson.hashCode()));
+            ThingUID freeThingUID = new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, brigdeThingUID,
+                    Integer.toString(currentFlashBriefingJson.hashCode()));
             DiscoveryResult result = DiscoveryResultBuilder.create(freeThingUID).withLabel("FlashBriefing")
                     .withProperty(DEVICE_PROPERTY_FLASH_BRIEFING_PROFILE, currentFlashBriefingJson)
                     .withBridge(accountHandler.getThing().getUID()).build();


### PR DESCRIPTION
An issue has been found where the login to the amazon account fails. Device-ids generated by bindings-versions before #8139 may have problems to login if they do not conform to the specification. The binding was not properly detecting this and further logins re-used the device-id which failed again. 

This PR adds a check for the correct format of the device-id and also adds a console command to fore renewal of all connection settings.
 
Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
