### PR TITLE
[miio] Update vacuumThing.xml, change channel type for 3 channels

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/ESH-INF/thing/vacuumThing.xml
@@ -125,15 +125,14 @@
 		<state min="1" max="99" step="1" pattern="%.0f%%" readOnly="false"/>
 	</channel-type>
 	<channel-type id="in_cleaning" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Switch</item-type>
 		<label>In Cleaning</label>
-		<state pattern="%.0f" readOnly="true"/>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="map_present" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Switch</item-type>
 		<label>Map Present</label>
-		<category>Energy</category>
-		<state pattern="%.0f" readOnly="true"/>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="msg_seq" advanced="true">
 		<item-type>Number</item-type>
@@ -307,7 +306,7 @@
 		<state pattern="%.0f" readOnly="true"/>
 	</channel-type>
 	<channel-type id="last_clean_finish">
-		<item-type>Number</item-type>
+		<item-type>Switch</item-type>
 		<label>Cleaning Finished</label>
 		<state readOnly="true"/>
 	</channel-type>


### PR DESCRIPTION
[miio] Update vacuumThing.xml, change channel type for 3 channels

Channels in_cleaning, map_present, last_clean_finish should be of type Switch, not Number

As far as I can see these channels report a 0 or a 1, translated to false or true, for switch item as OFF or ON
Documentation of binding was adapted as well.