### PR TITLE
[homematic] Checking of full datapoint name is necessary

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -61,8 +61,7 @@ public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
                 boolean isHmSenMdirNextTrans = dpInfo.getName().equals("NEXT_TRANSMISSION")
                         && (deviceType.startsWith("HM-Sen-MDIR-O") || deviceType.startsWith("HM-Sen-MDIR-WM55"));
                 if (!isHmSenMdirNextTrans) {
-                    if (dpInfo.getAddress().contains(":M_")
-                            && channel.getDevice().getHmInterface() == HmInterface.HMIP) {
+                    if (dpInfo.toString().contains(":M_") && channel.getDevice().getHmInterface() == HmInterface.HMIP) {
                         // These data points can't currently be recognized and therefore can't be created
                         logger.debug("Can't set value for channel configuration datapoint '{}'", dpInfo);
                     } else {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -59,7 +59,8 @@ public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
                 // suppress warning for this datapoint due wrong CCU metadata
                 String deviceType = channel.getDevice().getType();
                 boolean isHmSenMdirNextTrans = dpInfo.getName().equals("NEXT_TRANSMISSION")
-                        && (deviceType.startsWith("HM-Sen-MDIR-O") || deviceType.startsWith("HM-Sen-MDIR-WM55"));
+                        && (deviceType.startsWith("HM-Sen-MDIR-O") || deviceType.startsWith("HM-Sen-MDIR-WM55")
+                                || deviceType.startsWith("HM-Sec-MDIR-2"));
                 if (!isHmSenMdirNextTrans) {
                     if (dpInfo.getParamsetType() == HmParamsetType.MASTER
                             && channel.getDevice().getHmInterface() == HmInterface.HMIP) {

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/GetParamsetParser.java
@@ -61,7 +61,8 @@ public class GetParamsetParser extends CommonRpcParser<Object[], Void> {
                 boolean isHmSenMdirNextTrans = dpInfo.getName().equals("NEXT_TRANSMISSION")
                         && (deviceType.startsWith("HM-Sen-MDIR-O") || deviceType.startsWith("HM-Sen-MDIR-WM55"));
                 if (!isHmSenMdirNextTrans) {
-                    if (dpInfo.toString().contains(":M_") && channel.getDevice().getHmInterface() == HmInterface.HMIP) {
+                    if (dpInfo.getParamsetType() == HmParamsetType.MASTER
+                            && channel.getDevice().getHmInterface() == HmInterface.HMIP) {
                         // These data points can't currently be recognized and therefore can't be created
                         logger.debug("Can't set value for channel configuration datapoint '{}'", dpInfo);
                     } else {


### PR DESCRIPTION
Only the string value contains the complete name that is necessary for
the check.

Additional fix for #5048

Fix has already been successfully tested.

Signed-off-by: Martin Herbst <develop@mherbst.de>
