### PR TITLE
[lcn] Remove status-only Channels from LCN Group Thing

### DIFF
--- a/bundles/org.openhab.binding.lcn/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lcn/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -62,8 +62,6 @@
 			<channel-group typeId="leds" id="led"/>
 			<channel-group typeId="relays" id="relay"/>
 			<channel-group typeId="rollershutterrelays" id="rollershutterrelay"/>
-			<channel-group typeId="logics" id="logic"/>
-			<channel-group typeId="binarysensors" id="binarysensor"/>
 			<channel-group typeId="variables" id="variable"/>
 			<channel-group typeId="rvarsetpoints" id="rvarsetpoint"/>
 			<channel-group typeId="rvarlocks" id="rvarlock"/>
@@ -71,12 +69,10 @@
 			<channel-group typeId="thresholdregisters2" id="thresholdregister2"/>
 			<channel-group typeId="thresholdregisters3" id="thresholdregister3"/>
 			<channel-group typeId="thresholdregisters4" id="thresholdregister4"/>
-			<channel-group typeId="s0inputs" id="s0input"/>
 			<channel-group typeId="keyslocktablea" id="keylocktablea"/>
 			<channel-group typeId="keyslocktableb" id="keylocktableb"/>
 			<channel-group typeId="keyslocktablec" id="keylocktablec"/>
 			<channel-group typeId="keyslocktabled" id="keylocktabled"/>
-			<channel-group typeId="codes" id="code"/>
 		</channel-groups>
 
 		<config-description-ref uri="thing-type:lcn:group"/>


### PR DESCRIPTION
As LCN groups don't send any status messages, it makes no sense to have status Channels for LCN groups. They will never be updated.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>