### PR TITLE
[lutron] Dimmer enhancements

### DIFF
--- a/bundles/org.openhab.binding.lutron/README.md
+++ b/bundles/org.openhab.binding.lutron/README.md
@@ -108,6 +108,13 @@ Dimmers can optionally be configured to specify a default fade in and fade out t
 These are used for ON and OFF commands, respectively, and default to 1 second if not set.
 Commands using a specific percent value will use a default fade time of 0.25 seconds.
 
+Dimmers also support the optional advanced parameters `onLevel` and `onToLast`.
+The `onLevel` parameter specifies the level to which the dimmer will go when sent an ON command.
+It defaults to 100.
+The `onToLast` parameter is a boolean that defaults to false.
+If set to "true", the dimmer will go to its last non-zero level when sent an ON command.
+If the last non-zero level cannot be determined, the value of `onLevel` will be used instead.
+
 A **dimmer** thing has a single channel *lightlevel* with type Dimmer and category DimmableLight.
 
 Thing configuration file example:

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/DimmerConfig.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/config/DimmerConfig.java
@@ -24,8 +24,12 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class DimmerConfig {
     private static final int DEFAULT_FADE = 1;
+    private static final int DEFAULT_ONLEVEL = 100;
+    private static final boolean DEFAULT_ONTOLAST = false;
 
     public int integrationId;
     public BigDecimal fadeInTime = new BigDecimal(DEFAULT_FADE);
     public BigDecimal fadeOutTime = new BigDecimal(DEFAULT_FADE);
+    public BigDecimal onLevel = new BigDecimal(DEFAULT_ONLEVEL);
+    public Boolean onToLast = new Boolean(DEFAULT_ONTOLAST);
 }

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -91,7 +91,7 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="onToLast" type="boolean">
-				<label>Turn on to last level</label>
+				<label>Turn On To Last Level</label>
 				<description>
 					If set to true, dimmer will go to the last non-zero level set when an ON command is received.
 					If the last level cannot be determined, the value of onLevel will be used instead.

--- a/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lutron/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -84,6 +84,21 @@
 				<label>Fade Out Time</label>
 				<description>Fade time in seconds when turning off the light</description>
 			</parameter>
+			<parameter name="onLevel" type="decimal" min="0.01" max="100.00">
+				<label>On Level</label>
+				<description>Output level to go to when an ON command is received. Default is 100%.</description>
+				<default>100</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="onToLast" type="boolean">
+				<label>Turn on to last level</label>
+				<description>
+					If set to true, dimmer will go to the last non-zero level set when an ON command is received.
+					If the last level cannot be determined, the value of onLevel will be used instead.
+				</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
This update adds two new configuration parameters to the dimmer thing:

* The `onLevel` parameter specifies the level to which the dimmer will go when sent an ON command. It defaults to 100.
* The `onToLast` parameter is a boolean that defaults to false. If set to "true", the dimmer will go to its last non-zero level when sent an ON command. If the last non-zero level cannot be determined, the value of `onLevel` will be used instead.

If these parameters are left at their defaults, there will be no change in behavior from the current dimmer handler.
