### PR TITLE
[openwebnet] Fixes #8327 Compilation errors on openHAB 3

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -38,7 +38,7 @@ The following Things and OpenWebNet `WHOs` are supported:
 | Category             | WHO          | Thing Type IDs                      | Description                                                 | Status           |
 | -------------------- | :----------: | :---------------------------------: | ----------------------------------------------------------- | ---------------- |
 | Gateway Management   | `13`         | `bus_gateway`                       | Any IP gateway supporting OpenWebNet protocol should work (e.g. F454 / MyHOMEServer1 / MH202 / F455 / MH200N, ...) | Successfully tested: F454, MyHOMEServer1, MyHOME_Screen10, F455, F452, F453AV, MH201, MH202, MH200N. Some connection stability issues/gateway resets reported with MH202  |
-| Lightning            | `1`          | `bus_on_off_switch`, `bus_dimmer`   | BUS switches and dimmers.                   | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)  |
+| Lighting            | `1`          | `bus_on_off_switch`, `bus_dimmer`   | BUS switches and dimmers.                   | Successfully tested: F411/2, F411/4, F411U2, F422, F429. Some discovery issues reported with F429 (DALI Dimmers)  |
 
 ### For ZigBee (Radio)
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -173,7 +173,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public ThingHandler getThingHandler() {
+    public @Nullable ThingHandler getThingHandler() {
         return bridgeHandler;
     }
 }


### PR DESCRIPTION
Fixes #8327 Compilation errors on openHAB 3 adding annotation to getThingHandler().
Fixes a typo in README.