### PR TITLE
[mqtt.generic] Clear availability subscriptions on stop

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/AbstractMQTTThingHandler.java
@@ -113,12 +113,7 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler
      * You should clean up all resources that depend on a working connection.
      */
     protected void stop() {
-        availabilityStates.values().stream().map(s -> {
-            if (s != null) {
-                return s.stop();
-            }
-            return CompletableFuture.allOf();
-        }).collect(FutureCollector.allOf()).join();
+        clearAllAvailabilityTopics();
         resetMessageReceived();
     }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/internal/handler/GenericMQTTThingHandler.java
@@ -91,6 +91,7 @@ public class GenericMQTTThingHandler extends AbstractMQTTThingHandler implements
     @Override
     protected void stop() {
         channelStateByChannelUID.values().forEach(c -> c.getCache().resetState());
+        super.stop();
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -189,8 +189,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
         started = true;
 
         connection.setQos(1);
-
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "No response from the device yet");
+        updateStatus(ThingStatus.UNKNOWN);
 
         // Start all known components and channels within the components and put the Thing offline
         // if any subscribing failed ( == broker connection lost)
@@ -218,6 +217,7 @@ public class HomeAssistantThingHandler extends AbstractMQTTThingHandler
 
             started = false;
         }
+        super.stop();
     }
 
     @SuppressWarnings({ "null", "unused" })

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandler.java
@@ -142,6 +142,7 @@ public class HomieThingHandler extends AbstractMQTTThingHandler implements Devic
         }
         delayedProcessing.join();
         device.stop();
+        super.stop();
     }
 
     @Override


### PR DESCRIPTION
When Home Assistant and MQTT generic things were disposed (and stopped), parent class (AbstractMQTTThingHandler) ```stop()``` method was not called and, thus, availability subscriptions were not removed. This made the Thing stay offline in some cases, as described in #8316. 

The AbstractMQTTThingHandler's ```stop()``` method has also been simplified calling ```clearAllAvailabilityTopics();```. @jochen314, what do you think about this last change? I don't see any problem emptying the availabilityStates map of AbstractMQTTThingHandler, because the ```initialize()``` method of both GenericThingHandler and HomeAssistantThingHandler takes care of creating the map again.

Fixes #8316

Review request: @jochen314, @J-N-K, @fwolter, @cpmeister, @Hilbrand.

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>