### PR TITLE
Upgrade Travis CI to use Ubuntu 18.04 and fix warnings/caching (2.5.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-dist: xenial
+os: linux
+dist: bionic
 
 language: java
 
@@ -10,17 +10,10 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.bnd/cache/
 
 before_cache:
   # remove resolver-status.properties, they change with each run and invalidate the cache
   - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;
-
-before_script:
-  # enable IPv6, see: https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-    fi
 
 notifications:
     webhooks: https://www.travisbuddy.com/


### PR DESCRIPTION
Upgrades the Travis CI build environment to Ubuntu 18.04 (Bionic Beaver).
The openjdk8 package is unsupported in newer Ubuntu versions.

Also fixes the following Travis configuration validation warnings:

* deprecated key sudo (The key `sudo` has no effect anymore.)
* missing os, using the default linux

Removes $HOME/.bnd/cache which does not exist after builds.

It's also no longer necessary to disable IPv6 with builds.
This was an actual issue in the hueemulation add-on which was fixed by #7305.