### PR TITLE
[alarmdecoder] allow keypad messages with !KPM:

### DIFF
--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADMsgType.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADMsgType.java
@@ -43,6 +43,7 @@ public enum ADMsgType {
         startToMsgType.put("!EXP", ADMsgType.EXP);
         startToMsgType.put("!LRR", ADMsgType.LRR);
         startToMsgType.put("!VER", ADMsgType.VER);
+        startToMsgType.put("!KPM", ADMsgType.KPM);
     }
 
     /**

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/KeypadMessage.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/KeypadMessage.java
@@ -56,8 +56,7 @@ public class KeypadMessage extends ADMessage {
 
     public KeypadMessage(String message) throws IllegalArgumentException {
         super(message);
-        String topLevel[] = message.split(":");
-        List<String> parts = splitMsg(topLevel[(topLevel.length - 1)]);
+        List<String> parts = splitMsg(message.replace("!KPM:", ""));
 
         if (parts.size() != 4) {
             throw new IllegalArgumentException("Invalid number of parts in keypad message");

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/KeypadMessage.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/KeypadMessage.java
@@ -56,7 +56,8 @@ public class KeypadMessage extends ADMessage {
 
     public KeypadMessage(String message) throws IllegalArgumentException {
         super(message);
-        List<String> parts = splitMsg(message);
+        String topLevel[] = message.split(":");
+        List<String> parts = splitMsg(topLevel[(topLevel.length - 1)]);
 
         if (parts.size() != 4) {
             throw new IllegalArgumentException("Invalid number of parts in keypad message");


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->
[alarmdecoder] allow keypad messages with !KPM:

<!-- DESCRIPTION -->
This PR updates the alarmdecoder binding to accept KeyPad messages with the `!KPM` prefix.  

Logs from my serial AD2USB, which indicate the prefix.
```
10:41:44.219 [TRACE] [oder.internal.handler.ADBridgeHandler] - Received msg: !KPM:[10000001100000003A--],008,[f70000051008001c28020000000000]," DISARMED CHIME   Ready to Arm  "
10:41:48.178 [TRACE] [oder.internal.handler.ADBridgeHandler] - Received msg: !KPM:[10000001100100000A--],011,[f70000051011005028020000000000],"LOBAT 11                        "

```
<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->
I was able to verify the changes here enable the KeyPad.
<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
Thread started.
https://community.openhab.org/t/alarmdecoder-2-5-7-binding-serial-keypad/103242