### PR TITLE
[modbus] Fix for polling that stops

### DIFF
--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusPoolConfig.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusPoolConfig.java
@@ -66,6 +66,11 @@ public class ModbusPoolConfig extends GenericKeyedObjectPoolConfig<ModbusSlaveCo
         // Evict idle connections every 10 seconds
         setEvictionPolicy(new ModbusSlaveConnectionEvictionPolicy());
         setTimeBetweenEvictionRunsMillis(10000);
+        // Let eviction re-create ready-to-use idle (=unconnected) connections
+        // This is to avoid occasional / rare deadlocks seen with pool 2.8.1 & 2.4.3 when
+        // borrow hangs (waiting indefinitely for idle object to appear in the pool)
+        // https://github.com/openhab/openhab-addons/issues/8460
+        setMinIdlePerKey(1);
     }
 
     @Override


### PR DESCRIPTION
Resolves #8460

To my understanding, this is really a workaround for a hard-to-reproduce bug in Apache Pool2 2.8.1. I have not been able to find out detailed sequence-of-events that leads to the deadlock.

As explained in #8460, the borrow sometimes waits for idle connection to appear in the pool but there is no one to return any connection. With this PR the eviction thread (run every 10s) will ensure that there is at least one idle connection in the pool, resolving the deadlock.

Based on PR #8411. 8411 Should be merged first, marking this as "awaiting other PR".

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
