### PR TITLE
[max] improve setchannel definition

### DIFF
--- a/bundles/org.openhab.binding.max/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.max/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -471,7 +471,7 @@
 		<tags>
 			<tag>heating</tag>
 		</tags>
-		<state pattern="%.1f %unit%"/>
+		<state min="4.5" max="30.5" step="0.5" pattern="%.1f %unit%"/>
 	</channel-type>
 
 	<channel-type id="locked" advanced="true">


### PR DESCRIPTION
As paperUI only gives whole numbers now instead of the .5 values

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>