### PR TITLE
[mqtt][HA] ConcurrentHashMap to avoid ConcurrentModificationException

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/discovery/HomeAssistantDiscovery.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -65,7 +65,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
     private final Logger logger = LoggerFactory.getLogger(HomeAssistantDiscovery.class);
     protected final Map<String, Set<HaID>> componentsPerThingID = new TreeMap<>();
     protected final Map<String, ThingUID> thingIDPerTopic = new TreeMap<>();
-    protected final Map<String, DiscoveryResult> results = new TreeMap<>();
+    protected final ConcurrentHashMap<String, DiscoveryResult> results = new ConcurrentHashMap<>();
 
     private @Nullable ScheduledFuture<?> future;
     private final Gson gson;
@@ -165,7 +165,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         thingIDPerTopic.put(topic, thingUID);
 
         // We need to keep track of already found component topics for a specific thing
-        Set<HaID> components = componentsPerThingID.computeIfAbsent(thingID, key -> new HashSet<>());
+        Set<HaID> components = componentsPerThingID.computeIfAbsent(thingID, key -> ConcurrentHashMap.newKeySet());
         components.add(haID);
 
         final String componentNames = components.stream().map(id -> id.component)
@@ -178,23 +178,19 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         properties = handlerConfig.appendToProperties(properties);
         properties = config.appendToProperties(properties);
 
-        synchronized (results) {
-            // Because we need the new properties map with the updated "components" list
-            results.put(thingUID.getAsString(),
-                    DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                            .withRepresentationProperty("objectid").withBridge(connectionBridge)
-                            .withLabel(config.getThingName() + " (" + componentNames + ")").build());
-        }
+        // Because we need the new properties map with the updated "components" list
+        results.put(thingUID.getAsString(),
+                DiscoveryResultBuilder.create(thingUID).withProperties(properties).withRepresentationProperty(thingID)
+                        .withBridge(connectionBridge).withLabel(config.getThingName() + " (" + componentNames + ")")
+                        .build());
     }
 
     protected void publishResults() {
         Collection<DiscoveryResult> localResults;
 
-        synchronized (results) {
-            localResults = new ArrayList<>(results.values());
-            results.clear();
-            componentsPerThingID.clear();
-        }
+        localResults = new ArrayList<>(results.values());
+        results.clear();
+        componentsPerThingID.clear();
         for (DiscoveryResult result : localResults) {
             final ThingTypeUID typeID = result.getThingTypeUID();
             ThingType type = typeProvider.derive(typeID, MqttBindingConstants.HOMEASSISTANT_MQTT_THING).build();


### PR DESCRIPTION
Hi @jochen314!

I've been able to fix the ConcurrentModifiedException errors using a ConcurrentHashMap for the 'results' of the discovery process.

What do you think?

Sadly the problem described in https://github.com/openhab/openhab-addons/pull/7716#issuecomment-667450136 is still present :disappointed: 

Fixes #7661

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>
