### PR TITLE
[jsscripting] ES6+ Support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 *       @openhab/add-ons-maintainers
 
 # Add-on maintainers:
+/bundles/org.openhab.automation.jsscripting/ @jpg0
 /bundles/org.openhab.binding.airquality/ @kubawolanin
 /bundles/org.openhab.binding.airvisualnode/ @3cky
 /bundles/org.openhab.binding.allplay/ @dominicdesu
@@ -215,7 +216,7 @@
 /bundles/org.openhab.persistence.influxdb/ @lujop
 /bundles/org.openhab.transform.exec/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.javascript/ @openhab/add-ons-maintainers
-/bundles/org.openhab.transform.jinja/ @jochen314 
+/bundles/org.openhab.transform.jinja/ @jochen314
 /bundles/org.openhab.transform.jsonpath/ @clinique
 /bundles/org.openhab.transform.map/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.regex/ @openhab/add-ons-maintainers
@@ -241,7 +242,7 @@
 /itests/org.openhab.binding.tradfri.tests/ @cweitkamp @kaikreuzer
 /itests/org.openhab.binding.wemo.tests/ @hmerk
 /itests/org.openhab.io.hueemulation.tests/ @davidgraeff @digitaldan
-/itests/org.openhab.io.mqttembeddedbroker.tests/ @J-N-K 
+/itests/org.openhab.io.mqttembeddedbroker.tests/ @J-N-K
 /itests/org.openhab.persistence.mapdb.tests/ @mkhl
 
 # PLEASE HELP ADDING FURTHER LINES HERE!

--- a/bundles/org.openhab.automation.jsscripting/.classpath
+++ b/bundles/org.openhab.automation.jsscripting/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.automation.jsscripting/.project
+++ b/bundles/org.openhab.automation.jsscripting/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.automation.jsscripting</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.automation.jsscripting/NOTICE
+++ b/bundles/org.openhab.automation.jsscripting/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.automation.jsscripting/README.md
+++ b/bundles/org.openhab.automation.jsscripting/README.md
@@ -1,0 +1,3 @@
+# JSScripting
+
+TODO

--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.jsscripting</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Automation :: JSScripting</name>
+
+</project>

--- a/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.jsscripting/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.automation.jsscripting-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-automation-jsscripting" description="JSScripting" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.jsscripting/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -17,6 +17,7 @@
   <name>openHAB Add-ons :: Bundles</name>
 
   <modules>
+    <module>org.openhab.automation.jsscripting</module>
     <module>org.openhab.binding.nest</module>
     <module>org.openhab.persistence.dynamodb</module>
     <module>org.openhab.persistence.influxdb</module>


### PR DESCRIPTION
Parent PR to track all the changes required to get ES6+ support into OH. This will remain WIP until it's dependencies are merged. This supercedes https://github.com/openhab/openhab-addons/pull/6399.

Remaining pieces currently implemented that need to go somewhere:
  - Lifecycle / OSGiScriptExtensionProvider - osgi + lifecycle for script libs (https://github.com/openhab/openhab-core/pull/1635)
  - BindingItemProviderDelegate + package / ProvidersScriptExtensionProvider - allows creation of item provider. This provider allows items to be bound based on their metadata. (TBD)
  - RuleFactory + ModuleHandlerStuff - allows wiring up of *unmanaged* rules. Currently always registered which causes some lifecycle problems. (will open PR)
  - FixedProvider / SuspendableFixedProvider - allows suspendable providers to allow correct insertion order (TBD)
  - LifecycleAwareDelegate / - General stuff that is aware of consumer lifecycles (TBD)
  - ~~Sitemap package - all sitemap API assistance stuff (moved to https://github.com/jpg0/ohj-support)~~
  - ClassExtender - Graal specific (TBD)
  - additional context from script manager (will open a PR)
     - dependency tracking
     - engine identifier (blocks https://github.com/openhab/openhab-core/pull/1196)


