### PR TITLE
[miio] add automatic tokens to miio MDNSDiscoveryParticipant

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscoveryParticipant.java
@@ -47,13 +47,12 @@ import org.slf4j.LoggerFactory;
 @Component(service = MDNSDiscoveryParticipant.class, immediate = true)
 public class MiIoDiscoveryParticipant implements MDNSDiscoveryParticipant {
 
-    @Nullable
-    @Reference
-    CloudConnector cloudConnector;
+    private final CloudConnector cloudConnector;
     private Logger logger = LoggerFactory.getLogger(MiIoDiscoveryParticipant.class);
 
     @Activate
-    private void miIoDiscoveryParticipantStart() {
+    public MiIoDiscoveryParticipant(@Reference CloudConnector cloudConnector) {
+        this.cloudConnector = cloudConnector;
         logger.debug("Start Xiaomi Mi IO mDNS discovery");
     }
 
@@ -112,13 +111,13 @@ public class MiIoDiscoveryParticipant implements MDNSDiscoveryParticipant {
             // remove the domain from the name
             InetAddress ip = getIpAddress(service);
             if (ip == null) {
+                logger.debug("Mi IO mDNS Discovery could not determine ip address from service info: {}", service);
                 return null;
             }
             String inetAddress = ip.toString().substring(1); // trim leading slash
             String id = uid.getId();
             String label = "Xiaomi Mi Device " + id + " (" + Long.parseUnsignedLong(id, 16) + ") " + service.getName();
-            final CloudConnector cloudConnector = this.cloudConnector;
-            if (cloudConnector != null && cloudConnector.isConnected()) {
+            if (cloudConnector.isConnected()) {
                 cloudConnector.getDevicesList();
                 CloudDeviceDTO cloudInfo = cloudConnector.getDeviceInfo(id);
                 if (cloudInfo != null) {

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -312,6 +312,7 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         if (!hasChannelStructure) {
             if (configuration.model == null || configuration.model.isEmpty()) {
                 logger.debug("Model needs to be determined");
+                isIdentified = false;
             } else {
                 hasChannelStructure = buildChannelStructure(configuration.model);
             }


### PR DESCRIPTION
* get tokens from cloud if possible and add them during discovery.
(similar to the other discovery method)

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>

Note to reviewer: 
for some reason the @Reference CloudConnector cloudConnector did not want to work with final. Ugly framework errors as result.  Having it with a @Nullable did work fine.
