### PR TITLE
[NEATO] add option to clean house with map and no-go lines

### DIFF
--- a/bundles/org.openhab.binding.neato/README.md
+++ b/bundles/org.openhab.binding.neato/README.md
@@ -57,7 +57,7 @@ Vacuum Cleaner Config
 | is-charging         | Switch | Is Charging                | Is the vacuum cleaner currently charging?                                                 | True      |
 | available-commands  | String | Available Commands         | List of available commands.                                                               | True      |
 | error               | String | Error                      | Current error message in system.                                                          | True      |
-| command             | String | Send Command               | Send Commands to Vacuum Cleaner. (clean, pause, resume, stop, dock)                       | False     |
+| command             | String | Send Command               | Send Commands to Vacuum Cleaner. (clean with map, clean, pause, resume, stop, dock)                       | False     |
 | cleaning-category   | String | Cleaning Category          | Current or Last category of the cleaning. Manual, Normal House Cleaning or Spot Cleaning. | True      |
 | cleaning-mode       | String | Cleaning Mode              | Current or Last cleaning mode. Eco or Turbo.                                              | True      |
 | cleaning-modifier   | String | Cleaning Modifier          | Modifier of current or last cleaning. Normal or Double.                                   | True      |
@@ -92,7 +92,7 @@ String FannDammCommand  "Send Command" { channel = "neato:vacuumcleaner:fanndamm
 
 ```
 Frame label="Neato BotVac Connected" {
-    Switch item=FannDammCommand mappings=[clean="Clean",stop="Stop",pause="Pause",resume="Resume", dock="Send to dock"]
+    Switch item=FannDammCommand mappings=[cleanWithMap="cleanWithMap", clean="Clean",stop="Stop",pause="Pause",resume="Resume", dock="Send to dock"]
     Text item=FannDammBattery label="Battery level"
     Text item=FannDammState
     Text item=FannDammError label="Error Message" icon="siren"

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/NeatoRobot.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/NeatoRobot.java
@@ -31,18 +31,20 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.smarthome.core.util.HexUtils;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
-import org.openhab.binding.neato.internal.classes.ErrorMessage;
-import org.openhab.binding.neato.internal.classes.NeatoGeneralInfo;
-import org.openhab.binding.neato.internal.classes.NeatoRobotInfo;
-import org.openhab.binding.neato.internal.classes.NeatoState;
+import org.openhab.binding.neato.internal.classes.*;
 import org.openhab.binding.neato.internal.config.NeatoRobotConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
+import static org.openhab.binding.neato.internal.classes.Category.HOUSE;
+import static org.openhab.binding.neato.internal.classes.Category.MAP;
+import static org.openhab.binding.neato.internal.classes.Mode.TURBO;
+import static org.openhab.binding.neato.internal.classes.NavigationMode.DEEP;
+
 /**
- * The {@link NeatoBinding} class defines common constants, which are
+ * The {@link NeatoRobot} class defines common constants, which are
  * used across the whole binding.
  *
  * @author Patrik Wimnell - Initial contribution
@@ -107,11 +109,10 @@ public class NeatoRobot {
 
             InputStream stream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
 
-            String result = HttpUtil.executeUrl("POST",
+            return HttpUtil.executeUrl("POST",
                     "https://nucleo.neatocloud.com:4443/vendors/neato/robots/" + this.serialNumber + "/messages",
                     headers, stream, "text/html; charset=ISO-8859-1", 20000);
 
-            return result;
         } catch (IOException | NoSuchAlgorithmException | InvalidKeyException e) {
             throw new NeatoCommunicationException(e);
         }
@@ -119,12 +120,15 @@ public class NeatoRobot {
 
     public void sendCommand(String command) throws NeatoCommunicationException {
         CommandRequest request = new CommandRequest();
+        logger.debug("State neato : {}", this.state);
 
         if ("clean".equalsIgnoreCase(command)) {
             String houseCleaningStr = this.state.getAvailableServices().getHouseCleaning();
+            logger.debug("Mode cleaning : {}", houseCleaningStr);
+            logger.debug("State neato : {}", this.state);
 
             request.setCmd("startCleaning");
-            request.addParam("category", 2);
+            request.addParam("category", HOUSE.getCategory());
 
             if ("basic-1".equalsIgnoreCase(houseCleaningStr)) {
                 request.addParam("mode", this.state.getCleaning().getModeValue());
@@ -139,29 +143,34 @@ public class NeatoRobot {
                 }
 
                 request.addParam("mode", this.state.getCleaning().getModeValue());
-                request.addParam("category", "2");
+                request.addParam("category", HOUSE.getCategory());
 
                 Integer navigationMode = this.state.getCleaning().getNavigationModeValue();
-                if (Integer.valueOf(2).equals(this.state.getCleaning().getModeValue())) {
+                if (Integer.valueOf(TURBO.getMode()).equals(this.state.getCleaning().getModeValue())) {
                     // From the Neato API Docs...
                     // Note that navigationMode can only be set to 3 if mode is 2,
                     // otherwise an error will be returned.
-                    navigationMode = 3;
+                    navigationMode = DEEP.getNavigationMode();
                 }
                 request.addParam("navigationMode", navigationMode);
             }
-        } else if ("pause".equalsIgnoreCase(command.toString())) {
+        } else if ("cleanWithMap".equalsIgnoreCase(command)) {
+            request.setCmd("startCleaning");
+            request.addParam("category", MAP.getCategory());
+            request.addParam("mode", TURBO.getMode());
+            request.addParam("navigationMode", DEEP.getNavigationMode());
+        } else if ("pause".equalsIgnoreCase(command)) {
             request.setCmd("pauseCleaning");
-        } else if ("stop".equalsIgnoreCase(command.toString())) {
+        } else if ("stop".equalsIgnoreCase(command)) {
             request.setCmd("stopCleaning");
-        } else if ("resume".equalsIgnoreCase(command.toString())) {
+        } else if ("resume".equalsIgnoreCase(command)) {
             request.setCmd("resumeCleaning");
-        } else if ("dock".equalsIgnoreCase(command.toString())) {
+        } else if ("dock".equalsIgnoreCase(command)) {
             request.setCmd("sendToBase");
-        } else if ("dismissAlert".equalsIgnoreCase(command.toString())) {
+        } else if ("dismissAlert".equalsIgnoreCase(command)) {
             request.setCmd("dismissCurrentAlert");
         } else {
-            logger.debug("Unexpected command received: {}", command.toString());
+            logger.debug("Unexpected command received: {}", command);
             return;
         }
 

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/Category.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/Category.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.neato.internal.classes;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The enum {@link Category} is the internal class to set category to the cleaning request
+ *
+ * @author Lapenta Giuseppe - Initial Contribution
+ */
+@NonNullByDefault
+public enum Category {
+    MANUAL(1),
+    HOUSE(2),
+    SPOT(3),
+    MAP(4);
+    private final int category;
+
+    Category(int category) {
+        this.category = category;
+    }
+
+    public int getCategory() {
+        return category;
+    }
+
+}

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/Mode.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/Mode.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.neato.internal.classes;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The enum {@link Mode} is the internal class to set cleaning mode to the cleaning request
+ *
+ * @author Lapenta Giuseppe - Initial Contribution
+ */
+@NonNullByDefault
+public enum Mode {
+    ECO(1),
+    TURBO(2); // Note that navigationMode can only be set to 3 if mode is 2, otherwise an error will be returned.
+
+    private final int mode;
+
+    Mode(int mode) {
+        this.mode = mode;
+    }
+
+    public int getMode() {
+        return mode;
+    }
+
+}

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/NavigationMode.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/NavigationMode.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.neato.internal.classes;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The enum {@link NavigationMode} is the internal class to set navigation mode to the cleaning request
+ *
+ * @author Lapenta Giuseppe - Initial Contribution
+ */
+@NonNullByDefault
+public enum NavigationMode {
+    NORMAL(1),
+    EXTRA_CARE(2),
+    DEEP(3); // Note that navigationMode can only be set to 3 if mode is 2, otherwise an error will be returned.
+    private final int navigationMode;
+
+    NavigationMode(int navigationMode) {
+        this.navigationMode = navigationMode;
+    }
+
+    public int getNavigationMode() {
+        return navigationMode;
+    }
+
+}

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/NeatoState.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/classes/NeatoState.java
@@ -41,7 +41,7 @@ public class NeatoState {
 
         private int value;
 
-        private RobotState(int value) {
+        RobotState(int value) {
             this.value = value;
         }
 
@@ -75,7 +75,7 @@ public class NeatoState {
 
         private int value;
 
-        private RobotAction(int value) {
+        RobotAction(int value) {
             this.value = value;
         }
 
@@ -187,6 +187,24 @@ public class NeatoState {
 
     public Meta getMeta() {
         return meta;
+    }
+
+    @Override
+    public String toString() {
+        return "NeatoState{" +
+                "version=" + version +
+                ", reqId='" + reqId + '\'' +
+                ", result='" + result + '\'' +
+                ", error='" + error + '\'' +
+                ", data=" + data +
+                ", state=" + state +
+                ", action=" + action +
+                ", cleaning=" + cleaning +
+                ", details=" + details +
+                ", availableCommands=" + availableCommands +
+                ", availableServices=" + availableServices +
+                ", meta=" + meta +
+                '}';
     }
 
     public void setMeta(Meta meta) {

--- a/bundles/org.openhab.binding.neato/src/main/resources/ESH-INF/thing/vacuumcleaner.xml
+++ b/bundles/org.openhab.binding.neato/src/main/resources/ESH-INF/thing/vacuumcleaner.xml
@@ -148,10 +148,11 @@
 	<channel-type id="command">
 		<item-type>String</item-type>
 		<label>Send Command</label>
-		<description>Send Commands to Vacuum Cleaner. (clean, pause, resume, stop, dock)</description>
+		<description>Send Commands to Vacuum Cleaner. (clean with map, clean, pause, resume, stop, dock)</description>
 		<state readOnly="false" pattern="%s">
 			<options>
 				<option value="clean">Clean</option>
+				<option value="cleanWithMap">Clean with Map</option>
 				<option value="pause">Pause</option>
 				<option value="resume">Resume</option>
 				<option value="stop">Stop</option>


### PR DESCRIPTION

[NEATO] add option to clean house with map and no-go lines


<!-- DESCRIPTION -->

Improvements to Add option Clean with map to binding neato to launch clean with no-go line activated.
I don't remove the old clean option because of legacy and I don't know if this code work on a Neato D5
Tested only on neato D7.

see issue for more info #5761


<!-- TESTING -->


