### PR TITLE
[max] add @notnullbydefault to eliminate warnings from commands classes

### DIFF
--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ACommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ACommand.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ACommand} deletes the device and room configuration from the Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class ACommand extends CubeCommand {
 
     @Override

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CCommand.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link C_CubeCommand} to request configuration of a new MAX! device after inclusion.
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class CCommand extends CubeCommand {
     private final String rfAddress;
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/CubeCommand.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link CubeCommand} is the base class for commands to be send to the MAX! Cube.
  *
  * @author Marcel Verpaalen - Initial contribution
  *
  */
+@NonNullByDefault
 public abstract class CubeCommand {
 
     /**

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/FCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/FCommand.java
@@ -12,11 +12,15 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link F_CubeCommand} is used to query and update the NTP servers used by the Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class FCommand extends CubeCommand {
 
     private String ntpServer1 = "";
@@ -31,7 +35,7 @@ public class FCommand extends CubeCommand {
     /**
      * Updates the Cube the NTP info
      */
-    public FCommand(String ntpServer1, String ntpServer2) {
+    public FCommand(@Nullable String ntpServer1, @Nullable String ntpServer2) {
         this.ntpServer1 = ntpServer1 != null ? ntpServer1 : "";
         this.ntpServer2 = ntpServer2 != null ? ntpServer2 : "";
     }
@@ -44,7 +48,6 @@ public class FCommand extends CubeCommand {
         } else {
             servers = ntpServer1 + ntpServer2;
         }
-
         return "f:" + servers + '\r' + '\n';
     }
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/LCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/LCommand.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link LCommand} request a status update for MAX! devices.
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class LCommand extends CubeCommand {
 
     @Override

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/MCommand.java
@@ -22,6 +22,7 @@ import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.util.Base64;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.RoomInformation;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class MCommand extends CubeCommand {
     private final Logger logger = LoggerFactory.getLogger(MCommand.class);
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/NCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/NCommand.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link N_CubeCommand} starts the inclusion mode for new MAX! devices.
- * 
+ *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class NCommand extends CubeCommand {
     // Example n:003c = start inclusion, timeout 003c = 60 sec
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/QCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/QCommand.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link QCommand} Quits the connection to the MAX! Cube.
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class QCommand extends CubeCommand {
 
     @Override
@@ -26,6 +29,6 @@ public class QCommand extends CubeCommand {
 
     @Override
     public String getReturnStrings() {
-        return null;
+        return "";
     }
 }

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SCommand.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.max.internal.command;
 
 import org.apache.commons.net.util.Base64;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.ThermostatModeType;
 
@@ -22,6 +23,7 @@ import org.openhab.binding.max.internal.device.ThermostatModeType;
  * @author Andreas Heil (info@aheil.de) - Initial contribution
  * @author Marcel Verpaalen - OH2 update + simplification
  */
+@NonNullByDefault
 public class SCommand extends CubeCommand {
 
     private static final String BASE_STRING_S = "000040000000"; // for single devices

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/SConfigCommand.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.max.internal.command;
 
 import org.apache.commons.net.util.Base64;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.max.internal.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,13 +23,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Marcel Verpaalen - Initial contribution
  */
+@NonNullByDefault
 public class SConfigCommand extends CubeCommand {
 
-    private String baseString;
+    private String baseString = "";
     private final String rfAddress;
     private final int roomId;
 
-    private byte[] commandBytes;
+    private byte[] commandBytes = new byte[0];
 
     private final Logger logger = LoggerFactory.getLogger(SConfigCommand.class);
 

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/TCommand.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.net.util.Base64;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.max.internal.Utils;
 
 /**
@@ -24,6 +25,7 @@ import org.openhab.binding.max.internal.Utils;
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class TCommand extends CubeCommand {
 
     private static final int FORCE_UPDATE = 1;

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/UdpCubeCommand.java
@@ -24,6 +24,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.max.internal.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Marcel Verpaalen - Initial contribution
  */
+@NonNullByDefault
 public class UdpCubeCommand {
 
     private static final String MAXCUBE_COMMAND_STRING = "eQ3Max*\0";
@@ -45,9 +48,10 @@ public class UdpCubeCommand {
     private final UdpCommandType commandType;
     private final String serialNumber;
     private Map<String, String> commandResponse = new HashMap<>();
+    @Nullable
     private String ipAddress;
 
-    public UdpCubeCommand(UdpCommandType commandType, String serialNumber) {
+    public UdpCubeCommand(UdpCommandType commandType, @Nullable String serialNumber) {
         this.commandType = commandType;
         if (serialNumber == null || serialNumber.isEmpty()) {
             this.serialNumber = "**********";
@@ -168,7 +172,7 @@ public class UdpCubeCommand {
      * @param ipAddress IP address of the MAX! Cube
      *
      */
-    private void sendUdpCommand(String commandString, String ipAddress) {
+    private void sendUdpCommand(String commandString, @Nullable String ipAddress) {
         DatagramSocket bcSend = null;
         try {
             bcSend = new DatagramSocket();
@@ -184,7 +188,6 @@ public class UdpCubeCommand {
                     continue;
                 }
                 for (InterfaceAddress interfaceAddress : networkInterface.getInterfaceAddresses()) {
-
                     InetAddress[] broadcast = new InetAddress[3];
                     if (ipAddress != null && !ipAddress.isEmpty()) {
                         broadcast[0] = InetAddress.getByName(ipAddress);

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ZCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/command/ZCommand.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.max.internal.command;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.max.internal.Utils;
 
 /**
@@ -19,6 +20,7 @@ import org.openhab.binding.max.internal.Utils;
  *
  * @author Marcel Verpaalen - Initial Contribution
  */
+@NonNullByDefault
 public class ZCommand extends CubeCommand {
 
     public enum WakeUpType {

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
@@ -573,7 +573,7 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
                 writer.write(command.getCommandString());
                 logger.trace("Write string to Max! Cube {}: {}", ipAddress, command.getCommandString());
                 writer.flush();
-                if (command.getReturnStrings() != null) {
+                if (!command.getReturnStrings().isEmpty()) {
                     readLines(command.getReturnStrings());
                 } else {
                     socketClose();

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/SendCommand.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/SendCommand.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.binding.max.internal.handler;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.max.internal.command.CubeCommand;
@@ -22,14 +23,15 @@ import org.openhab.binding.max.internal.command.CubeCommand;
  *
  * @author Marcel Verpaalen - Initial contribution
  */
+@NonNullByDefault
 public final class SendCommand {
 
     private int id;
     private static int commandId = -1;
 
-    private ChannelUID channelUID;
-    private Command command;
-    private CubeCommand cubeCommand;
+    private @Nullable ChannelUID channelUID;
+    private @Nullable Command command;
+    private @Nullable CubeCommand cubeCommand;
     private String serialNumber;
     private String key;
     private String commandText;
@@ -41,7 +43,7 @@ public final class SendCommand {
         this.channelUID = channelUID;
         this.command = command;
         key = getKey(serialNumber, channelUID);
-        this.setCommandText(command.toString());
+        this.commandText = command.toString();
     }
 
     public SendCommand(String serialNumber, CubeCommand cubeCommand, String commandText) {
@@ -50,7 +52,7 @@ public final class SendCommand {
         this.serialNumber = serialNumber;
         this.cubeCommand = cubeCommand;
         key = getKey(serialNumber, cubeCommand);
-        this.setCommandText(commandText);
+        this.commandText = commandText;
     }
 
     /**
@@ -82,7 +84,7 @@ public final class SendCommand {
         return id;
     }
 
-    public ChannelUID getChannelUID() {
+    public @Nullable ChannelUID getChannelUID() {
         return channelUID;
     }
 
@@ -91,7 +93,7 @@ public final class SendCommand {
         key = getKey(serialNumber, channelUID);
     }
 
-    public Command getCommand() {
+    public @Nullable Command getCommand() {
         return command;
     }
 
@@ -99,7 +101,7 @@ public final class SendCommand {
         this.command = command;
     }
 
-    public CubeCommand getCubeCommand() {
+    public @Nullable CubeCommand getCubeCommand() {
         return cubeCommand;
     }
 
@@ -109,7 +111,10 @@ public final class SendCommand {
 
     public void setDeviceSerial(String device) {
         this.serialNumber = device;
-        key = getKey(serialNumber, channelUID);
+        final ChannelUID channelUID = this.channelUID;
+        if (channelUID != null) {
+            key = getKey(serialNumber, channelUID);
+        }
     }
 
     public String getCommandText() {
@@ -122,8 +127,10 @@ public final class SendCommand {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append("id", id).append("channelUID", channelUID).append("command", command)
-                .append("cubeCommand", cubeCommand).append("serialNumber", serialNumber).append("key", key)
-                .append("commandText", commandText).toString();
+        StringBuilder sb = new StringBuilder();
+        return sb.append("id: ").append(id).append(", channelUID: ").append(channelUID).append(", command: ")
+                .append(command).append(", cubeCommand: ").append(cubeCommand).append(", serialNumber: ")
+                .append(serialNumber).append(", key: ").append(key).append(", commandText: ").append(commandText)
+                .toString();
     }
 }


### PR DESCRIPTION
* add @notnullbydefault to classes in command
* replace org.apache.commons.lang.builder.ToStringBuilder with
StringBuilder (#7722)

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
