### PR TITLE
[mqtt][homie] Implement non-retained and non-settable properties

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/OnOffValue.java
@@ -21,6 +21,8 @@ import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
+import org.eclipse.smarthome.core.types.CommandOption;
 
 /**
  * Implements an on/off boolean value.
@@ -94,5 +96,13 @@ public class OnOffValue extends Value {
         }
 
         return String.format(formatPattern, state == OnOffType.ON ? onCommand : offCommand);
+    }
+
+    @Override
+    public CommandDescriptionBuilder createCommandDescription() {
+        CommandDescriptionBuilder builder = super.createCommandDescription();
+        builder = builder.withCommandOption(new CommandOption(onCommand, onCommand));
+        builder = builder.withCommandOption(new CommandOption(offCommand, offCommand));
+        return builder;
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/TextValue.java
@@ -23,6 +23,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
+import org.eclipse.smarthome.core.types.CommandOption;
 import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.StateOption;
 
@@ -80,6 +82,18 @@ public class TextValue extends Value {
         if (states != null) {
             for (String state : states) {
                 builder = builder.withOption(new StateOption(state, state));
+            }
+        }
+        return builder;
+    }
+
+    @Override
+    public CommandDescriptionBuilder createCommandDescription() {
+        CommandDescriptionBuilder builder = super.createCommandDescription();
+        final Set<String> commands = this.states;
+        if (states != null) {
+            for (String command : commands) {
+                builder = builder.withCommandOption(new CommandOption(command, command));
             }
         }
         return builder;

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/Value.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.RawType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -168,5 +169,14 @@ public abstract class Value {
      */
     public StateDescriptionFragmentBuilder createStateDescription(boolean readOnly) {
         return StateDescriptionFragmentBuilder.create().withReadOnly(readOnly).withPattern("%s");
+    }
+
+    /**
+     * Return the command description builder for this value state.
+     *
+     * @return A command description builder
+     */
+    public CommandDescriptionBuilder createCommandDescription() {
+        return CommandDescriptionBuilder.create();
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -137,6 +138,7 @@ public class Property implements AttributeChanged {
      * @return Returns the ChannelType to be used to build the Channel.
      */
     private ChannelType createChannelType(PropertyAttributes attributes, ChannelState channelState) {
+        // Retained property -> State channel
         if (attributes.retained) {
             return ChannelTypeBuilder.state(channelTypeUID, attributes.name, channelState.getItemType())
                     .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HOMIE_CHANNEL))
@@ -144,6 +146,14 @@ public class Property implements AttributeChanged {
                             .toStateDescription())
                     .build();
         } else {
+            // Non-retained and settable property -> State channel
+            if (attributes.settable) {
+                return ChannelTypeBuilder.state(channelTypeUID, attributes.name, channelState.getItemType())
+                        .withConfigDescriptionURI(URI.create(MqttBindingConstants.CONFIG_HOMIE_CHANNEL))
+                        .withCommandDescription(channelState.getCache().createCommandDescription().build())
+                        .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+            }
+            // Non-retained and non settable property -> Trigger channel
             if (attributes.datatype.equals(DataTypeEnum.enum_)) {
                 if (attributes.format.contains("PRESSED") && attributes.format.contains("RELEASED")) {
                     return DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON;


### PR DESCRIPTION
This PR makes non-retained and non-settable properties usable, because right now they not fully supported as described in #8164.

With the proposed changes, this type of properties are modeled as state channels and as such are able to receive commands, but they don't update their states, as they are meant to be "stateless" (non-retained -> we don't want to store the value). That's why I have defined the VETO option for the AutoUpdatePolicy. At the same time, I have extended the generic Value class so that its children classes can implement the createCommandDescription() method. Usually this type of properties will be used with the "enum" data type, so providing a list of command options makes sense.

Feedback from @jochen314, @J-N-K, @cpmeister, @Hilbrand and @fwolter would be highly appreciated :wink: 

Closes #8164.

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>