### PR TITLE
[HEOS] Update handling of groups

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosBridgeHandler.java
@@ -322,16 +322,17 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
      * Sets the HEOS Thing offline
      */
     @SuppressWarnings("null")
-    public void setGroupOffline(String hashValue) {
-        HeosGroupHandler groupHandler = groupHandlerMap.get(hashValue);
+    public void setGroupOffline(String groupMemberHash) {
+        HeosGroupHandler groupHandler = groupHandlerMap.get(groupMemberHash);
         if (groupHandler != null) {
             groupHandler.setStatusOffline();
         }
+        hashToGidMap.remove(groupMemberHash);
     }
 
     /**
      * Sets the HEOS Thing online. Also updates the link between
-     * the groupMemberHash value with the actual gid of this group *
+     * the groupMemberHash value with the actual gid of this group
      */
     public void setGroupOnline(String groupMemberHash, String groupId) {
         hashToGidMap.put(groupMemberHash, groupId);

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosGroupHandler.java
@@ -278,6 +278,8 @@ public class HeosGroupHandler extends HeosThingBaseHandler {
                     throw new IllegalStateException("Invalid group response received");
                 }
 
+                assertSameGroup(group);
+
                 gid = groupId;
                 updateConfiguration(groupId, group);
                 updateStatus(ThingStatus.ONLINE);
@@ -288,6 +290,20 @@ public class HeosGroupHandler extends HeosThingBaseHandler {
                 cancel(scheduledStartupFuture, false);
                 scheduledStartupFuture = scheduler.schedule(this::delayedInitialize, 30, TimeUnit.SECONDS);
             }
+        }
+    }
+
+    /**
+     * Make sure the given group is group which this handler represents
+     * 
+     * @param group retrieved from HEOS system
+     */
+    private void assertSameGroup(Group group) {
+        String storedGroupHash = HeosGroup.calculateGroupMemberHash(configuration.members);
+        String retrievedGroupHash = HeosGroup.calculateGroupMemberHash(group);
+
+        if (!retrievedGroupHash.equals(storedGroupHash)) {
+            throw new IllegalStateException("Invalid group received, members / hash do not match.");
         }
     }
 


### PR DESCRIPTION
Remove group-mapping when marking group OFFLINE
Bail out in group-handler if the pid matches but the members do not match.

See: https://community.openhab.org/t/heos-denon-support/3449/360?u=martinvw / https://community.openhab.org/t/heos-denon-support/3449/355?u=martinvw