### PR TITLE
 [wemo] bugfix: the light's state was not OFF when the brightness was set to 0

### DIFF
--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -273,7 +273,8 @@ public class WemoLightHandler extends AbstractWemoHandler implements UpnpIOParti
                     if (wemoCallResponse != null) {
                         if (capability.equals("10008")) {
                             OnOffType binaryState = null;
-                            binaryState = value.startsWith("0") ? OnOffType.OFF : OnOffType.ON;
+                            // value was like  int:0 when capability == 10008
+			    binaryState = value.startsWith("0") ? OnOffType.OFF : OnOffType.ON;
                             updateState(CHANNEL_STATE, binaryState);
                         }
                     }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -274,7 +274,7 @@ public class WemoLightHandler extends AbstractWemoHandler implements UpnpIOParti
                         if (capability.equals("10008")) {
                             OnOffType binaryState = null;
                             // value was like  int:0 when capability == 10008
-			    binaryState = value.startsWith("0") ? OnOffType.OFF : OnOffType.ON;
+                            binaryState = value.startsWith("0") ? OnOffType.OFF : OnOffType.ON;
                             updateState(CHANNEL_STATE, binaryState);
                         }
                     }

--- a/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
+++ b/bundles/org.openhab.binding.wemo/src/main/java/org/openhab/binding/wemo/internal/handler/WemoLightHandler.java
@@ -273,7 +273,7 @@ public class WemoLightHandler extends AbstractWemoHandler implements UpnpIOParti
                     if (wemoCallResponse != null) {
                         if (capability.equals("10008")) {
                             OnOffType binaryState = null;
-                            binaryState = value.equals("0") ? OnOffType.OFF : OnOffType.ON;
+                            binaryState = value.startsWith("0") ? OnOffType.OFF : OnOffType.ON;
                             updateState(CHANNEL_STATE, binaryState);
                         }
                     }


### PR DESCRIPTION
When using slider/switch in brightness channel, the lights state will not set to OFF as expected.


The bug is when the `capability == "10008"`, the `value = aString +  ":0"`, and  `value.equals("0")` was always false.