### PR TITLE
[Digitalstrom] Bugfixes/Improvements

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
@@ -668,7 +668,16 @@ public class BridgeHandler extends BaseBridgeHandler
                 case INVALID_URL:
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid URL is set.");
                     break;
+                case CONNECTION_LOST:
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            "IOException / Connection lost.");
+                    break;
+                case SSL_HANDSHAKE_ERROR:
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            "SSL Handshake error / Connection lost.");
+                    break;
                 default:
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, reason);
             }
             // reset connection timeout counter
             connectionTimeoutCounter = 0;

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
@@ -549,13 +549,13 @@ public class BridgeHandler extends BaseBridgeHandler
                 return;
             case CONNECTION_RESUMED:
                 if (connectionTimeoutCounter > 0) {
+                    // reset connection timeout counter
+                    connectionTimeoutCounter = 0;
                     if (connMan.checkConnection()) {
                         restartServices();
                         setStatus(ThingStatus.ONLINE);
                     }
                 }
-                // reset connection timeout counter
-                connectionTimeoutCounter = 0;
                 return;
             case APPLICATION_TOKEN_GENERATED:
                 if (connMan != null) {

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/listener/ConnectionListener.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/listener/ConnectionListener.java
@@ -31,6 +31,10 @@ public interface ConnectionListener {
      */
     final String CONNECTION_LOST = "connLost";
     /**
+     * State, if a ssl handshake problem occured while communicating with the digitalSTROM-Server.
+     */
+    final String SSL_HANDSHAKE_ERROR = "sslHandshakeError";
+    /**
      * State, if the connection to the digitalSTROM-Server is resumed.
      */
     final String CONNECTION_RESUMED = "connResumed";

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/ConnectionManager.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/ConnectionManager.java
@@ -31,6 +31,7 @@ public interface ConnectionManager {
     public static final int SOCKET_TIMEOUT_EXCEPTION = -4;
     public static final int UNKNOWN_HOST_EXCEPTION = -5;
     public static final int AUTHENTIFICATION_PROBLEM = -6;
+    public static final int SSL_HANDSHAKE_EXCEPTION = -7;
 
     /**
      * Returns the {@link HttpTransport} to execute queries or special commands on the digitalSTROM-Server.

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/ConnectionManagerImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/ConnectionManagerImpl.java
@@ -314,7 +314,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
             case HttpURLConnection.HTTP_INTERNAL_ERROR:
             case HttpURLConnection.HTTP_OK:
                 if (!connectionEstablished) {
-                    connectionEstablished = true;
                     onConnectionResumed();
                 }
                 break;
@@ -326,7 +325,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
                 if (sessionToken != null) {
                     if (!connectionEstablished) {
                         onConnectionResumed();
-                        connectionEstablished = true;
                     }
                 } else {
                     if (this.genAppToken) {
@@ -337,22 +335,19 @@ public class ConnectionManagerImpl implements ConnectionManager {
                 break;
             case ConnectionManager.MALFORMED_URL_EXCEPTION:
                 onConnectionLost(ConnectionListener.INVALID_URL);
-                connectionEstablished = false;
                 break;
             case ConnectionManager.CONNECTION_EXCEPTION:
             case ConnectionManager.SOCKET_TIMEOUT_EXCEPTION:
                 onConnectionLost(ConnectionListener.CONNECTON_TIMEOUT);
-                connectionEstablished = false;
+                break;
+            case ConnectionManager.SSL_HANDSHAKE_EXCEPTION:
+                onConnectionLost(ConnectionListener.SSL_HANDSHAKE_ERROR);
                 break;
             case ConnectionManager.GENERAL_EXCEPTION:
-                if (connListener != null) {
-                    connListener.onConnectionStateChange(ConnectionListener.CONNECTION_LOST);
-                }
+                onConnectionLost(ConnectionListener.CONNECTION_LOST);
                 break;
             case ConnectionManager.UNKNOWN_HOST_EXCEPTION:
-                if (connListener != null) {
-                    onConnectionLost(ConnectionListener.UNKNOWN_HOST);
-                }
+                onConnectionLost(ConnectionListener.UNKNOWN_HOST);
                 break;
             case ConnectionManager.AUTHENTIFICATION_PROBLEM:
                 if (connListener != null) {
@@ -367,7 +362,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
                 break;
             case HttpURLConnection.HTTP_NOT_FOUND:
                 onConnectionLost(ConnectionListener.HOST_NOT_FOUND);
-                connectionEstablished = false;
                 break;
         }
         return connectionEstablished;
@@ -485,6 +479,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
         if (connListener != null) {
             connListener.onConnectionStateChange(ConnectionListener.CONNECTION_LOST, reason);
         }
+        connectionEstablished = false;
     }
 
     /**
@@ -494,6 +489,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
         if (connListener != null) {
             connListener.onConnectionStateChange(ConnectionListener.CONNECTION_RESUMED);
         }
+        connectionEstablished = true;
     }
 
     @Override

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
@@ -262,10 +262,12 @@ public class SceneManagerImpl implements SceneManager {
     public void callInternalScene(String sceneID) {
         InternalScene intScene = this.internalSceneMap.get(sceneID);
         if (intScene != null) {
+            logger.debug("activating existing scene {}", intScene.getSceneName());
             intScene.activateScene();
         } else {
             intScene = createNewScene(sceneID);
             if (intScene != null) {
+                logger.debug("created new scene, activating it: {}", intScene.getSceneName());
                 discovery.sceneDiscoverd(intScene);
                 intScene.activateScene();
             }
@@ -373,10 +375,12 @@ public class SceneManagerImpl implements SceneManager {
     public void undoInternalScene(String sceneID) {
         InternalScene intScene = this.internalSceneMap.get(sceneID);
         if (intScene != null) {
+            logger.debug("deactivating existing scene {}", intScene.getSceneName());
             intScene.deactivateScene();
         } else {
             intScene = createNewScene(sceneID);
             if (intScene != null) {
+                logger.debug("created new scene, deactivating it: {}", intScene.getSceneName());
                 intScene.deactivateScene();
             }
         }

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
@@ -35,6 +35,7 @@ import java.util.Base64;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -296,11 +297,11 @@ public class HttpTransportImpl implements HttpTransport {
             informConnectionManager(ConnectionManager.MALFORMED_URL_EXCEPTION);
         } catch (java.net.UnknownHostException e) {
             informConnectionManager(ConnectionManager.UNKNOWN_HOST_EXCEPTION);
+        } catch (SSLHandshakeException e) {
+            informConnectionManager(ConnectionManager.SSL_HANDSHAKE_EXCEPTION);
         } catch (IOException e) {
             logger.error("An IOException occurred: ", e);
-            if (connectionManager != null) {
-                informConnectionManager(ConnectionManager.GENERAL_EXCEPTION);
-            }
+            informConnectionManager(ConnectionManager.GENERAL_EXCEPTION);
         } finally {
             if (connection != null) {
                 connection.disconnect();

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/scene/InternalScene.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/scene/InternalScene.java
@@ -95,19 +95,14 @@ public class InternalScene {
      */
     public void activateScene() {
         logger.debug("activate scene: {}", this.getSceneName());
-        if (!active) {
-            this.active = true;
-            deviceHasChanged = false;
-            informListener();
-            if (this.devices != null) {
-                for (Device device : this.devices) {
-                    device.callInternalScene(this);
-                }
+        this.active = true;
+        deviceHasChanged = false;
+        informListener();
+        if (this.devices != null) {
+            for (Device device : this.devices) {
+                device.callInternalScene(this);
             }
-        } else {
-            logger.debug("skipping activation, scene already active: {}", this.getSceneName());
         }
-
     }
 
     /**

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/scene/InternalScene.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/structure/scene/InternalScene.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.digitalstrom.internal.lib.listener.SceneStatusListener;
 import org.openhab.binding.digitalstrom.internal.lib.structure.devices.Device;
 import org.openhab.binding.digitalstrom.internal.lib.structure.scene.constants.SceneTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link InternalScene} represents a digitalSTROM-Scene for the internal model.
@@ -28,6 +30,7 @@ import org.openhab.binding.digitalstrom.internal.lib.structure.scene.constants.S
  * @author Matthias Siegele - Initial contribution
  */
 public class InternalScene {
+    private final Logger logger = LoggerFactory.getLogger(InternalScene.class);
 
     private final Short sceneID;
     private final Short groupID;
@@ -91,6 +94,7 @@ public class InternalScene {
      * Activates this Scene.
      */
     public void activateScene() {
+        logger.debug("activate scene: {}", this.getSceneName());
         if (!active) {
             this.active = true;
             deviceHasChanged = false;
@@ -100,13 +104,17 @@ public class InternalScene {
                     device.callInternalScene(this);
                 }
             }
+        } else {
+            logger.debug("skipping activation, scene already active: {}", this.getSceneName());
         }
+
     }
 
     /**
      * Deactivates this Scene.
      */
     public void deactivateScene() {
+        logger.debug("deactivate scene: {}", this.getSceneName());
         if (active) {
             this.active = false;
             deviceHasChanged = false;
@@ -123,6 +131,7 @@ public class InternalScene {
      * Will be called by a device, if an undo call of an other scene activated this scene.
      */
     public void activateSceneByDevice() {
+        logger.debug("activate scene by device: {}", this.getSceneName());
         if (!active && !deviceHasChanged) {
             this.active = true;
             deviceHasChanged = false;
@@ -134,6 +143,7 @@ public class InternalScene {
      * Will be called by a device, if an call of an other scene deactivated this scene.
      */
     public void deactivateSceneByDevice() {
+        logger.debug("deactivate scene by device: {}", this.getSceneName());
         if (active) {
             this.active = false;
             deviceHasChanged = false;
@@ -157,8 +167,11 @@ public class InternalScene {
     }
 
     private void informListener() {
+        logger.debug("inform listener: {}", this.getSceneName());
         if (this.listener != null) {
             listener.onSceneStateChanged(this.active);
+        } else {
+            logger.debug("no listener found for scene: {}", this.getSceneName());
         }
     }
 


### PR DESCRIPTION
This PR addresses several issues/probems:

1. This fixes issue #8214 
2. There was no specific handling of SSLHandshakeExecptions, which resulted in a default handling a lots of stacktraces printed to the logs
3. The default connection error handling was faulty, because the bridge was not set to "offline"
4. There was some kind of "loop" in the reconnect process which resulted in stack overflows.
5. Sometimes scene calls get "lost" which ends up in scenes being not updated anymore. Fix: Any scene activation will now be sent to the core even if the status in the binding is already "active".