### PR TITLE
[modbus] Avoid unnecessary IllegalArgumentException on dispose

### DIFF
--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -94,4 +94,16 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      */
     public Future<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request, ModbusWriteCallback resultCallback,
             ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
+
+    /**
+     * Close this communication interface and try to free all resources associated with it
+     *
+     * Upon close, all polling tasks registered by this instance are unregistered. In addition, connections are closed
+     * eagerly if this was the last connection interface pointing to the endpoint.
+     *
+     * After close, the communication interface cannot be used to communicate with the device.
+     *
+     */
+    @Override
+    public void close() throws Exception;
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -74,10 +74,11 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
     /**
      * Unregister regularly polled task
      *
+     * If this communication interface is closed already, the method returns immediately with false return value
+     *
      * @param task poll task to unregister
      * @return whether poll task was unregistered. Poll task is not unregistered in case of unexpected errors or
      *         in the case where the poll task is not registered in the first place
-     * @throws IllegalStateException when this communication has been closed already
      */
     public boolean unregisterRegularPoll(PollTask task);
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -808,7 +808,8 @@ public class ModbusManagerImpl implements ModbusManager {
         public boolean unregisterRegularPoll(PollTask task) {
             synchronized (ModbusManagerImpl.this) {
                 if (closed) {
-                    throw new IllegalStateException("Communication interface is closed already!");
+                    // Closed already, nothing to unregister
+                    return false;
                 }
                 pollTasksRegisteredByThisCommInterface.remove(task);
                 ModbusSlaveConnectionFactoryImpl localConnectionFactory = connectionFactory;
@@ -853,7 +854,8 @@ public class ModbusManagerImpl implements ModbusManager {
         public void close() throws Exception {
             synchronized (ModbusManagerImpl.this) {
                 if (closed) {
-                    throw new IllegalStateException("Communication interface is closed already!");
+                    // Closed already, nothing to unregister
+                    return;
                 }
                 // Iterate over all tasks registered by this communication interface, and unregister those
                 // We copy pollTasksRegisteredByThisCommInterface temporarily so that unregisterRegularPoll can


### PR DESCRIPTION
If communication interface is closed, you cannot naturally interact with the device anymore. `IllegalArgumentException` is raised with all methods that would need to interact with the device.

In this commit, `close` and `unregisterRegularPoll` methods are not raising the exception anymore since they are essentially no-ops with closed communication interface. After all, close automatically unregisters all registered regular polls. Thus, it should be considered harmless to call these methods again on a closed instance, making them mostly idempotent.

This change was motivated by seeing the `IllegalStateException` in the wild (when disposing modbus `poller` thing), possibly triggered by certain dispose/initialize/reload of things: https://community.openhab.org/t/snip/102809/43

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
