### PR TITLE
Fix missing bridge UID in thing UID during discovery

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -12,15 +12,7 @@
  */
 package org.openhab.binding.amazonechocontrol.internal.discovery;
 
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_FAMILY;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_FLASH_BRIEFING_PROFILE;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_SERIAL_NUMBER;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.SUPPORTED_ECHO_THING_TYPES_UIDS;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO_SHOW;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO_SPOT;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ECHO_WHA;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_FLASH_BRIEFING_PROFILE;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.*;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -160,13 +152,13 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService {
                         continue;
                     }
 
-                    ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
-                    ThingUID thingUID = new ThingUID(thingTypeId, brigdeThingUID, serialNumber);
+                    ThingUID bridgeThingUID = this.accountHandler.getThing().getUID();
+                    ThingUID thingUID = new ThingUID(thingTypeId, bridgeThingUID, serialNumber);
 
                     DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withLabel(device.accountName)
                             .withProperty(DEVICE_PROPERTY_SERIAL_NUMBER, serialNumber)
                             .withProperty(DEVICE_PROPERTY_FAMILY, deviceFamily)
-                            .withRepresentationProperty(DEVICE_PROPERTY_SERIAL_NUMBER).withBridge(brigdeThingUID)
+                            .withRepresentationProperty(DEVICE_PROPERTY_SERIAL_NUMBER).withBridge(bridgeThingUID)
                             .build();
 
                     logger.debug("Device [{}: {}] found. Mapped to thing type {}", device.deviceFamily, serialNumber,
@@ -184,8 +176,8 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService {
         }
 
         if (!discoveredFlashBriefings.contains(currentFlashBriefingJson)) {
-            ThingUID brigdeThingUID = this.accountHandler.getThing().getUID();
-            ThingUID freeThingUID = new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, brigdeThingUID,
+            ThingUID bridgeThingUID = this.accountHandler.getThing().getUID();
+            ThingUID freeThingUID = new ThingUID(THING_TYPE_FLASH_BRIEFING_PROFILE, bridgeThingUID,
                     Integer.toString(currentFlashBriefingJson.hashCode()));
             DiscoveryResult result = DiscoveryResultBuilder.create(freeThingUID).withLabel("FlashBriefing")
                     .withProperty(DEVICE_PROPERTY_FLASH_BRIEFING_PROFILE, currentFlashBriefingJson)

--- a/bundles/org.openhab.binding.foobot/src/main/java/org/openhab/binding/foobot/internal/discovery/FoobotAccountDiscoveryService.java
+++ b/bundles/org.openhab.binding.foobot/src/main/java/org/openhab/binding/foobot/internal/discovery/FoobotAccountDiscoveryService.java
@@ -85,7 +85,7 @@ public class FoobotAccountDiscoveryService extends AbstractDiscoveryService
     private void addThing(final FoobotDevice foobot) {
         logger.debug("Adding new Foobot '{}' with uuid: {}", foobot.getName(), foobot.getUuid());
 
-        final ThingUID thingUID = new ThingUID(FoobotBindingConstants.THING_TYPE_FOOBOT, foobot.getUuid());
+        final ThingUID thingUID = new ThingUID(FoobotBindingConstants.THING_TYPE_FOOBOT, bridgeUID, foobot.getUuid());
         final Map<String, Object> properties = new HashMap<>();
         properties.put(Thing.PROPERTY_SERIAL_NUMBER, foobot.getUuid());
         properties.put(FoobotBindingConstants.CONFIG_UUID, foobot.getUuid());

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/discovery/GroheOndusDiscoveryService.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/discovery/GroheOndusDiscoveryService.java
@@ -79,10 +79,10 @@ public class GroheOndusDiscoveryService extends AbstractDiscoveryService {
             ThingUID thingUID = null;
             switch (appliance.getType()) {
                 case org.grohe.ondus.api.model.guard.Appliance.TYPE:
-                    thingUID = new ThingUID(THING_TYPE_SENSEGUARD, appliance.getApplianceId());
+                    thingUID = new ThingUID(THING_TYPE_SENSEGUARD, bridgeUID, appliance.getApplianceId());
                     break;
                 case org.grohe.ondus.api.model.sense.Appliance.TYPE:
-                    thingUID = new ThingUID(THING_TYPE_SENSE, appliance.getApplianceId());
+                    thingUID = new ThingUID(THING_TYPE_SENSE, bridgeUID, appliance.getApplianceId());
                     break;
                 default:
                     return;

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/discovery/HeosPlayerDiscovery.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/discovery/HeosPlayerDiscovery.java
@@ -108,7 +108,7 @@ public class HeosPlayerDiscovery extends AbstractDiscoveryService implements Heo
         ThingUID bridgeUID = bridge.getThing().getUID();
 
         for (Player player : currentPlayers.values()) {
-            ThingUID uid = new ThingUID(THING_TYPE_PLAYER, String.valueOf(player.playerId));
+            ThingUID uid = new ThingUID(THING_TYPE_PLAYER, bridgeUID, String.valueOf(player.playerId));
             Map<String, Object> properties = new HashMap<>();
             HeosPlayerHandler.propertiesFromPlayer(properties, player);
 
@@ -162,7 +162,7 @@ public class HeosPlayerDiscovery extends AbstractDiscoveryService implements Heo
             // Using an unsigned hashCode from the group members to identify
             // the group and generates the Thing UID.
             // This allows identifying the group even if the sorting within the group has changed
-            ThingUID uid = new ThingUID(THING_TYPE_GROUP, groupMemberHash);
+            ThingUID uid = new ThingUID(THING_TYPE_GROUP, bridgeUID, groupMemberHash);
             Map<String, Object> properties = new HashMap<>();
             properties.put(PROP_NAME, group.name);
             properties.put(PROP_GID, group.id);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/discovery/InsteonDeviceDiscoveryService.java
@@ -60,7 +60,7 @@ public class InsteonDeviceDiscoveryService extends AbstractDiscoveryService {
             }
 
             String name = parts[0] + parts[1] + parts[2];
-            ThingUID uid = new ThingUID(InsteonBindingConstants.DEVICE_THING_TYPE, name);
+            ThingUID uid = new ThingUID(InsteonBindingConstants.DEVICE_THING_TYPE, bridgeUid, name);
             Map<String, Object> properties = new HashMap<>();
             properties.put(ADDRESS, address);
 

--- a/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
+++ b/bundles/org.openhab.binding.jeelink/src/main/java/org/openhab/binding/jeelink/internal/discovery/SensorDiscoveryService.java
@@ -102,17 +102,18 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
                     || id.equals(t.getConfiguration().as(JeeLinkSensorConfig.class).sensorId);
         }
 
+        ThingUID bridgeUID = bridge.getThing().getUID();
+
         if (!sensorThingExists) {
             SensorDefinition<?> def = SensorDefinition.getSensorDefinition(reading);
-            logger.debug("discovery for bridge {} found unknown sensor of type {} with id {}",
-                    bridge.getThing().getUID(), def.getThingTypeUID(), id);
+            logger.debug("discovery for bridge {} found unknown sensor of type {} with id {}", bridgeUID,
+                    def.getThingTypeUID(), id);
 
             boolean idExists = idExistsAtBridge(id);
             String newId = id;
 
             if (idExists) {
-                logger.debug("bridge {} already has a connected sensor with thing id {}", bridge.getThing().getUID(),
-                        id);
+                logger.debug("bridge {} already has a connected sensor with thing id {}", bridgeUID, id);
 
                 int idx = 1;
                 while (idExists) {
@@ -120,17 +121,17 @@ public class SensorDiscoveryService extends AbstractDiscoveryService implements 
                     idExists = idExistsAtBridge(newId);
                 }
 
-                logger.debug("Bridge {} uses thing id {} instead of {}", bridge.getThing().getUID(), newId, id);
+                logger.debug("Bridge {} uses thing id {} instead of {}", bridgeUID, newId, id);
             }
 
-            ThingUID sensorThing = new ThingUID(def.getThingTypeUID(), newId);
+            ThingUID sensorThing = new ThingUID(def.getThingTypeUID(), bridgeUID, newId);
 
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(sensorThing).withLabel(def.getName())
-                    .withBridge(bridge.getThing().getUID()).withRepresentationProperty("id")
-                    .withProperty(PROPERTY_SENSOR_ID, id).build();
+                    .withBridge(bridgeUID).withRepresentationProperty("id").withProperty(PROPERTY_SENSOR_ID, id)
+                    .build();
             thingDiscovered(discoveryResult);
         } else {
-            logger.debug("discovery for bridge {} found already known sensor id {}", bridge.getThing().getUID(), id);
+            logger.debug("discovery for bridge {} found already known sensor id {}", bridgeUID, id);
         }
     }
 

--- a/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
+++ b/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/discovery/XiaomiItemDiscoveryService.java
@@ -105,12 +105,12 @@ public class XiaomiItemDiscoveryService extends AbstractDiscoveryService impleme
             Map<String, Object> properties = new HashMap<>(1);
             properties.put(ITEM_ID, sid);
 
-            ThingUID thingUID = new ThingUID(thingType, sid);
+            ThingUID bridgeUID = xiaomiBridgeHandler.getThing().getUID();
+            ThingUID thingUID = new ThingUID(thingType, bridgeUID, sid);
 
             logger.debug("Discovered device - sid: {} model: {}", sid, model);
             thingDiscovered(DiscoveryResultBuilder.create(thingUID).withThingType(thingType).withProperties(properties)
-                    .withRepresentationProperty(ITEM_ID).withLabel(modelLabel)
-                    .withBridge(xiaomiBridgeHandler.getThing().getUID()).build());
+                    .withRepresentationProperty(ITEM_ID).withLabel(modelLabel).withBridge(bridgeUID).build());
         }
     }
 

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/discovery/NeatoAccountDiscoveryService.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/discovery/NeatoAccountDiscoveryService.java
@@ -87,7 +87,7 @@ public class NeatoAccountDiscoveryService extends AbstractDiscoveryService {
         logger.debug("addThing(): Adding new Neato unit {} to the smarthome inbox", robot.getName());
 
         Map<String, Object> properties = new HashMap<>();
-        ThingUID thingUID = new ThingUID(NeatoBindingConstants.THING_TYPE_VACUUMCLEANER, robot.getSerial());
+        ThingUID thingUID = new ThingUID(NeatoBindingConstants.THING_TYPE_VACUUMCLEANER, bridgeUID, robot.getSerial());
         properties.put(NeatoBindingConstants.CONFIG_SECRET, robot.getSecretKey());
         properties.put(NeatoBindingConstants.CONFIG_SERIAL, robot.getSerial());
         properties.put(Thing.PROPERTY_MODEL_ID, robot.getModel());

--- a/bundles/org.openhab.binding.openuv/src/main/java/org/openhab/binding/openuv/internal/discovery/OpenUVDiscoveryService.java
+++ b/bundles/org.openhab.binding.openuv/src/main/java/org/openhab/binding/openuv/internal/discovery/OpenUVDiscoveryService.java
@@ -97,8 +97,8 @@ public class OpenUVDiscoveryService extends AbstractDiscoveryService {
     }
 
     public void createResults(PointType location) {
-        ThingUID localOpenUVThing = new ThingUID(LOCATION_REPORT_THING_TYPE, LOCAL);
         ThingUID bridgeUID = bridgeHandler.getThing().getUID();
+        ThingUID localOpenUVThing = new ThingUID(LOCATION_REPORT_THING_TYPE, bridgeUID, LOCAL);
         Map<String, Object> properties = new HashMap<>();
         properties.put(LOCATION, location.toString());
         thingDiscovered(DiscoveryResultBuilder.create(localOpenUVThing).withLabel("Local UV Information")

--- a/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/discovery/VolvoOnCallDiscoveryService.java
+++ b/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/discovery/VolvoOnCallDiscoveryService.java
@@ -56,11 +56,12 @@ public class VolvoOnCallDiscoveryService extends AbstractDiscoveryService {
                 Vehicles vehicle = bridgeHandler.getURL(accountVehicle.vehicleURL, Vehicles.class);
                 Attributes attributes = bridgeHandler.getURL(Attributes.class, vehicle.vehicleId);
 
-                thingDiscovered(
-                        DiscoveryResultBuilder.create(new ThingUID(VEHICLE_THING_TYPE, accountVehicle.vehicleId))
-                                .withLabel(attributes.vehicleType + " " + attributes.registrationNumber)
-                                .withBridge(bridgeHandler.getThing().getUID()).withProperty(VIN, attributes.vin)
-                                .withRepresentationProperty(accountVehicle.vehicleId).build());
+                thingDiscovered(DiscoveryResultBuilder
+                        .create(new ThingUID(VEHICLE_THING_TYPE, bridgeHandler.getThing().getUID(),
+                                accountVehicle.vehicleId))
+                        .withLabel(attributes.vehicleType + " " + attributes.registrationNumber)
+                        .withBridge(bridgeHandler.getThing().getUID()).withProperty(VIN, attributes.vin)
+                        .withRepresentationProperty(accountVehicle.vehicleId).build());
 
             } catch (VolvoOnCallException e) {
                 logger.warn("Error while discovering vehicle: {}", e.getMessage());

--- a/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
@@ -141,7 +141,7 @@ public class WeatherUndergroundDiscoveryService extends AbstractDiscoveryService
     }
 
     private void createResults(PointType location, Locale locale) {
-        ThingUID localWeatherThing = new ThingUID(THING_TYPE_WEATHER, LOCAL);
+        ThingUID localWeatherThing = new ThingUID(THING_TYPE_WEATHER, bridgeUID, LOCAL);
         Map<String, Object> properties = new HashMap<>(3);
         properties.put(LOCATION, String.format("%s,%s", location.getLatitude(), location.getLongitude()));
         String lang = WeatherUndergroundHandler.getCodeFromLanguage(locale);


### PR DESCRIPTION
Fixes exceptions thrown in OH3 when building discovery results for things with bridges where the thing UID is missing the bridge UID.

Related to openhab/openhab-core#1481