### PR TITLE
[nuki] Add smart lock door sensor state as new channel (#8438)

### DIFF
--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -62,6 +62,10 @@ The following configuration options are available:
 - **lowBattery** (Switch)  
     Use this channel to receive a low battery warning.
 
+- **doorsensorState** (Number)  
+    Use this channel if you want to display the current door state provided by the door sensor.  
+    Supported Door Sensor States are : `0` (Unavailable), `1` (Deactivated), `2` (Closed), `3` (Open), `4` (Unknown) and `5` (Calibrating).
+
 ## Full Example
 
 A manual setup through files could look like this:
@@ -78,8 +82,9 @@ Bridge nuki:bridge:NB1 [ ip="192.168.0.50", port=8080, apiToken="myS3cr3t!", man
 
 ```
 Switch Frontdoor_Lock		"Frontdoor (Unlock / Lock)"		<nukiwhite>		{ channel="nuki:smartlock:NB1:SL1:lock" }
-Number Frontdoor_State		"Frontdoor (State)"				<nukisl>		{ channel="nuki:smartlock:NB1:SL1:lockState" }
+Number Frontdoor_LockState		"Frontdoor (Lock State)"	<nukisl>		{ channel="nuki:smartlock:NB1:SL1:lockState" }
 Switch Frontdoor_LowBattery	"Frontdoor Low Battery"			<nukibattery>	{ channel="nuki:smartlock:NB1:SL1:lowBattery" }
+Number Frontdoor_DoorState		"Frontdoor (Door State)"	<door>		{ channel="nuki:smartlock:NB1:SL1:doorsensorState" }
 ```
 
 ### sitemaps/nuki.sitemap
@@ -93,10 +98,13 @@ sitemap nuki label="Nuki Smart Lock" {
 		Switch item=Frontdoor_State mappings=[2="Unlock", 7="Unlatch", 1002="LnGo", 1007="LnGoU", 4="Lock"]
 	}
 	Frame label="Channel State" {
-		Text item=Frontdoor_State label="Lock State [MAP(nukilockstates.map):%s]"
+		Text item=Frontdoor_LockState label="Lock State [MAP(nukilockstates.map):%s]"
 	}
 	Frame label="Channel Low Battery" {
 		Text item=Frontdoor_LowBattery	label="Low Battery [%s]"
+	}
+	Frame label="Channel Door State" {
+		Text item=Frontdoor_DoorState label="Door State [MAP(nukidoorsensorstates.map):%s]"
 	}
 }
 ```

--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -81,10 +81,10 @@ Bridge nuki:bridge:NB1 [ ip="192.168.0.50", port=8080, apiToken="myS3cr3t!", man
 ### items/nuki.items
 
 ```
-Switch Frontdoor_Lock		"Frontdoor (Unlock / Lock)"		<nukiwhite>		{ channel="nuki:smartlock:NB1:SL1:lock" }
-Number Frontdoor_LockState		"Frontdoor (Lock State)"	<nukisl>		{ channel="nuki:smartlock:NB1:SL1:lockState" }
-Switch Frontdoor_LowBattery	"Frontdoor Low Battery"			<nukibattery>	{ channel="nuki:smartlock:NB1:SL1:lowBattery" }
-Number Frontdoor_DoorState		"Frontdoor (Door State)"	<door>		{ channel="nuki:smartlock:NB1:SL1:doorsensorState" }
+Switch Frontdoor_Lock		"Frontdoor (Unlock / Lock)"	<nukiwhite>		{ channel="nuki:smartlock:NB1:SL1:lock" }
+Number Frontdoor_LockState	"Frontdoor (Lock State)"	<nukisl>		{ channel="nuki:smartlock:NB1:SL1:lockState" }
+Switch Frontdoor_LowBattery	"Frontdoor Low Battery"		<nukibattery>		{ channel="nuki:smartlock:NB1:SL1:lowBattery" }
+Number Frontdoor_DoorState	"Frontdoor (Door State)"	<door>			{ channel="nuki:smartlock:NB1:SL1:doorsensorState" }
 ```
 
 ### sitemaps/nuki.sitemap

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/NukiBindingConstants.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/NukiBindingConstants.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class NukiBindingConstants {
 
@@ -43,6 +44,7 @@ public class NukiBindingConstants {
     public static final String CHANNEL_SMARTLOCK_LOCK = "lock";
     public static final String CHANNEL_SMARTLOCK_STATE = "lockState";
     public static final String CHANNEL_SMARTLOCK_LOW_BATTERY = "lowBattery";
+    public static final String CHANNEL_SMARTLOCK_DOOR_STATE = "doorsensorState";
 
     // List of all config-description parameters
     public static final String CONFIG_IP = "ip";
@@ -86,4 +88,12 @@ public class NukiBindingConstants {
     // Nuki Binding additional Lock States
     public static final int LOCK_STATES_UNLOCKING_LOCKNGO = 1002;
     public static final int LOCK_STATES_UNLATCHING_LOCKNGO = 1007;
+
+    // Nuki Binding Door States
+    public static final int DOORSENSOR_STATES_UNAVAILABLE = 0;
+    public static final int DOORSENSOR_STATES_DEACTIVATED = 1;
+    public static final int DOORSENSOR_STATES_CLOSED = 2;
+    public static final int DOORSENSOR_STATES_OPEN = 3;
+    public static final int DOORSENSOR_STATES_UNKNOWN = 4;
+    public static final int DOORSENSOR_STATES_CALIBRATING = 5;
 }

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/BridgeLockStateResponse.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/BridgeLockStateResponse.java
@@ -18,12 +18,14 @@ import org.openhab.binding.nuki.internal.dto.BridgeApiLockStateDto;
  * The {@link BridgeLockStateResponse} class wraps {@link BridgeApiLockStateDto} class.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class BridgeLockStateResponse extends NukiBaseResponse {
 
     private int state;
     private String stateName;
     private boolean batteryCritical;
+    private int doorsensorState;
 
     public BridgeLockStateResponse(int status, String message, BridgeApiLockStateDto bridgeApiLockStateDto) {
         super(status, message);
@@ -31,6 +33,7 @@ public class BridgeLockStateResponse extends NukiBaseResponse {
             this.setSuccess(bridgeApiLockStateDto.isSuccess());
             this.setState(bridgeApiLockStateDto.getState());
             this.setStateName(bridgeApiLockStateDto.getStateName());
+            this.setDoorsensorState(bridgeApiLockStateDto.getDoorsensorState());
             this.setBatteryCritical(bridgeApiLockStateDto.isBatteryCritical());
         }
     }
@@ -61,5 +64,13 @@ public class BridgeLockStateResponse extends NukiBaseResponse {
 
     public void setBatteryCritical(boolean batteryCritical) {
         this.batteryCritical = batteryCritical;
+    }
+
+    public int getDoorsensorState() {
+        return doorsensorState;
+    }
+
+    public void setDoorsensorState(int doorsensorState) {
+        this.doorsensorState = doorsensorState;
     }
 }

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiApiServlet.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dataexchange/NukiApiServlet.java
@@ -47,6 +47,7 @@ import com.google.gson.Gson;
  * The {@link NukiApiServlet} class is responsible for handling the callbacks from the Nuki Bridge.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class NukiApiServlet extends HttpServlet {
 
@@ -159,6 +160,11 @@ public class NukiApiServlet extends HttpServlet {
                     channel = thing.getChannel(NukiBindingConstants.CHANNEL_SMARTLOCK_LOW_BATTERY);
                     if (channel != null) {
                         State state = bridgeApiLockStateRequestDto.isBatteryCritical() ? OnOffType.ON : OnOffType.OFF;
+                        nsh.handleApiServletUpdate(channel.getUID(), state);
+                    }
+                    channel = thing.getChannel(NukiBindingConstants.CHANNEL_SMARTLOCK_DOOR_STATE);
+                    if (channel != null) {
+                        State state = new DecimalType(bridgeApiLockStateRequestDto.getDoorsensorState());
                         nsh.handleApiServletUpdate(channel.getUID(), state);
                     }
                     setHeaders(response);

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dto/BridgeApiLockStateDto.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dto/BridgeApiLockStateDto.java
@@ -17,12 +17,14 @@ package org.openhab.binding.nuki.internal.dto;
  * endpoint.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class BridgeApiLockStateDto {
 
     private int state;
     private String stateName;
     private boolean batteryCritical;
+    private int doorsensorState;
     private boolean success;
 
     public int getState() {
@@ -47,6 +49,14 @@ public class BridgeApiLockStateDto {
 
     public void setBatteryCritical(boolean batteryCritical) {
         this.batteryCritical = batteryCritical;
+    }
+
+    public int getDoorsensorState() {
+        return doorsensorState;
+    }
+
+    public void setDoorsensorState(int doorsensorState) {
+        this.doorsensorState = doorsensorState;
     }
 
     public boolean isSuccess() {

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dto/BridgeApiLockStateRequestDto.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/dto/BridgeApiLockStateRequestDto.java
@@ -17,6 +17,7 @@ package org.openhab.binding.nuki.internal.dto;
  * Bridge to the openHAB Server.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class BridgeApiLockStateRequestDto {
 
@@ -24,6 +25,7 @@ public class BridgeApiLockStateRequestDto {
     private int state;
     private String stateName;
     private boolean batteryCritical;
+    private int doorsensorState;
 
     public int getNukiId() {
         return nukiId;
@@ -55,5 +57,13 @@ public class BridgeApiLockStateRequestDto {
 
     public void setBatteryCritical(boolean batteryCritical) {
         this.batteryCritical = batteryCritical;
+    }
+
+    public int getDoorsensorState() {
+        return doorsensorState;
+    }
+
+    public void setDoorsensorState(int doorsensorState) {
+        this.doorsensorState = doorsensorState;
     }
 }

--- a/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiSmartLockHandler.java
+++ b/bundles/org.openhab.binding.nuki/src/main/java/org/openhab/binding/nuki/internal/handler/NukiSmartLockHandler.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Markus Katter - Initial contribution
+ * @contributer Christian Hoefler - Door sensor integration
  */
 public class NukiSmartLockHandler extends BaseThingHandler {
 
@@ -220,6 +221,12 @@ public class NukiSmartLockHandler extends BaseThingHandler {
                     updateState(channelUID, bridgeLockStateResponse.isBatteryCritical() ? OnOffType.ON : OnOffType.OFF);
                 }
                 break;
+            case NukiBindingConstants.CHANNEL_SMARTLOCK_DOOR_STATE:
+                bridgeLockStateResponse = nukiHttpClient.getBridgeLockState(nukiId);
+                if (handleResponse(bridgeLockStateResponse, channelUID.getAsString(), command.toString())) {
+                    updateState(channelUID, new DecimalType(bridgeLockStateResponse.getDoorsensorState()));
+                }
+                break;
             default:
                 logger.debug("Command[{}] for channelUID[{}] not implemented!", command, channelUID);
                 return;
@@ -247,6 +254,10 @@ public class NukiSmartLockHandler extends BaseThingHandler {
         Channel channelLockState = thing.getChannel(NukiBindingConstants.CHANNEL_SMARTLOCK_STATE);
         if (channelLockState != null) {
             updateState(channelLockState.getUID(), new DecimalType(NukiBindingConstants.LOCK_STATES_UNDEFINED));
+        }
+        Channel channelDoorState = thing.getChannel(NukiBindingConstants.CHANNEL_SMARTLOCK_DOOR_STATE);
+        if (channelDoorState != null) {
+            updateState(channelDoorState.getUID(), new DecimalType(NukiBindingConstants.DOORSENSOR_STATES_UNKNOWN));
         }
         startReInitJob();
         return false;

--- a/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -47,7 +47,7 @@
 			<channel id="lock" typeId="smartlockLock"/>
 			<channel id="lockState" typeId="smartlockState"/>
 			<channel id="lowBattery" typeId="system.low-battery"/>
-			<channel typeId="smartlockDoorState" id="doorsensorState"/>
+			<channel id="doorsensorState" typeId="smartlockDoorState"/>
 		</channels>
 		<config-description>
 			<parameter name="nukiId" type="text" required="true">

--- a/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -106,16 +106,16 @@
 		<label>Door State</label>
 		<description>Use this channel to display the current state of the door sensor</description>
 		<category>Door</category>
-        <state>
-            <options>
-                <option value="0">Unavailable</option>
-                <option value="1">Deactivated</option>
-                <option value="2">Closed</option>
-                <option value="3">Open</option>
-                <option value="4">Unknown</option>
-                <option value="5">Calibrating</option>
-            </options>
-        </state>
+		<state>
+			<options>
+				<option value="0">Unavailable</option>
+				<option value="1">Deactivated</option>
+				<option value="2">Closed</option>
+				<option value="3">Open</option>
+				<option value="4">Unknown</option>
+				<option value="5">Calibrating</option>
+			</options>
+		</state>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -46,7 +46,7 @@
 		<channels>
 			<channel id="lock" typeId="smartlockLock"/>
 			<channel id="lockState" typeId="smartlockState"/>
-			<channel id="lowBattery" typeId="system.low-battery"/>
+			<channel id="lowBattery" typeId="system.low-battery"/><channel typeId="smartlockDoorState" id="doorsensorState"></channel>
 		</channels>
 		<config-description>
 			<parameter name="nukiId" type="text" required="true">
@@ -100,6 +100,22 @@
 				<option value="255">UNDEFINED</option>
 			</options>
 		</state>
+	</channel-type>
+	<channel-type id="smartlockDoorState">
+		<item-type>Number</item-type>
+		<label>Door State</label>
+		<description>Use this channel to display the current state of the door sensor</description>
+		<category>Door</category>
+        <state>
+            <options>
+                <option value="0">Unavailable</option>
+                <option value="1">Deactivated</option>
+                <option value="2">Closed</option>
+                <option value="3">Open</option>
+                <option value="4">Unknown</option>
+                <option value="5">Calibrating</option>
+            </options>
+        </state>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -46,7 +46,8 @@
 		<channels>
 			<channel id="lock" typeId="smartlockLock"/>
 			<channel id="lockState" typeId="smartlockState"/>
-			<channel id="lowBattery" typeId="system.low-battery"/><channel typeId="smartlockDoorState" id="doorsensorState"></channel>
+			<channel id="lowBattery" typeId="system.low-battery"/>
+			<channel typeId="smartlockDoorState" id="doorsensorState"/>
 		</channels>
 		<config-description>
 			<parameter name="nukiId" type="text" required="true">


### PR DESCRIPTION
After one of the latest updates, the API of the Nuki smart lock device 2.0 includes the state of the door sensor. 

This improvement adds a new channel to the Nuki SmartLock device in OpenHab which displays the door sensor state. 
This PR includes the code changes, updated documentation and is already tested in my local demo and production environment. 

This PR is related to [issue #8438](https://github.com/openhab/openhab-addons/issues/8438). 

Link to the JAR file: 
[https://cloud.seeage.com/s/N3bZ7MpgRaoaMrZ](https://cloud.seeage.com/s/N3bZ7MpgRaoaMrZ)