### PR TITLE
[gree] Add channel for temperature sensor

### DIFF
--- a/bundles/org.openhab.binding.gree/README.md
+++ b/bundles/org.openhab.binding.gree/README.md
@@ -19,41 +19,48 @@ No binding configuration is required.
 
 ## Thing Configuration
 
-| Channel Name     | Type       | Description                                                                                   |
-|------------------|------------|-----------------------------------------------------------------------------------------------|
-| ipAddress        | IP Address | IP address of the unit.                                                                       |
-| broadcastAddress | IP Address | Broadcast address being used for discovery, usually derived from the IP interface address.    |
-| refresh          | Integer    | Refresh interval in seconds for polling the device status.                                    |
+| Channel Name             | Type       | Description                                                                                   |
+|--------------------------|------------|-----------------------------------------------------------------------------------------------|
+| ipAddress                | IP Address | IP address of the unit.                                                                       |
+| broadcastAddress         | IP Address | Broadcast address being used for discovery, usually derived from the IP interface address.    |
+| refresh                  | Integer    | Refresh interval in seconds for polling the device status.                                    |
+| currentTemperatureOffset | Decimal    | The offset in Celsius for the current temperature value received from the device.             |
 
 The Air Conditioner's IP address is mandatory, all other parameters are optional. 
 If the broadcast is not set (default) it will be derived from openHAB's network setting (PaperUI:Configuration:System:Network Settings). 
 Only change this if you have a good reason to.
 
+The currentTemperatureOffset defaults to -40 degrees Celsius. GREE airconditioners usually return a value from the temperature sensor
+which is offset by +40 degrees Celsius. The temperature value shown on the device LCD display should match the value shown by this binding.
+See [here](https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor) for more details.
+This currentTemperatureOffset configureable in case you would want to offset this temperature for calibration of the temperature sensor.
+
 ## Channels
 
 The following channels are supported for fans:
 
-| Channel Name  | Item Type | Description                                                                                       |
-|---------------|-----------|---------------------------------------------------------------------------------------------------|
-| power         | Switch    | Power on/off the Air Conditioner                                                                  |
-| mode          | String    | Sets the operating mode of the Air Conditioner                                                    |
-|               |           | Mode can be one of auto/cool/eco/dry/fan/heat or on/off                                           |
-|               |           | Check the Air Conditioner's operating manual for supported modes.                                 |
-| temperature   | Number:Temperature | Sets the desired room temperature                                                        |
-| air           | Switch    | Set on/off the Air Conditioner's Air function if applicable to the Air Conditioner model          |
-| dry           | Switch    | Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model          |
-| health        | Switch    | Set on/off the Air Conditioner's Health function if applicable to the Air Conditioner model       |
-| turbo         | Switch    | Set on/off the Air Conditioner's Turbo Mode.                                                      |
-| quiet         | String    | Set Quiet Mode: off/auto/quiet                                                                    |
-| swingUpDown   | Number    | Sets the vertical (up..down) swing action on the Air Conditioner,                                 |
-|               |           | OFF: 0, Full Swing: 1, Up: 2, MidUp: 3, Mid: 4, Mid Down: 5, Down : 6                             |
-| swingLeftRight| Number    | Sets the horizontal (left..right) swing action on the Air Conditioner                             |
-|               |           | OFF: 0, Full Swing: 1, Left: 2, Mid Left: 3, Mid: 4, Mid Right: 5, Right : 6                      |
-| windspeed     | Number    | Sets the fan speed on the Air conditioner Auto:0, Low:1, MidLow:2, Mid:3, MidHigh:4, High:5       |
-|               |           | The number of speeds depends on the Air Conditioner model.                                        |
-| powersave     | Switch    | Set on/off the Air Conditioner's Power Saving function if applicable to the Air Conditioner model |
-| light         | Switch    | Enable/disable the front display on the Air Conditioner if applicable to the Air Conditioner model|
-|               |           | Full Swing: 1, Up: 2, MidUp: 3, Mid: 4, Mid Down: 5, Down : 6                                     |
+| Channel Name       | Item Type | Description                                                                                       |
+|--------------------|-----------|---------------------------------------------------------------------------------------------------|
+| power              | Switch    | Power on/off the Air Conditioner                                                                  |
+| mode               | String    | Sets the operating mode of the Air Conditioner                                                    |
+|                    |           | Mode can be one of auto/cool/eco/dry/fan/heat or on/off                                           |
+|                    |           | Check the Air Conditioner's operating manual for supported modes.                                 |
+| targetTemperature  | Number:Temperature | Sets the desired room temperature.                                                       |
+| currentTemperature | Number:Temperature | Displays the current room temperature.                                                   |
+| air                | Switch    | Set on/off the Air Conditioner's Air function if applicable to the Air Conditioner model          |
+| dry                | Switch    | Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model          |
+| health             | Switch    | Set on/off the Air Conditioner's Health function if applicable to the Air Conditioner model       |
+| turbo              | Switch    | Set on/off the Air Conditioner's Turbo Mode.                                                      |
+| quiet              | String    | Set Quiet Mode: off/auto/quiet                                                                    |
+| swingUpDown        | Number    | Sets the vertical (up..down) swing action on the Air Conditioner,                                 |
+|                    |           | OFF: 0, Full Swing: 1, Up: 2, MidUp: 3, Mid: 4, Mid Down: 5, Down : 6                             |
+| swingLeftRight     | Number    | Sets the horizontal (left..right) swing action on the Air Conditioner                             |
+|                    |           | OFF: 0, Full Swing: 1, Left: 2, Mid Left: 3, Mid: 4, Mid Right: 5, Right : 6                      |
+| windspeed          | Number    | Sets the fan speed on the Air conditioner Auto:0, Low:1, MidLow:2, Mid:3, MidHigh:4, High:5       |
+|                    |           | The number of speeds depends on the Air Conditioner model.                                        |
+| powersave          | Switch    | Set on/off the Air Conditioner's Power Saving function if applicable to the Air Conditioner model |
+| light              | Switch    | Enable/disable the front display on the Air Conditioner if applicable to the Air Conditioner model|
+|                    |           | Full Swing: 1, Up: 2, MidUp: 3, Mid: 4, Mid Down: 5, Down : 6                                     |
 
 
 When changing mode, the air conditioner will be turned on unless "off" is selected.
@@ -73,7 +80,8 @@ Switch AirconPower                  { channel="gree:airconditioner:a1234561:powe
 String AirconMode                   { channel="gree:airconditioner:a1234561:mode" }
 Switch AirconTurbo                  { channel="gree:airconditioner:a1234561:turbo" }
 Switch AirconLight                  { channel="gree:airconditioner:a1234561:light" }
-Number AirconTemp "Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:temperature" }
+Number AirconTargetTemp "Target Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:targetTemperature" }
+Number AirconCurrentTemp "Current Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:currentTemperature" }
 Number AirconSwingVertical          { channel="gree:airconditioner:a1234561:swingUpDown" }
 Number AirconSwingHorizontal        { channel="gree:airconditioner:a1234561:swingLeftRight" }
 Number AirconFanSpeed               { channel="gree:airconditioner:a1234561:windspeed" }
