### PR TITLE
[plugwise] Use OH thread naming scheme and constructor injection

### DIFF
--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseCommunicationHandler.java
@@ -13,8 +13,10 @@
 package org.openhab.binding.plugwise.internal;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
 import org.openhab.binding.plugwise.internal.config.PlugwiseStickConfig;
 import org.openhab.binding.plugwise.internal.listener.PlugwiseMessageListener;
@@ -29,11 +31,18 @@ import org.openhab.binding.plugwise.internal.protocol.field.MACAddress;
 @NonNullByDefault
 public class PlugwiseCommunicationHandler {
 
-    private final PlugwiseCommunicationContext context = new PlugwiseCommunicationContext();
-    private final PlugwiseMessageProcessor messageProcessor = new PlugwiseMessageProcessor(context);
-    private final PlugwiseMessageSender messageSender = new PlugwiseMessageSender(context);
+    private final PlugwiseCommunicationContext context;
+    private final PlugwiseMessageProcessor messageProcessor;
+    private final PlugwiseMessageSender messageSender;
 
     private boolean initialized = false;
+
+    public PlugwiseCommunicationHandler(ThingUID bridgeUID, Supplier<PlugwiseStickConfig> configurationSupplier,
+            SerialPortManager serialPortManager) {
+        context = new PlugwiseCommunicationContext(bridgeUID, configurationSupplier, serialPortManager);
+        messageProcessor = new PlugwiseMessageProcessor(context);
+        messageSender = new PlugwiseMessageSender(context);
+    }
 
     public void addMessageListener(PlugwiseMessageListener listener) {
         context.getFilteredListeners().addListener(listener);
@@ -41,10 +50,6 @@ public class PlugwiseCommunicationHandler {
 
     public void addMessageListener(PlugwiseMessageListener listener, MACAddress macAddress) {
         context.getFilteredListeners().addListener(listener, macAddress);
-    }
-
-    public PlugwiseStickConfig getConfiguration() {
-        return context.getConfiguration();
     }
 
     public void removeMessageListener(PlugwiseMessageListener listener) {
@@ -55,14 +60,6 @@ public class PlugwiseCommunicationHandler {
         if (initialized) {
             messageSender.sendMessage(message, priority);
         }
-    }
-
-    public void setConfiguration(PlugwiseStickConfig configuration) {
-        context.setConfiguration(configuration);
-    }
-
-    public void setSerialPortManager(SerialPortManager serialPortManager) {
-        context.setSerialPortManager(serialPortManager);
     }
 
     public void start() throws PlugwiseInitializationException {

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageProcessor.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageProcessor.java
@@ -46,7 +46,7 @@ public class PlugwiseMessageProcessor implements SerialPortEventListener {
     private class MessageProcessorThread extends Thread {
 
         public MessageProcessorThread() {
-            super("Plugwise MessageProcessorThread");
+            super("OH-binding-" + context.getBridgeUID() + "-message-processor");
             setDaemon(true);
         }
 

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageSender.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseMessageSender.java
@@ -42,7 +42,7 @@ public class PlugwiseMessageSender {
         private int messageWaitTime;
 
         public MessageSenderThread(int messageWaitTime) {
-            super("Plugwise MessageSenderThread");
+            super("OH-binding-" + context.getBridgeUID() + "-message-sender");
             this.messageWaitTime = messageWaitTime;
             setDaemon(true);
         }

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/handler/PlugwiseStickHandler.java
@@ -84,18 +84,18 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     };
 
     private final Logger logger = LoggerFactory.getLogger(PlugwiseStickHandler.class);
-    private final PlugwiseCommunicationHandler communicationHandler = new PlugwiseCommunicationHandler();
-    private final SerialPortManager serialPortManager;
+    private final PlugwiseCommunicationHandler communicationHandler;
     private final List<PlugwiseStickStatusListener> statusListeners = new CopyOnWriteArrayList<>();
 
-    private @NonNullByDefault({}) PlugwiseStickConfig configuration;
+    private PlugwiseStickConfig configuration = new PlugwiseStickConfig();
 
     private @Nullable MACAddress circlePlusMAC;
     private @Nullable MACAddress stickMAC;
 
     public PlugwiseStickHandler(Bridge bridge, SerialPortManager serialPortManager) {
         super(bridge);
-        this.serialPortManager = serialPortManager;
+        communicationHandler = new PlugwiseCommunicationHandler(bridge.getUID(), () -> configuration,
+                serialPortManager);
     }
 
     public void addMessageListener(PlugwiseMessageListener listener) {
@@ -190,8 +190,6 @@ public class PlugwiseStickHandler extends BaseBridgeHandler implements PlugwiseM
     @Override
     public void initialize() {
         configuration = getConfigAs(PlugwiseStickConfig.class);
-        communicationHandler.setConfiguration(configuration);
-        communicationHandler.setSerialPortManager(serialPortManager);
         communicationHandler.addMessageListener(this);
 
         try {


### PR DESCRIPTION
By using the OH thread naming scheme it will be easier to find the Plugwise Binding threads. Because the bridge UID is added in the thread names, the thread names will be unique and it will be easier to identify threads when using multiple Sticks. I also used some more construction injection and final to prevent null values.