### PR TITLE
[plugwise] Add bridgeUID to thingUID during discovery

### DIFF
--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
@@ -125,9 +125,10 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
 
     private DiscoveryResult createDiscoveryResult(DiscoveredNode node) {
         String mac = node.macAddress.toString();
-        ThingUID thingUID = new ThingUID(PlugwiseUtils.getThingTypeUID(node.deviceType), mac);
+        ThingUID bridgeUID = stickHandler.getThing().getUID();
+        ThingUID thingUID = new ThingUID(PlugwiseUtils.getThingTypeUID(node.deviceType), bridgeUID, mac);
 
-        return DiscoveryResultBuilder.create(thingUID).withBridge(stickHandler.getThing().getUID())
+        return DiscoveryResultBuilder.create(thingUID).withBridge(bridgeUID)
                 .withLabel("Plugwise " + node.deviceType.toString())
                 .withProperty(PlugwiseBindingConstants.CONFIG_PROPERTY_MAC_ADDRESS, mac)
                 .withProperties(new HashMap<>(node.properties))


### PR DESCRIPTION
Additional validation got added in OH3 to make sure that the bridgeUID is added to Things with bridges (https://github.com/openhab/openhab-core/pull/1481).

The `PlugwiseThingDiscoveryService` did not add the bridgeUID so it would cause the following exceptions during discovery:

```
java.lang.IllegalArgumentException: Thing UID 'plugwise:circleplus:abc' does not match bridge UID 'plugwise:stick:xyz'
	at org.openhab.core.config.discovery.DiscoveryResultBuilder.validateThingUID(DiscoveryResultBuilder.java:166) ~[bundleFile:?]
	at org.openhab.core.config.discovery.DiscoveryResultBuilder.withBridge(DiscoveryResultBuilder.java:120) ~[bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.createDiscoveryResult(PlugwiseThingDiscoveryService.java:130) ~[bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.handleInformationResponse(PlugwiseThingDiscoveryService.java:195) ~[bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseThingDiscoveryService.handleReponseMessage(PlugwiseThingDiscoveryService.java:211) ~[bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseFilteredMessageListenerList.notifyListeners(PlugwiseFilteredMessageListenerList.java:64) [bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseMessageProcessor.processMessage(PlugwiseMessageProcessor.java:153) [bundleFile:?]
	at org.openhab.binding.plugwise.internal.PlugwiseMessageProcessor$MessageProcessorThread.run(PlugwiseMessageProcessor.java:60) [bundleFile:?]
```