@@ -91,7 +99,11 @@ This is an example of how to set up your sitemap.
 Frame label="Controls"
 {
    Switch item=AirconMode label="Mode" mappings=["auto"="Auto", "cool"="Cool", "eco"="Eco", "dry"="Dry", "fan"="Fan", "turbo"="Turbo", "heat"="Heat", "on"="ON", "off"="OFF"]
-   Setpoint item=AirconTemp label="Set temperature" icon=temperature minValue=16 maxValue=30 step=1
+   Setpoint item=AirconTargetTemp label="Set target temperature" icon=temperature minValue=16 maxValue=30 step=1
+}
+Frame label="Current Temperature"
+{
+   Text item=AirconCurrentTemp label="Current temperature [%.1f °C]" icon="temperature"
 }
 Frame label="Fan Speed"
 {
@@ -123,8 +135,8 @@ This example shows how to make a GREE Air Conditioner controllable by Google HA 
 Group Gree_Modechannel              "Gree"                { ga="Thermostat" } // allows mapping for Google Home Assistent
 Switch   GreeAirConditioner_Power   "Aircon"              {channel="gree:airconditioner:a1234561:power", ga="Switch"}
 String   GreeAirConditioner_Mode    "Aircon Mode"         {channel="gree:airconditioner:a1234561:mode", ga="thermostatMode"}
-Number   GreeAirConditioner_Temp    "Aircon Temperature"  {channel="gree:airconditioner:a1234561:temperature}
-Switch   GreeAirConditioner_Lightl  "Light"               {channel="gree:airconditioner:a1234561:light"}
+Number   GreeAirConditioner_Temp    "Aircon Temperature"  {channel="gree:airconditioner:a1234561:targetTemperature}
+Switch   GreeAirConditioner_Light   "Light"               {channel="gree:airconditioner:a1234561:light"}
 ```
 
 **Rules**

--- a/bundles/org.openhab.binding.gree/README.md
+++ b/bundles/org.openhab.binding.gree/README.md
@@ -45,7 +45,7 @@ The following channels are supported for fans:
 | mode               | String    | Sets the operating mode of the Air Conditioner                                                    |
 |                    |           | Mode can be one of auto/cool/eco/dry/fan/heat or on/off                                           |
 |                    |           | Check the Air Conditioner's operating manual for supported modes.                                 |
-| targetTemperature  | Number:Temperature | Sets the desired room temperature.                                                       |
+| temperature        | Number:Temperature | Sets the desired room temperature.                                                       |
 | currentTemperature | Number:Temperature | Displays the current room temperature.                                                   |
 | air                | Switch    | Set on/off the Air Conditioner's Air function if applicable to the Air Conditioner model          |
 | dry                | Switch    | Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model          |
@@ -80,7 +80,7 @@ Switch AirconPower                  { channel="gree:airconditioner:a1234561:powe
 String AirconMode                   { channel="gree:airconditioner:a1234561:mode" }
 Switch AirconTurbo                  { channel="gree:airconditioner:a1234561:turbo" }
 Switch AirconLight                  { channel="gree:airconditioner:a1234561:light" }
-Number AirconTargetTemp "Target Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:targetTemperature" }
+Number AirconTargetTemp "Target Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:temperature" }
 Number AirconCurrentTemp "Current Temperature [%.1f °C]" {channel="gree:airconditioner:a1234561:currentTemperature" }
 Number AirconSwingVertical          { channel="gree:airconditioner:a1234561:swingUpDown" }
 Number AirconSwingHorizontal        { channel="gree:airconditioner:a1234561:swingLeftRight" }
@@ -135,7 +135,7 @@ This example shows how to make a GREE Air Conditioner controllable by Google HA 
 Group Gree_Modechannel              "Gree"                { ga="Thermostat" } // allows mapping for Google Home Assistent
 Switch   GreeAirConditioner_Power   "Aircon"              {channel="gree:airconditioner:a1234561:power", ga="Switch"}
 String   GreeAirConditioner_Mode    "Aircon Mode"         {channel="gree:airconditioner:a1234561:mode", ga="thermostatMode"}
-Number   GreeAirConditioner_Temp    "Aircon Temperature"  {channel="gree:airconditioner:a1234561:targetTemperature}
+Number   GreeAirConditioner_Temp    "Aircon Temperature"  {channel="gree:airconditioner:a1234561:temperature}
 Switch   GreeAirConditioner_Light   "Light"               {channel="gree:airconditioner:a1234561:light"}
 ```
 

--- a/bundles/org.openhab.binding.gree/README.md
+++ b/bundles/org.openhab.binding.gree/README.md
@@ -30,11 +30,6 @@ The Air Conditioner's IP address is mandatory, all other parameters are optional
 If the broadcast is not set (default) it will be derived from openHAB's network setting (PaperUI:Configuration:System:Network Settings). 
 Only change this if you have a good reason to.
 
-The currentTemperatureOffset defaults to -40 degrees Celsius. GREE airconditioners usually return a value from the temperature sensor
-which is offset by +40 degrees Celsius. The temperature value shown on the device LCD display should match the value shown by this binding.
-See [here](https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor) for more details.
-This currentTemperatureOffset configureable in case you would want to offset this temperature for calibration of the temperature sensor.
-
 ## Channels
 
 The following channels are supported for fans:

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -138,7 +138,7 @@ public class GreeBindingConstants {
     public static final String GREE_PROP_HEAT = "StHt";
     public static final String GREE_PROP_HEATCOOL = "HeatCoolType";
     public static final String GREE_PROP_NOISESET = "NoiseSet";
-    public static final String GREE_PROP_TEMP_SENSOR = "TemSen";
+    public static final String GREE_PROP_CURRENT_TEMP_SENSOR = "TemSen";
 
     // Temperatur types and min/max ranges
     public static final int TEMP_UNIT_CELSIUS = 0;

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -45,7 +45,8 @@ public class GreeBindingConstants {
     public static final String MODE_CHANNEL = "mode";
     public static final String TURBO_CHANNEL = "turbo";
     public static final String LIGHT_CHANNEL = "light";
-    public static final String TEMP_CHANNEL = "temperature";
+    public static final String TARGET_TEMP_CHANNEL = "targetTemperature";
+    public static final String CURRENT_TEMP_CHANNEL = "currentTemperature";
     public static final String SWINGUD_CHANNEL = "swingUpDown";
     public static final String SWINGLR_CHANNEL = "swingLeftRight";
     public static final String WINDSPEED_CHANNEL = "windspeed";
@@ -137,6 +138,7 @@ public class GreeBindingConstants {
     public static final String GREE_PROP_HEAT = "StHt";
     public static final String GREE_PROP_HEATCOOL = "HeatCoolType";
     public static final String GREE_PROP_NOISESET = "NoiseSet";
+    public static final String GREE_PROP_TEMP_SENSOR = "TemSen";
 
     // Temperatur types and min/max ranges
     public static final int TEMP_UNIT_CELSIUS = 0;

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.gree.internal;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.binding.gree.internal;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 
@@ -170,5 +169,5 @@ public class GreeBindingConstants {
      *
      * @See https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor for more details.
      */
-    public static final BigDecimal CURRENT_TEMP_OFFSET_DEFAULT = new BigDecimal(-40.0);
+    public static final double INTERNAL_TEMP_SENSOR_OFFSET = -40.0;
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -163,11 +163,13 @@ public class GreeBindingConstants {
     public static final int DIGITS_TEMP = 1;
 
     /**
-     * The internal offset for the temperature sensor which is set to a constant of -40 degrees Celsius. GREE airconditioners usually
-     * return a value from the temperature sensor which is offset by +40 degrees Celsius. The temperature value shown on the device
-     * LCD display should match the value shown by this binding when the config parameter currentTemperatureOffset is set to 0.
+     * The internal offset for the temperature sensor which is set to a constant of -40 degrees Celsius. GREE
+     * airconditioners usually return a value from the temperature sensor which is offset by +40 degrees Celsius. The
+     * temperature value shown on the device LCD display should match the value shown by this binding when the config
+     * parameter currentTemperatureOffset is set to 0.
      *
-     * @See https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor for more details.
+     * @See https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor
+     *      for more details.
      */
     public static final double INTERNAL_TEMP_SENSOR_OFFSET = -40.0;
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -45,7 +45,7 @@ public class GreeBindingConstants {
     public static final String MODE_CHANNEL = "mode";
     public static final String TURBO_CHANNEL = "turbo";
     public static final String LIGHT_CHANNEL = "light";
-    public static final String TARGET_TEMP_CHANNEL = "targetTemperature";
+    public static final String TARGET_TEMP_CHANNEL = "temperature";
     public static final String CURRENT_TEMP_CHANNEL = "currentTemperature";
     public static final String SWINGUD_CHANNEL = "swingUpDown";
     public static final String SWINGLR_CHANNEL = "swingLeftRight";

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -163,9 +163,9 @@ public class GreeBindingConstants {
     public static final int DIGITS_TEMP = 1;
 
     /**
-     * The default value for the currentTemperatureOffset
-     * This defaults to -40 degrees Celsius. GREE airconditioners usually return a value from the temperature sensor which is offset by +40 
-     * degrees Celsius. The temperature value shown on the device LCD display should match the value shown by this binding.
+     * The internal offset for the temperature sensor which is set to a constant of -40 degrees Celsius. GREE airconditioners usually
+     * return a value from the temperature sensor which is offset by +40 degrees Celsius. The temperature value shown on the device
+     * LCD display should match the value shown by this binding when the config parameter currentTemperatureOffset is set to 0.
      *
      * @See https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor for more details.
      */

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeBindingConstants.java
@@ -161,4 +161,13 @@ public class GreeBindingConstants {
     public static final int REFRESH_INTERVAL_SEC = 5;
 
     public static final int DIGITS_TEMP = 1;
+
+    /**
+     * The default value for the currentTemperatureOffset
+     * This defaults to -40 degrees Celsius. GREE airconditioners usually return a value from the temperature sensor which is offset by +40 
+     * degrees Celsius. The temperature value shown on the device LCD display should match the value shown by this binding.
+     *
+     * @See https://github.com/tomikaa87/gree-remote#getting-the-current-temperature-reading-from-the-internal-sensor for more details.
+     */
+    public static final BigDecimal CURRENT_TEMP_OFFSET_DEFAULT = new BigDecimal(-40.0);
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.gree.internal;
 
+import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -25,9 +26,10 @@ public class GreeConfiguration {
     public String ipAddress = "";
     public String broadcastAddress = "";
     public int refresh = 60;
+    public BigDecimal currentTemperatureOffset = new BigDecimal(-40.0);
 
     @Override
     public String toString() {
-        return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh;
+        return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh + ", currentTemperatureOffset=" + currentTemperatureOffset;
     }
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.gree.internal;
 
 import java.math.BigDecimal;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -27,12 +28,14 @@ public class GreeConfiguration {
     public String broadcastAddress = "";
     public int refresh = 60;
     /**
-     * The currentTemperatureOffset is configureable in case the user wants to offset this temperature for calibration of the temperature sensor.
+     * The currentTemperatureOffset is configureable in case the user wants to offset this temperature for calibration
+     * of the temperature sensor.
      */
     public BigDecimal currentTemperatureOffset = new BigDecimal(0.0);
 
     @Override
     public String toString() {
-        return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh + ", currentTemperatureOffset=" + currentTemperatureOffset;
+        return "Config: ipAddress=" + ipAddress + ", broadcastAddress=" + broadcastAddress + ", refresh=" + refresh
+                + ", currentTemperatureOffset=" + currentTemperatureOffset;
     }
 }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.gree.internal;
 
+import static org.openhab.binding.gree.internal.GreeBindingConstants.CURRENT_TEMP_OFFSET_DEFAULT;
+
 import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -26,7 +28,10 @@ public class GreeConfiguration {
     public String ipAddress = "";
     public String broadcastAddress = "";
     public int refresh = 60;
-    public BigDecimal currentTemperatureOffset = new BigDecimal(-40.0);
+    /**
+     * The currentTemperatureOffset is configureable in case the user wants to offset this temperature for calibration of the temperature sensor.
+     */
+    public BigDecimal currentTemperatureOffset = CURRENT_TEMP_OFFSET_DEFAULT;
 
     @Override
     public String toString() {

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/GreeConfiguration.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.gree.internal;
 
-import static org.openhab.binding.gree.internal.GreeBindingConstants.CURRENT_TEMP_OFFSET_DEFAULT;
-
 import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -31,7 +29,7 @@ public class GreeConfiguration {
     /**
      * The currentTemperatureOffset is configureable in case the user wants to offset this temperature for calibration of the temperature sensor.
      */
-    public BigDecimal currentTemperatureOffset = CURRENT_TEMP_OFFSET_DEFAULT;
+    public BigDecimal currentTemperatureOffset = new BigDecimal(0.0);
 
     @Override
     public String toString() {

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
@@ -105,6 +105,7 @@ public class GreeAirDevice {
             columns.add(GREE_PROP_TEMPREC);
             columns.add(GREE_PROP_PWR_SAVING);
             columns.add(GREE_PROP_NOISESET);
+            columns.add(GREE_PROP_TEMP_SENSOR);
 
             // Convert the parameter map values to arrays
             String[] colArray = columns.toArray(new String[0]);
@@ -229,10 +230,6 @@ public class GreeAirDevice {
 
     public void setQuietMode(DatagramSocket clientSocket, int value) throws GreeException {
         setCommandValue(clientSocket, GREE_PROP_QUIET, value, 0, 2);
-    }
-
-    public int getDeviceTurbo() {
-        return getIntStatusVal(GREE_PROP_TURBO);
     }
 
     public void setDeviceLight(DatagramSocket clientSocket, int value) throws GreeException {

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeAirDevice.java
@@ -105,7 +105,7 @@ public class GreeAirDevice {
             columns.add(GREE_PROP_TEMPREC);
             columns.add(GREE_PROP_PWR_SAVING);
             columns.add(GREE_PROP_NOISESET);
-            columns.add(GREE_PROP_TEMP_SENSOR);
+            columns.add(GREE_PROP_CURRENT_TEMP_SENSOR);
 
             // Convert the parameter map values to arrays
             String[] colArray = columns.toArray(new String[0]);

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -518,8 +518,8 @@ public class GreeHandler extends BaseThingHandler {
     }
 
     private @Nullable State updateCurrentTemp() throws GreeException {
-        if (device.hasStatusValChanged(GREE_PROP_TEMP_SENSOR)) {
-            return new DecimalType(device.getIntStatusVal(GREE_PROP_TEMP_SENSOR) + config.currentTemperatureOffset.doubleValue());
+        if (device.hasStatusValChanged(GREE_PROP_CURRENT_TEMP_SENSOR)) {
+            return new DecimalType(device.getIntStatusVal(GREE_PROP_CURRENT_TEMP_SENSOR) + config.currentTemperatureOffset.doubleValue());
         }
         return null;
     }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -519,7 +519,7 @@ public class GreeHandler extends BaseThingHandler {
 
     private @Nullable State updateCurrentTemp() throws GreeException {
         if (device.hasStatusValChanged(GREE_PROP_CURRENT_TEMP_SENSOR)) {
-            return new DecimalType(device.getIntStatusVal(GREE_PROP_CURRENT_TEMP_SENSOR) + config.currentTemperatureOffset.doubleValue());
+            return new DecimalType(device.getIntStatusVal(GREE_PROP_CURRENT_TEMP_SENSOR) + INTERNAL_TEMP_SENSOR_OFFSET + config.currentTemperatureOffset.doubleValue());
         }
         return null;
     }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -153,7 +153,7 @@ public class GreeHandler extends BaseThingHandler {
                     case LIGHT_CHANNEL:
                         device.setDeviceLight(socket, getOnOff(command));
                         break;
-                    case TEMP_CHANNEL:
+                    case TARGET_TEMP_CHANNEL:
                         // Set value, read back effective one and update channel
                         // e.g. 22.5C will result in 22.0, because the AC doesn't support half-steps for C
                         device.setDeviceTempSet(socket, convertTemp(command));
@@ -405,8 +405,11 @@ public class GreeHandler extends BaseThingHandler {
                 case LIGHT_CHANNEL:
                     state = updateOnOff(GREE_PROP_LIGHT);
                     break;
-                case TEMP_CHANNEL:
-                    state = updateTemp();
+                case TARGET_TEMP_CHANNEL:
+                    state = updateTargetTemp();
+                    break;
+                case CURRENT_TEMP_CHANNEL:
+                    state = updateCurrentTemp();
                     break;
                 case SWINGUD_CHANNEL:
                     state = updateNumber(GREE_PROP_SWINGUPDOWN);
@@ -505,11 +508,18 @@ public class GreeHandler extends BaseThingHandler {
         return null;
     }
 
-    private @Nullable State updateTemp() throws GreeException {
+    private @Nullable State updateTargetTemp() throws GreeException {
         if (device.hasStatusValChanged(GREE_PROP_SETTEMP) || device.hasStatusValChanged(GREE_PROP_TEMPUNIT)) {
             int unit = device.getIntStatusVal(GREE_PROP_TEMPUNIT);
             return toQuantityType(device.getIntStatusVal(GREE_PROP_SETTEMP), DIGITS_TEMP,
                     unit == TEMP_UNIT_CELSIUS ? SIUnits.CELSIUS : ImperialUnits.FAHRENHEIT);
+        }
+        return null;
+    }
+
+    private @Nullable State updateCurrentTemp() throws GreeException {
+        if (device.hasStatusValChanged(GREE_PROP_TEMP_SENSOR)) {
+            return new DecimalType(device.getIntStatusVal(GREE_PROP_TEMP_SENSOR) + config.currentTemperatureOffset.doubleValue());
         }
         return null;
     }
@@ -525,7 +535,7 @@ public class GreeHandler extends BaseThingHandler {
         return new QuantityType<>(bd.setScale(digits, BigDecimal.ROUND_HALF_EVEN), unit);
     }
 
-    private void stopRefrestTask() {
+    private void stopRefreshTask() {
         forceRefresh = false;
         if (refreshTask == null) {
             return;
@@ -544,7 +554,7 @@ public class GreeHandler extends BaseThingHandler {
             clientSocket.get().close();
             clientSocket = Optional.empty();
         }
-        stopRefrestTask();
+        stopRefreshTask();
         if (initializeFuture != null) {
             initializeFuture.cancel(true);
         }

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -519,7 +519,8 @@ public class GreeHandler extends BaseThingHandler {
 
     private @Nullable State updateCurrentTemp() throws GreeException {
         if (device.hasStatusValChanged(GREE_PROP_CURRENT_TEMP_SENSOR)) {
-            return new DecimalType(device.getIntStatusVal(GREE_PROP_CURRENT_TEMP_SENSOR) + INTERNAL_TEMP_SENSOR_OFFSET + config.currentTemperatureOffset.doubleValue());
+            return new DecimalType(device.getIntStatusVal(GREE_PROP_CURRENT_TEMP_SENSOR) + INTERNAL_TEMP_SENSOR_OFFSET
+                    + config.currentTemperatureOffset.doubleValue());
         }
         return null;
     }

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
@@ -14,7 +14,7 @@ thing-type.config.gree.airconditioner.broadcastAddress.label = Subnet Broadcast 
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP address of the local subnet.
 thing-type.config.gree.airconditioner.refresh.label = Refresh Interval
 thing-type.config.gree.airconditioner.refresh.description = Interval to query an update from the device.
-thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for temperature sensor reading
+thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for Current Temperature
 thing-type.config.gree.airconditioner.currentTemperatureOffset.description = The offset in Celsius for the current temperature value received from the device.
 
 # channel types

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
@@ -1,6 +1,5 @@
 # GREE Binding
 binding.gree.name = GREE Binding
-binding.gree.label = GREE Air Conditioner
 binding.gree.description = This binding integrates the GREE series of air conditioners
 
 # thing types
@@ -14,8 +13,7 @@ thing-type.config.gree.airconditioner.broadcastAddress.label = Subnet Broadcast 
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP address of the local subnet.
 thing-type.config.gree.airconditioner.refresh.label = Refresh Interval
 thing-type.config.gree.airconditioner.refresh.description = Interval to query an update from the device.
-thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for Current Temperature
-thing-type.config.gree.airconditioner.currentTemperatureOffset.description = The offset in Celsius for the current temperature value received from the device.
+
 
 # channel types
 channel-type.gree.power.label = Power
@@ -37,10 +35,8 @@ channel-type.gree.dry.label = Dry Mode
 channel-type.gree.dry.description = Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model.
 channel-type.gree.turbo.label = Turbo Mode
 channel-type.gree.turbo.description = Set on/off the Air Conditioner's Turbo mode.
-channel-type.gree.targettemperature.label = Target Temperature
-channel-type.gree.targettemperature.description = Sets the desired room temperature.
-channel-type.gree.currenttemperature.label = Current Temperature
-channel-type.gree.currenttemperature.description = Displays the current room temperature.
+channel-type.gree.temperature.label = Temperature
+channel-type.gree.temperature.description = Sets the desired room temperature.
 channel-type.gree.windspeed.label = Wind Speed
 channel-type.gree.windspeed.description = Sets the fan speed on the Air conditioner: Auto:0, Low:1, MidLow:2, Mid:3, MidHigh:4, High:5. The number of speeds depends on the Air Conditioner model.
 channel-type.gree.windspeed.state.option.0 = Auto
@@ -49,11 +45,9 @@ channel-type.gree.windspeed.state.option.2 = Medium Low
 channel-type.gree.windspeed.state.option.3 = Medium
 channel-type.gree.windspeed.state.option.4 = Medium High
 channel-type.gree.windspeed.state.option.5 = High
-channel-type.gree.quiet.label = Quiet Mode
-channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
-channel-type.gree.quiet.state.option.off = OFF
-channel-type.gree.quiet.state.option.auto = Auto
-channel-type.gree.quiet.state.option.quiet = Quiet
+channel-type.gree.mode.label = Unit Mode
+channel-type.gree.mode.description = Operating mode of the Air Conditioner: Auto: 0, Cool: 1, Dry: 2, Fan: 3, Heat: 4
+channel-type.gree.mode.state.option.auto = Auto
 channel-type.gree.swingupdown.label = Vertical Swing Mode
 channel-type.gree.swingupdown.description = Sets the vertical swing action on the Air Conditioner: 0=OFF, 1=Full Swing, 2=Up, 3=Mid-Up 4=Mid, 5=Mid-Down, 6=Down
 channel-type.gree.swingupdown.option.0 = OFF
@@ -72,6 +66,11 @@ channel-type.gree.swingleftright.option.3 = Mid-Left
 channel-type.gree.swingleftright.option.4 = Mid
 channel-type.gree.swingleftright.option.5 = Mid-Right
 channel-type.gree.swingleftright.option.6 = Right
+channel-type.gree.quiet.label = Quiet Mode
+channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
+channel-type.gree.quiet.state.option.off = OFF
+channel-type.gree.quiet.state.option.auto = Auto
+channel-type.gree.quiet.state.option.quiet = Quiet
 channel-type.gree.powersave.label = Power Save
 channel-type.gree.powersave.description = Set on/off the Air Conditioner's Power Saving function if applicable to the Air Conditioner model.
 channel-type.gree.light.label = Light
@@ -83,8 +82,8 @@ channel-type.gree.health.description = Set on/off the Air Conditioner's Health f
 message.thinginit.failed = Unable to connect to air conditioner
 message.thinginit.invconf = Invalid configuration data
 message.thinginit.exception = Thing initialization failed: {0}
-message.command.invarg = Invalid command value {} for channel {}
-message.command.exception = Unable to execute command {0} for channel {1}
+message.command.invarg = Invalid command value {} for channel {}
+message.command.exception = Unable to execute command {0} for channel {1}
 message.update.exception = Unable to perform auto-update: {0}
 message.channel.exception = Unable to update channel {0} with {1}
 message.discovery.result = {0} units discovered.

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
@@ -1,5 +1,6 @@
 # GREE Binding
 binding.gree.name = GREE Binding
+binding.gree.label = GREE Air Conditioner
 binding.gree.description = This binding integrates the GREE series of air conditioners
 
 # thing types
@@ -48,9 +49,11 @@ channel-type.gree.windspeed.state.option.2 = Medium Low
 channel-type.gree.windspeed.state.option.3 = Medium
 channel-type.gree.windspeed.state.option.4 = Medium High
 channel-type.gree.windspeed.state.option.5 = High
-channel-type.gree.mode.label = Unit Mode
-channel-type.gree.mode.description = Operating mode of the Air Conditioner: Auto: 0, Cool: 1, Dry: 2, Fan: 3, Heat: 4
-channel-type.gree.mode.state.option.auto = Auto
+channel-type.gree.quiet.label = Quiet Mode
+channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
+channel-type.gree.quiet.state.option.off = OFF
+channel-type.gree.quiet.state.option.auto = Auto
+channel-type.gree.quiet.state.option.quiet = Quiet
 channel-type.gree.swingupdown.label = Vertical Swing Mode
 channel-type.gree.swingupdown.description = Sets the vertical swing action on the Air Conditioner: 0=OFF, 1=Full Swing, 2=Up, 3=Mid-Up 4=Mid, 5=Mid-Down, 6=Down
 channel-type.gree.swingupdown.option.0 = OFF
@@ -69,11 +72,6 @@ channel-type.gree.swingleftright.option.3 = Mid-Left
 channel-type.gree.swingleftright.option.4 = Mid
 channel-type.gree.swingleftright.option.5 = Mid-Right
 channel-type.gree.swingleftright.option.6 = Right
-channel-type.gree.quiet.label = Quiet Mode
-channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
-channel-type.gree.quiet.state.option.off = OFF
-channel-type.gree.quiet.state.option.auto = Auto
-channel-type.gree.quiet.state.option.quiet = Quiet
 channel-type.gree.powersave.label = Power Save
 channel-type.gree.powersave.description = Set on/off the Air Conditioner's Power Saving function if applicable to the Air Conditioner model.
 channel-type.gree.light.label = Light
@@ -85,8 +83,8 @@ channel-type.gree.health.description = Set on/off the Air Conditioner's Health f
 message.thinginit.failed = Unable to connect to air conditioner
 message.thinginit.invconf = Invalid configuration data
 message.thinginit.exception = Thing initialization failed: {0}
-message.command.invarg = Invalid command value {}�for channel {}
-message.command.exception = Unable to execute command {0}�for channel {1}
+message.command.invarg = Invalid command value {} for channel {}
+message.command.exception = Unable to execute command {0} for channel {1}
 message.update.exception = Unable to perform auto-update: {0}
 message.channel.exception = Unable to update channel {0} with {1}
 message.discovery.result = {0} units discovered.

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
@@ -1,5 +1,6 @@
 # GREE Binding
 binding.gree.name = GREE Binding
+binding.gree.label = GREE Air Conditioner
 binding.gree.description = This binding integrates the GREE series of air conditioners
 
 # thing types
@@ -13,7 +14,8 @@ thing-type.config.gree.airconditioner.broadcastAddress.label = Subnet Broadcast 
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP address of the local subnet.
 thing-type.config.gree.airconditioner.refresh.label = Refresh Interval
 thing-type.config.gree.airconditioner.refresh.description = Interval to query an update from the device.
-
+thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for Current Temperature
+thing-type.config.gree.airconditioner.currentTemperatureOffset.description = The offset in Celsius for the current temperature value received from the device.
 
 # channel types
 channel-type.gree.power.label = Power
@@ -35,8 +37,10 @@ channel-type.gree.dry.label = Dry Mode
 channel-type.gree.dry.description = Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model.
 channel-type.gree.turbo.label = Turbo Mode
 channel-type.gree.turbo.description = Set on/off the Air Conditioner's Turbo mode.
-channel-type.gree.temperature.label = Temperature
-channel-type.gree.temperature.description = Sets the desired room temperature.
+channel-type.gree.targettemperature.label = Target Temperature
+channel-type.gree.targettemperature.description = Sets the desired room temperature.
+channel-type.gree.currenttemperature.label = Current Temperature
+channel-type.gree.currenttemperature.description = Displays the current room temperature.
 channel-type.gree.windspeed.label = Wind Speed
 channel-type.gree.windspeed.description = Sets the fan speed on the Air conditioner: Auto:0, Low:1, MidLow:2, Mid:3, MidHigh:4, High:5. The number of speeds depends on the Air Conditioner model.
 channel-type.gree.windspeed.state.option.0 = Auto
@@ -45,9 +49,11 @@ channel-type.gree.windspeed.state.option.2 = Medium Low
 channel-type.gree.windspeed.state.option.3 = Medium
 channel-type.gree.windspeed.state.option.4 = Medium High
 channel-type.gree.windspeed.state.option.5 = High
-channel-type.gree.mode.label = Unit Mode
-channel-type.gree.mode.description = Operating mode of the Air Conditioner: Auto: 0, Cool: 1, Dry: 2, Fan: 3, Heat: 4
-channel-type.gree.mode.state.option.auto = Auto
+channel-type.gree.quiet.label = Quiet Mode
+channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
+channel-type.gree.quiet.state.option.off = OFF
+channel-type.gree.quiet.state.option.auto = Auto
+channel-type.gree.quiet.state.option.quiet = Quiet
 channel-type.gree.swingupdown.label = Vertical Swing Mode
 channel-type.gree.swingupdown.description = Sets the vertical swing action on the Air Conditioner: 0=OFF, 1=Full Swing, 2=Up, 3=Mid-Up 4=Mid, 5=Mid-Down, 6=Down
 channel-type.gree.swingupdown.option.0 = OFF
@@ -66,11 +72,6 @@ channel-type.gree.swingleftright.option.3 = Mid-Left
 channel-type.gree.swingleftright.option.4 = Mid
 channel-type.gree.swingleftright.option.5 = Mid-Right
 channel-type.gree.swingleftright.option.6 = Right
-channel-type.gree.quiet.label = Quiet Mode
-channel-type.gree.quiet.description = Sets the quiet mode, 0=OFF, 1=Auto, 2=Quiet
-channel-type.gree.quiet.state.option.off = OFF
-channel-type.gree.quiet.state.option.auto = Auto
-channel-type.gree.quiet.state.option.quiet = Quiet
 channel-type.gree.powersave.label = Power Save
 channel-type.gree.powersave.description = Set on/off the Air Conditioner's Power Saving function if applicable to the Air Conditioner model.
 channel-type.gree.light.label = Light
@@ -82,8 +83,8 @@ channel-type.gree.health.description = Set on/off the Air Conditioner's Health f
 message.thinginit.failed = Unable to connect to air conditioner
 message.thinginit.invconf = Invalid configuration data
 message.thinginit.exception = Thing initialization failed: {0}
-message.command.invarg = Invalid command value {} for channel {}
-message.command.exception = Unable to execute command {0} for channel {1}
+message.command.invarg = Invalid command value {} for channel {}
+message.command.exception = Unable to execute command {0} for channel {1}
 message.update.exception = Unable to perform auto-update: {0}
 message.channel.exception = Unable to update channel {0} with {1}
 message.discovery.result = {0} units discovered.

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree.properties
@@ -13,7 +13,8 @@ thing-type.config.gree.airconditioner.broadcastAddress.label = Subnet Broadcast 
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP address of the local subnet.
 thing-type.config.gree.airconditioner.refresh.label = Refresh Interval
 thing-type.config.gree.airconditioner.refresh.description = Interval to query an update from the device.
-
+thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset for temperature sensor reading
+thing-type.config.gree.airconditioner.currentTemperatureOffset.description = The offset in Celsius for the current temperature value received from the device.
 
 # channel types
 channel-type.gree.power.label = Power
@@ -35,8 +36,10 @@ channel-type.gree.dry.label = Dry Mode
 channel-type.gree.dry.description = Set on/off the Air Conditioner's Dry function if applicable to the Air Conditioner model.
 channel-type.gree.turbo.label = Turbo Mode
 channel-type.gree.turbo.description = Set on/off the Air Conditioner's Turbo mode.
-channel-type.gree.temperature.label = Temperature
-channel-type.gree.temperature.description = Sets the desired room temperature.
+channel-type.gree.targettemperature.label = Target Temperature
+channel-type.gree.targettemperature.description = Sets the desired room temperature.
+channel-type.gree.currenttemperature.label = Current Temperature
+channel-type.gree.currenttemperature.description = Displays the current room temperature.
 channel-type.gree.windspeed.label = Wind Speed
 channel-type.gree.windspeed.description = Sets the fan speed on the Air conditioner: Auto:0, Low:1, MidLow:2, Mid:3, MidHigh:4, High:5. The number of speeds depends on the Air Conditioner model.
 channel-type.gree.windspeed.state.option.0 = Auto
@@ -82,8 +85,8 @@ channel-type.gree.health.description = Set on/off the Air Conditioner's Health f
 message.thinginit.failed = Unable to connect to air conditioner
 message.thinginit.invconf = Invalid configuration data
 message.thinginit.exception = Thing initialization failed: {0}
-message.command.invarg = Invalid command value {} for channel {}
-message.command.exception = Unable to execute command {0} for channel {1}
+message.command.invarg = Invalid command value {}ï¿½for channel {}
+message.command.exception = Unable to execute command {0}ï¿½for channel {1}
 message.update.exception = Unable to perform auto-update: {0}
 message.channel.exception = Unable to update channel {0} with {1}
 message.discovery.result = {0} units discovered.

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
@@ -9,20 +9,21 @@ thing-type.gree.airconditioner.description = Eine GREE Klimaanlage mit WiFi Modu
 
 # thing type config description
 thing-type.config.gree.airconditioner.ipAddress.label = IP Adresse
-thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-Gerätes.
+thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-Gerï¿½tes.
 thing-type.config.gree.airconditioner.broadcastAddress.label = IP Broadcast-Adresse
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP Adresse des lokalen Subnetzes.
 thing-type.config.gree.airconditioner.refresh.label = Aktualisierungsintervall
-thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Gerätes aktualisiert wird.
-
+thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Gerï¿½tes aktualisiert wird.
+thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset zum Ablesen des Temperatursensors
+thing-type.config.gree.airconditioner.currentTemperatureOffset.description = Der Offset in Celsius fÃ¼r den aktuellen Temperaturwert, der vom GerÃ¤t empfangen wird.
 
 # channel types
 channel-type.gree.power.label = Betrieb
-channel-type.gree.power.description = Schaltet das Gerät ein/aus.
+channel-type.gree.power.description = Schaltet das Gerï¿½t ein/aus.
 channel-type.gree.mode.label = Betriebsmodus
 channel-type.gree.mode.description = Betriebsmodus der Klimaanlage: auto/cool/eco/fan/dry/turbo or on/off
 channel-type.gree.mode.state.option.auto = Auto
-channel-type.gree.mode.state.option.cool = Kühlen
+channel-type.gree.mode.state.option.cool = Kï¿½hlen
 channel-type.gree.mode.state.option.eco = Eco
 channel-type.gree.mode.state.option.dry = Trocknen
 channel-type.gree.mode.state.option.fan = Ventilator
@@ -31,15 +32,17 @@ channel-type.gree.mode.state.option.heat = Heizen
 channel-type.gree.mode.state.option.on = Ein
 channel-type.gree.mode.state.option.off = Aus
 channel-type.gree.air.label = LÂ¸ftung
-channel-type.gree.air.description = Schaltet das Gerät in den LÂ¸ftermodus (keine Kühlung). Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.air.description = Schaltet das Gerï¿½t in den LÂ¸ftermodus (keine Kï¿½hlung). Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.dry.label = Trocknen
-channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.turbo.label = Turbo
-channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
-channel-type.gree.temperature.label = Temperatur
-channel-type.gree.temperature.description = Setzt die Zieltemperatur.
-channel-type.gree.windspeed.label = Lüftergeschwindigkeit
-channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verfügbarkeit der Geschwindigkeitsstufen ist abhängig vom Gerätemodell.
+channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
+channel-type.gree.targettemperature.label  = Zieltemperatur
+channel-type.gree.targettemperature.description = Setzt die Zieltemperatur.
+channel-type.gree.currenttemperature.label = Aktuelle Temperatur
+channel-type.gree.currenttemperature.description = Zeigt die aktuelle Temperatur an.
+channel-type.gree.windspeed.label = Lï¿½ftergeschwindigkeit
+channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verfï¿½gbarkeit der Geschwindigkeitsstufen ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.windspeed.state.option.0 = Auto
 channel-type.gree.windspeed.state.option.1 = Niedrig
 channel-type.gree.windspeed.state.option.2 = Mittel
@@ -47,44 +50,44 @@ channel-type.gree.windspeed.state.option.3 = Schnell
 channel-type.gree.windspeed.state.option.4 = Stark
 channel-type.gree.windspeed.state.option.5 = Max
 channel-type.gree.quiet.label = Leisemodus
-channel-type.gree.quiet.description = Leisemodus wählen: 0=Aus, 1=Auto, 2=Leise
+channel-type.gree.quiet.description = Leisemodus wï¿½hlen: 0=Aus, 1=Auto, 2=Leise
 channel-type.gree.quiet.state.option.off = Aus
 channel-type.gree.quiet.state.option.auto = Auto
 channel-type.gree.quiet.state.option.quiet = Leise
 channel-type.gree.swingupdown.label = Lamellenmodus
-channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flï¿½gel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.swingupdown.option.0 = Aus
-channel-type.gree.swingupdown.option.1 = Voller Flügel
+channel-type.gree.swingupdown.option.1 = Voller Flï¿½gel
 channel-type.gree.swingupdown.option.2 = Hoch
 channel-type.gree.swingupdown.option.3 = Mittelhoch
 channel-type.gree.swingupdown.option.4 = Mitte
 channel-type.gree.swingupdown.option.5 = Mitteltief
 channel-type.gree.swingupdown.option.6 = Tief
 channel-type.gree.swingleftright.label = Lamellenmodus
-channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flï¿½gel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.swingleftright.option.0 = AUS
-channel-type.gree.swingleftright.option.1 = Voller Flügel 
+channel-type.gree.swingleftright.option.1 = Voller Flï¿½gel 
 channel-type.gree.swingleftright.option.2 = Links
 channel-type.gree.swingleftright.option.3 = Mitte-Links
 channel-type.gree.swingleftright.option.4 = Mitte
 channel-type.gree.swingleftright.option.5 = Mitte-Rechts
 channel-type.gree.swingleftright.option.6 = Rechts
 channel-type.gree.powersave.label = Energiesparen
-channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. Verfï¿½gbarkeit ist abhï¿½ngig vom Gerï¿½temodell.
 channel-type.gree.light.label = Kontrollleuchte
 channel-type.gree.light.description = Die Beleuchtung an der Frontseite ein/ausschalten.
 channel-type.gree.health.label = Betriebsbereitschaft
-channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Gerätes an.
+channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Gerï¿½tes an.
 
 # User Messages
 message.thinginit.failed = Klimaanlage nicht erreichbar
-message.thinginit.invconf = Ungültiger Thing-Konfigurationswert
+message.thinginit.invconf = Ungï¿½ltiger Thing-Konfigurationswert
 message.thinginit.exception = Initialisierung fehlgeschlagen: {0}
-message.command.invarg = Ungültiger Befehlswert {0} für Channel {1}
-message.command.exception = Befehl {0} für Channel {1} kann nichts ausgeführt werden
+message.command.invarg = Ungï¿½ltiger Befehlswert {0}ï¿½fï¿½r Channel {1}
+message.command.exception = Befehl {0}ï¿½fï¿½r Channel {1} kann nichts ausgefï¿½hrt werden
 message.update.exception = Status-Update fehlgeschlagen: {0}
 message.channel.exception = Aktualisierung des Channels {0} mit dem Wert {1} ist fehlgeschlagen
-message.discovery.result = {0} Geräte gefunden.
-message.discovery.newunit = Gerät {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
-message.discovery.exception =Geräteerkennung fehlgeschlagen: {0} 
+message.discovery.result = {0} Gerï¿½te gefunden.
+message.discovery.newunit = Gerï¿½t {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
+message.discovery.exception =Gerï¿½teerkennung fehlgeschlagen: {0} 
 

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
@@ -4,26 +4,25 @@ binding.gree.label = GREE Air Conditioner
 binding.gree.description = Dieses Binding integriert Klimaanlagen der Marke GREE
 
 # thing types
-thing-type.gree.airconditioner.label = GREE 
+thing-type.gree.airconditioner.label = GREE Klimaanlage
 thing-type.gree.airconditioner.description = Eine GREE Klimaanlage mit WiFi Modul
 
 # thing type config description
 thing-type.config.gree.airconditioner.ipAddress.label = IP Adresse
-thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-GerÃ¤tes.
+thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-Gerätes.
 thing-type.config.gree.airconditioner.broadcastAddress.label = IP Broadcast-Adresse
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP Adresse des lokalen Subnetzes.
 thing-type.config.gree.airconditioner.refresh.label = Aktualisierungsintervall
-thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des GerÃ¤tes aktualisiert wird.
-thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset zum Ablesen des Temperatursensors
-thing-type.config.gree.airconditioner.currentTemperatureOffset.description = Der Offset in Celsius fÃ¼r den aktuellen Temperaturwert, der vom GerÃ¤t empfangen wird.
+thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Gerätes aktualisiert wird.
+
 
 # channel types
 channel-type.gree.power.label = Betrieb
-channel-type.gree.power.description = Schaltet das GerÃ¤t ein/aus.
+channel-type.gree.power.description = Schaltet das Gerät ein/aus.
 channel-type.gree.mode.label = Betriebsmodus
 channel-type.gree.mode.description = Betriebsmodus der Klimaanlage: auto/cool/eco/fan/dry/turbo or on/off
 channel-type.gree.mode.state.option.auto = Auto
-channel-type.gree.mode.state.option.cool = KÃ¼hlen
+channel-type.gree.mode.state.option.cool = Kühlen
 channel-type.gree.mode.state.option.eco = Eco
 channel-type.gree.mode.state.option.dry = Trocknen
 channel-type.gree.mode.state.option.fan = Ventilator
@@ -31,18 +30,16 @@ channel-type.gree.mode.state.option.turbo = Turbo
 channel-type.gree.mode.state.option.heat = Heizen
 channel-type.gree.mode.state.option.on = Ein
 channel-type.gree.mode.state.option.off = Aus
-channel-type.gree.air.label = LÃ‚Â¸ftung
-channel-type.gree.air.description = Schaltet das GerÃ¤t in den LÃ‚Â¸ftermodus (keine KÃ¼hlung). VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.air.label = LÂ¸ftung
+channel-type.gree.air.description = Schaltet das Gerät in den LÂ¸ftermodus (keine Kühlung). Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.dry.label = Trocknen
-channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.turbo.label = Turbo
-channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
-channel-type.gree.targettemperature.label  = Zieltemperatur
-channel-type.gree.targettemperature.description = Setzt die Zieltemperatur.
-channel-type.gree.currenttemperature.label = Aktuelle Temperatur
-channel-type.gree.currenttemperature.description = Zeigt die aktuelle Temperatur an.
-channel-type.gree.windspeed.label = LÃ¼ftergeschwindigkeit
-channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. VerfÃ¼gbarkeit der Geschwindigkeitsstufen ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
+channel-type.gree.temperature.label = Temperatur
+channel-type.gree.temperature.description = Setzt die Zieltemperatur.
+channel-type.gree.windspeed.label = Lüftergeschwindigkeit
+channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verfügbarkeit der Geschwindigkeitsstufen ist abhängig vom Gerätemodell.
 channel-type.gree.windspeed.state.option.0 = Auto
 channel-type.gree.windspeed.state.option.1 = Niedrig
 channel-type.gree.windspeed.state.option.2 = Mittel
@@ -50,43 +47,44 @@ channel-type.gree.windspeed.state.option.3 = Schnell
 channel-type.gree.windspeed.state.option.4 = Stark
 channel-type.gree.windspeed.state.option.5 = Max
 channel-type.gree.quiet.label = Leisemodus
-channel-type.gree.quiet.description = Leisemodus wÃ¤hlen: 0=Aus, 1=Auto, 2=Leise
+channel-type.gree.quiet.description = Leisemodus wählen: 0=Aus, 1=Auto, 2=Leise
 channel-type.gree.quiet.state.option.off = Aus
 channel-type.gree.quiet.state.option.auto = Auto
 channel-type.gree.quiet.state.option.quiet = Leise
 channel-type.gree.swingupdown.label = Lamellenmodus
-channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller FlÃ¼gel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.swingupdown.option.0 = Aus
-channel-type.gree.swingupdown.option.1 = Voller FlÃ¼gel
+channel-type.gree.swingupdown.option.1 = Voller Flügel
 channel-type.gree.swingupdown.option.2 = Hoch
 channel-type.gree.swingupdown.option.3 = Mittelhoch
 channel-type.gree.swingupdown.option.4 = Mitte
 channel-type.gree.swingupdown.option.5 = Mitteltief
 channel-type.gree.swingupdown.option.6 = Tief
 channel-type.gree.swingleftright.label = Lamellenmodus
-channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller FlÃ¼gel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.swingleftright.option.0 = AUS
-channel-type.gree.swingleftright.option.1 = Voller FlÃ¼gel 
+channel-type.gree.swingleftright.option.1 = Voller Flügel 
 channel-type.gree.swingleftright.option.2 = Links
 channel-type.gree.swingleftright.option.3 = Mitte-Links
 channel-type.gree.swingleftright.option.4 = Mitte
 channel-type.gree.swingleftright.option.5 = Mitte-Rechts
 channel-type.gree.swingleftright.option.6 = Rechts
 channel-type.gree.powersave.label = Energiesparen
-channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. VerfÃ¼gbarkeit ist abhÃ¤ngig vom GerÃ¤temodell.
+channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.light.label = Kontrollleuchte
 channel-type.gree.light.description = Die Beleuchtung an der Frontseite ein/ausschalten.
 channel-type.gree.health.label = Betriebsbereitschaft
-channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des GerÃ¤tes an.
+channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Gerätes an.
 
 # User Messages
 message.thinginit.failed = Klimaanlage nicht erreichbar
-message.thinginit.invconf = UngÃ¼ltiger Thing-Konfigurationswert
+message.thinginit.invconf = Ungültiger Thing-Konfigurationswert
 message.thinginit.exception = Initialisierung fehlgeschlagen: {0}
-message.command.invarg = UngÃ¼ltiger Befehlswert {0} fÃ¼r Channel {1}
-message.command.exception = Befehl {0} fÃ¼r Channel {1} kann nichts ausgefÃ¼hrt werden
+message.command.invarg = Ungültiger Befehlswert {0} für Channel {1}
+message.command.exception = Befehl {0} für Channel {1} kann nichts ausgeführt werden
 message.update.exception = Status-Update fehlgeschlagen: {0}
 message.channel.exception = Aktualisierung des Channels {0} mit dem Wert {1} ist fehlgeschlagen
-message.discovery.result = {0} GerÃ¤te gefunden.
-message.discovery.newunit = GerÃ¤t {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
-message.discovery.exception =GerÃ¤teerkennung fehlgeschlagen: {0}
+message.discovery.result = {0} Geräte gefunden.
+message.discovery.newunit = Gerät {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
+message.discovery.exception =Geräteerkennung fehlgeschlagen: {0} 
+

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
@@ -4,7 +4,7 @@ binding.gree.label = GREE Air Conditioner
 binding.gree.description = Dieses Binding integriert Klimaanlagen der Marke GREE
 
 # thing types
-thing-type.gree.airconditioner.label = GREE Klimaanlage
+thing-type.gree.airconditioner.label = GREE 
 thing-type.gree.airconditioner.description = Eine GREE Klimaanlage mit WiFi Modul
 
 # thing type config description
@@ -14,7 +14,8 @@ thing-type.config.gree.airconditioner.broadcastAddress.label = IP Broadcast-Adre
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP Adresse des lokalen Subnetzes.
 thing-type.config.gree.airconditioner.refresh.label = Aktualisierungsintervall
 thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Gerätes aktualisiert wird.
-
+thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset zum Ablesen des Temperatursensors
+thing-type.config.gree.airconditioner.currentTemperatureOffset.description = Der Offset in Celsius für den aktuellen Temperaturwert, der vom Gerät empfangen wird.
 
 # channel types
 channel-type.gree.power.label = Betrieb
@@ -36,8 +37,10 @@ channel-type.gree.dry.label = Trocknen
 channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.turbo.label = Turbo
 channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
-channel-type.gree.temperature.label = Temperatur
-channel-type.gree.temperature.description = Setzt die Zieltemperatur.
+channel-type.gree.targettemperature.label  = Zieltemperatur
+channel-type.gree.targettemperature.description = Setzt die Zieltemperatur.
+channel-type.gree.currenttemperature.label = Aktuelle Temperatur
+channel-type.gree.currenttemperature.description = Zeigt die aktuelle Temperatur an.
 channel-type.gree.windspeed.label = Lüftergeschwindigkeit
 channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verfügbarkeit der Geschwindigkeitsstufen ist abhängig vom Gerätemodell.
 channel-type.gree.windspeed.state.option.0 = Auto
@@ -80,11 +83,10 @@ channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Ger
 message.thinginit.failed = Klimaanlage nicht erreichbar
 message.thinginit.invconf = Ungültiger Thing-Konfigurationswert
 message.thinginit.exception = Initialisierung fehlgeschlagen: {0}
-message.command.invarg = Ungültiger Befehlswert {0} für Channel {1}
-message.command.exception = Befehl {0} für Channel {1} kann nichts ausgeführt werden
+message.command.invarg = Ungültiger Befehlswert {0} für Channel {1}
+message.command.exception = Befehl {0} für Channel {1} kann nichts ausgeführt werden
 message.update.exception = Status-Update fehlgeschlagen: {0}
 message.channel.exception = Aktualisierung des Channels {0} mit dem Wert {1} ist fehlgeschlagen
 message.discovery.result = {0} Geräte gefunden.
 message.discovery.newunit = Gerät {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
-message.discovery.exception =Geräteerkennung fehlgeschlagen: {0} 
-
+message.discovery.exception =Geräteerkennung fehlgeschlagen: {0}

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
@@ -4,7 +4,7 @@ binding.gree.label = GREE Air Conditioner
 binding.gree.description = Dieses Binding integriert Klimaanlagen der Marke GREE
 
 # thing types
-thing-type.gree.airconditioner.label = GREE 
+thing-type.gree.airconditioner.label = GREE Klimaanlage
 thing-type.gree.airconditioner.description = Eine GREE Klimaanlage mit WiFi Modul
 
 # thing type config description

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/i18n/gree_DE.properties
@@ -4,26 +4,26 @@ binding.gree.label = GREE Air Conditioner
 binding.gree.description = Dieses Binding integriert Klimaanlagen der Marke GREE
 
 # thing types
-thing-type.gree.airconditioner.label = GREE Klimaanlage
+thing-type.gree.airconditioner.label = GREE 
 thing-type.gree.airconditioner.description = Eine GREE Klimaanlage mit WiFi Modul
 
 # thing type config description
 thing-type.config.gree.airconditioner.ipAddress.label = IP Adresse
-thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-Ger�tes.
+thing-type.config.gree.airconditioner.ipAddress.description = IP Adresse des GREE-Gerätes.
 thing-type.config.gree.airconditioner.broadcastAddress.label = IP Broadcast-Adresse
 thing-type.config.gree.airconditioner.broadcastAddress.description = Broadcast IP Adresse des lokalen Subnetzes.
 thing-type.config.gree.airconditioner.refresh.label = Aktualisierungsintervall
-thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Ger�tes aktualisiert wird.
+thing-type.config.gree.airconditioner.refresh.description = Intervall, in dem der Status des Gerätes aktualisiert wird.
 thing-type.config.gree.airconditioner.currentTemperatureOffset.label = Offset zum Ablesen des Temperatursensors
 thing-type.config.gree.airconditioner.currentTemperatureOffset.description = Der Offset in Celsius für den aktuellen Temperaturwert, der vom Gerät empfangen wird.
 
 # channel types
 channel-type.gree.power.label = Betrieb
-channel-type.gree.power.description = Schaltet das Ger�t ein/aus.
+channel-type.gree.power.description = Schaltet das Gerät ein/aus.
 channel-type.gree.mode.label = Betriebsmodus
 channel-type.gree.mode.description = Betriebsmodus der Klimaanlage: auto/cool/eco/fan/dry/turbo or on/off
 channel-type.gree.mode.state.option.auto = Auto
-channel-type.gree.mode.state.option.cool = K�hlen
+channel-type.gree.mode.state.option.cool = Kühlen
 channel-type.gree.mode.state.option.eco = Eco
 channel-type.gree.mode.state.option.dry = Trocknen
 channel-type.gree.mode.state.option.fan = Ventilator
@@ -31,18 +31,18 @@ channel-type.gree.mode.state.option.turbo = Turbo
 channel-type.gree.mode.state.option.heat = Heizen
 channel-type.gree.mode.state.option.on = Ein
 channel-type.gree.mode.state.option.off = Aus
-channel-type.gree.air.label = L¸ftung
-channel-type.gree.air.description = Schaltet das Ger�t in den L¸ftermodus (keine K�hlung). Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.air.label = LÂ¸ftung
+channel-type.gree.air.description = Schaltet das Gerät in den LÂ¸ftermodus (keine Kühlung). Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.dry.label = Trocknen
-channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.dry.description = Schaltet den Trocknungsmodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.turbo.label = Turbo
-channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.turbo.description = Schaltet den Turbomodus ein/aus. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.targettemperature.label  = Zieltemperatur
 channel-type.gree.targettemperature.description = Setzt die Zieltemperatur.
 channel-type.gree.currenttemperature.label = Aktuelle Temperatur
 channel-type.gree.currenttemperature.description = Zeigt die aktuelle Temperatur an.
-channel-type.gree.windspeed.label = L�ftergeschwindigkeit
-channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verf�gbarkeit der Geschwindigkeitsstufen ist abh�ngig vom Ger�temodell.
+channel-type.gree.windspeed.label = Lüftergeschwindigkeit
+channel-type.gree.windspeed.description = Geschwindigkeit der Ventilation: 0:Auto, 1=niedrig, 2: langsam, 3: mittel, 4: schneller, 5: hoch. Verfügbarkeit der Geschwindigkeitsstufen ist abhängig vom Gerätemodell.
 channel-type.gree.windspeed.state.option.0 = Auto
 channel-type.gree.windspeed.state.option.1 = Niedrig
 channel-type.gree.windspeed.state.option.2 = Mittel
@@ -50,44 +50,43 @@ channel-type.gree.windspeed.state.option.3 = Schnell
 channel-type.gree.windspeed.state.option.4 = Stark
 channel-type.gree.windspeed.state.option.5 = Max
 channel-type.gree.quiet.label = Leisemodus
-channel-type.gree.quiet.description = Leisemodus w�hlen: 0=Aus, 1=Auto, 2=Leise
+channel-type.gree.quiet.description = Leisemodus wählen: 0=Aus, 1=Auto, 2=Leise
 channel-type.gree.quiet.state.option.off = Aus
 channel-type.gree.quiet.state.option.auto = Auto
 channel-type.gree.quiet.state.option.quiet = Leise
 channel-type.gree.swingupdown.label = Lamellenmodus
-channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Fl�gel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.swingupdown.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Hoch, 3=Mittelhoch, 3=Mitte, 5=Mitteltief, 6=Tief. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.swingupdown.option.0 = Aus
-channel-type.gree.swingupdown.option.1 = Voller Fl�gel
+channel-type.gree.swingupdown.option.1 = Voller Flügel
 channel-type.gree.swingupdown.option.2 = Hoch
 channel-type.gree.swingupdown.option.3 = Mittelhoch
 channel-type.gree.swingupdown.option.4 = Mitte
 channel-type.gree.swingupdown.option.5 = Mitteltief
 channel-type.gree.swingupdown.option.6 = Tief
 channel-type.gree.swingleftright.label = Lamellenmodus
-channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Fl�gel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.swingleftright.description = Auswahl des Lamellenmodus: 0=Aus, 1=Voller Flügel, 2=Links, 3=Mitte-Links, 4=Mitte, 5=Mitte-Rechts, 6=Rechts. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.swingleftright.option.0 = AUS
-channel-type.gree.swingleftright.option.1 = Voller Fl�gel 
+channel-type.gree.swingleftright.option.1 = Voller Flügel 
 channel-type.gree.swingleftright.option.2 = Links
 channel-type.gree.swingleftright.option.3 = Mitte-Links
 channel-type.gree.swingleftright.option.4 = Mitte
 channel-type.gree.swingleftright.option.5 = Mitte-Rechts
 channel-type.gree.swingleftright.option.6 = Rechts
 channel-type.gree.powersave.label = Energiesparen
-channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. Verf�gbarkeit ist abh�ngig vom Ger�temodell.
+channel-type.gree.powersave.description = Aktivierung der Energiesparfunktion. Verfügbarkeit ist abhängig vom Gerätemodell.
 channel-type.gree.light.label = Kontrollleuchte
 channel-type.gree.light.description = Die Beleuchtung an der Frontseite ein/ausschalten.
 channel-type.gree.health.label = Betriebsbereitschaft
-channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Ger�tes an.
+channel-type.gree.health.description = Zeigt die Betriebsbeschreitschaft des Gerätes an.
 
 # User Messages
 message.thinginit.failed = Klimaanlage nicht erreichbar
-message.thinginit.invconf = Ung�ltiger Thing-Konfigurationswert
+message.thinginit.invconf = Ungültiger Thing-Konfigurationswert
 message.thinginit.exception = Initialisierung fehlgeschlagen: {0}
-message.command.invarg = Ung�ltiger Befehlswert {0}�f�r Channel {1}
-message.command.exception = Befehl {0}�f�r Channel {1} kann nichts ausgef�hrt werden
+message.command.invarg = Ungültiger Befehlswert {0} für Channel {1}
+message.command.exception = Befehl {0} für Channel {1} kann nichts ausgeführt werden
 message.update.exception = Status-Update fehlgeschlagen: {0}
 message.channel.exception = Aktualisierung des Channels {0} mit dem Wert {1} ist fehlgeschlagen
-message.discovery.result = {0} Ger�te gefunden.
-message.discovery.newunit = Ger�t {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
-message.discovery.exception =Ger�teerkennung fehlgeschlagen: {0} 
-
+message.discovery.result = {0} Geräte gefunden.
+message.discovery.newunit = Gerät {0} wurde mit IP-Adresse {1} erkannt (MAC={2}) 
+message.discovery.exception =Geräteerkennung fehlgeschlagen: {0}

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -7,20 +7,20 @@
 	<thing-type id="airconditioner">
 		<label>@text/thing-type.gree.airconditioner.label</label>
 		<channels>
-			<channel id="power" typeId="system.power" />
-			<channel id="mode" typeId="mode" />
-			<channel id="temperature" typeId="targetTemperature" />
-			<channel id="currentTemperature" typeId="currentTemperature" />
-			<channel id="air" typeId="air" />
-			<channel id="dry" typeId="dry" />
-			<channel id="turbo" typeId="turbo" />
-			<channel id="windspeed" typeId="windspeed" />
-			<channel id="quiet" typeId="quiet" />
-			<channel id="swingUpDown" typeId="swingUpDown" />
-			<channel id="swingLeftRight" typeId="swingLeftRight" />
-			<channel id="powersave" typeId="powersave" />
-			<channel id="light" typeId="light" />
-			<channel id="health" typeId="health" />
+			<channel id="power" typeId="system.power"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="temperature" typeId="targetTemperature"/>
+			<channel id="currentTemperature" typeId="currentTemperature"/>
+			<channel id="air" typeId="air"/>
+			<channel id="dry" typeId="dry"/>
+			<channel id="turbo" typeId="turbo"/>
+			<channel id="windspeed" typeId="windspeed"/>
+			<channel id="quiet" typeId="quiet"/>
+			<channel id="swingUpDown" typeId="swingUpDown"/>
+			<channel id="swingLeftRight" typeId="swingLeftRight"/>
+			<channel id="powersave" typeId="powersave"/>
+			<channel id="light" typeId="light"/>
+			<channel id="health" typeId="health"/>
 		</channels>
 
 		<config-description>

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -36,7 +36,7 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="currentTemperatureOffset" type="decimal" step="0.5" required="true" unit="C">
-				<default>-40</default>
+				<default>0</default>
 				<unitLabel>Degrees Celsius</unitLabel>
 				<advanced>true</advanced>
 			</parameter>

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -7,20 +7,20 @@
 	<thing-type id="airconditioner">
 		<label>@text/thing-type.gree.airconditioner.label</label>
 		<channels>
-			<channel id="power" typeId="system.power"/>
-			<channel id="mode" typeId="mode"/>
-			<channel id="targetTemperature" typeId="targetTemperature"/>
-			<channel id="currentTemperature" typeId="currentTemperature"/>
-			<channel id="air" typeId="air"/>
-			<channel id="dry" typeId="dry"/>
-			<channel id="turbo" typeId="turbo"/>
-			<channel id="windspeed" typeId="windspeed"/>
-			<channel id="quiet" typeId="quiet"/>
-			<channel id="swingUpDown" typeId="swingUpDown"/>
-			<channel id="swingLeftRight" typeId="swingLeftRight"/>
-			<channel id="powersave" typeId="powersave"/>
-			<channel id="light" typeId="light"/>
-			<channel id="health" typeId="health"/>
+			<channel id="power" typeId="system.power" />
+			<channel id="mode" typeId="mode" />
+			<channel id="temperature" typeId="targetTemperature" />
+			<channel id="currentTemperature" typeId="currentTemperature" />
+			<channel id="air" typeId="air" />
+			<channel id="dry" typeId="dry" />
+			<channel id="turbo" typeId="turbo" />
+			<channel id="windspeed" typeId="windspeed" />
+			<channel id="quiet" typeId="quiet" />
+			<channel id="swingUpDown" typeId="swingUpDown" />
+			<channel id="swingLeftRight" typeId="swingLeftRight" />
+			<channel id="powersave" typeId="powersave" />
+			<channel id="light" typeId="light" />
+			<channel id="health" typeId="health" />
 		</channels>
 
 		<config-description>

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -35,7 +35,7 @@
 				<unitLabel>seconds</unitLabel>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="currentTemperatureOffset" type="decimal" required="true" unit="C">
+			<parameter name="currentTemperatureOffset" type="decimal" step="0.5" required="true" unit="C">
 				<default>-40</default>
 				<unitLabel>Degrees Celsius</unitLabel>
 				<advanced>true</advanced>

--- a/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.gree/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -9,7 +9,8 @@
 		<channels>
 			<channel id="power" typeId="system.power"/>
 			<channel id="mode" typeId="mode"/>
-			<channel id="temperature" typeId="temperature"/>
+			<channel id="targetTemperature" typeId="targetTemperature"/>
+			<channel id="currentTemperature" typeId="currentTemperature"/>
 			<channel id="air" typeId="air"/>
 			<channel id="dry" typeId="dry"/>
 			<channel id="turbo" typeId="turbo"/>
@@ -34,6 +35,11 @@
 				<unitLabel>seconds</unitLabel>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="currentTemperatureOffset" type="decimal" required="true" unit="C">
+				<default>-40</default>
+				<unitLabel>Degrees Celsius</unitLabel>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 
 	</thing-type>
@@ -55,11 +61,17 @@
 			</options>
 		</state>
 	</channel-type>
-	<channel-type id="temperature">
+	<channel-type id="targetTemperature">
 		<item-type>Number:Temperature</item-type>
-		<label>@text/channel-type.gree.temperature.label</label>
-		<description>@text/channel-type.gree.temperature.description</description>
+		<label>@text/channel-type.gree.targettemperature.label</label>
+		<description>@text/channel-type.gree.targettemperature.description</description>
 		<state min="16" max="86" step="1" pattern="%d %unit%"></state>
+	</channel-type>
+	<channel-type id="currentTemperature">
+		<item-type>Number:Temperature</item-type>
+		<label>@text/channel-type.gree.currenttemperature.label</label>
+		<description>@text/channel-type.gree.currenttemperature.description</description>
+		<state readOnly="true" pattern="%d %unit%"></state>
 	</channel-type>
 	<channel-type id="air">
 		<item-type>Switch</item-type>


### PR DESCRIPTION
### New Feature/Improvement
Added a new channel called "currentTemperature" which maps to the temperature sensor which is present on GREE AC devices. This should allow for the addition of rules which are based on the actual room temperature, Eg: switch on AC in heating/cooling mode if room temperature is higher/lower than X. This temperature sensing channel can also be used to control other features like ventilation, etc by comparing the indoor and outdoor temperature. This usually requires a dedicated temperature sensor for reading the indoor temperature and such temperature is readily available in GREE AC devices and readable over this binding with the help of this PR.

~### Breaking Change!
This binding which was only recently introduced already contained a temperature channel called "temperature". This was meant to be able to set the desired/target temperature on the AC device. In order to avoid any confusion between the desired/target and actual/current temperature channels, the old existing channel has been renamed from "temperature" to "targetTemperature".~ The `temperature` channel name has been reverted to the original naming so no breaking changes.

### Additional Notes:
This is my first contribution to openHAB so please make sure that everything is in order. ~I am not 100% sure if I messed up any character encoding in the il8n strings.~ The character encoding has been modified from UTF8 to ISO 8859-1. Also, my proficiency in the German language is very limited so certain translation strings might require some improvements.
Static code analysis passes successfully and the changes have been tested locally on openHAB versions 2.5.7 and 2.5.8 running on Rasbian Buster on a Raspberry Pi 3.