### PR TITLE
[RFXCOM] Adding support for T11 Blinds

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -301,6 +301,7 @@ A Blinds1 device
         *   T6 - DC106/Rohrmotor24-RMF/Yooda
         *   T7 - Forest
         *   T8 - Chamberlain CS4330CN
+        *   T11 - ASP
 
 ### chime - RFXCOM Chime
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/blinds1.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/ESH-INF/thing/blinds1.xml
@@ -41,6 +41,7 @@
 					<option value="T6">DC106/Rohrmotor24-RMF/Yooda</option>
 					<option value="T7">Forest</option>
 					<option value="T8">Chamberlain CS4330CN</option>
+					<option value="T11">ASP</option>
 				</options>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
Right - apologies for all the confusion on the last PR. This is a clean branch with a clean update.

This PR adds support for T11 blinds into the Blind1 actuator for the RFXCOM Binding. I've been using this built on my local instance for about 2 months on new Louvolite blinds which are reporting as ASP in the RFXMGR.

Signed-off-by: Michael Hazelden <michael@hazelden.me>

