### PR TITLE
[tellstick] Updates versions of libraries

### DIFF
--- a/bundles/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/org.openhab.binding.tellstick/pom.xml
@@ -46,61 +46,61 @@
     <dependency>
       <groupId>com.typesafe.netty</groupId>
       <artifactId>netty-reactive-streams</artifactId>
-      <version>1.0.8</version>
+      <version>2.0.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.34.Final</version>
+      <version>4.1.42.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updates related to snyk bot security suggestions.
Replaces #6391 and #6431 because those are based on old master branch.

I didn't update asynchttpclient because the new version has some additional dependencies.
