### PR TITLE
Upgrade Travis CI to use Ubuntu 20.04 and fix warnings/caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
-sudo: required
-dist: bionic
+os: linux
+dist: focal
 
 language: java
-
 jdk: openjdk11
 
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.bnd/cache/
 
 before_cache:
   # remove resolver-status.properties, they change with each run and invalidate the cache
   - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;
-
-before_script:
-  # enable IPv6, see: https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-    fi
 
 notifications:
     webhooks: https://www.travisbuddy.com/


### PR DESCRIPTION
Upgrades the Travis CI build environment to Ubuntu 20.04 (Focal Fossa).

Also fixes the following Travis configuration validation warnings:

* deprecated key sudo (The key `sudo` has no effect anymore.)
* missing os, using the default linux

Removes $HOME/.bnd/cache which does not exist after builds.

It's also no longer necessary to disable IPv6 with builds.
This was an actual issue in the hueemulation add-on which was fixed by #7305.