### PR TITLE
[miio] Set vacuum=ON on zone and room clean

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoVacuumHandler.java
@@ -279,6 +279,9 @@ public class MiIoVacuumHandler extends MiIoAbstractHandler {
                 control = "spot";
                 vacuum = OnOffType.ON;
                 break;
+            case ZONE:
+            case ROOM:
+                vacuum = OnOffType.ON;
             default:
                 control = "undef";
                 break;


### PR DESCRIPTION
[miio] Set vacuum=ON on zone and room clean

`vacuum` item answers the question: does vacuum cleaning right now? That's why we should set `vacuum=ON` if it does zone clean or room clean. It's helpful if you want to do some action when vacuum start cleaning or end cleaning
