### PR TITLE
[openwebnet] Embed dependency and update gnu.io version range

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -14,13 +14,17 @@
 
   <name>openHAB Add-ons :: Bundles :: OpenWebNet (BTicino/Legrand) Binding</name>
 
+  <properties>
+    <bnd.importpackage>gnu.io;version="[3.12,6)"</bnd.importpackage>
+  </properties>
+
   <dependencies>
 
     <dependency>
       <groupId>com.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
       <version>0.2.0</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
 
   </dependencies>

--- a/bundles/org.openhab.binding.openwebnet/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/feature/feature.xml
@@ -6,7 +6,6 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>
 		<feature>openhab-transport-upnp</feature>
-		<bundle dependency="true">mvn:com.github.openwebnet4j/openwebnet4j/0.2.0</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.openwebnet/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
This allows for more easily debugging the add-on in Eclipse and with the updated gnu.io version range it can also be used with OH3.

See also https://github.com/openhab/openhab-addons/pull/7589