### PR TITLE
Add gitlab ci/cd.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,43 @@
+variables:
+  MAVEN_SERVER_ID: ""
+  SNAPSHOT_REPOSITORY_URL: ""
+  SNAPSHOT_REPOSITORY_NAME: ""
+  MAVEN_REPO_USER: ""
+  MAVEN_REPO_PASS: ""
+  CENTRAL_PROXY_MIRROR_OF: ""
+  CENTRAL_PROXY_URL: ""
+  OPENHAB_PROXY_MIRROR_OF: ""
+  OPENHAB_PROXY_URL: ""
+
+image: maven:3.6.3-jdk-11
+
+# Cache downloaded dependencies and plugins between builds.
+# To keep cache across branches add 'key: "$CI_JOB_NAME"'
+cache:
+  paths:
+    - .m2/repository
+
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  script:
+    - 'mvn -s .gitlab/settings.xml $MAVEN_CLI_OPTS $MAVEN_OPTS_EXTRA package -DnoOhSnapRepo'
+
+deploy:
+  stage: deploy
+  script:
+    - if [ ! -f .gitlab/settings.xml ];
+      then echo "The .gitlab/settings.xml file is missing.";
+      fi
+    - mvn $MAVEN_CLI_OPTS $MAVEN_OPTS_EXTRA -s .gitlab/settings.xml
+      package org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy
+      -Dsnapshot.repository-id=${MAVEN_SERVER_ID}
+      -Dsnapshot.repository-url=${SNAPSHOT_REPOSITORY_URL}
+      -Dsnapshot.repository-name="${SNAPSHOT_REPOSITORY_NAME}"
+      -DaltSnapshotDeploymentRepository="${MAVEN_SERVER_ID}::${SNAPSHOT_REPOSITORY_URL}"
+      -Dmaven.test.skip.exec=true -DskipChecks -DnoOhSnapRepo
+  only:
+    - master

--- a/.gitlab/settings.xml
+++ b/.gitlab/settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
+  xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <servers>
+    <server>
+      <id>${env.MAVEN_SERVER_ID}</id>
+      <username>${env.MAVEN_REPO_USER}</username>
+      <password>${env.MAVEN_REPO_PASS}</password>
+    </server>
+    <server>
+      <id>${env.MAVEN_SERVER_ID}-central</id>
+      <username>${env.MAVEN_REPO_USER}</username>
+      <password>${env.MAVEN_REPO_PASS}</password>
+    </server>
+    <server>
+      <id>${env.MAVEN_SERVER_ID}-openhab</id>
+      <username>${env.MAVEN_REPO_USER}</username>
+      <password>${env.MAVEN_REPO_PASS}</password>
+    </server>
+  </servers>
+
+  <mirrors>
+    <mirror>
+      <id>${env.MAVEN_SERVER_ID}-central</id>
+      <mirrorOf>${env.CENTRAL_PROXY_MIRROR_OF}</mirrorOf>
+      <url>${env.CENTRAL_PROXY_URL}</url>
+    </mirror>
+    <mirror>
+      <id>${env.MAVEN_SERVER_ID}-openhab</id>
+      <mirrorOf>${env.OPENHAB_PROXY_MIRROR_OF}</mirrorOf>
+      <url>${env.OPENHAB_PROXY_URL}</url>
+    </mirror>
+  </mirrors>
+
+  <profiles>
+    <profile>
+      <id>deploy</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <repositories>
+        <repository>
+          <id>${env.MAVEN_SERVER_ID}</id>
+          <url>${env.SNAPSHOT_REPOSITORY_URL}</url>
+          <name>${env.SNAPSHOT_REPOSITORY_NAME}</name>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</settings>


### PR DESCRIPTION
This PR brings an additional configuration for gitlab ci/cd which allows to build project in isolated environment with mirrored maven repositories. Further configuration can be made using environment variables.