### PR TITLE
[nikohomecontrol] Check bridge status when thing ready to go online.

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -196,7 +196,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         // We need to do this in a separate thread because we may have to wait for the communication to become active
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE,
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Niko Home Control: no connection with Niko Home Control, could not initialize action "
                                 + actionId);
                 return;
@@ -221,6 +221,13 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
             actionEvent(nhcAction.getState());
 
             logger.debug("Niko Home Control: action initialized {}", actionId);
+
+            Bridge bridge = getBridge();
+            if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+                updateStatus(ThingStatus.ONLINE);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            }
         });
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -102,7 +102,6 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
                 nhcComm.startEnergyMeter(energyMeterId);
             }
 
-            updateStatus(ThingStatus.ONLINE);
             logger.debug("Niko Home Control: energy meter intialized {}", energyMeterId);
 
             Bridge bridge = getBridge();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -104,6 +104,13 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
             updateStatus(ThingStatus.ONLINE);
             logger.debug("Niko Home Control: energy meter intialized {}", energyMeterId);
+
+            Bridge bridge = getBridge();
+            if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+                updateStatus(ThingStatus.ONLINE);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            }
         });
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
@@ -187,6 +187,13 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
                     nhcThermostat.getOverrule(), nhcThermostat.getDemand());
 
             logger.debug("Niko Home Control: thermostat intialized {}", thermostatId);
+
+            Bridge bridge = getBridge();
+            if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+                updateStatus(ThingStatus.ONLINE);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            }
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

I had a report of a badly configured thing going online when the bridge went online, thereafter leading to a NPE on refresh. This should prevent this from happening.