### PR TITLE
[mqtt] Fix itests version number

### DIFF
--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homeassistant.tests</artifactId>

--- a/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homie.tests</artifactId>

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.io.mqttembeddedbroker.tests</artifactId>


### PR DESCRIPTION
As requested in https://github.com/openhab/openhab-addons/pull/7206#issuecomment-682730688, I have created this PR to update the version number of the MQTT itests, so that @jochen314 doesn't need to do it. I can close the PR if he prefers to change them :+1: 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>