### PR TITLE
Improve feature file aggregation

### DIFF
--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -1,38 +1,38 @@
-    <!-- aggregated features -->
-<feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
-	<feature>openhab-runtime-base</feature>
-	<feature>openhab-transport-serial</feature>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.blukii/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.ruuvitag/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluegiga/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.daikinmadoka/${project.version}</bundle>
-</feature>
-<feature name="openhab-binding-mqtt" description="MQTT Binding" version="${project.version}">
-	<feature>openhab-runtime-base</feature>
-	<feature>openhab-transport-mqtt</feature>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
-	<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.generic/${project.version}</bundle>
-	<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homeassistant/${project.version}</bundle>
-	<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homie/${project.version}</bundle>
-</feature>
-<feature name="openhab-binding-modbus" description="Modbus Binding" version="${project.version}">
-	<feature>openhab-runtime-base</feature>
-	<feature>openhab-transport-modbus</feature>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus/${project.version}</bundle>
-	<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.sunspec/${project.version}</bundle>
-</feature>
-<feature name="openhab-misc-ruleengine" description="Rule Engine (Experimental)" version="${project.version}">
-	<feature>openhab-runtime-base</feature>
-	<feature>openhab-core-automation</feature>
-	<feature>openhab-core-automation-module-media</feature>
-	<feature>openhab-core-automation-module-script</feature>
-	<feature>openhab-core-automation-module-script-rulesupport</feature>
-	<feature>openhab-core-automation-rest</feature>
-	<feature>openhab-io-javasound</feature>
-</feature>
+	<!-- aggregated features -->
+	<feature name="openhab-binding-bluetooth" description="Bluetooth Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-serial</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.airthings/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.am43/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.blukii/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.ruuvitag/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluez/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.bluegiga/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.bluetooth.daikinmadoka/${project.version}</bundle>
+	</feature>
+	<feature name="openhab-binding-mqtt" description="MQTT Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-mqtt</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
+		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.generic/${project.version}</bundle>
+		<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homeassistant/${project.version}</bundle>
+		<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homie/${project.version}</bundle>
+	</feature>
+	<feature name="openhab-binding-modbus" description="Modbus Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-modbus</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.sunspec/${project.version}</bundle>
+	</feature>
+	<feature name="openhab-misc-ruleengine" description="Rule Engine (Experimental)" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-core-automation</feature>
+		<feature>openhab-core-automation-module-media</feature>
+		<feature>openhab-core-automation-module-script</feature>
+		<feature>openhab-core-automation-module-script-rulesupport</feature>
+		<feature>openhab-core-automation-rest</feature>
+		<feature>openhab-io-javasound</feature>
+	</feature>
 
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -547,8 +547,8 @@ Import-Package: \\
                   <exclude>**/pom.xml</exclude>
                   <exclude>**/feature.xml</exclude>
                   <exclude>src/main/history/**/*.xml</exclude>
-                  <exclude>features/openhab-addons/src/main/resources/header.xml</exclude>
-                  <exclude>features/openhab-addons/src/main/resources/footer.xml</exclude>
+                  <exclude>src/main/resources/header.xml</exclude>
+                  <exclude>src/main/resources/footer.xml</exclude>
                   <exclude>src/main/resources/input/rss*.xml</exclude>
                   <exclude>src/test/resources/**/*.xml</exclude>
                 </excludes>


### PR DESCRIPTION
The footer doesn't use tabs or proper indentation so after the aggregated feature file was generated a subsequent build would fail.

Related to https://github.com/openhab/openhab-addons/pull/8401