### PR TITLE
[dsmr] Catch exceptions for RFC2217 compatibility

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/device/connector/DSMRSerialConnector.java
+++ b/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/device/connector/DSMRSerialConnector.java
@@ -155,8 +155,16 @@ public class DSMRSerialConnector extends DSMRBaseConnector implements SerialPort
             serialPort.notifyOnOverrunError(true);
             serialPort.notifyOnParityError(true);
 
-            serialPort.enableReceiveThreshold(SERIAL_TIMEOUT_MILLISECONDS);
-            serialPort.enableReceiveTimeout(SERIAL_TIMEOUT_MILLISECONDS);
+            try {
+                serialPort.enableReceiveThreshold(SERIAL_TIMEOUT_MILLISECONDS);
+            } catch (UnsupportedCommOperationException e) {
+                logger.debug("Enable receive threshold is unsupported");
+            }
+            try {
+                serialPort.enableReceiveTimeout(SERIAL_TIMEOUT_MILLISECONDS);
+            } catch (UnsupportedCommOperationException e) {
+                logger.debug("Enable receive timeout is unsupported");
+            }
             // The binding is ready, let the meter know we want to receive values
             serialPort.setRTS(true);
             if (!serialPortReference.compareAndSet(oldSerialPort, serialPort)) {


### PR DESCRIPTION
I did some testing with RFC2217 and the DSMR Binding some time ago and I didn't run into any issues after catching these `UnsupportedCommOperationException` exceptions.

A similar approach was used for ZWave in https://github.com/openhab/org.openhab.binding.zwave/pull/1337.

Related to https://github.com/openhab/openhab-core/issues/1462.