### PR TITLE
[max] remove dependency on org.apache.commons.net.util

### DIFF
--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
@@ -16,12 +16,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.RoomInformation;
@@ -165,7 +165,7 @@ public class MCommand extends CubeCommand {
 
         }
 
-        final String encodedString = Base64.encodeBase64StringUnChunked(message.toByteArray());
+        final String encodedString = Base64.getEncoder().encodeToString(message.toByteArray());
         final StringBuilder commandStringBuilder = new StringBuilder();
         int parts = (int) Math.round(encodedString.length() / MAX_MSG_LENGTH + 0.5);
         for (int i = 0; i < parts; i++) {

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import org.apache.commons.net.util.Base64;
+import java.util.Base64;
+
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.ThermostatModeType;
 
@@ -96,7 +97,7 @@ public class SCommand extends CubeCommand {
 
         final String commandString = baseString + rfAddress + Utils.toHex(roomId) + Utils.toHex(bits);
 
-        final String encodedString = Base64.encodeBase64String(Utils.hexStringToByteArray(commandString));
+        final String encodedString = Base64.getEncoder().encodeToString(Utils.hexStringToByteArray(commandString));
 
         return "s:" + encodedString;
     }

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import org.apache.commons.net.util.Base64;
+import java.util.Base64;
+
 import org.openhab.binding.max.internal.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,7 +152,7 @@ public class SConfigCommand extends CubeCommand {
             commandString = commandString + Utils.toHex(roomId) + commandConfigString;
         }
 
-        String encodedString = Base64.encodeBase64String(Utils.hexStringToByteArray(commandString));
+        String encodedString = Base64.getEncoder().encodeToString(Utils.hexStringToByteArray(commandString));
         return "s:" + encodedString;
     }
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
@@ -13,10 +13,10 @@
 package org.openhab.binding.max.internal.command;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 
 /**
@@ -51,7 +51,7 @@ public class TCommand extends CubeCommand {
         for (String rfAddress : rfAddresses) {
             commandArray = ArrayUtils.addAll(Utils.hexStringToByteArray(rfAddress), commandArray);
         }
-        String encodedString = Base64.encodeBase64StringUnChunked(commandArray);
+        String encodedString = Base64.getEncoder().encodeToString(commandArray);
 
         return "t:" + String.format("%02d", rfAddresses.size()) + "," + updateForced + "," + encodedString + '\r'
                 + '\n';

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/CMessage.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/CMessage.java
@@ -19,13 +19,13 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.DeviceType;
 import org.slf4j.Logger;
@@ -67,8 +67,7 @@ public final class CMessage extends Message {
         String[] tokens = this.getPayload().split(Message.DELIMETER);
 
         rfAddress = tokens[0];
-
-        byte[] bytes = Base64.decodeBase64(tokens[1].getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = Base64.getDecoder().decode((tokens[1].getBytes(StandardCharsets.UTF_8)));
 
         int[] data = new int[bytes.length];
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/LMessage.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/LMessage.java
@@ -14,10 +14,10 @@ package org.openhab.binding.max.internal.message;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.DeviceConfiguration;
@@ -39,7 +39,7 @@ public final class LMessage extends Message {
     public Collection<? extends Device> getDevices(List<DeviceConfiguration> configurations) {
         final List<Device> devices = new ArrayList<>();
 
-        final byte[] decodedRawMessage = Base64.decodeBase64(getPayload().getBytes(StandardCharsets.UTF_8));
+        final byte[] decodedRawMessage = Base64.getDecoder().decode(getPayload().getBytes(StandardCharsets.UTF_8));
 
         final MaxTokenizer tokenizer = new MaxTokenizer(decodedRawMessage);
 
@@ -55,7 +55,7 @@ public final class LMessage extends Message {
     }
 
     public Collection<? extends Device> updateDevices(List<Device> devices, List<DeviceConfiguration> configurations) {
-        byte[] decodedRawMessage = Base64.decodeBase64(getPayload().getBytes(StandardCharsets.UTF_8));
+        byte[] decodedRawMessage = Base64.getDecoder().decode(getPayload().getBytes(StandardCharsets.UTF_8));
 
         MaxTokenizer tokenizer = new MaxTokenizer(decodedRawMessage);
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MMessage.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/MMessage.java
@@ -14,9 +14,9 @@ package org.openhab.binding.max.internal.message;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.DeviceInformation;
 import org.openhab.binding.max.internal.device.DeviceType;
@@ -49,7 +49,7 @@ public final class MMessage extends Message {
             return;
         }
         try {
-            byte[] bytes = Base64.decodeBase64(tokens[2].getBytes(StandardCharsets.UTF_8));
+            byte[] bytes = Base64.getDecoder().decode(tokens[2].getBytes(StandardCharsets.UTF_8));
 
             hasConfiguration = true;
             logger.trace("*** M Message trace**** ");

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/NMessage.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/message/NMessage.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.max.internal.message;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
-import org.apache.commons.net.util.Base64;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.DeviceType;
 import org.slf4j.Logger;
@@ -45,8 +45,8 @@ public final class NMessage extends Message {
 
         if (msgPayload.length() > 0) {
             try {
-                decodedPayload = new String(Base64.decodeBase64(msgPayload), StandardCharsets.UTF_8);
-                byte[] bytes = Base64.decodeBase64(msgPayload);
+                decodedPayload = new String(Base64.getDecoder().decode(msgPayload), StandardCharsets.UTF_8);
+                byte[] bytes = Base64.getDecoder().decode(msgPayload);
 
                 deviceType = DeviceType.create(bytes[0] & 0xFF);
                 rfAddress = Utils.toHex(bytes[1] & 0xFF, bytes[2] & 0xFF, bytes[3] & 0xFF);


### PR DESCRIPTION
Replace org.apache.commons.net.util.Base64 with java.util.Base64

eliminating several warning messages
[WARNING] org.openhab.binding.max.internal.command.MCommand.java:[23]                                                                                                                                                                  **The package org.apache.commons.net.utils should not be used.**       


Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
