### PR TITLE
[lcn] Make requesting module serial numbers more reliable

### DIFF
--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBindingConstants.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBindingConstants.java
@@ -25,6 +25,8 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 public class LcnBindingConstants {
     /** The scope name of this binding */
     public static final String BINDING_ID = "lcn";
+    /** Name of the module's serial number property */
+    public static final String SERIAL_NUMBER_PROPERTY = "serialNumber";
     /**
      * Firmware version of the measurement processing since 2013. It has more variables and thresholds and event-based
      * variable updates.

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBindingConstants.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBindingConstants.java
@@ -25,8 +25,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 public class LcnBindingConstants {
     /** The scope name of this binding */
     public static final String BINDING_ID = "lcn";
-    /** Name of the module's serial number property */
-    public static final String SERIAL_NUMBER_PROPERTY = "serialNumber";
     /**
      * Firmware version of the measurement processing since 2013. It has more variables and thresholds and event-based
      * variable updates.

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnGroupHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnGroupHandler.java
@@ -45,6 +45,11 @@ public class LcnGroupHandler extends LcnModuleHandler {
     }
 
     @Override
+    protected void requestFirmwareVersionAndSerialNumberIfNotSet() throws LcnException {
+        // nothing, don't request the serial number of an LCN group representation module
+    }
+
+    @Override
     protected LcnAddr getCommandAddress() throws LcnException {
         LcnAddrGrp localAddress = groupAddress;
         if (localAddress == null) {

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleDiscoveryService.java
@@ -65,7 +65,6 @@ public class LcnModuleDiscoveryService extends AbstractDiscoveryService
             .compile("=M(?<segId>\\d{3})(?<modId>\\d{3}).N(?<part>[1-2]{1})(?<name>.*)");
     private static final String SEGMENT_ID = "segmentId";
     private static final String MODULE_ID = "moduleId";
-    private static final String SERIAL_NUMBER = "serialNumber";
     private static final int MODULE_NAME_PART_COUNT = 2;
     private static final int DISCOVERY_TIMEOUT_SEC = 90;
     private static final int ACK_TIMEOUT_MS = 1000;
@@ -161,10 +160,11 @@ public class LcnModuleDiscoveryService extends AbstractDiscoveryService
                             Map<String, Object> properties = new HashMap<>(3);
                             properties.put(SEGMENT_ID, addr.getSegmentId());
                             properties.put(MODULE_ID, addr.getModuleId());
-                            properties.put(SERIAL_NUMBER, serialNumber);
+                            properties.put(LcnBindingConstants.SERIAL_NUMBER_PROPERTY, serialNumber);
 
                             DiscoveryResultBuilder discoveryResult = DiscoveryResultBuilder.create(thingUid)
-                                    .withProperties(properties).withRepresentationProperty(SERIAL_NUMBER)
+                                    .withProperties(properties)
+                                    .withRepresentationProperty(LcnBindingConstants.SERIAL_NUMBER_PROPERTY)
                                     .withBridge(bridgeUid);
 
                             discoveryResultBuilders.put(addr, discoveryResult);

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleDiscoveryService.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -160,11 +161,10 @@ public class LcnModuleDiscoveryService extends AbstractDiscoveryService
                             Map<String, Object> properties = new HashMap<>(3);
                             properties.put(SEGMENT_ID, addr.getSegmentId());
                             properties.put(MODULE_ID, addr.getModuleId());
-                            properties.put(LcnBindingConstants.SERIAL_NUMBER_PROPERTY, serialNumber);
+                            properties.put(Thing.PROPERTY_SERIAL_NUMBER, serialNumber);
 
                             DiscoveryResultBuilder discoveryResult = DiscoveryResultBuilder.create(thingUid)
-                                    .withProperties(properties)
-                                    .withRepresentationProperty(LcnBindingConstants.SERIAL_NUMBER_PROPERTY)
+                                    .withProperties(properties).withRepresentationProperty(Thing.PROPERTY_SERIAL_NUMBER)
                                     .withBridge(bridgeUid);
 
                             discoveryResultBuilders.put(addr, discoveryResult);

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
@@ -150,7 +150,7 @@ public class LcnModuleHandler extends BaseThingHandler {
      */
     @SuppressWarnings("null")
     protected void requestFirmwareVersionAndSerialNumberIfNotSet() throws LcnException {
-        String serialNumber = getThing().getProperties().get(LcnBindingConstants.SERIAL_NUMBER_PROPERTY);
+        String serialNumber = getThing().getProperties().get(Thing.PROPERTY_SERIAL_NUMBER);
         if (serialNumber == null || serialNumber.isEmpty()) {
             LcnAddrMod localModuleAddress = moduleAddress;
             if (localModuleAddress != null) {
@@ -329,7 +329,7 @@ public class LcnModuleHandler extends BaseThingHandler {
      * @param serialNumber the new serial number
      */
     public void updateSerialNumberProperty(String serialNumber) {
-        updateProperty(LcnBindingConstants.SERIAL_NUMBER_PROPERTY, serialNumber);
+        updateProperty(Thing.PROPERTY_SERIAL_NUMBER, serialNumber);
     }
 
     /**

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.regex.Matcher;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -71,7 +70,6 @@ public class LcnModuleHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(LcnModuleHandler.class);
     private static final Map<String, Converter> VALUE_CONVERTERS = new HashMap<>();
     private static final InversionConverter INVERSION_CONVERTER = new InversionConverter();
-    private static final String SERIAL_NUMBER = "serialNumber";
     private @Nullable LcnAddrMod moduleAddress;
     private final Map<LcnChannelGroup, @Nullable AbstractLcnModuleSubHandler> subHandlers = new HashMap<>();
     private final List<AbstractLcnModuleSubHandler> metadataSubHandlers = new ArrayList<>();
@@ -91,7 +89,6 @@ public class LcnModuleHandler extends BaseThingHandler {
         super(thing);
     }
 
-    @SuppressWarnings("null")
     @Override
     public void initialize() {
         LcnModuleConfiguration localConfig = getConfigAs(LcnModuleConfiguration.class);
@@ -99,28 +96,7 @@ public class LcnModuleHandler extends BaseThingHandler {
 
         try {
             // Determine serial number of manually added modules
-            String serialNumberProperty = getThing().getProperties().get(SERIAL_NUMBER);
-            if (getThing().getThingTypeUID().equals(LcnBindingConstants.THING_TYPE_MODULE)
-                    && (serialNumberProperty == null || serialNumberProperty.isEmpty())) {
-                PckGatewayHandler localBridgeHandler = getPckGatewayHandler();
-                localBridgeHandler.registerPckListener(data -> {
-                    Matcher matcher;
-
-                    if ((matcher = LcnModuleMetaFirmwareSubHandler.PATTERN.matcher(data)).matches()) {
-                        if (isMyAddress(matcher.group("segId"), matcher.group("modId"))
-                                && matcher.pattern() == LcnModuleMetaFirmwareSubHandler.PATTERN) {
-                            String serialNumber = matcher.group("sn");
-                            updateProperty(SERIAL_NUMBER, serialNumber);
-                        }
-                    }
-                });
-                synchronized (LcnModuleHandler.this) {
-                    Connection connection = localBridgeHandler.getConnection();
-                    if (connection != null) {
-                        connection.sendSerialNumberRequest(localModuleAddress);
-                    }
-                }
-            }
+            requestFirmwareVersionAndSerialNumberIfNotSet();
 
             // create sub handlers
             ModInfo info = getPckGatewayHandler().getModInfo(localModuleAddress);
@@ -164,6 +140,22 @@ public class LcnModuleHandler extends BaseThingHandler {
             updateStatus(ThingStatus.ONLINE);
         } catch (LcnException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        }
+    }
+
+    /**
+     * Triggers requesting the firmware version of the LCN module. The message also contains the serial number.
+     *
+     * @throws LcnException when the handler is not initialized
+     */
+    @SuppressWarnings("null")
+    protected void requestFirmwareVersionAndSerialNumberIfNotSet() throws LcnException {
+        String serialNumber = getThing().getProperties().get(LcnBindingConstants.SERIAL_NUMBER_PROPERTY);
+        if (serialNumber == null || serialNumber.isEmpty()) {
+            LcnAddrMod localModuleAddress = moduleAddress;
+            if (localModuleAddress != null) {
+                getPckGatewayHandler().getModInfo(localModuleAddress).requestFirmwareVersion();
+            }
         }
     }
 
@@ -329,6 +321,15 @@ public class LcnModuleHandler extends BaseThingHandler {
         }
 
         updateState(channelUid, convertedState);
+    }
+
+    /**
+     * Updates the LCN module's serial number property.
+     *
+     * @param serialNumber the new serial number
+     */
+    public void updateSerialNumberProperty(String serialNumber) {
+        updateProperty(LcnBindingConstants.SERIAL_NUMBER_PROPERTY, serialNumber);
     }
 
     /**

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleMetaFirmwareSubHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleMetaFirmwareSubHandler.java
@@ -46,6 +46,7 @@ public class LcnModuleMetaFirmwareSubHandler extends AbstractLcnModuleSubHandler
     @Override
     public void handleStatusMessage(Matcher matcher) {
         info.setFirmwareVersion(Integer.parseInt(matcher.group("firmwareVersion"), 16));
+        handler.updateSerialNumberProperty(matcher.group("sn"));
     }
 
     @Override


### PR DESCRIPTION
The previous implementation sent serial number requests without throttling and without retrying, which lead to unresolved serial numbers. This occurs if more than a couple of modules have no serial number property set, yet.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>