### PR TITLE
[lametrictime] ignore javax.activation as it is not required

### DIFF
--- a/bundles/org.openhab.binding.lametrictime/pom.xml
+++ b/bundles/org.openhab.binding.lametrictime/pom.xml
@@ -12,6 +12,10 @@
 
   <name>openHAB Add-ons :: Bundles :: LaMetric Time Binding</name>
 
+  <properties>
+    <bnd.importpackage>!javax.activation</bnd.importpackage>
+  </properties>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Fixes https://ci.openhab.org/job/openHAB-Addons-port/209/

Signed-off-by: Kai Kreuzer <kai@openhab.org>