### PR TITLE
[dsmr] Add bridgeUID to thingUID during discovery

### DIFF
--- a/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/discovery/DSMRDiscoveryService.java
+++ b/bundles/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/discovery/DSMRDiscoveryService.java
@@ -70,7 +70,7 @@ public abstract class DSMRDiscoveryService extends AbstractDiscoveryService {
     public boolean meterDiscovered(DSMRMeterDescriptor meterDescriptor, ThingUID dsmrBridgeUID) {
         DSMRMeterType meterType = meterDescriptor.getMeterType();
         ThingTypeUID thingTypeUID = meterType.getThingTypeUID();
-        ThingUID thingUID = new ThingUID(thingTypeUID, meterDescriptor.getChannelId());
+        ThingUID thingUID = new ThingUID(thingTypeUID, dsmrBridgeUID, meterDescriptor.getChannelId());
 
         // Construct the configuration for this meter
         Map<String, Object> properties = new HashMap<>();

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/discovery/DSMRMeterDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/discovery/DSMRMeterDiscoveryServiceTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.serial.PortInUseException;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,6 +96,7 @@ public class DSMRMeterDiscoveryServiceTest {
             return detectMetersRef.get().next();
         });
         when(thing.getHandler()).thenReturn(meterHandler);
+        when(bridge.getThing().getUID()).thenReturn(new ThingUID("dsmr:dsmrBridge:22e5393c"));
         when(bridge.getThing().getThings()).thenReturn(things);
 
         service.telegramReceived(expected);
@@ -122,6 +124,7 @@ public class DSMRMeterDiscoveryServiceTest {
                 unregisteredMeter.set(true);
             }
         };
+        when(bridge.getThing().getUID()).thenReturn(new ThingUID("dsmr:dsmrBridge:22e5393c"));
         when(bridge.getThing().getThings()).thenReturn(Collections.emptyList());
 
         service.telegramReceived(telegram);


### PR DESCRIPTION
Additional validation got added in OH3 to make sure that the bridgeUID is added to Things with bridges (openhab/openhab-core#1481).

The `DSMRBridgeDiscoveryService` did not add the bridgeUID so it would cause the following exceptions during discovery:

```
java.lang.IllegalArgumentException: Thing UID 'dsmr:device_v4:default' does not match bridge UID 'dsmr:dsmrBridge:22e5393c'
	at org.openhab.core.config.discovery.DiscoveryResultBuilder.validateThingUID(DiscoveryResultBuilder.java:166) ~[bundleFile:?]
	at org.openhab.core.config.discovery.DiscoveryResultBuilder.withBridge(DiscoveryResultBuilder.java:120) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.discovery.DSMRDiscoveryService.meterDiscovered(DSMRDiscoveryService.java:81) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.discovery.DSMRBridgeDiscoveryService.lambda$1(DSMRBridgeDiscoveryService.java:171) ~[bundleFile:?]
	at java.util.HashMap$Values.forEach(HashMap.java:976) ~[?:?]
	at org.openhab.binding.dsmr.internal.discovery.DSMRBridgeDiscoveryService.handleTelegramReceived(DSMRBridgeDiscoveryService.java:171) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.DSMRTelegramListener.telegramReceived(DSMRTelegramListener.java:97) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.p1telegram.P1TelegramParser.parse(P1TelegramParser.java:265) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.SmartyDecrypter.parse(SmartyDecrypter.java:107) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.DSMRTelegramListener.handleData(DSMRTelegramListener.java:74) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.connector.DSMRBaseConnector.handleDataAvailable(DSMRBaseConnector.java:116) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.connector.DSMRSerialConnector.handleDataAvailable(DSMRSerialConnector.java:317) ~[bundleFile:?]
	at org.openhab.binding.dsmr.internal.device.connector.DSMRSerialConnector.serialEvent(DSMRSerialConnector.java:276) [bundleFile:?]
	at org.openhab.core.io.transport.serial.rxtx.RxTxSerialPort$1.serialEvent(RxTxSerialPort.java:81) [bundleFile:?]
	at gnu.io.RXTXPort.sendEvent(RXTXPort.java:834) [bundleFile:5.2.1]
	at gnu.io.RXTXPort.eventLoop(Native Method) [bundleFile:5.2.1]
	at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:108) [bundleFile:5.2.1]
```