### PR TITLE
[smhi][OH3] Fix bug running on OH3

### DIFF
--- a/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/SmhiConnector.java
+++ b/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/SmhiConnector.java
@@ -16,6 +16,7 @@ package org.openhab.binding.smhi.internal;
 import static org.openhab.binding.smhi.internal.SmhiBindingConstants.*;
 
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -76,7 +77,7 @@ public class SmhiConnector {
      */
     public TimeSeries getForecast(double lat, double lon) throws SmhiException, PointOutOfBoundsException {
         logger.debug("Fetching new forecast");
-        String url = String.format(POINT_FORECAST_URL, lon, lat);
+        String url = String.format(Locale.ROOT, POINT_FORECAST_URL, lon, lat);
         Request req = httpClient.newRequest(url);
         req.accept(ACCEPT);
         ContentResponse resp;


### PR DESCRIPTION
Noticed when testing on OH3 that `String.format` used the wrong decimal separator (might just be that I used a different locale setting for that instance) which caused the binding to stop working. This is a small fix to correct that.

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>
