### PR TITLE
[lutron] Fix potential NPE if bridge not initialized

### DIFF
--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronDeviceDiscoveryService.java
@@ -130,6 +130,11 @@ public class LutronDeviceDiscoveryService extends AbstractDiscoveryService {
 
     private void readDeviceDatabase() {
         Project project = null;
+
+        if (bridgeHandler == null || bridgeHandler.getIPBridgeConfig() == null) {
+            logger.debug("Unable to get bridge config. Exiting.");
+            return;
+        }
         String discFileName = bridgeHandler.getIPBridgeConfig().discoveryFile;
         String address = "http://" + bridgeHandler.getIPBridgeConfig().ipAddress + "/DbXmlInfo.xml";
 


### PR DESCRIPTION
Fixes a potential error in the XML discovery service if the bridge is not initialized.
