### PR TITLE
[velbus] Added support for additional Velbus modules and module features.

### DIFF
--- a/bundles/org.openhab.binding.velbus/README.md
+++ b/bundles/org.openhab.binding.velbus/README.md
@@ -1,10 +1,11 @@
 # Velbus Binding
 
-The Velbus binding integrates with a [Velbus](https://www.velbus.eu/) system through a Velbus configuration module (VMB1USB or VMB1RS) or a network connection (TCP/IP).
+The Velbus binding integrates with a [Velbus](https://www.velbus.eu/) system through a Velbus configuration module (VMBRSUSB, VMB1USB or VMB1RS) or a network connection (TCP/IP).
 
 The binding has been tested with a USB configuration module for universal mounting (VMB1USB).
+For optimal stability, the preferred configuration module is the VMBRSUSB module.
 
-The binding exposes basic actions from the Velbus System that can be triggered from the smartphone/tablet interface, as defined by the Velbus Protocol info sheets.
+The binding exposes basic actions from the Velbus System that can be triggered from the smartphone/tablet interface, as defined by the [Velbus Protocol info sheets](https://github.com/velbus).
 
 Supported item types are switches, dimmers and rollershutters.
 Pushbutton, temperature sensors and input module states are retrieved and made available in the binding.
@@ -12,12 +13,12 @@ Pushbutton, temperature sensors and input module states are retrieved and made a
 ## Supported Things
 
 
-A Velbus configuration module (e.g. VMB1USB) or a network server (e.g. [velserv](https://github.com/StefCoene/velserver/wiki/TCP-server-for-Velbus)) is required as a "bridge" for accessing any other Velbus devices.
+A Velbus configuration module (e.g. VMBRSUSB) or a network server (e.g. [velserv](https://github.com/StefCoene/velserver/wiki/TCP-server-for-Velbus)) is required as a "bridge" for accessing any other Velbus devices.
 
 The supported Velbus devices are:
 
 ```
-vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
+vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1rys, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
 ```
 
 The type of a specific device can be found in the configuration section for things in the Paper UI. It is part of the unique thing id which could look like:
@@ -89,7 +90,7 @@ or nested in the bridge configuration:
 The following thing types are valid for configuration:
 
 ```
-vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
+vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1rys, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
 ```
 
 `thingId` is the hexadecimal Velbus address of the thing.
@@ -142,7 +143,7 @@ OnOff command types are supported.
 For thing type `vmb4ry` 4 channels are available `CH1` ... `CH4`.
 OnOff command types are supported.
 
-For thing types `vmb1ryno`, `vmb1rynos`, `vmb4ryld` and `vmb4ryno` 5 channels are available `CH1` ... `CH5`.
+For thing types `vmb1ryno`, `vmb1rynos`, `vmb1rys`, `vmb4ryld` and `vmb4ryno` 5 channels are available `CH1` ... `CH5`.
 OnOff command types are supported.
 
 The module `vmb1ts` has a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE` and `thermostat:MODE`) and thermostat trigger channels: `thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`.

--- a/bundles/org.openhab.binding.velbus/README.md
+++ b/bundles/org.openhab.binding.velbus/README.md
@@ -1,6 +1,6 @@
 # Velbus Binding
 
-The Velbus binding integrates with a [Velbus](https://www.velbus.eu/) system through a Velbus configuration module (VMB1USB or VMB1RS).
+The Velbus binding integrates with a [Velbus](https://www.velbus.eu/) system through a Velbus configuration module (VMB1USB or VMB1RS) or a network connection (TCP/IP).
 
 The binding has been tested with a USB configuration module for universal mounting (VMB1USB).
 
@@ -12,12 +12,12 @@ Pushbutton, temperature sensors and input module states are retrieved and made a
 ## Supported Things
 
 
-A Velbus configuration module (e.g. VMB1USB) is required as a "bridge" for accessing any other Velbus devices.
+A Velbus configuration module (e.g. VMB1USB) or a network server (e.g. [velserv](https://github.com/StefCoene/velserver/wiki/TCP-server-for-Velbus)) is required as a "bridge" for accessing any other Velbus devices.
 
 The supported Velbus devices are:
 
 ```
-vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb2ble, vmb2pbn, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbpirc, vmbpirm, vmbpiro
+vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
 ```
 
 The type of a specific device can be found in the configuration section for things in the Paper UI. It is part of the unique thing id which could look like:
@@ -30,22 +30,49 @@ The thing type is the second string behind the first colon and in this example i
 
 ## Discovery
 
-The Velbus bridge cannot be discovered automatically. It has to be added manually by defining the serial port of the Velbus Configuration module.
+The Velbus bridge cannot be discovered automatically. It has to be added manually by defining the serial port of the Velbus Configuration module for the Velbus Serial Bridge or by defining the IP Address and port for the Velbus Network Bridge.
 
 Once the bridge has been added as a thing, a manual scan can be launched to discover all other supported Velbus devices on the bus. These devices will be available in the inbox. The discovery scan will also retrieve the channel names of the Velbus devices.
 
 ## Thing Configuration
 
 The Velbus bridge needs to be added first in the things file or through Paper UI.
-It is necessary to specify the serial port device used for communication.
+
+For the Velbus Serial Bridge it is necessary to specify the serial port device used for communication.
 On Linux systems, this will usually be either `/dev/ttyS0`, `/dev/ttyUSB0` or `/dev/ttyACM0` (or a higher  number than `0` if multiple devices are present).
 On Windows it will be `COM1`, `COM2`, etc.
 
-In the things file, this looks e.g. like
+In the things file, this might look e.g. like
 
 ```
 Bridge velbus:bridge:1 [ port="COM1" ]
 ```
+
+For the Velbus Network Bridge it is necessary to specify the IP Address or hostname and the port of the Velbus network server.
+This will usually be either the loopback address `127.0.0.1`, and port number. Or the specific IP of the machine `10.0.0.110` , and port number.
+
+In the things file, this might look like
+
+```
+Bridge velbus:networkbridge:1 "Velbus Network Bridge - Loopback" @ "Control" [ address="127.0.0.1", port=6000 ]
+```
+
+Optionally, both the serial bridge and the network bridge can also update the realtime clock, date and daylight savings status of the Velbus modules. This is achieved by setting the Time Update Interval (in minutes) on the bridge, e.g.:
+
+```
+Bridge velbus:bridge:1 [ port="COM1", timeUpdateInterval="360" ]
+```
+
+The default time update interval is every 360 minutes. Setting the interval to 0 minutes or leaving it empty disables the update of the realtime clock, date and daylight savings status of the Velbus modules.
+
+In case of a connection error, the bridges can also try to reconnect automatically. You can specify at which interval the bridge should try to reconnect by setting the Reconnection Interval (in seconds), e.g.:
+
+```
+Bridge velbus:bridge:1 [ port="COM1", reconnectionInterval="15" ]
+```
+
+The default reconnection interval is 15 seconds.
+
 
 For the other Velbus devices, the thing configuration has the following syntax:
 
@@ -62,7 +89,7 @@ or nested in the bridge configuration:
 The following thing types are valid for configuration:
 
 ```
-vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb2ble, vmb2pbn, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbpirc, vmbpirm, vmbpiro
+vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
 ```
 
 `thingId` is the hexadecimal Velbus address of the thing.
@@ -73,21 +100,67 @@ vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb2ble, vmb2pbn, vmb4dc,
 
 `[CHx="..."]` is optional, and represents the name of channel x, e.g. CH1 specifies the name of channel 1.
 
+For thing types with builtin sensors (e.g. temperature), the interval at which the sensors should be checked can be set by specifying the Refresh Interval, e.g.:
+
+```
+Thing velbus:vmbelo:<bridgeId>:<thingId> [refresh="300"]
+```
+
+The default refresh interval for the sensors is 300 seconds. Setting the refresh interval to 0 or leaving it empty will prevent the thing from periodically refreshing the sensor values.
+
+The following thing types support a sensor refresh interval:
+
+```
+vmb1ts, vmb4an, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
+```
+
+The `vmb7in` thing type also supports a refresh interval. For this thing type, the refresh interval is the interval at which the counter values should be refreshed.
+
+For dimmers the speed (in seconds) at which the modules should dim from 0% to 100% can be set by specifying the Dimspeed, e.g.:
+
+```
+Thing velbus:vmb4dc:<bridgeId>:<thingId> [dimspeed="5"]
+```
+
+The following thing types support setting the dimspeed:
+
+```
+vmb1dm, vmb1led, vmb4dc, vmbdme, vmbdmi, vmbdmir
+```
 
 ## Channels
 
-For thing type `vmb1bls` the supported channels is `CH1`. UpDown, StopMove and Percent command types are supported.
+For thing types `vmb1bl` and `vmb1bls` the supported channel is `CH1`. UpDown, StopMove and Percent command types are supported.
 
 For thing types `vmb1dm`, `vmb1led`, `vmbdme`, `vmbdmi` and `vmbdmir` the supported channel is `CH1`.
 OnOff and Percent command types are supported.
 Sending an ON command will switch the dimmer to the value stored when last turning the dimmer off.
 
+For thing type `vmb1ry` the supported channel is `CH1`.
+OnOff command types are supported.
+
+For thing type `vmb4ry` 4 channels are available `CH1` ... `CH4`.
+OnOff command types are supported.
+
 For thing types `vmb1ryno`, `vmb1rynos`, `vmb4ryld` and `vmb4ryno` 5 channels are available `CH1` ... `CH5`.
 OnOff command types are supported.
 
-For thing type `vmb2ble` the supported channels are `CH1` and `CH2`. UpDown, StopMove and Percent command types are supported.
+The module `vmb1ts` has a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE` and `thermostat:MODE`) and thermostat trigger channels: `thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`.
 
-Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8ir`, `vmb8pb` and `vmb8pbu` have 8 trigger channels `CH1` ... `CH8`.
+For thing types `vmb2bl` and `vmb2ble` the supported channels are `CH1` and `CH2`. UpDown, StopMove and Percent command types are supported.
+
+Thing type `vmb6in` has 6 trigger channels `input#CH1` ... `input#CH6`.
+
+Thing type `vmb7in` has 8 trigger channels `input#CH1` ... `input#CH8`.
+
+Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8ir`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` have 8 trigger channels (`input:CH1` ... `input:CH8`).
+Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8ir`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` have 8 trigger channels (`input:CH1` ... `input:CH8`).
+Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` also have and 2 channels to steer the button LED feedback (`feedback:CH1` and `feedback:CH2`).
+Additionally, the modules `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8pbu` and `vmbrfr8s` have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+
+For thing type`vmb4an` 8 trigger channels are avaiable `input:CH1` ... `input:CH8`. These channels will be triggered by the module's alarms.
+Four pairs of channels are available to retrieve the module's analog inputs. Each pair has a channel to retrieve the raw analog value (`analogInput:CH9RAW` ... `analogInput:CH12RAW`) and a channel to retrieve the textual analog value (`analogInput:CH9` ... `analogInput:CH12`).
+Four channels are available to set the module's analog outputs `analogOutput:CH13` ... `analogOutput:CH16`. 
 
 For thing type `vmb4dc` 4 channels are available `CH1` ... `CH4`.
 OnOff and Percent command types are supported.
@@ -96,17 +169,26 @@ Sending an ON command will switch the dimmer to the value stored when last turni
 For thing type `vmb4ry` 4 channels are available `CH1` ... `CH4`.
 OnOff command types are supported.
 
-For thing type `vmb4dc` the supported channels are `CH1` ... `CH4`.
-OnOff and Percent command types are supported.
-Sending an ON command will switch the dimmer to the value stored when last turning the dimmer off.
+Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4`, `vmbgp4pir` and `vmbpiro` have 8 trigger channels `input:CH1` ... `input:CH8` and one temperature channel `input:CH9`.
+The thing types `vmbel1` and `vmbgp1` have one channel to steer the button LED feedback `feedback:CH1`.
+The thing types `vmbel2` and `vmbgp2` have two channels to steer the button LED feedback `feedback:CH1` and `feedback:CH2`.
+The thing types `vmbel4`, `vmbgp4` and `vmbgp4pir` have four channels to steer the button LED feedback `feedback:CH1` ... `feedback:CH4`.
+The thing type `vmbpiro` has a channel `input:LIGHT` indicating the illuminance.
+Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` also have a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE`and `thermostat:MODE`) and thermostat trigger-channels `(thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`).
 
-Thing type `vmb6in`has 6 trigger channels `CH1` ... `CH6`.
+Thing types `vmbelo`, `vmbgpo` and `vmbgpod` have 32 trigger channels `input:CH1` ... `input:CH32` and one temperature channel `input:CH33`.
+They have have 32 channels to steer the button LED feedback `feedback:CH1` ... `feedback:CH32`.
+They have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+They have a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE`and `thermostat:MODE`) and thermostat trigger-channels `(thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`).
+They also have two channels to control the module's display `oledDisplay:MEMO` and `oledDisplay:SCREENSAVER`.
 
-Thing types `vmbgp1`, `vmbgp2`, `vmbgp4`, `vmbgp4pir` and `vmbpiro` have 8 trigger channels `CH1` ... `CH8` and one temperature channel `CH9`.
+Thing type `vmbmeteo`has 8 trigger channels (`input:CH1` ... `input:CH8`). These channels will be triggered by the module's alarms.
+It has a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+It also has a number of channels to read out the weather station's sensors: `weatherStation:temperature`, `weatherStation:rainfall`, `weatherStation:illuminance` and `weatherStation:windspeed`.
 
-Thing types `vmbgpo` and `vmbgpod` have 32 trigger channels `CH1` ... `CH32` and one temperature channel `CH33`.
-
-Thing types `vmbpirc` and `vmbpirm` have 7 trigger channels `CH1` ... `CH7`.
+Thing types `vmbpirc` and `vmbpirm` have 7 trigger channels `input:CH1` ... `input:CH7`.
+Additionally, these modules have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
 
 The trigger channels can be used as a trigger to rules. The event message can be `PRESSED`, `RELEASED`or `LONG_PRESSED`.
 

--- a/bundles/org.openhab.binding.velbus/README.md
+++ b/bundles/org.openhab.binding.velbus/README.md
@@ -13,7 +13,7 @@ Pushbutton, temperature sensors and input module states are retrieved and made a
 ## Supported Things
 
 
-A Velbus configuration module (e.g. VMBRSUSB) or a network server (e.g. [velserv](https://github.com/StefCoene/velserver/wiki/TCP-server-for-Velbus)) is required as a "bridge" for accessing any other Velbus devices.
+A Velbus configuration module (e.g. VMBRSUSB) or a network server (e.g. [VelServer](https://github.com/StefCoene/velserver/wiki/TCP-server-for-Velbus)) is required as a "bridge" for accessing any other Velbus devices.
 
 The supported Velbus devices are:
 
@@ -21,7 +21,8 @@ The supported Velbus devices are:
 vmb1bl, vmb1bls, vmb1dm, vmb1led, vmb1ry, vmb1ryno, vmb1rynos, vmb1rys, vmb1ts, vmb2bl, vmb2ble, vmb2pbn, vmb4an, vmb4dc, vmb4ry, vmb4ryld, vmb4ryno, vmb6in, vmb6pbn, vmb7in, vmb8ir, vmb8pb, vmb8pbu, vmbdme, vmbdmi, vmbdmir, vmbel1, vmbel2, vmbel4, vmbelo, vmbgp1, vmbgp2, vmbgp4, vmbgp4pir, vmbgpo, vmbgpod, vmbmeteo, vmbpirc, vmbpirm, vmbpiro
 ```
 
-The type of a specific device can be found in the configuration section for things in the Paper UI. It is part of the unique thing id which could look like:
+The type of a specific device can be found in the configuration section for things in the Paper UI. 
+It is part of the unique thing id which could look like:
 
 ```
 velbus:vmb4ryld:0424e5d2:01:CH1
@@ -31,9 +32,12 @@ The thing type is the second string behind the first colon and in this example i
 
 ## Discovery
 
-The Velbus bridge cannot be discovered automatically. It has to be added manually by defining the serial port of the Velbus Configuration module for the Velbus Serial Bridge or by defining the IP Address and port for the Velbus Network Bridge.
+The Velbus bridge cannot be discovered automatically. 
+It has to be added manually by defining the serial port of the Velbus Configuration module for the Velbus Serial Bridge or by defining the IP Address and port for the Velbus Network Bridge.
 
-Once the bridge has been added as a thing, a manual scan can be launched to discover all other supported Velbus devices on the bus. These devices will be available in the inbox. The discovery scan will also retrieve the channel names of the Velbus devices.
+Once the bridge has been added as a thing, a manual scan can be launched to discover all other supported Velbus devices on the bus. 
+These devices will be available in the inbox.
+The discovery scan will also retrieve the channel names of the Velbus devices.
 
 ## Thing Configuration
 
@@ -50,7 +54,8 @@ Bridge velbus:bridge:1 [ port="COM1" ]
 ```
 
 For the Velbus Network Bridge it is necessary to specify the IP Address or hostname and the port of the Velbus network server.
-This will usually be either the loopback address `127.0.0.1`, and port number. Or the specific IP of the machine `10.0.0.110` , and port number.
+This will usually be either the loopback address `127.0.0.1`, and port number. 
+Or the specific IP of the machine `10.0.0.110` , and port number.
 
 In the things file, this might look like
 
@@ -58,15 +63,18 @@ In the things file, this might look like
 Bridge velbus:networkbridge:1 "Velbus Network Bridge - Loopback" @ "Control" [ address="127.0.0.1", port=6000 ]
 ```
 
-Optionally, both the serial bridge and the network bridge can also update the realtime clock, date and daylight savings status of the Velbus modules. This is achieved by setting the Time Update Interval (in minutes) on the bridge, e.g.:
+Optionally, both the serial bridge and the network bridge can also update the realtime clock, date and daylight savings status of the Velbus modules. 
+This is achieved by setting the Time Update Interval (in minutes) on the bridge, e.g.:
 
 ```
 Bridge velbus:bridge:1 [ port="COM1", timeUpdateInterval="360" ]
 ```
 
-The default time update interval is every 360 minutes. Setting the interval to 0 minutes or leaving it empty disables the update of the realtime clock, date and daylight savings status of the Velbus modules.
+The default time update interval is every 360 minutes. 
+Setting the interval to 0 minutes or leaving it empty disables the update of the realtime clock, date and daylight savings status of the Velbus modules.
 
-In case of a connection error, the bridges can also try to reconnect automatically. You can specify at which interval the bridge should try to reconnect by setting the Reconnection Interval (in seconds), e.g.:
+In case of a connection error, the bridges can also try to reconnect automatically. 
+You can specify at which interval the bridge should try to reconnect by setting the Reconnection Interval (in seconds), e.g.:
 
 ```
 Bridge velbus:bridge:1 [ port="COM1", reconnectionInterval="15" ]
@@ -107,7 +115,8 @@ For thing types with builtin sensors (e.g. temperature), the interval at which t
 Thing velbus:vmbelo:<bridgeId>:<thingId> [refresh="300"]
 ```
 
-The default refresh interval for the sensors is 300 seconds. Setting the refresh interval to 0 or leaving it empty will prevent the thing from periodically refreshing the sensor values.
+The default refresh interval for the sensors is 300 seconds. 
+Setting the refresh interval to 0 or leaving it empty will prevent the thing from periodically refreshing the sensor values.
 
 The following thing types support a sensor refresh interval:
 
@@ -131,7 +140,8 @@ vmb1dm, vmb1led, vmb4dc, vmbdme, vmbdmi, vmbdmir
 
 ## Channels
 
-For thing types `vmb1bl` and `vmb1bls` the supported channel is `CH1`. UpDown, StopMove and Percent command types are supported.
+For thing types `vmb1bl` and `vmb1bls` the supported channel is `CH1`. 
+UpDown, StopMove and Percent command types are supported.
 
 For thing types `vmb1dm`, `vmb1led`, `vmbdme`, `vmbdmi` and `vmbdmir` the supported channel is `CH1`.
 OnOff and Percent command types are supported.
@@ -146,7 +156,7 @@ OnOff command types are supported.
 For thing types `vmb1ryno`, `vmb1rynos`, `vmb1rys`, `vmb4ryld` and `vmb4ryno` 5 channels are available `CH1` ... `CH5`.
 OnOff command types are supported.
 
-The module `vmb1ts` has a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE` and `thermostat:MODE`) and thermostat trigger channels: `thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`.
+The module `vmb1ts` has a number of channels to set the module's thermostat (`thermostat:currentTemperatureSetpoint`, `thermostat:heatingModeComfortTemperatureSetpoint`, `thermostat:heatingModeDayTemperatureSetpoint`, `thermostat:heatingModeNightTemperatureSetpoint`, `thermostat:heatingModeAntiFrostTemperatureSetpoint`, `thermostat:coolingModeComfortTemperatureSetpoint`, `thermostat:coolingModeDayTemperatureSetpoint`, `thermostat:coolingModeNightTemperatureSetpoint`, `thermostat:coolingModeSafeTemperatureSetpoint`, `operatingMode` and `thermostat:mode`) and thermostat trigger channels: `thermostat:heater`, `thermostat:boost`, `thermostat:pump`, `thermostat:cooler`, `thermostat:alarm1`, `thermostat:alarm2`, `thermostat:alarm3`, `thermostat:alarm4`.
 
 For thing types `vmb2bl` and `vmb2ble` the supported channels are `CH1` and `CH2`. UpDown, StopMove and Percent command types are supported.
 
@@ -157,10 +167,12 @@ Thing type `vmb7in` has 8 trigger channels `input#CH1` ... `input#CH8`.
 Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8ir`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` have 8 trigger channels (`input:CH1` ... `input:CH8`).
 Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8ir`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` have 8 trigger channels (`input:CH1` ... `input:CH8`).
 Thing types `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8pb`, `vmb8pbu` and `vmbrfr8s` also have and 2 channels to steer the button LED feedback (`feedback:CH1` and `feedback:CH2`).
-Additionally, the modules `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8pbu` and `vmbrfr8s` have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+Additionally, the modules `vmb2pbn`, `vmb6pbn`, `vmb7in`, `vmb8pbu` and `vmbrfr8s` have a number of channels to set the module's alarms: `clockAlarm:clockAlarm1Enabled`, `clockAlarm:clockAlarm1Type`, `clockAlarm:clockAlarm1WakeupHour`, `clockAlarm:clockAlarm1WakeupMinute`, `clockAlarm:clockAlarm1BedtimeHour`, `clockAlarm:clockAlarm1BedtimeMinute`, `clockAlarm:clockAlarm2Enabled`, `clockAlarm:clockAlarm2Type`, `clockAlarm:clockAlarm2WakeupHour`, `clockAlarm:clockAlarm2WakeupMinute`, `clockAlarm:clockAlarm2BedtimeHour` and `clockAlarm:clockAlarm2BedtimeMinute`.
 
-For thing type`vmb4an` 8 trigger channels are avaiable `input:CH1` ... `input:CH8`. These channels will be triggered by the module's alarms.
-Four pairs of channels are available to retrieve the module's analog inputs. Each pair has a channel to retrieve the raw analog value (`analogInput:CH9RAW` ... `analogInput:CH12RAW`) and a channel to retrieve the textual analog value (`analogInput:CH9` ... `analogInput:CH12`).
+For thing type`vmb4an` 8 trigger channels are avaiable `input:CH1` ... `input:CH8`. 
+These channels will be triggered by the module's alarms.
+Four pairs of channels are available to retrieve the module's analog inputs. 
+Each pair has a channel to retrieve the raw analog value (`analogInput:CH9Raw` ... `analogInput:CH12Raw`) and a channel to retrieve the textual analog value (`analogInput:CH9` ... `analogInput:CH12`).
 Four channels are available to set the module's analog outputs `analogOutput:CH13` ... `analogOutput:CH16`. 
 
 For thing type `vmb4dc` 4 channels are available `CH1` ... `CH4`.
@@ -175,21 +187,21 @@ The thing types `vmbel1` and `vmbgp1` have one channel to steer the button LED f
 The thing types `vmbel2` and `vmbgp2` have two channels to steer the button LED feedback `feedback:CH1` and `feedback:CH2`.
 The thing types `vmbel4`, `vmbgp4` and `vmbgp4pir` have four channels to steer the button LED feedback `feedback:CH1` ... `feedback:CH4`.
 The thing type `vmbpiro` has a channel `input:LIGHT` indicating the illuminance.
-Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
-Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` also have a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE`and `thermostat:MODE`) and thermostat trigger-channels `(thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`).
+Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` have a number of channels to set the module's alarms: `clockAlarm:clockAlarm1Enabled`, `clockAlarm:clockAlarm1Type`, `clockAlarm:clockAlarm1WakeupHour`, `clockAlarm:clockAlarm1WakeupMinute`, `clockAlarm:clockAlarm1BedtimeHour`, `clockAlarm:clockAlarm1BedtimeMinute`, `clockAlarm:clockAlarm2Enabled`, `clockAlarm:clockAlarm2Type`, `clockAlarm:clockAlarm2WakeupHour`, `clockAlarm:clockAlarm2WakeupMinute`, `clockAlarm:clockAlarm2BedtimeHour` and `clockAlarm:clockAlarm2BedtimeMinute`.
+Thing types `vmbel1`, `vmbel2`, `vmbel4`, `vmbgp1`, `vmbgp2`, `vmbgp4` and `vmbgp4pir` also have a number of channels to set the module's thermostat (`thermostat:currentTemperatureSetpoint`, `thermostat:heatingModeComfortTemperatureSetpoint`, `thermostat:heatingModeDayTemperatureSetpoint`, `thermostat:heatingModeNightTemperatureSetpoint`, `thermostat:heatingModeAntiFrostTemperatureSetpoint`, `thermostat:coolingModeComfortTemperatureSetpoint`, `thermostat:coolingModeDayTemperatureSetpoint`, `thermostat:coolingModeNightTemperatureSetpoint`, `thermostat:coolingModeSafeTemperatureSetpoint`, `operatingMode` and `thermostat:mode`) and thermostat trigger channels: `thermostat:heater`, `thermostat:boost`, `thermostat:pump`, `thermostat:cooler`, `thermostat:alarm1`, `thermostat:alarm2`, `thermostat:alarm3`, `thermostat:alarm4`.
 
 Thing types `vmbelo`, `vmbgpo` and `vmbgpod` have 32 trigger channels `input:CH1` ... `input:CH32` and one temperature channel `input:CH33`.
 They have have 32 channels to steer the button LED feedback `feedback:CH1` ... `feedback:CH32`.
-They have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
-They have a number of channels to set the module's thermostat (`thermostat:CURRENTTEMPERATURESETPOINT`, `thermostat:HEATINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEDAYTEMPERATURESETPOINT`, `thermostat:HEATINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:HEATINGMODEANTIFROSTTEMPERATURESETPOINT`, `thermostat:COOLINGMODECOMFORTTEMPERATURESETPOINT`, `thermostat:COOLINGMODEDAYTEMPERATURESETPOINT`, `thermostat:COOLINGMODENIGHTTEMPERATURESETPOINT`, `thermostat:COOLINGMODESAFETEMPERATURESETPOINT`, `thermostat:OPERATINGMODE`and `thermostat:MODE`) and thermostat trigger-channels `(thermostat:HEATER`, `thermostat:BOOST`, `thermostat:PUMP`, `thermostat:COOLER`, `thermostat:ALARM1`, `thermostat:ALARM2`, `thermostat:ALARM3`, `thermostat:ALARM4`).
+They have a number of channels to set the module's alarms: `clockAlarm:clockAlarm1Enabled`, `clockAlarm:clockAlarm1Type`, `clockAlarm:clockAlarm1WakeupHour`, `clockAlarm:clockAlarm1WakeupMinute`, `clockAlarm:clockAlarm1BedtimeHour`, `clockAlarm:clockAlarm1BedtimeMinute`, `clockAlarm:clockAlarm2Enabled`, `clockAlarm:clockAlarm2Type`, `clockAlarm:clockAlarm2WakeupHour`, `clockAlarm:clockAlarm2WakeupMinute`, `clockAlarm:clockAlarm2BedtimeHour` and `clockAlarm:clockAlarm2BedtimeMinute`.
+They have a number of channels to set the module's thermostat thermostat (`thermostat:currentTemperatureSetpoint`, `thermostat:heatingModeComfortTemperatureSetpoint`, `thermostat:heatingModeDayTemperatureSetpoint`, `thermostat:heatingModeNightTemperatureSetpoint`, `thermostat:heatingModeAntiFrostTemperatureSetpoint`, `thermostat:coolingModeComfortTemperatureSetpoint`, `thermostat:coolingModeDayTemperatureSetpoint`, `thermostat:coolingModeNightTemperatureSetpoint`, `thermostat:coolingModeSafeTemperatureSetpoint`, `operatingMode` and `thermostat:mode`) and thermostat trigger channels: `thermostat:heater`, `thermostat:boost`, `thermostat:pump`, `thermostat:cooler`, `thermostat:alarm1`, `thermostat:alarm2`, `thermostat:alarm3`, `thermostat:alarm4`.
 They also have two channels to control the module's display `oledDisplay:MEMO` and `oledDisplay:SCREENSAVER`.
 
 Thing type `vmbmeteo`has 8 trigger channels (`input:CH1` ... `input:CH8`). These channels will be triggered by the module's alarms.
-It has a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+It has a number of channels to set the module's alarms: `clockAlarm:clockAlarm1Enabled`, `clockAlarm:clockAlarm1Type`, `clockAlarm:clockAlarm1WakeupHour`, `clockAlarm:clockAlarm1WakeupMinute`, `clockAlarm:clockAlarm1BedtimeHour`, `clockAlarm:clockAlarm1BedtimeMinute`, `clockAlarm:clockAlarm2Enabled`, `clockAlarm:clockAlarm2Type`, `clockAlarm:clockAlarm2WakeupHour`, `clockAlarm:clockAlarm2WakeupMinute`, `clockAlarm:clockAlarm2BedtimeHour` and `clockAlarm:clockAlarm2BedtimeMinute`.
 It also has a number of channels to read out the weather station's sensors: `weatherStation:temperature`, `weatherStation:rainfall`, `weatherStation:illuminance` and `weatherStation:windspeed`.
 
 Thing types `vmbpirc` and `vmbpirm` have 7 trigger channels `input:CH1` ... `input:CH7`.
-Additionally, these modules have a number of channels to set the module's alarms: `clockAlarm:CLOCKALARM1ENABLED`, `clockAlarm:CLOCKALARM1TYPE`, `clockAlarm:CLOCKALARM1WAKEUPHOUR`, `clockAlarm:CLOCKALARM1WAKEUPMINUTE`, `clockAlarm:CLOCKALARM1BEDTIMEHOUR`, `clockAlarm:CLOCKALARM1BEDTIMEMINUTE`, `clockAlarm:CLOCKALARM2ENABLED`, `clockAlarm:CLOCKALARM2TYPE`, `clockAlarm:CLOCKALARM2WAKEUPHOUR`, `clockAlarm:CLOCKALARM2WAKEUPMINUTE`, `clockAlarm:CLOCKALARM2BEDTIMEHOUR` and `clockAlarm:CLOCKALARM2BEDTIMEMINUTE`.
+Additionally, these modules have a number of channels to set the module's alarms: `clockAlarm:clockAlarm1Enabled`, `clockAlarm:clockAlarm1Type`, `clockAlarm:clockAlarm1WakeupHour`, `clockAlarm:clockAlarm1WakeupMinute`, `clockAlarm:clockAlarm1BedtimeHour`, `clockAlarm:clockAlarm1BedtimeMinute`, `clockAlarm:clockAlarm2Enabled`, `clockAlarm:clockAlarm2Type`, `clockAlarm:clockAlarm2WakeupHour`, `clockAlarm:clockAlarm2WakeupMinute`, `clockAlarm:clockAlarm2BedtimeHour` and `clockAlarm:clockAlarm2BedtimeMinute`.
 
 The trigger channels can be used as a trigger to rules. The event message can be `PRESSED`, `RELEASED`or `LONG_PRESSED`.
 

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusBindingConstants.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusBindingConstants.java
@@ -43,6 +43,7 @@ public class VelbusBindingConstants {
     public static final ThingTypeUID THING_TYPE_VMB1RY = new ThingTypeUID(BINDING_ID, "vmb1ry");
     public static final ThingTypeUID THING_TYPE_VMB1RYNO = new ThingTypeUID(BINDING_ID, "vmb1ryno");
     public static final ThingTypeUID THING_TYPE_VMB1RYNOS = new ThingTypeUID(BINDING_ID, "vmb1rynos");
+    public static final ThingTypeUID THING_TYPE_VMB1RYS = new ThingTypeUID(BINDING_ID, "vmb1rys");
     public static final ThingTypeUID THING_TYPE_VMB1TS = new ThingTypeUID(BINDING_ID, "vmb1ts");
     public static final ThingTypeUID THING_TYPE_VMB2BL = new ThingTypeUID(BINDING_ID, "vmb2bl");
     public static final ThingTypeUID THING_TYPE_VMB2BLE = new ThingTypeUID(BINDING_ID, "vmb2ble");
@@ -85,9 +86,9 @@ public class VelbusBindingConstants {
     // thing type sets
     public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(BRIDGE_THING_TYPE, NETWORK_BRIDGE_THING_TYPE)));
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(THING_TYPE_VMB1BL, THING_TYPE_VMB1BLS, THING_TYPE_VMB1DM,
-                    THING_TYPE_VMB1LED, THING_TYPE_VMB1RY, THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB1TS,
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(THING_TYPE_VMB1BL, THING_TYPE_VMB1BLS, THING_TYPE_VMB1DM, THING_TYPE_VMB1LED,
+                    THING_TYPE_VMB1RY, THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB1RYS, THING_TYPE_VMB1TS,
                     THING_TYPE_VMB2BL, THING_TYPE_VMB2BLE, THING_TYPE_VMB2PBN, THING_TYPE_VMB4AN, THING_TYPE_VMB4DC,
                     THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO, THING_TYPE_VMB6IN, THING_TYPE_VMB6PBN,
                     THING_TYPE_VMB7IN, THING_TYPE_VMB8IR, THING_TYPE_VMB8PB, THING_TYPE_VMB8PBU, THING_TYPE_VMBDME,
@@ -143,6 +144,7 @@ public class VelbusBindingConstants {
     public static final byte MODULE_TYPE_VMBGP4_2 = 0x3C;
     public static final byte MODULE_TYPE_VMBGPOD_2 = 0x3D;
     public static final byte MODULE_TYPE_VMBGP4PIR_2 = 0x3E;
+    public static final byte MODULE_TYPE_VMB1RYS = 0x41;
 
     // Velbus commands
     public static final byte COMMAND_PUSH_BUTTON_STATUS = 0x00;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusBindingConstants.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusBindingConstants.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -25,22 +26,28 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusBindingConstants {
 
     public static final String BINDING_ID = "velbus";
 
-    // bridge
+    // bridges
     public static final ThingTypeUID BRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, "bridge");
+    public static final ThingTypeUID NETWORK_BRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, "networkbridge");
 
     // generic thing types
+    public static final ThingTypeUID THING_TYPE_VMB1BL = new ThingTypeUID(BINDING_ID, "vmb1bl");
     public static final ThingTypeUID THING_TYPE_VMB1BLS = new ThingTypeUID(BINDING_ID, "vmb1bls");
     public static final ThingTypeUID THING_TYPE_VMB1DM = new ThingTypeUID(BINDING_ID, "vmb1dm");
     public static final ThingTypeUID THING_TYPE_VMB1LED = new ThingTypeUID(BINDING_ID, "vmb1led");
     public static final ThingTypeUID THING_TYPE_VMB1RY = new ThingTypeUID(BINDING_ID, "vmb1ry");
     public static final ThingTypeUID THING_TYPE_VMB1RYNO = new ThingTypeUID(BINDING_ID, "vmb1ryno");
     public static final ThingTypeUID THING_TYPE_VMB1RYNOS = new ThingTypeUID(BINDING_ID, "vmb1rynos");
+    public static final ThingTypeUID THING_TYPE_VMB1TS = new ThingTypeUID(BINDING_ID, "vmb1ts");
+    public static final ThingTypeUID THING_TYPE_VMB2BL = new ThingTypeUID(BINDING_ID, "vmb2bl");
     public static final ThingTypeUID THING_TYPE_VMB2BLE = new ThingTypeUID(BINDING_ID, "vmb2ble");
     public static final ThingTypeUID THING_TYPE_VMB2PBN = new ThingTypeUID(BINDING_ID, "vmb2pbn");
+    public static final ThingTypeUID THING_TYPE_VMB4AN = new ThingTypeUID(BINDING_ID, "vmb4an");
     public static final ThingTypeUID THING_TYPE_VMB4DC = new ThingTypeUID(BINDING_ID, "vmb4dc");
     public static final ThingTypeUID THING_TYPE_VMB4RY = new ThingTypeUID(BINDING_ID, "vmb4ry");
     public static final ThingTypeUID THING_TYPE_VMB4RYLD = new ThingTypeUID(BINDING_ID, "vmb4ryld");
@@ -54,34 +61,52 @@ public class VelbusBindingConstants {
     public static final ThingTypeUID THING_TYPE_VMBDME = new ThingTypeUID(BINDING_ID, "vmbdme");
     public static final ThingTypeUID THING_TYPE_VMBDMI = new ThingTypeUID(BINDING_ID, "vmbdmi");
     public static final ThingTypeUID THING_TYPE_VMBDMIR = new ThingTypeUID(BINDING_ID, "vmbdmir");
+    public static final ThingTypeUID THING_TYPE_VMBEL1 = new ThingTypeUID(BINDING_ID, "vmbel1");
+    public static final ThingTypeUID THING_TYPE_VMBEL2 = new ThingTypeUID(BINDING_ID, "vmbel2");
+    public static final ThingTypeUID THING_TYPE_VMBEL4 = new ThingTypeUID(BINDING_ID, "vmbel4");
+    public static final ThingTypeUID THING_TYPE_VMBELO = new ThingTypeUID(BINDING_ID, "vmbelo");
     public static final ThingTypeUID THING_TYPE_VMBGP1 = new ThingTypeUID(BINDING_ID, "vmbgp1");
+    public static final ThingTypeUID THING_TYPE_VMBGP1_2 = new ThingTypeUID(BINDING_ID, "vmbgp1-2");
     public static final ThingTypeUID THING_TYPE_VMBGP2 = new ThingTypeUID(BINDING_ID, "vmbgp2");
+    public static final ThingTypeUID THING_TYPE_VMBGP2_2 = new ThingTypeUID(BINDING_ID, "vmbgp2-2");
     public static final ThingTypeUID THING_TYPE_VMBGP4 = new ThingTypeUID(BINDING_ID, "vmbgp4");
+    public static final ThingTypeUID THING_TYPE_VMBGP4_2 = new ThingTypeUID(BINDING_ID, "vmbgp4-2");
     public static final ThingTypeUID THING_TYPE_VMBGP4PIR = new ThingTypeUID(BINDING_ID, "vmbgp4pir");
+    public static final ThingTypeUID THING_TYPE_VMBGP4PIR_2 = new ThingTypeUID(BINDING_ID, "vmbgp4pir-2");
     public static final ThingTypeUID THING_TYPE_VMBGPO = new ThingTypeUID(BINDING_ID, "vmbgpo");
     public static final ThingTypeUID THING_TYPE_VMBGPOD = new ThingTypeUID(BINDING_ID, "vmbgpod");
+    public static final ThingTypeUID THING_TYPE_VMBGPOD_2 = new ThingTypeUID(BINDING_ID, "vmbgpod-2");
+    public static final ThingTypeUID THING_TYPE_VMBMETEO = new ThingTypeUID(BINDING_ID, "vmbmeteo");
     public static final ThingTypeUID THING_TYPE_VMBPIRC = new ThingTypeUID(BINDING_ID, "vmbpirc");
     public static final ThingTypeUID THING_TYPE_VMBPIRM = new ThingTypeUID(BINDING_ID, "vmbpirm");
     public static final ThingTypeUID THING_TYPE_VMBPIRO = new ThingTypeUID(BINDING_ID, "vmbpiro");
+    public static final ThingTypeUID THING_TYPE_VMBRFR8S = new ThingTypeUID(BINDING_ID, "vmbrfr8s");
 
     // thing type sets
-    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections.singleton(BRIDGE_THING_TYPE);
+    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(BRIDGE_THING_TYPE, NETWORK_BRIDGE_THING_TYPE)));
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(THING_TYPE_VMB1BLS, THING_TYPE_VMB1DM, THING_TYPE_VMB1LED,
-                    THING_TYPE_VMB1RY, THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB2BLE,
-                    THING_TYPE_VMB2PBN, THING_TYPE_VMB4DC, THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO,
-                    THING_TYPE_VMB6IN, THING_TYPE_VMB6PBN, THING_TYPE_VMB7IN, THING_TYPE_VMB8IR, THING_TYPE_VMB8PB,
-                    THING_TYPE_VMB8PBU, THING_TYPE_VMBDME, THING_TYPE_VMBDMI, THING_TYPE_VMBDMIR, THING_TYPE_VMBGP1,
-                    THING_TYPE_VMBGP2, THING_TYPE_VMBGP4, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGPO, THING_TYPE_VMBGPOD,
-                    THING_TYPE_VMBPIRC, THING_TYPE_VMBPIRM, THING_TYPE_VMBPIRO)));
+            .unmodifiableSet(new HashSet<>(Arrays.asList(THING_TYPE_VMB1BL, THING_TYPE_VMB1BLS, THING_TYPE_VMB1DM,
+                    THING_TYPE_VMB1LED, THING_TYPE_VMB1RY, THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB1TS,
+                    THING_TYPE_VMB2BL, THING_TYPE_VMB2BLE, THING_TYPE_VMB2PBN, THING_TYPE_VMB4AN, THING_TYPE_VMB4DC,
+                    THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO, THING_TYPE_VMB6IN, THING_TYPE_VMB6PBN,
+                    THING_TYPE_VMB7IN, THING_TYPE_VMB8IR, THING_TYPE_VMB8PB, THING_TYPE_VMB8PBU, THING_TYPE_VMBDME,
+                    THING_TYPE_VMBDMI, THING_TYPE_VMBDMIR, THING_TYPE_VMBEL1, THING_TYPE_VMBEL2, THING_TYPE_VMBEL4,
+                    THING_TYPE_VMBELO, THING_TYPE_VMBGP1, THING_TYPE_VMBGP1_2, THING_TYPE_VMBGP2, THING_TYPE_VMBGP2_2,
+                    THING_TYPE_VMBGP4, THING_TYPE_VMBGP4_2, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGP4PIR_2,
+                    THING_TYPE_VMBGPO, THING_TYPE_VMBGPOD, THING_TYPE_VMBGPOD_2, THING_TYPE_VMBMETEO,
+                    THING_TYPE_VMBPIRC, THING_TYPE_VMBPIRM, THING_TYPE_VMBPIRO, THING_TYPE_VMBRFR8S)));
 
     // Velbus module types
     public static final byte MODULE_TYPE_VMB8PB = 0x01;
     public static final byte MODULE_TYPE_VMB1RY = 0x02;
+    public static final byte MODULE_TYPE_VMB1BL = 0x03;
     public static final byte MODULE_TYPE_VMB6IN = 0x05;
     public static final byte MODULE_TYPE_VMB1DM = 0x07;
     public static final byte MODULE_TYPE_VMB4RY = 0x08;
+    public static final byte MODULE_TYPE_VMB2BL = 0x09;
     public static final byte MODULE_TYPE_VMB8IR = 0x0A;
+    public static final byte MODULE_TYPE_VMB1TS = 0x0C;
     public static final byte MODULE_TYPE_VMB1LED = 0x0F;
     public static final byte MODULE_TYPE_VMB4RYLD = 0x10;
     public static final byte MODULE_TYPE_VMB4RYNO = 0x11;
@@ -106,6 +131,18 @@ public class VelbusBindingConstants {
     public static final byte MODULE_TYPE_VMBGP4PIR = 0x2D;
     public static final byte MODULE_TYPE_VMB1BLS = 0x2E;
     public static final byte MODULE_TYPE_VMBDMIR = 0x2F;
+    public static final byte MODULE_TYPE_VMBRFR8S = 0x30;
+    public static final byte MODULE_TYPE_VMBMETEO = 0x31;
+    public static final byte MODULE_TYPE_VMB4AN = 0x32;
+    public static final byte MODULE_TYPE_VMBEL1 = 0x34;
+    public static final byte MODULE_TYPE_VMBEL2 = 0x35;
+    public static final byte MODULE_TYPE_VMBEL4 = 0x36;
+    public static final byte MODULE_TYPE_VMBELO = 0x37;
+    public static final byte MODULE_TYPE_VMBGP1_2 = 0x3A;
+    public static final byte MODULE_TYPE_VMBGP2_2 = 0x3B;
+    public static final byte MODULE_TYPE_VMBGP4_2 = 0x3C;
+    public static final byte MODULE_TYPE_VMBGPOD_2 = 0x3D;
+    public static final byte MODULE_TYPE_VMBGP4PIR_2 = 0x3E;
 
     // Velbus commands
     public static final byte COMMAND_PUSH_BUTTON_STATUS = 0x00;
@@ -114,30 +151,72 @@ public class VelbusBindingConstants {
     public static final byte COMMAND_SWITCH_BLIND_OFF = 0x04;
     public static final byte COMMAND_BLIND_UP = 0x05;
     public static final byte COMMAND_BLIND_DOWN = 0x06;
-    public static final byte COMMAND_SET_DIMVALUE = 0x07;
+    public static final byte COMMAND_SET_VALUE = 0x07;
+    public static final byte COMMAND_SLIDER_STATUS = 0x0F;
     public static final byte COMMAND_RESTORE_LAST_DIMVALUE = 0x11;
     public static final byte COMMAND_BLIND_POS = 0x1C;
+    public static final byte COMMAND_SENSOR_RAW_DATA = (byte) 0xA9;
+    public static final byte COMMAND_LIGHT_VALUE_REQUEST = (byte) 0xAA;
+    public static final byte COMMAND_TEXT = (byte) 0xAC;
+    public static final byte COMMAND_DAYLIGHT_SAVING_STATUS = (byte) 0xAF;
     public static final byte COMMAND_SUBTYPE = (byte) 0xB0;
+    public static final byte COMMAND_SET_REALTIME_DATE = (byte) 0xB7;
     public static final byte COMMAND_DIMMERCONTROLLER_STATUS = (byte) 0xB8;
-    public static final byte COMMAND_BLIND_STATUS = (byte) 0xEC;
-    public static final byte COMMAND_SENSOR_TEMP_REQUEST = (byte) 0xE5;
+    public static final byte COMMAND_TEMP_SENSOR_SETTINGS_PART4 = (byte) 0xB9;
+    public static final byte COMMAND_COUNTER_STATUS_REQUEST = (byte) 0xBD;
+    public static final byte COMMAND_COUNTER_STATUS = (byte) 0xBE;
+    public static final byte COMMAND_SET_ALARM_CLOCK = (byte) 0xC3;
+    public static final byte COMMAND_TEMP_SENSOR_SETTINGS_PART3 = (byte) 0xC6;
+    public static final byte COMMAND_READ_MEMORY_BLOCK = (byte) 0xC9;
+    public static final byte COMMAND_MEMORY_DATA_BLOCK = (byte) 0xCC;
+    public static final byte COMMAND_SET_REALTIME_CLOCK = (byte) 0xD8;
+    public static final byte COMMAND_SWITCH_TO_COMFORT_MODE = (byte) 0xDB;
+    public static final byte COMMAND_SWITCH_TO_DAY_MODE = (byte) 0xDC;
+    public static final byte COMMAND_SWITCH_TO_NIGHT_MODE = (byte) 0xDD;
+    public static final byte COMMAND_SWITCH_TO_SAFE_MODE = (byte) 0xDE;
+    public static final byte COMMAND_SET_COOLING_MODE = (byte) 0xDF;
+    public static final byte COMMAND_SET_HEATING_MODE = (byte) 0xE0;
+    public static final byte COMMAND_SET_TEMP = (byte) 0xE4;
+    public static final byte COMMAND_SENSOR_READOUT_REQUEST = (byte) 0xE5;
     public static final byte COMMAND_SENSOR_TEMPERATURE = (byte) 0xE6;
+    public static final byte COMMAND_TEMP_SENSOR_SETTINGS_REQUEST = (byte) 0xE7;
+    public static final byte COMMAND_TEMP_SENSOR_SETTINGS_PART1 = (byte) 0xE8;
+    public static final byte COMMAND_TEMP_SENSOR_SETTINGS_PART2 = (byte) 0xE9;
+    public static final byte COMMAND_TEMP_SENSOR_STATUS = (byte) 0xEA;
+    public static final byte COMMAND_BLIND_STATUS = (byte) 0xEC;
+    public static final byte COMMAND_MODULE_STATUS = (byte) 0xED;
     public static final byte COMMAND_DIMMER_STATUS = (byte) 0xEE;
     public static final byte COMMAND_MODULE_NAME_REQUEST = (byte) 0xEF;
     public static final byte COMMAND_MODULE_NAME_PART1 = (byte) 0xF0;
     public static final byte COMMAND_MODULE_NAME_PART2 = (byte) 0xF1;
     public static final byte COMMAND_MODULE_NAME_PART3 = (byte) 0xF2;
+    public static final byte COMMAND_CLEAR_LED = (byte) 0xF5;
+    public static final byte COMMAND_SET_LED = (byte) 0xF6;
+    public static final byte COMMAND_SLOW_BLINK_LED = (byte) 0xF7;
+    public static final byte COMMAND_FAST_BLINK_LED = (byte) 0xF8;
+    public static final byte COMMAND_VERY_FAST_BLINK_LED = (byte) 0xF9;
     public static final byte COMMAND_STATUS_REQUEST = (byte) 0xFA;
     public static final byte COMMAND_RELAY_STATUS = (byte) 0xFB;
+    public static final byte COMMAND_WRITE_DATA_TO_MEMORY = (byte) 0xFC;
+    public static final byte COMMAND_READ_DATA_FROM_MEMORY = (byte) 0xFD;
+    public static final byte COMMAND_MEMORY_DATA = (byte) 0xFE;
     public static final byte COMMAND_MODULE_TYPE = (byte) 0xFF;
+    public static final byte ALL_CHANNELS = (byte) 0xFF;
 
     // Module properties
     public static final String PORT = "port";
-    public static final String MODULE_ADDRESS = "address";
+    public static final String ADDRESS = "address";
     public static final String REFRESH_INTERVAL = "refresh";
+    public static final String COUNTER1_PULSE_MULTIPLIER = "COUNTER1_PULSE_MULTIPLIER";
+    public static final String COUNTER2_PULSE_MULTIPLIER = "COUNTER2_PULSE_MULTIPLIER";
+    public static final String COUNTER3_PULSE_MULTIPLIER = "COUNTER3_PULSE_MULTIPLIER";
+    public static final String COUNTER4_PULSE_MULTIPLIER = "COUNTER4_PULSE_MULTIPLIER";
+    public static final String RECONNECTION_INTERVAL = "reconnectionInterval";
+    public static final String TIME_UPDATE_INTERVAL = "timeUpdateInterval";
     public static final String MODULE_SERIAL_NUMBER = "serial number";
     public static final String MODULE_MEMORY_MAP_VERSION = "memory map version";
     public static final String MODULE_BUILD = "build";
     public static final String CHANNEL = "CH";
     public static final String SUB_ADDRESS = "subaddress";
+    public static final String DIMSPEED = "dimspeed";
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusChannelIdentifier.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusChannelIdentifier.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.velbus.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link VelbusChannelIdentifier} represents a class with properties that uniquely identify a channel.
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusChannelIdentifier {
 
     private byte address;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusClockAlarm.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusClockAlarm.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusClockAlarm} represents a class that contains the state representation of a velbus clock alarm.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusClockAlarm {
+    private boolean enabled;
+    private boolean isLocal;
+    private byte wakeupHour;
+    private byte wakeupMinute;
+    private byte bedtimeHour;
+    private byte bedtimeMinute;
+
+    public VelbusClockAlarm() {
+        this.enabled = true;
+        this.isLocal = true;
+        this.wakeupHour = 7;
+        this.wakeupMinute = 0;
+        this.bedtimeHour = 23;
+        this.bedtimeMinute = 0;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public boolean isLocal() {
+        return this.isLocal;
+    }
+
+    public void setEnabled(boolean value) {
+        this.enabled = value;
+    }
+
+    public void setLocal(boolean value) {
+        this.isLocal = value;
+    }
+
+    public byte getWakeupHour() {
+        return this.wakeupHour;
+    }
+
+    public void setWakeupHour(byte value) {
+        this.wakeupHour = value;
+    }
+
+    public byte getWakeupMinute() {
+        return this.wakeupMinute;
+    }
+
+    public void setWakeupMinute(byte value) {
+        this.wakeupMinute = value;
+    }
+
+    public byte getBedtimeHour() {
+        return this.bedtimeHour;
+    }
+
+    public void setBedtimeHour(byte value) {
+        this.bedtimeHour = value;
+    }
+
+    public byte getBedtimeMinute() {
+        return this.bedtimeMinute;
+    }
+
+    public void setBedtimeMinute(byte value) {
+        this.bedtimeMinute = value;
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusClockAlarmConfiguration.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusClockAlarmConfiguration.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusClockAlarmConfiguration} represents a class that contains the configuration of a velbus clock alarm.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusClockAlarmConfiguration {
+    private VelbusClockAlarm alarmClock1;
+    private VelbusClockAlarm alarmClock2;
+
+    public VelbusClockAlarmConfiguration() {
+        this.alarmClock1 = new VelbusClockAlarm();
+        this.alarmClock2 = new VelbusClockAlarm();
+    }
+
+    public VelbusClockAlarm getAlarmClock1() {
+        return alarmClock1;
+    }
+
+    public VelbusClockAlarm getAlarmClock2() {
+        return alarmClock2;
+    }
+
+    public VelbusClockAlarm getAlarmClock(int alarmNumber) {
+        if (alarmNumber == 1) {
+            return getAlarmClock1();
+        } else if (alarmNumber == 2) {
+            return getAlarmClock2();
+        } else {
+            throw new IllegalArgumentException("The alarm clock '" + alarmNumber + "' does not exist.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusFirstGenerationDeviceModuleAddress.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusFirstGenerationDeviceModuleAddress.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusFirstGenerationDeviceModuleAddress} represents the address Velbus
+ * module of the 1st generation.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusFirstGenerationDeviceModuleAddress extends VelbusModuleAddress {
+
+    public VelbusFirstGenerationDeviceModuleAddress(byte address) {
+        super(address, 0);
+    }
+
+    @Override
+    public int getChannelNumber(VelbusChannelIdentifier velbusChannelIdentifier) {
+        byte channelByte = velbusChannelIdentifier.getChannelByte();
+        if (channelByte == (byte) 0x03) {
+            return 1;
+        } else if (channelByte == (byte) 0x0C) {
+            return 2;
+        }
+
+        throw new IllegalArgumentException("The byte '" + channelByte
+                + "' does not represent a valid channel on the first generation device with address '"
+                + velbusChannelIdentifier.getAddress() + "'.");
+    }
+
+    @Override
+    public VelbusChannelIdentifier getChannelIdentifier(int channelIndex) {
+        if (channelIndex == 0) {
+            return new VelbusChannelIdentifier(getAddress(), (byte) 0x03);
+        } else if (channelIndex == 1) {
+            return new VelbusChannelIdentifier(getAddress(), (byte) 0x0C);
+        } else {
+            throw new IllegalArgumentException("The channel index '" + channelIndex
+                    + "' is not valid for the first generation device on the address '" + getAddress() + "'.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusHandlerFactory.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusHandlerFactory.java
@@ -33,10 +33,19 @@ import org.openhab.binding.velbus.internal.discovery.VelbusThingDiscoveryService
 import org.openhab.binding.velbus.internal.handler.VelbusBlindsHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusBridgeHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusDimmerHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusNetworkBridgeHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusRelayHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusSensorHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusSensorWithAlarmClockHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusSerialBridgeHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMB1TSHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMB4ANHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMB7INHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMBELHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMBELOHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusVMBGPHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusVMBGPOHandler;
+import org.openhab.binding.velbus.internal.handler.VelbusVMBMeteoHandler;
 import org.openhab.binding.velbus.internal.handler.VelbusVMBPIROHandler;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -71,7 +80,9 @@ public class VelbusHandlerFactory extends BaseThingHandlerFactory {
         ThingHandler thingHandler = null;
 
         if (BRIDGE_THING_TYPES_UIDS.contains(thingTypeUID)) {
-            VelbusBridgeHandler velbusBridgeHandler = new VelbusBridgeHandler((Bridge) thing, serialPortManager);
+            VelbusBridgeHandler velbusBridgeHandler = thingTypeUID.equals(NETWORK_BRIDGE_THING_TYPE)
+                    ? new VelbusNetworkBridgeHandler((Bridge) thing)
+                    : new VelbusSerialBridgeHandler((Bridge) thing, serialPortManager);
             registerDiscoveryService(velbusBridgeHandler);
             thingHandler = velbusBridgeHandler;
         } else if (VelbusRelayHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
@@ -82,12 +93,26 @@ public class VelbusHandlerFactory extends BaseThingHandlerFactory {
             thingHandler = new VelbusBlindsHandler(thing);
         } else if (VelbusSensorHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             thingHandler = new VelbusSensorHandler(thing);
+        } else if (VelbusSensorWithAlarmClockHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusSensorWithAlarmClockHandler(thing);
+        } else if (VelbusVMBMeteoHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMBMeteoHandler(thing);
         } else if (VelbusVMBGPHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             thingHandler = new VelbusVMBGPHandler(thing);
         } else if (VelbusVMBGPOHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             thingHandler = new VelbusVMBGPOHandler(thing);
         } else if (VelbusVMBPIROHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             thingHandler = new VelbusVMBPIROHandler(thing);
+        } else if (VelbusVMB7INHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMB7INHandler(thing);
+        } else if (VelbusVMBELHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMBELHandler(thing);
+        } else if (VelbusVMBELOHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMBELOHandler(thing);
+        } else if (VelbusVMB4ANHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMB4ANHandler(thing);
+        } else if (VelbusVMB1TSHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            thingHandler = new VelbusVMB1TSHandler(thing);
         }
 
         return thingHandler;
@@ -109,13 +134,11 @@ public class VelbusHandlerFactory extends BaseThingHandlerFactory {
 
     private synchronized void unregisterDiscoveryService(VelbusBridgeHandler bridgeHandler) {
         ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.remove(bridgeHandler.getThing().getUID());
-        if (serviceReg != null) {
-            VelbusThingDiscoveryService service = (VelbusThingDiscoveryService) bundleContext
-                    .getService(serviceReg.getReference());
-            serviceReg.unregister();
-            if (service != null) {
-                service.deactivate();
-            }
+        VelbusThingDiscoveryService service = (VelbusThingDiscoveryService) bundleContext
+                .getService(serviceReg.getReference());
+        serviceReg.unregister();
+        if (service != null) {
+            service.deactivate();
         }
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModule.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModule.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.velbus.internal.handler.VelbusBridgeHandler;
@@ -106,10 +107,12 @@ public class VelbusModule {
         return channelName;
     }
 
-    public void sendChannelNameRequests(VelbusBridgeHandler bridgeHandler) {
-        VelbusChannelNameRequestPacket channelNameRequest = new VelbusChannelNameRequestPacket(
-                velbusModuleAddress.getAddress());
-        bridgeHandler.sendPacket(channelNameRequest.getBytes());
+    public void sendChannelNameRequests(@Nullable VelbusBridgeHandler bridgeHandler) {
+        if (bridgeHandler != null) {
+            VelbusChannelNameRequestPacket channelNameRequest = new VelbusChannelNameRequestPacket(
+                    velbusModuleAddress.getAddress());
+            bridgeHandler.sendPacket(channelNameRequest.getBytes());
+        }
     }
 
     public void setChannelName(VelbusChannelIdentifier channelIdentifier, int namePartNumber, byte[] namePart) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModuleAddress.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModuleAddress.java
@@ -15,6 +15,7 @@ package org.openhab.binding.velbus.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 
 /**
@@ -22,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusModuleAddress {
     private byte address;
     private byte[] subAddresses;
@@ -73,7 +75,8 @@ public class VelbusModuleAddress {
     }
 
     public int getChannelNumber(ChannelUID channelUID) {
-        return Integer.parseInt(channelUID.getId().substring(2));
+        String id = channelUID.getId();
+        return Integer.parseInt(id.substring(id.indexOf("#") + 1).substring(2));
     }
 
     public int getChannelIndex(ChannelUID channelUID) {
@@ -82,6 +85,10 @@ public class VelbusModuleAddress {
 
     public String getChannelId(VelbusChannelIdentifier velbusChannelIdentifier) {
         return "CH" + getChannelNumber(velbusChannelIdentifier);
+    }
+
+    public int getChannelIndex(VelbusChannelIdentifier velbusChannelIdentifier) {
+        return this.getChannelNumber(velbusChannelIdentifier) - 1;
     }
 
     public int getChannelNumber(VelbusChannelIdentifier velbusChannelIdentifier) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModuleAddress.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusModuleAddress.java
@@ -75,8 +75,7 @@ public class VelbusModuleAddress {
     }
 
     public int getChannelNumber(ChannelUID channelUID) {
-        String id = channelUID.getId();
-        return Integer.parseInt(id.substring(id.indexOf("#") + 1).substring(2));
+        return Integer.parseInt(channelUID.getIdWithoutGroup().substring(2));
     }
 
     public int getChannelIndex(ChannelUID channelUID) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusPacketInputStream.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusPacketInputStream.java
@@ -15,8 +15,9 @@ package org.openhab.binding.velbus.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.velbus.internal.packets.VelbusPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,17 +28,18 @@ import org.slf4j.LoggerFactory;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusPacketInputStream {
-    private Logger logger = LoggerFactory.getLogger(VelbusPacketInputStream.class);
+    private final Logger logger = LoggerFactory.getLogger(VelbusPacketInputStream.class);
 
     public InputStream inputStream;
 
-    private Byte currentSTX = null;
-    private Byte currentPriority = null;
-    private Byte currentAddress = null;
-    private Byte currentDataLength = null;
-    private List<Byte> currentData = new ArrayList<>();
-    private Byte currentChecksum = null;
+    private ArrayList<Byte> currentData = new ArrayList<Byte>();
+    private @Nullable Byte currentSTX = null;
+    private @Nullable Byte currentPriority = null;
+    private @Nullable Byte currentAddress = null;
+    private @Nullable Byte currentDataLength = null;
+    private @Nullable Byte currentChecksum = null;
 
     public VelbusPacketInputStream(InputStream inputStream) {
         this.inputStream = inputStream;
@@ -69,7 +71,7 @@ public class VelbusPacketInputStream {
             } else if (currentDataLength == null) {
                 currentDataLength = 1;
                 currentData.add((byte) currentDataByte);
-            } else if (currentData.size() < currentDataLength) {
+            } else if (currentDataLength != null && (currentData.size() < currentDataLength)) {
                 currentData.add((byte) currentDataByte);
             } else if (currentChecksum == null) {
                 currentChecksum = (byte) currentDataByte;
@@ -93,24 +95,33 @@ public class VelbusPacketInputStream {
             }
         }
 
-        return null;
+        return new byte[0];
+    }
+
+    public void close() throws IOException {
+        inputStream.close();
     }
 
     protected byte[] getCurrentPacket() {
-        byte[] packet = new byte[6 + currentDataLength];
-        packet[0] = currentSTX;
-        packet[1] = currentPriority;
-        packet[2] = currentAddress;
-        packet[3] = currentDataLength;
+        if (currentDataLength != null && currentSTX != null && currentPriority != null && currentAddress != null
+                && currentChecksum != null) {
+            byte[] packet = new byte[6 + currentDataLength];
+            packet[0] = currentSTX;
+            packet[1] = currentPriority;
+            packet[2] = currentAddress;
+            packet[3] = currentDataLength;
 
-        for (int i = 0; i < currentDataLength; i++) {
-            packet[4 + i] = currentData.get(i);
+            for (int i = 0; i < currentDataLength; i++) {
+                packet[4 + i] = currentData.get(i);
+            }
+
+            packet[4 + currentDataLength] = currentChecksum;
+            packet[5 + currentDataLength] = VelbusPacket.ETX;
+
+            return packet;
         }
 
-        packet[4 + currentDataLength] = currentChecksum;
-        packet[5 + currentDataLength] = VelbusPacket.ETX;
-
-        return packet;
+        return new byte[0];
     }
 
     protected void resetCurrentState() {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusPacketListener.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/VelbusPacketListener.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.velbus.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link VelbusPacketListener} is notified when a Velbus packet for
  * the listener's address is sent on the bus.
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public interface VelbusPacketListener {
     /**
      * This method is called whenever the state of the given relay has changed.

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusBridgeConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusBridgeConfig} class represents the configuration of a Velbus Bridge.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusBridgeConfig {
+    public @NonNullByDefault({}) Integer timeUpdateInterval;
+    public @NonNullByDefault({}) Integer reconnectionInterval;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusBridgeConfig.java
@@ -21,6 +21,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusBridgeConfig {
-    public @NonNullByDefault({}) Integer timeUpdateInterval;
-    public @NonNullByDefault({}) Integer reconnectionInterval;
+    public int timeUpdateInterval;
+    public int reconnectionInterval;
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusDimmerConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusDimmerConfig.java
@@ -21,5 +21,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusDimmerConfig {
-    public @NonNullByDefault({}) Integer dimspeed;
+    public int dimspeed;
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusDimmerConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusDimmerConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusDimmerConfig} class represents the configuration of a Velbus dimmer.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusDimmerConfig {
+    public @NonNullByDefault({}) Integer dimspeed;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusNetworkBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusNetworkBridgeConfig.java
@@ -21,6 +21,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusNetworkBridgeConfig {
-    public @NonNullByDefault({}) String address;
-    public @NonNullByDefault({}) Integer port;
+    public String address = "";
+    public int port;
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusNetworkBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusNetworkBridgeConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusNetworkBridgeConfig} class represents the configuration of a Velbus Network Bridge.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusNetworkBridgeConfig {
+    public @NonNullByDefault({}) String address;
+    public @NonNullByDefault({}) Integer port;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSensorConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSensorConfig.java
@@ -21,5 +21,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusSensorConfig {
-    public @NonNullByDefault({}) Integer refresh;
+    public int refresh;
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSensorConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSensorConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusSensorConfig} class represents the configuration of a Velbus Temperature Sensor.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSensorConfig {
+    public @NonNullByDefault({}) Integer refresh;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSerialBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSerialBridgeConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusSerialBridgeConfig} class represents the configuration of a Velbus Serial Bridge.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSerialBridgeConfig {
+    public @NonNullByDefault({}) String port;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSerialBridgeConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusSerialBridgeConfig.java
@@ -21,5 +21,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusSerialBridgeConfig {
-    public @NonNullByDefault({}) String port;
+    public String port = "";
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusThingConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusThingConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusThingConfig} class represents the configuration of a Velbus thing.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusThingConfig {
+    public @NonNullByDefault({}) String address;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusThingConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusThingConfig.java
@@ -21,5 +21,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusThingConfig {
-    public @NonNullByDefault({}) String address;
+    public String address = "";
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusVMB7INConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusVMB7INConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusVMB7INConfig} class represents the configuration of a Velbus VMB7IN module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusVMB7INConfig extends VelbusSensorConfig {
+    public @NonNullByDefault({}) Double counter1PulseMultiplier;
+    public @NonNullByDefault({}) Double counter2PulseMultiplier;
+    public @NonNullByDefault({}) Double counter3PulseMultiplier;
+    public @NonNullByDefault({}) Double counter4PulseMultiplier;
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusVMB7INConfig.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/config/VelbusVMB7INConfig.java
@@ -21,8 +21,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class VelbusVMB7INConfig extends VelbusSensorConfig {
-    public @NonNullByDefault({}) Double counter1PulseMultiplier;
-    public @NonNullByDefault({}) Double counter2PulseMultiplier;
-    public @NonNullByDefault({}) Double counter3PulseMultiplier;
-    public @NonNullByDefault({}) Double counter4PulseMultiplier;
+    public double counter1PulseMultiplier;
+    public double counter2PulseMultiplier;
+    public double counter3PulseMultiplier;
+    public double counter4PulseMultiplier;
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
@@ -19,11 +19,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.VelbusFirstGenerationDeviceModuleAddress;
 import org.openhab.binding.velbus.internal.VelbusModule;
 import org.openhab.binding.velbus.internal.VelbusModuleAddress;
 import org.openhab.binding.velbus.internal.VelbusPacketListener;
@@ -40,6 +42,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusThingDiscoveryService extends AbstractDiscoveryService implements VelbusPacketListener {
     private static final int SEARCH_TIME = 60;
 
@@ -61,7 +64,7 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
     @Override
     public void deactivate() {
         removeOlderResults(new Date().getTime());
-        velbusBridgeHandler.setDefaultPacketListener(null);
+        velbusBridgeHandler.clearDefaultPacketListener();
     }
 
     @Override
@@ -107,6 +110,11 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
 
         VelbusModule velbusModule = null;
         switch (moduleType) {
+            case MODULE_TYPE_VMB1BL:
+                velbusModule = new VelbusModule(new VelbusFirstGenerationDeviceModuleAddress(address), moduleType,
+                        highByteOfSerialNumber, lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek,
+                        THING_TYPE_VMB1BL, 1);
+                break;
             case MODULE_TYPE_VMB1BLS:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1BLS, 1);
@@ -131,6 +139,15 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1RYNOS, 5);
                 break;
+            case MODULE_TYPE_VMB1TS:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1TS, 1);
+                break;
+            case MODULE_TYPE_VMB2BL:
+                velbusModule = new VelbusModule(new VelbusFirstGenerationDeviceModuleAddress(address), moduleType,
+                        highByteOfSerialNumber, lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek,
+                        THING_TYPE_VMB2BL, 2);
+                break;
             case MODULE_TYPE_VMB2BLE:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB2BLE, 2);
@@ -138,6 +155,10 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
             case MODULE_TYPE_VMB2PBN:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB2PBN, 8);
+                break;
+            case MODULE_TYPE_VMB4AN:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB4AN, 4);
                 break;
             case MODULE_TYPE_VMB4DC:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
@@ -191,21 +212,53 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBDMIR, 1);
                 break;
+            case MODULE_TYPE_VMBEL1:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBEL1, 9);
+                break;
+            case MODULE_TYPE_VMBEL2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBEL2, 9);
+                break;
+            case MODULE_TYPE_VMBEL4:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBEL4, 9);
+                break;
+            case MODULE_TYPE_VMBELO:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBELO, 33);
+                break;
             case MODULE_TYPE_VMBGP1:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP1, 9);
+                break;
+            case MODULE_TYPE_VMBGP1_2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP1_2, 9);
                 break;
             case MODULE_TYPE_VMBGP2:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP2, 9);
                 break;
+            case MODULE_TYPE_VMBGP2_2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP2_2, 9);
+                break;
             case MODULE_TYPE_VMBGP4:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP4, 9);
                 break;
+            case MODULE_TYPE_VMBGP4_2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP4_2, 9);
+                break;
             case MODULE_TYPE_VMBGP4PIR:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP4PIR, 9);
+                break;
+            case MODULE_TYPE_VMBGP4PIR_2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGP4PIR_2, 9);
                 break;
             case MODULE_TYPE_VMBGPO:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
@@ -214,6 +267,14 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
             case MODULE_TYPE_VMBGPOD:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGPOD, 33);
+                break;
+            case MODULE_TYPE_VMBGPOD_2:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 4), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBGPOD_2, 33);
+                break;
+            case MODULE_TYPE_VMBMETEO:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBMETEO, 13);
                 break;
             case MODULE_TYPE_VMBPIRC:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
@@ -227,6 +288,10 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBPIRO, 9);
                 break;
+            case MODULE_TYPE_VMBRFR8S:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMBRFR8S, 8);
+                break;
         }
 
         if (velbusModule != null) {
@@ -235,9 +300,9 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
     }
 
     private void handleModuleSubtypeCommand(byte[] packet, byte address) {
-        VelbusModule velbusModule = velbusModules.get(address);
+        if (velbusModules.containsKey(address)) {
+            VelbusModule velbusModule = velbusModules.get(address);
 
-        if (velbusModule != null) {
             byte[] subAddresses = new byte[4];
             System.arraycopy(packet, 8, subAddresses, 0, 4);
 
@@ -261,9 +326,9 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
     }
 
     private void handleChannelNameCommand(byte[] packet, byte address, byte length, int namePartNumber) {
-        VelbusModule velbusModule = velbusModules.get(address);
+        if (velbusModules.containsKey(address)) {
+            VelbusModule velbusModule = velbusModules.get(address);
 
-        if (velbusModule != null) {
             byte channel = packet[5];
             byte[] namePart = Arrays.copyOfRange(packet, 6, 6 + length - 2);
 
@@ -278,8 +343,7 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
 
         DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(velbusModule.getThingUID(bridgeUID))
                 .withThingType(velbusModule.getThingTypeUID()).withProperties(velbusModule.getProperties())
-                .withRepresentationProperty(MODULE_ADDRESS).withBridge(bridgeUID).withLabel(velbusModule.getLabel())
-                .build();
+                .withRepresentationProperty(ADDRESS).withBridge(bridgeUID).withLabel(velbusModule.getLabel()).build();
 
         thingDiscovered(discoveryResult);
     }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/discovery/VelbusThingDiscoveryService.java
@@ -139,6 +139,10 @@ public class VelbusThingDiscoveryService extends AbstractDiscoveryService implem
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1RYNOS, 5);
                 break;
+            case MODULE_TYPE_VMB1RYS:
+                velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
+                        lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1RYS, 5);
+                break;
             case MODULE_TYPE_VMB1TS:
                 velbusModule = new VelbusModule(new VelbusModuleAddress(address, 0), moduleType, highByteOfSerialNumber,
                         lowByteOfSerialNumber, memoryMapVersion, buildYear, buildWeek, THING_TYPE_VMB1TS, 1);

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBlindsHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBlindsHandler.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
@@ -29,6 +30,8 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.VelbusFirstGenerationDeviceModuleAddress;
+import org.openhab.binding.velbus.internal.VelbusModuleAddress;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindOffPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindPositionPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindUpDownPacket;
@@ -41,12 +44,13 @@ import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusBlindsHandler extends VelbusThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMB1BLS, THING_TYPE_VMB2BLE));
+            Arrays.asList(THING_TYPE_VMB1BL, THING_TYPE_VMB1BLS, THING_TYPE_VMB2BL, THING_TYPE_VMB2BLE));
 
     public VelbusBlindsHandler(Thing thing) {
-        super(thing, 0, "Rollershutter");
+        super(thing, 0);
     }
 
     @Override
@@ -100,6 +104,22 @@ public class VelbusBlindsHandler extends VelbusThingHandler {
         } else {
             logger.debug("The command '{}' is not supported by this handler.", command.getClass());
         }
+    }
+
+    @Override
+    protected VelbusModuleAddress createVelbusModuleAddress(Thing thing, int numberOfSubAddresses) {
+        byte address = hexToByte((String) getConfig().get(ADDRESS));
+
+        if (isFirstGenerationDevice()) {
+            return new VelbusFirstGenerationDeviceModuleAddress(address);
+        }
+
+        return new VelbusModuleAddress(address, numberOfSubAddresses);
+    }
+
+    private Boolean isFirstGenerationDevice() {
+        ThingTypeUID thingTypeUID = this.getThing().getThingTypeUID();
+        return thingTypeUID.equals(THING_TYPE_VMB1BL) || thingTypeUID.equals(THING_TYPE_VMB2BL);
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBlindsHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBlindsHandler.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
@@ -32,6 +33,7 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 import org.openhab.binding.velbus.internal.VelbusFirstGenerationDeviceModuleAddress;
 import org.openhab.binding.velbus.internal.VelbusModuleAddress;
+import org.openhab.binding.velbus.internal.config.VelbusThingConfig;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindOffPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindPositionPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusBlindUpDownPacket;
@@ -107,14 +109,19 @@ public class VelbusBlindsHandler extends VelbusThingHandler {
     }
 
     @Override
-    protected VelbusModuleAddress createVelbusModuleAddress(Thing thing, int numberOfSubAddresses) {
-        byte address = hexToByte((String) getConfig().get(ADDRESS));
+    protected @Nullable VelbusModuleAddress createVelbusModuleAddress(int numberOfSubAddresses) {
+        final VelbusThingConfig velbusThingConfig = this.velbusThingConfig;
+        if (velbusThingConfig != null) {
+            byte address = hexToByte(velbusThingConfig.address);
 
-        if (isFirstGenerationDevice()) {
-            return new VelbusFirstGenerationDeviceModuleAddress(address);
+            if (isFirstGenerationDevice()) {
+                return new VelbusFirstGenerationDeviceModuleAddress(address);
+            }
+
+            return new VelbusModuleAddress(address, numberOfSubAddresses);
         }
 
-        return new VelbusModuleAddress(address, numberOfSubAddresses);
+        return null;
     }
 
     private Boolean isFirstGenerationDevice() {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBridgeHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBridgeHandler.java
@@ -12,101 +12,134 @@
  */
 package org.openhab.binding.velbus.internal.handler;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.PORT;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TooManyListenersException;
+import java.util.TimeZone;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.io.transport.serial.PortInUseException;
-import org.eclipse.smarthome.io.transport.serial.SerialPort;
-import org.eclipse.smarthome.io.transport.serial.SerialPortEvent;
-import org.eclipse.smarthome.io.transport.serial.SerialPortEventListener;
-import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
-import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
-import org.eclipse.smarthome.io.transport.serial.UnsupportedCommOperationException;
 import org.openhab.binding.velbus.internal.VelbusPacketInputStream;
 import org.openhab.binding.velbus.internal.VelbusPacketListener;
+import org.openhab.binding.velbus.internal.packets.VelbusSetDatePacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSetDaylightSavingsStatusPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSetRealtimeClockPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link VelbusBridgeHandler} is the handler for a Velbus Serial-interface and connects it to
+ * {@link VelbusBridgeHandler} is an abstract handler for a Velbus interface and connects it to
  * the framework.
  *
  * @author Cedric Boon - Initial contribution
  */
-public class VelbusBridgeHandler extends BaseBridgeHandler implements SerialPortEventListener {
+@NonNullByDefault
+public abstract class VelbusBridgeHandler extends BaseBridgeHandler {
+    private final Logger logger = LoggerFactory.getLogger(VelbusBridgeHandler.class);
 
-    private Logger logger = LoggerFactory.getLogger(VelbusBridgeHandler.class);
-
-    private static final int BAUD = 9600;
-    private SerialPort serialPort;
-    private final SerialPortManager serialPortManager;
-    private OutputStream outputStream;
-    private VelbusPacketInputStream inputStream;
     private long lastPacketTimeMillis;
 
-    private VelbusPacketListener defaultPacketListener;
-    private final Map<Byte, VelbusPacketListener> packetListeners = new HashMap<>();
+    protected @Nullable VelbusPacketListener defaultPacketListener;
+    protected Map<Byte, VelbusPacketListener> packetListeners = new HashMap<Byte, VelbusPacketListener>();
 
-    public VelbusBridgeHandler(Bridge velbusBridge, SerialPortManager serialPortManager) {
+    private @Nullable ScheduledFuture<?> timeUpdateJob;
+    private @Nullable ScheduledFuture<?> reconnectionHandler;
+
+    private @NonNullByDefault({}) OutputStream outputStream;
+    private @NonNullByDefault({}) VelbusPacketInputStream inputStream;
+
+    private boolean listenerStopped;
+
+    public VelbusBridgeHandler(Bridge velbusBridge) {
         super(velbusBridge);
-        this.serialPortManager = serialPortManager;
-    }
-
-    @Override
-    public void handleCommand(ChannelUID channelUID, Command command) {
-        // There is nothing to handle in the bridge handler
     }
 
     @Override
     public void initialize() {
         logger.debug("Initializing velbus bridge handler.");
 
-        String port = (String) getConfig().get(PORT);
-        if (port == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Serial port name not configured");
-            return;
+        connect();
+        initializeTimeUpdate();
+    }
+
+    private void initializeTimeUpdate() {
+        Object timeUpdateIntervalObject = getConfig().get(TIME_UPDATE_INTERVAL);
+        if (timeUpdateIntervalObject != null) {
+            int timeUpdateInterval = ((BigDecimal) timeUpdateIntervalObject).intValue();
+
+            if (timeUpdateInterval > 0) {
+                startTimeUpdates(timeUpdateInterval);
+            }
         }
+    }
 
-        SerialPortIdentifier serialPortIdentifier = serialPortManager.getIdentifier(port);
-        if (serialPortIdentifier == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Serial port not found: " + port);
-            return;
+    private void startTimeUpdates(int timeUpdatesInterval) {
+        timeUpdateJob = scheduler.scheduleWithFixedDelay(() -> {
+            updateDateTime();
+        }, 0, timeUpdatesInterval, TimeUnit.MINUTES);
+    }
+
+    private void updateDateTime() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.now(), TimeZone.getDefault().toZoneId());
+
+        updateDate(zonedDateTime);
+        updateTime(zonedDateTime);
+        updateDaylightSavingsStatus(zonedDateTime);
+    }
+
+    private void updateTime(ZonedDateTime zonedDateTime) {
+        VelbusSetRealtimeClockPacket packet = new VelbusSetRealtimeClockPacket((byte) 0x00, zonedDateTime);
+
+        byte[] packetBytes = packet.getBytes();
+        this.sendPacket(packetBytes);
+    }
+
+    private void updateDate(ZonedDateTime zonedDateTime) {
+        VelbusSetDatePacket packet = new VelbusSetDatePacket((byte) 0x00, zonedDateTime);
+
+        byte[] packetBytes = packet.getBytes();
+        this.sendPacket(packetBytes);
+    }
+
+    private void updateDaylightSavingsStatus(ZonedDateTime zonedDateTime) {
+        VelbusSetDaylightSavingsStatusPacket packet = new VelbusSetDaylightSavingsStatusPacket((byte) 0x00,
+                zonedDateTime);
+
+        byte[] packetBytes = packet.getBytes();
+        this.sendPacket(packetBytes);
+    }
+
+    protected void initializeStreams(OutputStream outputStream, InputStream inputStream) {
+        this.outputStream = outputStream;
+        this.inputStream = new VelbusPacketInputStream(inputStream);
+    }
+
+    @Override
+    public void dispose() {
+        if (timeUpdateJob != null) {
+            timeUpdateJob.cancel(true);
         }
+        disconnect();
+    }
 
-        try {
-            serialPort = serialPortIdentifier.open(VelbusBridgeHandler.class.getCanonicalName(), 2000);
-            serialPort.setSerialPortParams(BAUD, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-
-            inputStream = new VelbusPacketInputStream(serialPort.getInputStream());
-            outputStream = serialPort.getOutputStream();
-
-            serialPort.addEventListener(this);
-            serialPort.notifyOnDataAvailable(true);
-
-            updateStatus(ThingStatus.ONLINE);
-        } catch (IOException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Error: " + e.getMessage());
-        } catch (PortInUseException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Port already used: " + port);
-        } catch (TooManyListenersException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Failed to register event listener on serial port: " + port);
-        } catch (UnsupportedCommOperationException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Unsupported operation on port '" + port + "': " + e.getMessage());
-        }
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // There is nothing to handle in the bridge handler
     }
 
     public synchronized void sendPacket(byte[] packet) {
@@ -124,61 +157,125 @@ public class VelbusBridgeHandler extends BaseBridgeHandler implements SerialPort
             return;
         }
 
+        writePacket(packet);
+
+        lastPacketTimeMillis = System.currentTimeMillis();
+    }
+
+    private void readPacket(byte[] packet) {
+        byte address = packet[2];
+
+        if (packetListeners.containsKey(address)) {
+            VelbusPacketListener packetListener = packetListeners.get(address);
+            packetListener.onPacketReceived(packet);
+        } else if (defaultPacketListener != null) {
+            defaultPacketListener.onPacketReceived(packet);
+        }
+    }
+
+    protected void readPackets() {
+        if (inputStream == null) {
+            onConnectionLost();
+            return;
+        }
+
+        byte[] packet;
+
+        listenerStopped = false;
+
+        try {
+            while (!listenerStopped & ((packet = inputStream.readPacket()).length > 0)) {
+                readPacket(packet);
+            }
+        } catch (IOException e) {
+            if (!listenerStopped) {
+                onConnectionLost();
+            }
+        }
+    }
+
+    private void writePacket(byte[] packet) {
+        if (outputStream == null) {
+            onConnectionLost();
+            return;
+        }
+
         try {
             outputStream.write(packet);
             outputStream.flush();
         } catch (IOException e) {
-            logger.error("Serial port write error", e);
+            onConnectionLost();
+        }
+    }
+
+    protected void onConnectionLost() {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                "A network communication error occurred.");
+        disconnect();
+        startReconnectionHandler();
+    }
+
+    protected abstract void connect();
+
+    protected void disconnect() {
+        listenerStopped = true;
+
+        try {
+            if (outputStream != null) {
+                outputStream.close();
+            }
+        } catch (IOException e) {
+            logger.error("Error while closing output stream", e);
         }
 
-        lastPacketTimeMillis = System.currentTimeMillis();
+        try {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        } catch (IOException e) {
+            logger.error("Error while closing input stream", e);
+        }
+    }
+
+    public void startReconnectionHandler() {
+        if (reconnectionHandler == null || reconnectionHandler.isCancelled()) {
+            Object reconnectionIntervalObject = getConfig().get(RECONNECTION_INTERVAL);
+            if (reconnectionIntervalObject != null) {
+                long reconnectionInterval = ((BigDecimal) reconnectionIntervalObject).longValue();
+
+                if (reconnectionInterval > 0) {
+                    reconnectionHandler = scheduler.scheduleWithFixedDelay(new Runnable() {
+
+                        @Override
+                        public void run() {
+                            try {
+                                connect();
+                                if (reconnectionHandler != null) {
+                                    reconnectionHandler.cancel(false);
+                                }
+                            } catch (Exception e) {
+                                logger.error("Reconnection failed", e);
+                            }
+                        }
+                    }, reconnectionInterval, reconnectionInterval, TimeUnit.SECONDS);
+                }
+            }
+        }
     }
 
     public void setDefaultPacketListener(VelbusPacketListener velbusPacketListener) {
         defaultPacketListener = velbusPacketListener;
     }
 
-    public void registerPacketListener(byte address, VelbusPacketListener packetListener) {
-        if (packetListener == null) {
-            throw new IllegalArgumentException("It's not allowed to pass a null RelayStatusListener.");
-        }
+    public void clearDefaultPacketListener() {
+        defaultPacketListener = null;
+    }
 
+    public void registerPacketListener(byte address, VelbusPacketListener packetListener) {
         packetListeners.put(Byte.valueOf(address), packetListener);
     }
 
-    public void unregisterRelayStatusListener(byte address, VelbusPacketListener packetListener) {
+    public void unregisterRelayStatusListener(byte address) {
         packetListeners.remove(Byte.valueOf(address));
-    }
-
-    @Override
-    public void dispose() {
-        if (serialPort != null) {
-            serialPort.removeEventListener();
-            serialPort.close();
-            serialPort = null;
-        }
-    }
-
-    @Override
-    public void serialEvent(SerialPortEvent event) {
-        logger.debug("Serial port event triggered");
-
-        if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
-            try {
-                byte[] packet;
-                while ((packet = inputStream.readPacket()) != null) {
-                    byte address = packet[2];
-
-                    VelbusPacketListener packetListener = packetListeners.get(address);
-                    if (packetListener != null) {
-                        packetListener.onPacketReceived(packet);
-                    } else if (defaultPacketListener != null) {
-                        defaultPacketListener.onPacketReceived(packet);
-                    }
-                }
-            } catch (IOException e) {
-                logger.error("Serial port read error", e);
-            }
-        }
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusDimmerHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusDimmerHandler.java
@@ -14,10 +14,12 @@ package org.openhab.binding.velbus.internal.handler;
 
 import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -38,12 +40,25 @@ import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusDimmerHandler extends VelbusThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1DM,
             THING_TYPE_VMB1LED, THING_TYPE_VMB4DC, THING_TYPE_VMBDME, THING_TYPE_VMBDMI, THING_TYPE_VMBDMIR));
 
+    private int dimSpeed = 0;
+
     public VelbusDimmerHandler(Thing thing) {
-        super(thing, 0, "Dimmer");
+        super(thing, 0);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        Object dimspeedObject = getConfig().get(DIMSPEED);
+        if (dimspeedObject != null) {
+            this.dimSpeed = ((BigDecimal) dimspeedObject).intValue();
+        }
     }
 
     @Override
@@ -61,10 +76,10 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
             byte[] packetBytes = packet.getBytes();
             velbusBridgeHandler.sendPacket(packetBytes);
         } else if (command instanceof PercentType) {
-            byte commandByte = COMMAND_SET_DIMVALUE;
+            byte commandByte = COMMAND_SET_VALUE;
 
             VelbusDimmerPacket packet = new VelbusDimmerPacket(getModuleAddress().getChannelIdentifier(channelUID),
-                    commandByte, ((PercentType) command).byteValue());
+                    commandByte, ((PercentType) command).byteValue(), this.dimSpeed, isFirstGenerationDevice());
 
             byte[] packetBytes = packet.getBytes();
             velbusBridgeHandler.sendPacket(packetBytes);
@@ -72,7 +87,7 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
             byte commandByte = determineCommandByte((OnOffType) command);
 
             VelbusDimmerPacket packet = new VelbusDimmerPacket(getModuleAddress().getChannelIdentifier(channelUID),
-                    commandByte, (byte) 0x00);
+                    commandByte, (byte) 0x00, this.dimSpeed, isFirstGenerationDevice());
 
             byte[] packetBytes = packet.getBytes();
             velbusBridgeHandler.sendPacket(packetBytes);
@@ -82,7 +97,13 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
     }
 
     private byte determineCommandByte(OnOffType command) {
-        return (command == OnOffType.ON) ? COMMAND_RESTORE_LAST_DIMVALUE : COMMAND_SET_DIMVALUE;
+        return (command == OnOffType.ON) ? COMMAND_RESTORE_LAST_DIMVALUE : COMMAND_SET_VALUE;
+    }
+
+    private Boolean isFirstGenerationDevice() {
+        ThingTypeUID thingTypeUID = this.getThing().getThingTypeUID();
+        return thingTypeUID.equals(THING_TYPE_VMB1DM) || thingTypeUID.equals(THING_TYPE_VMB1LED)
+                || thingTypeUID.equals(THING_TYPE_VMBDME);
     }
 
     @Override
@@ -90,16 +111,21 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
         logger.trace("onPacketReceived() was called");
 
         if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte address = packet[2];
             byte command = packet[4];
 
-            if ((command == COMMAND_DIMMERCONTROLLER_STATUS || command == COMMAND_DIMMER_STATUS)
-                    && packet.length >= 7) {
-                byte address = packet[2];
+            if ((command == COMMAND_DIMMERCONTROLLER_STATUS) && packet.length >= 8) {
                 byte channel = packet[5];
-                byte dimvalue = packet[7];
+                byte dimValue = packet[7];
 
                 VelbusChannelIdentifier velbusChannelIdentifier = new VelbusChannelIdentifier(address, channel);
-                PercentType state = new PercentType(dimvalue);
+                PercentType state = new PercentType(dimValue);
+                updateState(getModuleAddress().getChannelId(velbusChannelIdentifier), state);
+            } else if ((command == COMMAND_DIMMER_STATUS) && packet.length >= 7) {
+                byte dimValue = packet[6];
+
+                VelbusChannelIdentifier velbusChannelIdentifier = new VelbusChannelIdentifier(address, (byte) 0x01);
+                PercentType state = new PercentType(dimValue);
                 updateState(getModuleAddress().getChannelId(velbusChannelIdentifier), state);
             }
         }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusDimmerHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusDimmerHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.velbus.internal.handler;
 
 import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -30,6 +29,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.config.VelbusDimmerConfig;
 import org.openhab.binding.velbus.internal.packets.VelbusDimmerPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
@@ -45,7 +45,7 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1DM,
             THING_TYPE_VMB1LED, THING_TYPE_VMB4DC, THING_TYPE_VMBDME, THING_TYPE_VMBDMI, THING_TYPE_VMBDMIR));
 
-    private int dimSpeed = 0;
+    private @NonNullByDefault({}) VelbusDimmerConfig dimmerConfig;
 
     public VelbusDimmerHandler(Thing thing) {
         super(thing, 0);
@@ -53,12 +53,9 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
 
     @Override
     public void initialize() {
-        super.initialize();
+        this.dimmerConfig = getConfigAs(VelbusDimmerConfig.class);
 
-        Object dimspeedObject = getConfig().get(DIMSPEED);
-        if (dimspeedObject != null) {
-            this.dimSpeed = ((BigDecimal) dimspeedObject).intValue();
-        }
+        super.initialize();
     }
 
     @Override
@@ -79,7 +76,8 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
             byte commandByte = COMMAND_SET_VALUE;
 
             VelbusDimmerPacket packet = new VelbusDimmerPacket(getModuleAddress().getChannelIdentifier(channelUID),
-                    commandByte, ((PercentType) command).byteValue(), this.dimSpeed, isFirstGenerationDevice());
+                    commandByte, ((PercentType) command).byteValue(), this.dimmerConfig.dimspeed,
+                    isFirstGenerationDevice());
 
             byte[] packetBytes = packet.getBytes();
             velbusBridgeHandler.sendPacket(packetBytes);
@@ -87,7 +85,7 @@ public class VelbusDimmerHandler extends VelbusThingHandler {
             byte commandByte = determineCommandByte((OnOffType) command);
 
             VelbusDimmerPacket packet = new VelbusDimmerPacket(getModuleAddress().getChannelIdentifier(channelUID),
-                    commandByte, (byte) 0x00, this.dimSpeed, isFirstGenerationDevice());
+                    commandByte, (byte) 0x00, this.dimmerConfig.dimspeed, isFirstGenerationDevice());
 
             byte[] packetBytes = packet.getBytes();
             velbusBridgeHandler.sendPacket(packetBytes);

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusMemoHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusMemoHandler.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.velbus.internal.packets.VelbusMemoTextPacket;
+
+/**
+ * The {@link VelbusMemoHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public abstract class VelbusMemoHandler extends VelbusThermostatHandler {
+    public static final int MEMO_TEXT_MAX_LENGTH = 63;
+
+    private final ChannelUID memoChannel = new ChannelUID(thing.getUID(), "oledDisplay#MEMO");
+
+    public VelbusMemoHandler(Thing thing) {
+        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH33"));
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (channelUID.equals(memoChannel) && command instanceof StringType) {
+            String memoText = ((StringType) command).toFullString();
+            String trucatedMemoText = memoText.substring(0, Math.min(memoText.length(), MEMO_TEXT_MAX_LENGTH));
+            String[] splittedMemoText = trucatedMemoText.split("(?<=\\G.....)");
+
+            for (int i = 0; i < splittedMemoText.length; i++) {
+                VelbusMemoTextPacket packet = new VelbusMemoTextPacket(getModuleAddress().getAddress(), (byte) (i * 5),
+                        splittedMemoText[i].toCharArray());
+
+                byte[] packetBytes = packet.getBytes();
+                velbusBridgeHandler.sendPacket(packetBytes);
+
+                // The last character must be zero
+                if ((((i * 5) + 5) >= trucatedMemoText.length()) && (splittedMemoText[i].length() == 5)) {
+                    packet = new VelbusMemoTextPacket(getModuleAddress().getAddress(), (byte) ((i + 1) * 5),
+                            new char[0]);
+
+                    packetBytes = packet.getBytes();
+                    velbusBridgeHandler.sendPacket(packetBytes);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusMemoHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusMemoHandler.java
@@ -31,10 +31,10 @@ import org.openhab.binding.velbus.internal.packets.VelbusMemoTextPacket;
 public abstract class VelbusMemoHandler extends VelbusThermostatHandler {
     public static final int MEMO_TEXT_MAX_LENGTH = 63;
 
-    private final ChannelUID memoChannel = new ChannelUID(thing.getUID(), "oledDisplay#MEMO");
+    private final ChannelUID memoChannel = new ChannelUID(thing.getUID(), "oledDisplay", "MEMO");
 
     public VelbusMemoHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH33"));
+        super(thing, 4, new ChannelUID(thing.getUID(), "input", "CH33"));
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusNetworkBridgeHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusNetworkBridgeHandler.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.Socket;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link VelbusNetworkBridgeHandler} is the handler for a Velbus network interface and connects it to
+ * the framework.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusNetworkBridgeHandler extends VelbusBridgeHandler {
+    private final Logger logger = LoggerFactory.getLogger(VelbusNetworkBridgeHandler.class);
+
+    private @Nullable Socket socket;
+
+    public VelbusNetworkBridgeHandler(Bridge velbusBridge) {
+        super(velbusBridge);
+    }
+
+    /**
+     * Runnable that handles inbound communication from Velbus network interface.
+     * <p>
+     * The thread listens to the TCP socket opened at initialization of the {@link VelbusNetworkBridgeHandler} class
+     * and interprets all inbound velbus packets.
+     */
+    private Runnable networkEvents = () -> {
+        readPackets();
+    };
+
+    @Override
+    protected void connect() {
+        String address = (String) getConfig().get(ADDRESS);
+        BigDecimal port = (BigDecimal) getConfig().get(PORT);
+
+        if (address != null && port != null) {
+            int portInt = port.intValue();
+            try {
+                Socket socket = new Socket(address, portInt);
+                this.socket = socket;
+
+                initializeStreams(socket.getOutputStream(), socket.getInputStream());
+
+                updateStatus(ThingStatus.ONLINE);
+                logger.debug("Bridge online on network address {}:{}", address, portInt);
+            } catch (IOException ex) {
+                onConnectionLost();
+                logger.debug("Failed to connect to network address {}:{}", address, port);
+            }
+
+            // Start Velbus packet listener. This listener will act on all packets coming from
+            // IP-interface.
+            (new Thread(networkEvents)).start();
+        } else {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Network address or port not configured");
+            logger.debug("Network address or port not configured");
+        }
+    }
+
+    @Override
+    protected void disconnect() {
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                logger.error("Error while closing socket", e);
+            }
+            socket = null;
+        }
+
+        super.disconnect();
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusRelayHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusRelayHandler.java
@@ -40,8 +40,9 @@ import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
  */
 @NonNullByDefault
 public class VelbusRelayHandler extends VelbusThingHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1RY,
-            THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
+            Arrays.asList(THING_TYPE_VMB1RY, THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB1RYS,
+                    THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO));
 
     public VelbusRelayHandler(Thing thing) {
         super(thing, 0);

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusRelayHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusRelayHandler.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -37,12 +38,13 @@ import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusRelayHandler extends VelbusThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1RY,
             THING_TYPE_VMB1RYNO, THING_TYPE_VMB1RYNOS, THING_TYPE_VMB4RY, THING_TYPE_VMB4RYLD, THING_TYPE_VMB4RYNO));
 
     public VelbusRelayHandler(Thing thing) {
-        super(thing, 0, "Switch");
+        super(thing, 0);
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorHandler.java
@@ -18,12 +18,17 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.packets.VelbusFeedbackLEDPacket;
 import org.openhab.binding.velbus.internal.packets.VelbusPacket;
 
 /**
@@ -32,21 +37,62 @@ import org.openhab.binding.velbus.internal.packets.VelbusPacket;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusSensorHandler extends VelbusThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMB2PBN, THING_TYPE_VMB6IN, THING_TYPE_VMB6PBN, THING_TYPE_VMB7IN,
-                    THING_TYPE_VMB8IR, THING_TYPE_VMB8PB, THING_TYPE_VMB8PBU, THING_TYPE_VMBPIRC, THING_TYPE_VMBPIRM));
+            Arrays.asList(THING_TYPE_VMB6IN, THING_TYPE_VMB8IR, THING_TYPE_VMB8PB));
+
+    private static final StringType SET_LED = new StringType("SET_LED");
+    private static final StringType SLOW_BLINK_LED = new StringType("SLOW_BLINK_LED");
+    private static final StringType FAST_BLINK_LED = new StringType("FAST_BLINK_LED");
+    private static final StringType VERY_FAST_BLINK_LED = new StringType("VERY_FAST_BLINK_LED");
+    private static final StringType CLEAR_LED = new StringType("CLEAR_LED");
 
     public VelbusSensorHandler(Thing thing) {
         this(thing, 0);
     }
 
     public VelbusSensorHandler(Thing thing, int numberOfSubAddresses) {
-        super(thing, numberOfSubAddresses, null);
+        super(thing, numberOfSubAddresses);
     }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (isFeedbackChannel(channelUID) && command instanceof StringType) {
+            byte commandByte;
+
+            StringType stringTypeCommand = (StringType) command;
+            if (stringTypeCommand.equals(SET_LED)) {
+                commandByte = COMMAND_SET_LED;
+            } else if (stringTypeCommand.equals(SLOW_BLINK_LED)) {
+                commandByte = COMMAND_SLOW_BLINK_LED;
+            } else if (stringTypeCommand.equals(FAST_BLINK_LED)) {
+                commandByte = COMMAND_FAST_BLINK_LED;
+            } else if (stringTypeCommand.equals(VERY_FAST_BLINK_LED)) {
+                commandByte = COMMAND_VERY_FAST_BLINK_LED;
+            } else if (stringTypeCommand.equals(CLEAR_LED)) {
+                commandByte = COMMAND_CLEAR_LED;
+            } else {
+                throw new UnsupportedOperationException(
+                        "The command '" + command + "' is not supported on channel '" + channelUID + "'.");
+            }
+
+            VelbusFeedbackLEDPacket packet = new VelbusFeedbackLEDPacket(
+                    getModuleAddress().getChannelIdentifier(channelUID), commandByte);
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        }
+    }
+
+    private boolean isFeedbackChannel(ChannelUID channelUID) {
+        return channelUID.getId().startsWith("feedback#");
     }
 
     @Override
@@ -62,7 +108,7 @@ public class VelbusSensorHandler extends VelbusThingHandler {
                 if (channelJustPressed != 0) {
                     VelbusChannelIdentifier velbusChannelIdentifier = new VelbusChannelIdentifier(address,
                             channelJustPressed);
-                    triggerChannel(getModuleAddress().getChannelId(velbusChannelIdentifier),
+                    triggerChannel("input#" + getModuleAddress().getChannelId(velbusChannelIdentifier),
                             CommonTriggerEvents.PRESSED);
                 }
 
@@ -70,7 +116,7 @@ public class VelbusSensorHandler extends VelbusThingHandler {
                 if (channelJustReleased != 0) {
                     VelbusChannelIdentifier velbusChannelIdentifier = new VelbusChannelIdentifier(address,
                             channelJustReleased);
-                    triggerChannel(getModuleAddress().getChannelId(velbusChannelIdentifier),
+                    triggerChannel("input#" + getModuleAddress().getChannelId(velbusChannelIdentifier),
                             CommonTriggerEvents.RELEASED);
                 }
 
@@ -78,7 +124,7 @@ public class VelbusSensorHandler extends VelbusThingHandler {
                 if (channelLongPressed != 0) {
                     VelbusChannelIdentifier velbusChannelIdentifier = new VelbusChannelIdentifier(address,
                             channelLongPressed);
-                    triggerChannel(getModuleAddress().getChannelId(velbusChannelIdentifier),
+                    triggerChannel("input#" + getModuleAddress().getChannelId(velbusChannelIdentifier),
                             CommonTriggerEvents.LONG_PRESSED);
                 }
             }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorHandler.java
@@ -92,7 +92,7 @@ public class VelbusSensorHandler extends VelbusThingHandler {
     }
 
     private boolean isFeedbackChannel(ChannelUID channelUID) {
-        return channelUID.getId().startsWith("feedback#");
+        return "feedback".equals(channelUID.getGroupId());
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorWithAlarmClockHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorWithAlarmClockHandler.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.VelbusClockAlarm;
+import org.openhab.binding.velbus.internal.VelbusClockAlarmConfiguration;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSetLocalClockAlarmPacket;
+
+/**
+ * The {@link VelbusSensorWithAlarmClockHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSensorWithAlarmClockHandler extends VelbusSensorHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB2PBN,
+            THING_TYPE_VMB6PBN, THING_TYPE_VMB8PBU, THING_TYPE_VMBPIRC, THING_TYPE_VMBPIRM, THING_TYPE_VMBRFR8S));
+    private static final HashMap<ThingTypeUID, Integer> ALARM_CONFIGURATION_MEMORY_ADDRESSES = new HashMap<ThingTypeUID, Integer>();
+
+    static {
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMB2PBN, 0x0093);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMB4AN, 0x0046);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMB6PBN, 0x0093);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMB7IN, 0x0093);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMB8PBU, 0x0093);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBEL1, 0x0357);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBEL2, 0x0357);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBEL4, 0x0357);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBELO, 0x0593);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBPIRC, 0x0031);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBPIRM, 0x0031);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBPIRO, 0x0031);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBMETEO, 0x0083);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP1, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP1_2, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP2, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP2_2, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP4, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP4_2, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP4PIR, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGP4PIR_2, 0x00A4);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGPO, 0x0284);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGPOD, 0x0284);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBGPOD_2, 0x0284);
+        ALARM_CONFIGURATION_MEMORY_ADDRESSES.put(THING_TYPE_VMBRFR8S, 0x0093);
+    }
+
+    private static final byte ALARM_CONFIGURATION_MEMORY_SIZE = 0x09;
+    private static final byte ALARM_1_ENABLED_MASK = 0x01;
+    private static final byte ALARM_1_TYPE_MASK = 0x02;
+    private static final byte ALARM_2_ENABLED_MASK = 0x04;
+    private static final byte ALARM_2_TYPE_MASK = 0x08;
+
+    private static final StringType ALARM_TYPE_LOCAL = new StringType("LOCAL");
+    private static final StringType ALARM_TYPE_GLOBAL = new StringType("GLOBAL");
+
+    private final ChannelUID clockAlarm1Enabled = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1ENABLED");
+    private final ChannelUID clockAlarm1Type = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1TYPE");
+    private final ChannelUID clockAlarm1WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1WAKEUPHOUR");
+    private final ChannelUID clockAlarm1WakeupMinute = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM1WAKEUPMINUTE");
+    private final ChannelUID clockAlarm1BedtimeHour = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM1BEDTIMEHOUR");
+    private final ChannelUID clockAlarm1BedtimeMinute = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM1BEDTIMEMINUTE");
+    private final ChannelUID clockAlarm2Enabled = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2ENABLED");
+    private final ChannelUID clockAlarm2Type = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2TYPE");
+    private final ChannelUID clockAlarm2WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2WAKEUPHOUR");
+    private final ChannelUID clockAlarm2WakeupMinute = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM2WAKEUPMINUTE");
+    private final ChannelUID clockAlarm2BedtimeHour = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM2BEDTIMEHOUR");
+    private final ChannelUID clockAlarm2BedtimeMinute = new ChannelUID(thing.getUID(),
+            "clockAlarm#CLOCKALARM2BEDTIMEMINUTE");
+
+    private int clockAlarmConfigurationMemoryAddress;
+    private VelbusClockAlarmConfiguration alarmClockConfiguration = new VelbusClockAlarmConfiguration();
+
+    public VelbusSensorWithAlarmClockHandler(Thing thing) {
+        this(thing, 0);
+    }
+
+    public VelbusSensorWithAlarmClockHandler(Thing thing, int numberOfSubAddresses) {
+        super(thing, numberOfSubAddresses);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        if (ALARM_CONFIGURATION_MEMORY_ADDRESSES.containsKey(thing.getThingTypeUID())) {
+            this.clockAlarmConfigurationMemoryAddress = ALARM_CONFIGURATION_MEMORY_ADDRESSES
+                    .get(thing.getThingTypeUID());
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (isAlarmClockChannel(channelUID) && command instanceof RefreshType) {
+            sendReadMemoryBlockPacket(velbusBridgeHandler, this.clockAlarmConfigurationMemoryAddress + 0);
+            sendReadMemoryBlockPacket(velbusBridgeHandler, this.clockAlarmConfigurationMemoryAddress + 4);
+            sendReadMemoryPacket(velbusBridgeHandler, this.clockAlarmConfigurationMemoryAddress + 8);
+        } else if (isAlarmClockChannel(channelUID)) {
+            byte alarmNumber = determineAlarmNumber(channelUID);
+            VelbusClockAlarm alarmClock = alarmClockConfiguration.getAlarmClock(alarmNumber);
+
+            if ((channelUID.equals(clockAlarm1Enabled) || channelUID.equals(clockAlarm2Enabled))
+                    && command instanceof OnOffType) {
+                boolean enabled = (command == OnOffType.ON) ? true : false;
+                alarmClock.setEnabled(enabled);
+            } else if ((channelUID.equals(clockAlarm1Type) || channelUID.equals(clockAlarm2Type))
+                    && command instanceof StringType) {
+                boolean isLocal = (((StringType) command).equals(ALARM_TYPE_LOCAL)) ? true : false;
+                alarmClock.setLocal(isLocal);
+            } else if (channelUID.equals(clockAlarm1WakeupHour)
+                    || channelUID.equals(clockAlarm2WakeupHour) && command instanceof DecimalType) {
+                byte wakeupHour = ((DecimalType) command).byteValue();
+                alarmClock.setWakeupHour(wakeupHour);
+            } else if (channelUID.equals(clockAlarm1WakeupMinute)
+                    || channelUID.equals(clockAlarm2WakeupMinute) && command instanceof DecimalType) {
+                byte wakeupMinute = ((DecimalType) command).byteValue();
+                alarmClock.setWakeupMinute(wakeupMinute);
+            } else if (channelUID.equals(clockAlarm1BedtimeHour)
+                    || channelUID.equals(clockAlarm2BedtimeHour) && command instanceof DecimalType) {
+                byte bedTimeHour = ((DecimalType) command).byteValue();
+                alarmClock.setBedtimeHour(bedTimeHour);
+            } else if (channelUID.equals(clockAlarm1BedtimeMinute)
+                    || channelUID.equals(clockAlarm2BedtimeMinute) && command instanceof DecimalType) {
+                byte bedTimeMinute = ((DecimalType) command).byteValue();
+                alarmClock.setBedtimeMinute(bedTimeMinute);
+            }
+
+            byte address = alarmClock.isLocal() ? getModuleAddress().getAddress() : 0x00;
+            VelbusSetLocalClockAlarmPacket packet = new VelbusSetLocalClockAlarmPacket(address, alarmNumber,
+                    alarmClock);
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        } else {
+            logger.debug("The command '{}' is not supported by this handler.", command.getClass());
+        }
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if ((command == COMMAND_MEMORY_DATA_BLOCK && packet.length >= 11)
+                    || (command == COMMAND_MEMORY_DATA && packet.length >= 8)) {
+                byte highMemoryAddress = packet[5];
+                byte lowMemoryAddress = packet[6];
+                int memoryAddress = ((highMemoryAddress & 0xff) << 8) | (lowMemoryAddress & 0xff);
+                byte[] data = (command == COMMAND_MEMORY_DATA_BLOCK)
+                        ? new byte[] { packet[7], packet[8], packet[9], packet[10] }
+                        : new byte[] { packet[7] };
+
+                for (int i = 0; i < data.length; i++) {
+
+                    if (isClockAlarmConfigurationByte(memoryAddress + i)) {
+                        setClockAlarmConfigurationByte(memoryAddress + i, data[i]);
+                    }
+                }
+            } else if (command == COMMAND_MODULE_STATUS) {
+                int clockAlarmAndProgramSelectionIndexInModuleStatus = this
+                        .getClockAlarmAndProgramSelectionIndexInModuleStatus();
+                if (packet.length >= clockAlarmAndProgramSelectionIndexInModuleStatus + 1) {
+                    byte alarmAndProgramSelection = packet[clockAlarmAndProgramSelectionIndexInModuleStatus];
+
+                    boolean alarmClock1Enabled = (alarmAndProgramSelection & 0x04) > 0;
+                    boolean alarmClock1IsLocal = (alarmAndProgramSelection & 0x08) == 0;
+                    VelbusClockAlarm alarmClock1 = this.alarmClockConfiguration.getAlarmClock1();
+                    alarmClock1.setEnabled(alarmClock1Enabled);
+                    alarmClock1.setLocal(alarmClock1IsLocal);
+                    updateState(clockAlarm1Enabled, alarmClock1.isEnabled() ? OnOffType.ON : OnOffType.OFF);
+                    updateState(clockAlarm1Type, alarmClock1.isLocal() ? ALARM_TYPE_LOCAL : ALARM_TYPE_GLOBAL);
+
+                    boolean alarmClock2Enabled = (alarmAndProgramSelection & 0x10) > 0;
+                    boolean alarmClock2IsLocal = (alarmAndProgramSelection & 0x20) == 0;
+                    VelbusClockAlarm alarmClock2 = this.alarmClockConfiguration.getAlarmClock2();
+                    alarmClock2.setEnabled(alarmClock2Enabled);
+                    alarmClock2.setLocal(alarmClock2IsLocal);
+                    updateState(clockAlarm2Enabled, alarmClock2.isEnabled() ? OnOffType.ON : OnOffType.OFF);
+                    updateState(clockAlarm2Type, alarmClock2.isLocal() ? ALARM_TYPE_LOCAL : ALARM_TYPE_GLOBAL);
+                }
+            }
+        }
+    }
+
+    public Boolean isClockAlarmConfigurationByte(int memoryAddress) {
+        return memoryAddress >= this.clockAlarmConfigurationMemoryAddress
+                && memoryAddress < (this.clockAlarmConfigurationMemoryAddress + ALARM_CONFIGURATION_MEMORY_SIZE);
+    }
+
+    public void setClockAlarmConfigurationByte(int memoryAddress, byte data) {
+        VelbusClockAlarm alarmClock1 = this.alarmClockConfiguration.getAlarmClock1();
+        VelbusClockAlarm alarmClock2 = this.alarmClockConfiguration.getAlarmClock2();
+
+        switch (memoryAddress - this.clockAlarmConfigurationMemoryAddress) {
+            case 0:
+                alarmClock1.setEnabled((data & ALARM_1_ENABLED_MASK) > 0);
+                alarmClock1.setLocal((data & ALARM_1_TYPE_MASK) > 0);
+
+                updateState(clockAlarm1Enabled, alarmClock1.isEnabled() ? OnOffType.ON : OnOffType.OFF);
+                updateState(clockAlarm1Type, alarmClock1.isLocal() ? ALARM_TYPE_LOCAL : ALARM_TYPE_GLOBAL);
+
+                alarmClock2.setEnabled((data & ALARM_2_ENABLED_MASK) > 0);
+                alarmClock2.setLocal((data & ALARM_2_TYPE_MASK) > 0);
+
+                updateState(clockAlarm2Enabled, alarmClock2.isEnabled() ? OnOffType.ON : OnOffType.OFF);
+                updateState(clockAlarm2Type, alarmClock2.isLocal() ? ALARM_TYPE_LOCAL : ALARM_TYPE_GLOBAL);
+                break;
+            case 1:
+                alarmClock1.setWakeupHour(data);
+                updateState(clockAlarm1WakeupHour, new DecimalType(alarmClock1.getWakeupHour()));
+                break;
+            case 2:
+                alarmClock1.setWakeupMinute(data);
+                updateState(clockAlarm1WakeupMinute, new DecimalType(alarmClock1.getWakeupMinute()));
+                break;
+            case 3:
+                alarmClock1.setBedtimeHour(data);
+                updateState(clockAlarm1BedtimeHour, new DecimalType(alarmClock1.getBedtimeHour()));
+                break;
+            case 4:
+                alarmClock1.setBedtimeMinute(data);
+                updateState(clockAlarm1BedtimeMinute, new DecimalType(alarmClock1.getBedtimeMinute()));
+                break;
+            case 5:
+                alarmClock2.setWakeupHour(data);
+                updateState(clockAlarm2WakeupHour, new DecimalType(alarmClock2.getWakeupHour()));
+                break;
+            case 6:
+                alarmClock2.setWakeupMinute(data);
+                updateState(clockAlarm2WakeupMinute, new DecimalType(alarmClock2.getWakeupMinute()));
+                break;
+            case 7:
+                alarmClock2.setBedtimeHour(data);
+                updateState(clockAlarm2BedtimeHour, new DecimalType(alarmClock2.getBedtimeHour()));
+                break;
+            case 8:
+                alarmClock2.setBedtimeMinute(data);
+                updateState(clockAlarm2BedtimeMinute, new DecimalType(alarmClock2.getBedtimeMinute()));
+                break;
+            default:
+                throw new IllegalArgumentException("The memory address '" + memoryAddress
+                        + "' does not represent a clock alarm configuration for the thing '" + this.thing.getUID()
+                        + "'.");
+        }
+    }
+
+    protected boolean isAlarmClockChannel(ChannelUID channelUID) {
+        return channelUID.equals(clockAlarm1Enabled) || channelUID.equals(clockAlarm1Type)
+                || channelUID.equals(clockAlarm1WakeupHour) || channelUID.equals(clockAlarm1WakeupMinute)
+                || channelUID.equals(clockAlarm1BedtimeHour) || channelUID.equals(clockAlarm1BedtimeMinute)
+                || channelUID.equals(clockAlarm2Enabled) || channelUID.equals(clockAlarm2Type)
+                || channelUID.equals(clockAlarm2WakeupHour) || channelUID.equals(clockAlarm2WakeupMinute)
+                || channelUID.equals(clockAlarm2BedtimeHour) || channelUID.equals(clockAlarm2BedtimeMinute);
+    }
+
+    protected byte determineAlarmNumber(ChannelUID channelUID) {
+        if (channelUID.equals(clockAlarm1Enabled) || channelUID.equals(clockAlarm1Type)
+                || channelUID.equals(clockAlarm1WakeupHour) || channelUID.equals(clockAlarm1WakeupMinute)
+                || channelUID.equals(clockAlarm1BedtimeHour) || channelUID.equals(clockAlarm1BedtimeMinute)) {
+            return 1;
+        } else if (channelUID.equals(clockAlarm2Enabled) || channelUID.equals(clockAlarm2Type)
+                || channelUID.equals(clockAlarm2WakeupHour) || channelUID.equals(clockAlarm2WakeupMinute)
+                || channelUID.equals(clockAlarm2BedtimeHour) || channelUID.equals(clockAlarm2BedtimeMinute)) {
+            return 2;
+        } else {
+            throw new IllegalArgumentException("The given channelUID is not an alarm clock channel: " + channelUID);
+        }
+    }
+
+    protected int getClockAlarmAndProgramSelectionIndexInModuleStatus() {
+        return 10;
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorWithAlarmClockHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSensorWithAlarmClockHandler.java
@@ -84,24 +84,26 @@ public class VelbusSensorWithAlarmClockHandler extends VelbusSensorHandler {
     private static final StringType ALARM_TYPE_LOCAL = new StringType("LOCAL");
     private static final StringType ALARM_TYPE_GLOBAL = new StringType("GLOBAL");
 
-    private final ChannelUID clockAlarm1Enabled = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1ENABLED");
-    private final ChannelUID clockAlarm1Type = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1TYPE");
-    private final ChannelUID clockAlarm1WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM1WAKEUPHOUR");
-    private final ChannelUID clockAlarm1WakeupMinute = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM1WAKEUPMINUTE");
-    private final ChannelUID clockAlarm1BedtimeHour = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM1BEDTIMEHOUR");
-    private final ChannelUID clockAlarm1BedtimeMinute = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM1BEDTIMEMINUTE");
-    private final ChannelUID clockAlarm2Enabled = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2ENABLED");
-    private final ChannelUID clockAlarm2Type = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2TYPE");
-    private final ChannelUID clockAlarm2WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm#CLOCKALARM2WAKEUPHOUR");
-    private final ChannelUID clockAlarm2WakeupMinute = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM2WAKEUPMINUTE");
-    private final ChannelUID clockAlarm2BedtimeHour = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM2BEDTIMEHOUR");
-    private final ChannelUID clockAlarm2BedtimeMinute = new ChannelUID(thing.getUID(),
-            "clockAlarm#CLOCKALARM2BEDTIMEMINUTE");
+    private final ChannelUID clockAlarm1Enabled = new ChannelUID(thing.getUID(), "clockAlarm", "clockAlarm1Enabled");
+    private final ChannelUID clockAlarm1Type = new ChannelUID(thing.getUID(), "clockAlarm", "clockAlarm1Type");
+    private final ChannelUID clockAlarm1WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm1WakeupHour");
+    private final ChannelUID clockAlarm1WakeupMinute = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm1WakeupMinute");
+    private final ChannelUID clockAlarm1BedtimeHour = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm1BedtimeHour");
+    private final ChannelUID clockAlarm1BedtimeMinute = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm1BedtimeMinute");
+    private final ChannelUID clockAlarm2Enabled = new ChannelUID(thing.getUID(), "clockAlarm", "clockAlarm2Enabled");
+    private final ChannelUID clockAlarm2Type = new ChannelUID(thing.getUID(), "clockAlarm", "clockAlarm2Type");
+    private final ChannelUID clockAlarm2WakeupHour = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm2WakeupHour");
+    private final ChannelUID clockAlarm2WakeupMinute = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm2WakeupMinute");
+    private final ChannelUID clockAlarm2BedtimeHour = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm2BedtimeHour");
+    private final ChannelUID clockAlarm2BedtimeMinute = new ChannelUID(thing.getUID(), "clockAlarm",
+            "clockAlarm2BedtimeMinute");
 
     private int clockAlarmConfigurationMemoryAddress;
     private VelbusClockAlarmConfiguration alarmClockConfiguration = new VelbusClockAlarmConfiguration();
@@ -144,11 +146,11 @@ public class VelbusSensorWithAlarmClockHandler extends VelbusSensorHandler {
 
             if ((channelUID.equals(clockAlarm1Enabled) || channelUID.equals(clockAlarm2Enabled))
                     && command instanceof OnOffType) {
-                boolean enabled = (command == OnOffType.ON) ? true : false;
+                boolean enabled = command == OnOffType.ON;
                 alarmClock.setEnabled(enabled);
             } else if ((channelUID.equals(clockAlarm1Type) || channelUID.equals(clockAlarm2Type))
                     && command instanceof StringType) {
-                boolean isLocal = (((StringType) command).equals(ALARM_TYPE_LOCAL)) ? true : false;
+                boolean isLocal = ((StringType) command).equals(ALARM_TYPE_LOCAL);
                 alarmClock.setLocal(isLocal);
             } else if (channelUID.equals(clockAlarm1WakeupHour)
                     || channelUID.equals(clockAlarm2WakeupHour) && command instanceof DecimalType) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSerialBridgeHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusSerialBridgeHandler.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.PORT;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.TooManyListenersException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.io.transport.serial.PortInUseException;
+import org.eclipse.smarthome.io.transport.serial.SerialPort;
+import org.eclipse.smarthome.io.transport.serial.SerialPortEvent;
+import org.eclipse.smarthome.io.transport.serial.SerialPortEventListener;
+import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
+import org.eclipse.smarthome.io.transport.serial.SerialPortManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link VelbusSerialBridgeHandler} is the handler for a Velbus Serial-interface and connects it to
+ * the framework.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSerialBridgeHandler extends VelbusBridgeHandler implements SerialPortEventListener {
+    private final Logger logger = LoggerFactory.getLogger(VelbusSerialBridgeHandler.class);
+
+    private SerialPortManager serialPortManager;
+
+    private @Nullable SerialPort serialPort;
+
+    public VelbusSerialBridgeHandler(Bridge velbusBridge, SerialPortManager serialPortManager) {
+        super(velbusBridge);
+        this.serialPortManager = serialPortManager;
+    }
+
+    @Override
+    public void serialEvent(SerialPortEvent event) {
+        logger.debug("Serial port event triggered");
+
+        if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
+            readPackets();
+        }
+    }
+
+    @Override
+    protected void connect() {
+        String port = (String) getConfig().get(PORT);
+        if (port != null) {
+            // parse ports and if the port is found, initialize the reader
+            SerialPortIdentifier portId = serialPortManager.getIdentifier(port);
+            if (portId == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, "Port is not known!");
+                return;
+            }
+
+            // initialize serial port
+            try {
+                SerialPort serialPort = portId.open(getThing().getUID().toString(), 2000);
+                this.serialPort = serialPort;
+
+                OutputStream outputStream = serialPort.getOutputStream();
+                InputStream inputStream = serialPort.getInputStream();
+
+                if (outputStream != null && inputStream != null) {
+                    initializeStreams(outputStream, inputStream);
+
+                    serialPort.addEventListener(this);
+                    serialPort.notifyOnDataAvailable(true);
+
+                    updateStatus(ThingStatus.ONLINE);
+                    logger.debug("Bridge online on serial port {}", port);
+                }
+            } catch (final IOException ex) {
+                onConnectionLost();
+                logger.debug("I/O error on serial port {}", port);
+            } catch (PortInUseException e) {
+                onConnectionLost();
+                logger.debug("Port {} is in use", port);
+            } catch (TooManyListenersException e) {
+                onConnectionLost();
+                logger.debug("Cannot attach listener to port {}", port);
+            }
+        } else
+
+        {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Serial port name not configured");
+            logger.debug("Serial port name not configured");
+        }
+    }
+
+    @Override
+    protected void disconnect() {
+        if (serialPort != null) {
+            serialPort.removeEventListener();
+            serialPort.close();
+            serialPort = null;
+        }
+
+        super.disconnect();
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusThermostatHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusThermostatHandler.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSensorSettingsRequestPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSetTemperaturePacket;
+import org.openhab.binding.velbus.internal.packets.VelbusThermostatModePacket;
+import org.openhab.binding.velbus.internal.packets.VelbusThermostatOperatingModePacket;
+
+/**
+ * The {@link VelbusThermostatHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public abstract class VelbusThermostatHandler extends VelbusTemperatureSensorHandler {
+    private static final double THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION = 0.5;
+
+    private static final StringType OPERATING_MODE_HEATING = new StringType("HEATING");
+    private static final StringType OPERATING_MODE_COOLING = new StringType("COOLING");
+
+    private static final byte OPERATING_MODE_MASK = (byte) 0x80;
+    private static final byte COOLING_MODE_MASK = (byte) 0x80;
+
+    private static final StringType MODE_COMFORT = new StringType("COMFORT");
+    private static final StringType MODE_DAY = new StringType("DAY");
+    private static final StringType MODE_NIGHT = new StringType("NIGHT");
+    private static final StringType MODE_SAFE = new StringType("SAFE");
+
+    private static final byte MODE_MASK = (byte) 0x70;
+    private static final byte COMFORT_MODE_MASK = (byte) 0x40;
+    private static final byte DAY_MODE_MASK = (byte) 0x20;
+    private static final byte NIGHT_MODE_MASK = (byte) 0x10;
+
+    private final ChannelUID currentTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#CURRENTTEMPERATURESETPOINT");
+    private final ChannelUID heatingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#HEATINGMODECOMFORTTEMPERATURESETPOINT");
+    private final ChannelUID heatingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#HEATINGMODEDAYTEMPERATURESETPOINT");
+    private final ChannelUID heatingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#HEATINGMODENIGHTTEMPERATURESETPOINT");
+    private final ChannelUID heatingModeAntifrostTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#HEATINGMODEANTIFROSTTEMPERATURESETPOINT");
+    private final ChannelUID coolingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#COOLINGMODECOMFORTTEMPERATURESETPOINT");
+    private final ChannelUID coolingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#COOLINGMODEDAYTEMPERATURESETPOINT");
+    private final ChannelUID coolingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#COOLINGMODENIGHTTEMPERATURESETPOINT");
+    private final ChannelUID coolingModeSafeTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
+            "thermostat#COOLINGMODESAFETEMPERATURESETPOINT");
+    private final ChannelUID operatingModeChannel = new ChannelUID(thing.getUID(), "thermostat#OPERATINGMODE");
+    private final ChannelUID modeChannel = new ChannelUID(thing.getUID(), "thermostat#MODE");
+    private final ChannelUID heaterChannel = new ChannelUID(thing.getUID(), "thermostat#HEATER");
+    private final ChannelUID boostChannel = new ChannelUID(thing.getUID(), "thermostat#BOOST");
+    private final ChannelUID pumpChannel = new ChannelUID(thing.getUID(), "thermostat#PUMP");
+    private final ChannelUID coolerChannel = new ChannelUID(thing.getUID(), "thermostat#COOLER");
+    private final ChannelUID alarm1Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM1");
+    private final ChannelUID alarm2Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM2");
+    private final ChannelUID alarm3Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM3");
+    private final ChannelUID alarm4Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM4");
+
+    public VelbusThermostatHandler(Thing thing, int numberOfSubAddresses, ChannelUID temperatureChannel) {
+        super(thing, numberOfSubAddresses, temperatureChannel);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (isThermostatChannel(channelUID) && command instanceof RefreshType) {
+            VelbusSensorSettingsRequestPacket packet = new VelbusSensorSettingsRequestPacket(
+                    getModuleAddress().getAddress());
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        } else if (isThermostatChannel(channelUID)
+                && (command instanceof QuantityType<?> || command instanceof DecimalType)) {
+            byte temperatureVariable = determineTemperatureVariable(channelUID);
+            QuantityType<?> temperatureInDegreesCelcius = (command instanceof QuantityType<?>)
+                    ? ((QuantityType<?>) command).toUnit(SIUnits.CELSIUS)
+                    : new QuantityType<>(((DecimalType) command), SIUnits.CELSIUS);
+
+            if (temperatureInDegreesCelcius != null) {
+                byte temperature = convertToTwoComplementByte(temperatureInDegreesCelcius.doubleValue(),
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+
+                VelbusSetTemperaturePacket packet = new VelbusSetTemperaturePacket(getModuleAddress().getAddress(),
+                        temperatureVariable, temperature);
+
+                byte[] packetBytes = packet.getBytes();
+                velbusBridgeHandler.sendPacket(packetBytes);
+            }
+        } else if (channelUID.equals(operatingModeChannel) && command instanceof StringType) {
+            byte commandByte = ((StringType) command).equals(OPERATING_MODE_HEATING) ? COMMAND_SET_HEATING_MODE
+                    : COMMAND_SET_COOLING_MODE;
+
+            VelbusThermostatOperatingModePacket packet = new VelbusThermostatOperatingModePacket(
+                    getModuleAddress().getAddress(), commandByte);
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        } else if (channelUID.equals(modeChannel) && command instanceof StringType) {
+            byte commandByte = COMMAND_SWITCH_TO_SAFE_MODE;
+
+            StringType stringTypeCommand = (StringType) command;
+            if (stringTypeCommand.equals(MODE_COMFORT)) {
+                commandByte = COMMAND_SWITCH_TO_COMFORT_MODE;
+            } else if (stringTypeCommand.equals(MODE_DAY)) {
+                commandByte = COMMAND_SWITCH_TO_DAY_MODE;
+            } else if (stringTypeCommand.equals(MODE_NIGHT)) {
+                commandByte = COMMAND_SWITCH_TO_NIGHT_MODE;
+            }
+
+            VelbusThermostatModePacket packet = new VelbusThermostatModePacket(getModuleAddress().getAddress(),
+                    commandByte);
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        } else {
+            logger.debug("The command '{}' is not supported by this handler.", command.getClass());
+        }
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte address = packet[2];
+            byte command = packet[4];
+
+            if (command == COMMAND_TEMP_SENSOR_SETTINGS_PART1 && packet.length >= 9) {
+                byte currentTemperatureSetByte = packet[5];
+                byte heatingModeComfortTemperatureSetByte = packet[6];
+                byte heatingModeDayTemperatureSetByte = packet[7];
+                byte heatingModeNightTemperatureSetByte = packet[8];
+                byte heatingModeAntiFrostTemperatureSetByte = packet[9];
+
+                double currentTemperatureSet = convertFromTwoComplementByte(currentTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double heatingModeComfortTemperatureSet = convertFromTwoComplementByte(
+                        heatingModeComfortTemperatureSetByte, THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double heatingModeDayTemperatureSet = convertFromTwoComplementByte(heatingModeDayTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double heatingModeNightTemperatureSet = convertFromTwoComplementByte(heatingModeNightTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double heatingModeAntiFrostTemperatureSet = convertFromTwoComplementByte(
+                        heatingModeAntiFrostTemperatureSetByte, THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+
+                updateState(currentTemperatureSetpointChannel,
+                        new QuantityType<>(currentTemperatureSet, SIUnits.CELSIUS));
+                updateState(heatingModeComfortTemperatureSetpointChannel,
+                        new QuantityType<>(heatingModeComfortTemperatureSet, SIUnits.CELSIUS));
+                updateState(heatingModeDayTemperatureSetpointChannel,
+                        new QuantityType<>(heatingModeDayTemperatureSet, SIUnits.CELSIUS));
+                updateState(heatingModeNightTemperatureSetpointChannel,
+                        new QuantityType<>(heatingModeNightTemperatureSet, SIUnits.CELSIUS));
+                updateState(heatingModeAntifrostTemperatureSetpointChannel,
+                        new QuantityType<>(heatingModeAntiFrostTemperatureSet, SIUnits.CELSIUS));
+            } else if (command == COMMAND_TEMP_SENSOR_SETTINGS_PART2 && packet.length >= 8) {
+                byte coolingModeComfortTemperatureSetByte = packet[5];
+                byte coolingModeDayTemperatureSetByte = packet[6];
+                byte coolingModeNightTemperatureSetByte = packet[7];
+                byte coolingModeSafeTemperatureSetByte = packet[8];
+
+                double coolingModeComfortTemperatureSet = convertFromTwoComplementByte(
+                        coolingModeComfortTemperatureSetByte, THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double coolingModeDayTemperatureSet = convertFromTwoComplementByte(coolingModeDayTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double coolingModeNightTemperatureSet = convertFromTwoComplementByte(coolingModeNightTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                double coolingModeSafeTemperatureSet = convertFromTwoComplementByte(coolingModeSafeTemperatureSetByte,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+
+                updateState(coolingModeComfortTemperatureSetpointChannel,
+                        new QuantityType<>(coolingModeComfortTemperatureSet, SIUnits.CELSIUS));
+                updateState(coolingModeDayTemperatureSetpointChannel,
+                        new QuantityType<>(coolingModeDayTemperatureSet, SIUnits.CELSIUS));
+                updateState(coolingModeNightTemperatureSetpointChannel,
+                        new QuantityType<>(coolingModeNightTemperatureSet, SIUnits.CELSIUS));
+                updateState(coolingModeSafeTemperatureSetpointChannel,
+                        new QuantityType<>(coolingModeSafeTemperatureSet, SIUnits.CELSIUS));
+            } else if (command == COMMAND_TEMP_SENSOR_STATUS && packet.length >= 9) {
+                byte operatingMode = packet[5];
+                byte targetTemperature = packet[9];
+
+                if ((operatingMode & OPERATING_MODE_MASK) == COOLING_MODE_MASK) {
+                    updateState(operatingModeChannel, OPERATING_MODE_COOLING);
+                } else {
+                    updateState(operatingModeChannel, OPERATING_MODE_HEATING);
+                }
+
+                if ((operatingMode & MODE_MASK) == COMFORT_MODE_MASK) {
+                    updateState(modeChannel, MODE_COMFORT);
+                } else if ((operatingMode & MODE_MASK) == DAY_MODE_MASK) {
+                    updateState(modeChannel, MODE_DAY);
+                } else if ((operatingMode & MODE_MASK) == NIGHT_MODE_MASK) {
+                    updateState(modeChannel, MODE_NIGHT);
+                } else {
+                    updateState(modeChannel, MODE_SAFE);
+                }
+
+                double targetTemperatureValue = convertFromTwoComplementByte(targetTemperature,
+                        THERMOSTAT_TEMPERATURE_SETPOINT_RESOLUTION);
+                updateState(currentTemperatureSetpointChannel,
+                        new QuantityType<>(targetTemperatureValue, SIUnits.CELSIUS));
+            } else if (address != this.getModuleAddress().getAddress() && command == COMMAND_PUSH_BUTTON_STATUS) {
+                byte outputChannelsJustActivated = packet[5];
+                byte outputChannelsJustDeactivated = packet[6];
+
+                triggerThermostatChannels(outputChannelsJustActivated, CommonTriggerEvents.PRESSED);
+                triggerThermostatChannels(outputChannelsJustDeactivated, CommonTriggerEvents.RELEASED);
+            }
+        }
+    }
+
+    private void triggerThermostatChannels(byte outputChannels, String event) {
+        if ((outputChannels & 0x01) == 0x01) {
+            triggerChannel(heaterChannel, event);
+        }
+        if ((outputChannels & 0x02) == 0x02) {
+            triggerChannel(boostChannel, event);
+        }
+        if ((outputChannels & 0x04) == 0x04) {
+            triggerChannel(pumpChannel, event);
+        }
+        if ((outputChannels & 0x08) == 0x08) {
+            triggerChannel(coolerChannel, event);
+        }
+        if ((outputChannels & 0x10) == 0x10) {
+            triggerChannel(alarm1Channel, event);
+        }
+        if ((outputChannels & 0x20) == 0x20) {
+            triggerChannel(alarm2Channel, event);
+        }
+        if ((outputChannels & 0x40) == 0x40) {
+            triggerChannel(alarm3Channel, event);
+        }
+        if ((outputChannels & 0x80) == 0x80) {
+            triggerChannel(alarm4Channel, event);
+        }
+    }
+
+    protected boolean isThermostatChannel(ChannelUID channelUID) {
+        return channelUID.equals(currentTemperatureSetpointChannel)
+                || channelUID.equals(heatingModeComfortTemperatureSetpointChannel)
+                || channelUID.equals(heatingModeDayTemperatureSetpointChannel)
+                || channelUID.equals(heatingModeNightTemperatureSetpointChannel)
+                || channelUID.equals(heatingModeAntifrostTemperatureSetpointChannel)
+                || channelUID.equals(coolingModeComfortTemperatureSetpointChannel)
+                || channelUID.equals(coolingModeDayTemperatureSetpointChannel)
+                || channelUID.equals(coolingModeNightTemperatureSetpointChannel)
+                || channelUID.equals(coolingModeSafeTemperatureSetpointChannel)
+                || channelUID.equals(operatingModeChannel) || channelUID.equals(modeChannel);
+    }
+
+    protected byte determineTemperatureVariable(ChannelUID channelUID) {
+        if (channelUID.equals(currentTemperatureSetpointChannel)) {
+            return 0x00;
+        } else if (channelUID.equals(heatingModeComfortTemperatureSetpointChannel)) {
+            return 0x01;
+        } else if (channelUID.equals(heatingModeDayTemperatureSetpointChannel)) {
+            return 0x02;
+        } else if (channelUID.equals(heatingModeNightTemperatureSetpointChannel)) {
+            return 0x03;
+        } else if (channelUID.equals(heatingModeAntifrostTemperatureSetpointChannel)) {
+            return 0x04;
+        } else if (channelUID.equals(coolingModeComfortTemperatureSetpointChannel)) {
+            return 0x07;
+        } else if (channelUID.equals(coolingModeDayTemperatureSetpointChannel)) {
+            return 0x08;
+        } else if (channelUID.equals(coolingModeNightTemperatureSetpointChannel)) {
+            return 0x09;
+        } else if (channelUID.equals(coolingModeSafeTemperatureSetpointChannel)) {
+            return 0x0A;
+        } else {
+            throw new IllegalArgumentException("The given channelUID is not a thermostat channel: " + channelUID);
+        }
+    }
+
+    protected double convertFromTwoComplementByte(byte value, double resolution) {
+        return ((value & 0x80) == 0x00) ? value * resolution : ((value & 0x7F) - 0x80) * resolution;
+    }
+
+    protected byte convertToTwoComplementByte(double value, double resolution) {
+        return (byte) (value / resolution);
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusThermostatHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusThermostatHandler.java
@@ -58,34 +58,34 @@ public abstract class VelbusThermostatHandler extends VelbusTemperatureSensorHan
     private static final byte DAY_MODE_MASK = (byte) 0x20;
     private static final byte NIGHT_MODE_MASK = (byte) 0x10;
 
-    private final ChannelUID currentTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#CURRENTTEMPERATURESETPOINT");
-    private final ChannelUID heatingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#HEATINGMODECOMFORTTEMPERATURESETPOINT");
-    private final ChannelUID heatingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#HEATINGMODEDAYTEMPERATURESETPOINT");
-    private final ChannelUID heatingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#HEATINGMODENIGHTTEMPERATURESETPOINT");
+    private final ChannelUID currentTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "currentTemperatureSetpoint");
+    private final ChannelUID heatingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "heatingModeComfortTemperatureSetpoint");
+    private final ChannelUID heatingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "heatingModeDayTemperatureSetpoint");
+    private final ChannelUID heatingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "heatingModeNightTemperatureSetpoint");
     private final ChannelUID heatingModeAntifrostTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#HEATINGMODEANTIFROSTTEMPERATURESETPOINT");
-    private final ChannelUID coolingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#COOLINGMODECOMFORTTEMPERATURESETPOINT");
-    private final ChannelUID coolingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#COOLINGMODEDAYTEMPERATURESETPOINT");
-    private final ChannelUID coolingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#COOLINGMODENIGHTTEMPERATURESETPOINT");
-    private final ChannelUID coolingModeSafeTemperatureSetpointChannel = new ChannelUID(thing.getUID(),
-            "thermostat#COOLINGMODESAFETEMPERATURESETPOINT");
-    private final ChannelUID operatingModeChannel = new ChannelUID(thing.getUID(), "thermostat#OPERATINGMODE");
-    private final ChannelUID modeChannel = new ChannelUID(thing.getUID(), "thermostat#MODE");
-    private final ChannelUID heaterChannel = new ChannelUID(thing.getUID(), "thermostat#HEATER");
-    private final ChannelUID boostChannel = new ChannelUID(thing.getUID(), "thermostat#BOOST");
-    private final ChannelUID pumpChannel = new ChannelUID(thing.getUID(), "thermostat#PUMP");
-    private final ChannelUID coolerChannel = new ChannelUID(thing.getUID(), "thermostat#COOLER");
-    private final ChannelUID alarm1Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM1");
-    private final ChannelUID alarm2Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM2");
-    private final ChannelUID alarm3Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM3");
-    private final ChannelUID alarm4Channel = new ChannelUID(thing.getUID(), "thermostat#ALARM4");
+            "thermostat", "heatingModeAntiFrostTemperatureSetpoint");
+    private final ChannelUID coolingModeComfortTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "coolingModeComfortTemperatureSetpoint");
+    private final ChannelUID coolingModeDayTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "coolingModeDayTemperatureSetpoint");
+    private final ChannelUID coolingModeNightTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "coolingModeNightTemperatureSetpoint");
+    private final ChannelUID coolingModeSafeTemperatureSetpointChannel = new ChannelUID(thing.getUID(), "thermostat",
+            "coolingModeSafeTemperatureSetpoint");
+    private final ChannelUID operatingModeChannel = new ChannelUID(thing.getUID(), "thermostat", "operatingMode");
+    private final ChannelUID modeChannel = new ChannelUID(thing.getUID(), "thermostat", "mode");
+    private final ChannelUID heaterChannel = new ChannelUID(thing.getUID(), "thermostat", "heater");
+    private final ChannelUID boostChannel = new ChannelUID(thing.getUID(), "thermostat", "boost");
+    private final ChannelUID pumpChannel = new ChannelUID(thing.getUID(), "thermostat", "pump");
+    private final ChannelUID coolerChannel = new ChannelUID(thing.getUID(), "thermostat", "cooler");
+    private final ChannelUID alarm1Channel = new ChannelUID(thing.getUID(), "thermostat", "alarm1");
+    private final ChannelUID alarm2Channel = new ChannelUID(thing.getUID(), "thermostat", "alarm2");
+    private final ChannelUID alarm3Channel = new ChannelUID(thing.getUID(), "thermostat", "alarm3");
+    private final ChannelUID alarm4Channel = new ChannelUID(thing.getUID(), "thermostat", "alarm4");
 
     public VelbusThermostatHandler(Thing thing, int numberOfSubAddresses, ChannelUID temperatureChannel) {
         super(thing, numberOfSubAddresses, temperatureChannel);

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB1TSHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB1TSHandler.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.velbus.internal.handler;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.THING_TYPE_VMB1TS;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -24,18 +24,16 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link VelbusVMBGPHandler} is responsible for handling commands, which are
+ * The {@link VelbusVMB1TSHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusVMBGPHandler extends VelbusThermostatHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMBGP1, THING_TYPE_VMBGP1_2, THING_TYPE_VMBGP2, THING_TYPE_VMBGP2_2,
-                    THING_TYPE_VMBGP4, THING_TYPE_VMBGP4_2, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGP4PIR_2));
+public class VelbusVMB1TSHandler extends VelbusThermostatHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1TS));
 
-    public VelbusVMBGPHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH9"));
+    public VelbusVMB1TSHandler(Thing thing) {
+        super(thing, 0, new ChannelUID(thing.getUID(), "input#CH1"));
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB1TSHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB1TSHandler.java
@@ -34,6 +34,6 @@ public class VelbusVMB1TSHandler extends VelbusThermostatHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB1TS));
 
     public VelbusVMB1TSHandler(Thing thing) {
-        super(thing, 0, new ChannelUID(thing.getUID(), "input#CH1"));
+        super(thing, 0, new ChannelUID(thing.getUID(), "input", "CH1"));
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.unit.MetricPrefix;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.packets.VelbusDimmerPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSensorReadoutRequestPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusStatusRequestPacket;
+
+/**
+ * The {@link VelbusVMB4ANHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB4AN));
+
+    private static final String ALARM_CHANNEL_PREFIX = "alarm#CH";
+    private static final String ANALOG_INPUT_CHANNEL_PREFIX = "analogInput#CH";
+    private static final String ANALOG_OUTPUT_CHANNEL_PREFIX = "analogOutput#CH";
+    private static final String RAW_CHANNEL_SUFFIX = "RAW";
+
+    private static final byte VOLTAGE_SENSOR_TYPE = 0x00;
+    private static final byte CURRENT_SENSOR_TYPE = 0x01;
+    private static final byte RESISTANCE_SENSOR_TYPE = 0x02;
+    private static final byte PERIOD_MEASUREMENT_SENSOR_TYPE = 0x03;
+
+    private String[] channelText = new String[] { "", "", "", "" };
+
+    private @Nullable ScheduledFuture<?> refreshJob;
+
+    public VelbusVMB4ANHandler(Thing thing) {
+        super(thing, 0);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        initializeAutomaticRefresh();
+    }
+
+    private void initializeAutomaticRefresh() {
+        Object refreshIntervalObject = getConfig().get(REFRESH_INTERVAL);
+        if (refreshIntervalObject != null) {
+            int refreshInterval = ((BigDecimal) refreshIntervalObject).intValue();
+
+            if (refreshInterval > 0) {
+                startAutomaticRefresh(refreshInterval);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (refreshJob != null) {
+            refreshJob.cancel(true);
+        }
+    }
+
+    private void startAutomaticRefresh(int refreshInterval) {
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        refreshJob = scheduler.scheduleWithFixedDelay(() -> {
+            sendSensorReadoutRequest(velbusBridgeHandler, ALL_CHANNELS);
+        }, 0, refreshInterval, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        byte channelByte = convertChannelUIDToChannelByte(channelUID);
+
+        if (command instanceof RefreshType) {
+            VelbusStatusRequestPacket packet = new VelbusStatusRequestPacket(channelByte);
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        } else if (command instanceof PercentType && isAnalogOutputChannel(channelUID)) {
+            VelbusDimmerPacket packet = new VelbusDimmerPacket(
+                    new VelbusChannelIdentifier(this.getModuleAddress().getAddress(), channelByte), COMMAND_SET_VALUE,
+                    ((PercentType) command).byteValue(), 0x00, false);
+
+            byte[] packetBytes = packet.getBytes();
+            velbusBridgeHandler.sendPacket(packetBytes);
+        }
+    }
+
+    protected void sendSensorReadoutRequest(VelbusBridgeHandler velbusBridgeHandler, byte channel) {
+        VelbusSensorReadoutRequestPacket packet = new VelbusSensorReadoutRequestPacket(getModuleAddress().getAddress(),
+                channel);
+
+        byte[] packetBytes = packet.getBytes();
+        velbusBridgeHandler.sendPacket(packetBytes);
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if (command == COMMAND_SENSOR_RAW_DATA && packet.length >= 10) {
+                byte channel = packet[5];
+                byte operatingMode = packet[6];
+                byte upperByteSensorValue = packet[7];
+                byte highByteSensorValue = packet[8];
+                byte lowByteSensorValue = packet[9];
+
+                double sensorValue = (((upperByteSensorValue & 0xff) << 16) + ((highByteSensorValue & 0xff) << 8)
+                        + (lowByteSensorValue & 0xff));
+                String channelUID = convertAnalogInputChannelByteToRawChannelUID(channel);
+
+                switch (operatingMode) {
+                    case VOLTAGE_SENSOR_TYPE:
+                        double voltageResolution = 0.25;
+                        double voltageSensorValueState = sensorValue * voltageResolution;
+                        updateState(channelUID,
+                                new QuantityType<>(voltageSensorValueState, MetricPrefix.MILLI(SmartHomeUnits.VOLT)));
+                        break;
+                    case CURRENT_SENSOR_TYPE:
+                        double currentResolution = 5;
+                        double currentSensorValueState = sensorValue * currentResolution;
+                        updateState(channelUID,
+                                new QuantityType<>(currentSensorValueState, MetricPrefix.MICRO(SmartHomeUnits.AMPERE)));
+                        break;
+                    case RESISTANCE_SENSOR_TYPE:
+                        double resistanceResolution = 0.25;
+                        double resistanceSensorValueState = sensorValue * resistanceResolution;
+                        updateState(channelUID, new QuantityType<>(resistanceSensorValueState, SmartHomeUnits.OHM));
+                        break;
+                    case PERIOD_MEASUREMENT_SENSOR_TYPE:
+                        double periodResolution = 0.5;
+                        double periodSensorValueState = sensorValue * periodResolution;
+                        updateState(channelUID,
+                                new QuantityType<>(periodSensorValueState, MetricPrefix.MICRO(SmartHomeUnits.SECOND)));
+                        break;
+                }
+            } else if (command == COMMAND_TEXT) {
+                byte channel = packet[5];
+                byte textStartPosition = packet[6];
+
+                StringBuilder contents = new StringBuilder();
+                for (int i = 7; i < packet.length - 2; i++) {
+                    byte currentChar = packet[i];
+                    if (currentChar == (byte) -0x50) {
+                        contents.append("°");
+                    } else if (currentChar != (byte) 0x00) {
+                        contents.append((char) currentChar);
+                    }
+                }
+
+                channelText[channel - 9] = channelText[channel - 9].substring(0, textStartPosition)
+                        + contents.toString()
+                        + (channelText[channel - 9].length() > textStartPosition + 5 ? channelText[channel - 9]
+                                .substring(textStartPosition + 5, channelText[channel - 9].length()) : "");
+
+                String channelUID = convertAnalogInputChannelByteToChannelUID(channel);
+                updateState(channelUID, new StringType(channelText[channel - 9]));
+            }
+        }
+    }
+
+    protected byte convertChannelUIDToChannelByte(ChannelUID channelUID) {
+        if (isAlarmChannel(channelUID)) {
+            return convertAlarmChannelUIDToChannelByte(channelUID);
+        } else if (isTextAnalogInputChannel(channelUID)) {
+            return convertTextAnalogInputChannelUIDToChannelByte(channelUID);
+        } else if (isRawAnalogInputChannel(channelUID)) {
+            return convertRawAnalogInputChannelUIDToChannelByte(channelUID);
+        } else if (isAnalogOutputChannel(channelUID)) {
+            return convertAnalogOutputChannelUIDToChannelByte(channelUID);
+        } else {
+            throw new UnsupportedOperationException(
+                    "The channel '" + channelUID + "' is not supported on a VMB4AN module.");
+        }
+    }
+
+    protected boolean isAlarmChannel(ChannelUID channelUID) {
+        return channelUID.getId().startsWith(ALARM_CHANNEL_PREFIX);
+    }
+
+    protected byte convertAlarmChannelUIDToChannelByte(ChannelUID channelUID) {
+        return Byte.parseByte(channelUID.getId().replaceAll(ALARM_CHANNEL_PREFIX, ""));
+    }
+
+    protected String convertAlarmChannelByteToChannelUID(byte channelByte) {
+        return ALARM_CHANNEL_PREFIX + channelByte;
+    }
+
+    protected boolean isTextAnalogInputChannel(ChannelUID channelUID) {
+        String id = channelUID.getId();
+
+        return id.startsWith(ANALOG_INPUT_CHANNEL_PREFIX) && !id.endsWith(RAW_CHANNEL_SUFFIX);
+    }
+
+    protected boolean isRawAnalogInputChannel(ChannelUID channelUID) {
+        String id = channelUID.getId();
+
+        return id.startsWith(ANALOG_INPUT_CHANNEL_PREFIX) && id.endsWith(RAW_CHANNEL_SUFFIX);
+    }
+
+    protected byte convertRawAnalogInputChannelUIDToChannelByte(ChannelUID channelUID) {
+        return Byte.parseByte(
+                channelUID.getId().replaceAll(ANALOG_INPUT_CHANNEL_PREFIX, "").replaceAll(RAW_CHANNEL_SUFFIX, ""));
+    }
+
+    protected byte convertTextAnalogInputChannelUIDToChannelByte(ChannelUID channelUID) {
+        return Byte.parseByte(channelUID.getId().replaceAll(ANALOG_INPUT_CHANNEL_PREFIX, ""));
+    }
+
+    protected String convertAnalogInputChannelByteToRawChannelUID(byte channelByte) {
+        return convertAnalogInputChannelByteToChannelUID(channelByte) + RAW_CHANNEL_SUFFIX;
+    }
+
+    protected String convertAnalogInputChannelByteToChannelUID(byte channelByte) {
+        return ANALOG_INPUT_CHANNEL_PREFIX + channelByte;
+    }
+
+    protected boolean isAnalogOutputChannel(ChannelUID channelUID) {
+        return channelUID.getId().startsWith(ANALOG_OUTPUT_CHANNEL_PREFIX);
+    }
+
+    protected byte convertAnalogOutputChannelUIDToChannelByte(ChannelUID channelUID) {
+        return Byte.parseByte(channelUID.getId().replaceAll(ANALOG_OUTPUT_CHANNEL_PREFIX, ""));
+    }
+
+    protected String convertOutputChannelByteToChannelUID(byte channelByte) {
+        return ANALOG_OUTPUT_CHANNEL_PREFIX + channelByte;
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
@@ -228,7 +228,7 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected boolean isAlarmChannel(ChannelUID channelUID) {
-        return channelUID.getGroupId() == ALARM_GROUP;
+        return ALARM_GROUP.equals(channelUID.getGroupId());
     }
 
     protected byte convertAlarmChannelUIDToChannelByte(ChannelUID channelUID) {
@@ -236,12 +236,12 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected boolean isTextAnalogInputChannel(ChannelUID channelUID) {
-        return channelUID.getGroupId() == ANALOG_INPUT_GROUP
+        return ANALOG_INPUT_GROUP.equals(channelUID.getGroupId())
                 && !channelUID.getIdWithoutGroup().endsWith(RAW_CHANNEL_SUFFIX);
     }
 
     protected boolean isRawAnalogInputChannel(ChannelUID channelUID) {
-        return channelUID.getGroupId() == ANALOG_INPUT_GROUP
+        return ANALOG_INPUT_GROUP.equals(channelUID.getGroupId())
                 && channelUID.getIdWithoutGroup().endsWith(RAW_CHANNEL_SUFFIX);
     }
 
@@ -262,7 +262,7 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected boolean isAnalogOutputChannel(ChannelUID channelUID) {
-        return channelUID.getGroupId() == ANALOG_OUTPUT_GROUP;
+        return ANALOG_OUTPUT_GROUP.equals(channelUID.getGroupId());
     }
 
     protected byte convertAnalogOutputChannelUIDToChannelByte(ChannelUID channelUID) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB7INHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB7INHandler.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
+import org.openhab.binding.velbus.internal.packets.VelbusCounterStatusRequestPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
+
+/**
+ * The {@link VelbusVMB7INHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusVMB7INHandler extends VelbusSensorWithAlarmClockHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMB7IN));
+
+    private final ChannelUID counter1Channel = new ChannelUID(thing.getUID(), "counter#COUNTER1");
+    private final ChannelUID counter1ChannelCurrent = new ChannelUID(thing.getUID(), "counter#COUNTER1_CURRENT");
+    private final ChannelUID counter2Channel = new ChannelUID(thing.getUID(), "counter#COUNTER2");
+    private final ChannelUID counter2ChannelCurrent = new ChannelUID(thing.getUID(), "counter#COUNTER2_CURRENT");
+    private final ChannelUID counter3Channel = new ChannelUID(thing.getUID(), "counter#COUNTER3");
+    private final ChannelUID counter3ChannelCurrent = new ChannelUID(thing.getUID(), "counter#COUNTER3_CURRENT");
+    private final ChannelUID counter4Channel = new ChannelUID(thing.getUID(), "counter#COUNTER4");
+    private final ChannelUID counter4ChannelCurrent = new ChannelUID(thing.getUID(), "counter#COUNTER4_CURRENT");
+
+    private double counter1PulseMultiplier = 1;
+    private double counter2PulseMultiplier = 1;
+    private double counter3PulseMultiplier = 1;
+    private double counter4PulseMultiplier = 1;
+
+    private @Nullable ScheduledFuture<?> refreshJob;
+
+    public VelbusVMB7INHandler(Thing thing) {
+        super(thing, 0);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        initializePulseCounterMultipliers();
+        initializeAutomaticRefresh();
+    }
+
+    private void initializeAutomaticRefresh() {
+        Object refreshIntervalObject = getConfig().get(REFRESH_INTERVAL);
+        if (refreshIntervalObject != null) {
+            int refreshInterval = ((BigDecimal) refreshIntervalObject).intValue();
+
+            if (refreshInterval > 0) {
+                startAutomaticRefresh(refreshInterval);
+            }
+        }
+    }
+
+    private void initializePulseCounterMultipliers() {
+        Object counter1PulseMultiplierObject = getConfig().get(COUNTER1_PULSE_MULTIPLIER);
+        if (counter1PulseMultiplierObject != null) {
+            counter1PulseMultiplier = ((BigDecimal) counter1PulseMultiplierObject).doubleValue();
+        }
+
+        Object counter2PulseMultiplierObject = getConfig().get(COUNTER2_PULSE_MULTIPLIER);
+        if (counter2PulseMultiplierObject != null) {
+            counter2PulseMultiplier = ((BigDecimal) counter2PulseMultiplierObject).doubleValue();
+        }
+
+        Object counter3PulseMultiplierObject = getConfig().get(COUNTER3_PULSE_MULTIPLIER);
+        if (counter3PulseMultiplierObject != null) {
+            counter3PulseMultiplier = ((BigDecimal) counter3PulseMultiplierObject).doubleValue();
+        }
+
+        Object counter4PulseMultiplierObject = getConfig().get(COUNTER4_PULSE_MULTIPLIER);
+        if (counter4PulseMultiplierObject != null) {
+            counter4PulseMultiplier = ((BigDecimal) counter4PulseMultiplierObject).doubleValue();
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (refreshJob != null) {
+            refreshJob.cancel(true);
+        }
+    }
+
+    private void startAutomaticRefresh(int refreshInterval) {
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        refreshJob = scheduler.scheduleWithFixedDelay(() -> {
+            sendCounterStatusRequest(velbusBridgeHandler, ALL_CHANNELS);
+        }, 0, refreshInterval, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (command instanceof RefreshType) {
+            if (channelUID.equals(counter1Channel)) {
+                sendCounterStatusRequest(velbusBridgeHandler, (byte) 0x01);
+            } else if (channelUID.equals(counter2Channel)) {
+                sendCounterStatusRequest(velbusBridgeHandler, (byte) 0x02);
+            } else if (channelUID.equals(counter3Channel)) {
+                sendCounterStatusRequest(velbusBridgeHandler, (byte) 0x03);
+            } else if (channelUID.equals(counter4Channel)) {
+                sendCounterStatusRequest(velbusBridgeHandler, (byte) 0x04);
+            }
+        }
+    }
+
+    protected void sendCounterStatusRequest(VelbusBridgeHandler velbusBridgeHandler, byte channel) {
+        VelbusCounterStatusRequestPacket packet = new VelbusCounterStatusRequestPacket(
+                new VelbusChannelIdentifier(getModuleAddress().getAddress(), channel));
+
+        byte[] packetBytes = packet.getBytes();
+        velbusBridgeHandler.sendPacket(packetBytes);
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if (command == COMMAND_COUNTER_STATUS && packet.length >= 6) {
+                int counterChannel = packet[5] & 0x03;
+                int pulsesPerUnit = ((packet[5] & 0x7C) / 0x04) * 0x64;
+
+                double counterValue = ((double) (((packet[6] & 0xff) << 24) | ((packet[7] & 0xff) << 16)
+                        | ((packet[8] & 0xff) << 8) | (packet[9] & 0xff))) / pulsesPerUnit;
+                double currentValue = (1000 * 3600)
+                        / (((double) (((packet[10] & 0xff) << 8) | (packet[11] & 0xff))) * pulsesPerUnit);
+
+                switch (counterChannel) {
+                    case 0x00:
+                        updateState(counter1Channel, new DecimalType(counterValue / counter1PulseMultiplier));
+                        updateState(counter1ChannelCurrent, new DecimalType(currentValue / counter1PulseMultiplier));
+                        break;
+                    case 0x01:
+                        updateState(counter2Channel, new DecimalType(counterValue / counter2PulseMultiplier));
+                        updateState(counter2ChannelCurrent, new DecimalType(currentValue / counter2PulseMultiplier));
+                        break;
+                    case 0x02:
+                        updateState(counter3Channel, new DecimalType(counterValue / counter3PulseMultiplier));
+                        updateState(counter3ChannelCurrent, new DecimalType(currentValue / counter3PulseMultiplier));
+                        break;
+                    case 0x03:
+                        updateState(counter4Channel, new DecimalType(counterValue / counter4PulseMultiplier));
+                        updateState(counter4ChannelCurrent, new DecimalType(currentValue / counter4PulseMultiplier));
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "The given channel is not a counter channel: " + counterChannel);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELHandler.java
@@ -24,18 +24,17 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link VelbusVMBGPHandler} is responsible for handling commands, which are
+ * The {@link VelbusVMBELHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusVMBGPHandler extends VelbusThermostatHandler {
+public class VelbusVMBELHandler extends VelbusThermostatHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMBGP1, THING_TYPE_VMBGP1_2, THING_TYPE_VMBGP2, THING_TYPE_VMBGP2_2,
-                    THING_TYPE_VMBGP4, THING_TYPE_VMBGP4_2, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGP4PIR_2));
+            Arrays.asList(THING_TYPE_VMBEL1, THING_TYPE_VMBEL2, THING_TYPE_VMBEL4));
 
-    public VelbusVMBGPHandler(Thing thing) {
+    public VelbusVMBELHandler(Thing thing) {
         super(thing, 4, new ChannelUID(thing.getUID(), "input#CH9"));
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELHandler.java
@@ -35,6 +35,6 @@ public class VelbusVMBELHandler extends VelbusThermostatHandler {
             Arrays.asList(THING_TYPE_VMBEL1, THING_TYPE_VMBEL2, THING_TYPE_VMBEL4));
 
     public VelbusVMBELHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH9"));
+        super(thing, 4, new ChannelUID(thing.getUID(), "input", "CH9"));
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELOHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBELOHandler.java
@@ -12,30 +12,27 @@
  */
 package org.openhab.binding.velbus.internal.handler;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.THING_TYPE_VMBELO;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link VelbusVMBGPHandler} is responsible for handling commands, which are
+ * The {@link VelbusVMBELOHandler} is responsible for handling commands, which are
  * sent to one of the channels.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusVMBGPHandler extends VelbusThermostatHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMBGP1, THING_TYPE_VMBGP1_2, THING_TYPE_VMBGP2, THING_TYPE_VMBGP2_2,
-                    THING_TYPE_VMBGP4, THING_TYPE_VMBGP4_2, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGP4PIR_2));
+public class VelbusVMBELOHandler extends VelbusMemoHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMBELO));
 
-    public VelbusVMBGPHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH9"));
+    public VelbusVMBELOHandler(Thing thing) {
+        super(thing);
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPHandler.java
@@ -36,6 +36,6 @@ public class VelbusVMBGPHandler extends VelbusThermostatHandler {
                     THING_TYPE_VMBGP4, THING_TYPE_VMBGP4_2, THING_TYPE_VMBGP4PIR, THING_TYPE_VMBGP4PIR_2));
 
     public VelbusVMBGPHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "input#CH9"));
+        super(thing, 4, new ChannelUID(thing.getUID(), "input", "CH9"));
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPOHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPOHandler.java
@@ -18,9 +18,16 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
 
 /**
  * The {@link VelbusVMBGPOHandler} is responsible for handling commands, which are
@@ -28,11 +35,71 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Cedric Boon - Initial contribution
  */
-public class VelbusVMBGPOHandler extends VelbusTemperatureSensorHandler {
+@NonNullByDefault
+public class VelbusVMBGPOHandler extends VelbusMemoHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_VMBGPO, THING_TYPE_VMBGPOD));
+            Arrays.asList(THING_TYPE_VMBGPO, THING_TYPE_VMBGPOD, THING_TYPE_VMBGPOD_2));
+
+    public static final int MODULESETTINGS_MEMORY_ADDRESS = 0x02F0;
+    public static final int LAST_MEMORY_LOCATION_ADDRESS = 0x1A03;
+
+    private final ChannelUID screensaverChannel = new ChannelUID(thing.getUID(), "oledDisplay#SCREENSAVER");
+
+    private byte moduleSettings;
 
     public VelbusVMBGPOHandler(Thing thing) {
-        super(thing, 4, new ChannelUID(thing.getUID(), "CH33"));
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (channelUID.equals(screensaverChannel) && command instanceof RefreshType) {
+            sendReadMemoryPacket(velbusBridgeHandler, MODULESETTINGS_MEMORY_ADDRESS);
+        }
+
+        if (channelUID.equals(screensaverChannel) && command instanceof OnOffType) {
+            byte screenSaverOnOffByte = (byte) ((command == OnOffType.ON) ? 0x80 : 0x00);
+            moduleSettings = (byte) (screenSaverOnOffByte | (moduleSettings & 0x7F));
+            sendWriteMemoryPacket(velbusBridgeHandler, MODULESETTINGS_MEMORY_ADDRESS, moduleSettings);
+            sendWriteMemoryPacket(velbusBridgeHandler, LAST_MEMORY_LOCATION_ADDRESS, (byte) 0xFF);
+        }
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if ((command == COMMAND_MEMORY_DATA_BLOCK && packet.length >= 11)
+                    || (command == COMMAND_MEMORY_DATA && packet.length >= 8)) {
+                byte highMemoryAddress = packet[5];
+                byte lowMemoryAddress = packet[6];
+                int memoryAddress = ((highMemoryAddress & 0xff) << 8) | (lowMemoryAddress & 0xff);
+                byte[] data = (command == COMMAND_MEMORY_DATA_BLOCK)
+                        ? new byte[] { packet[7], packet[8], packet[9], packet[10] }
+                        : new byte[] { packet[7] };
+
+                for (int i = 0; i < data.length; i++) {
+
+                    if ((memoryAddress + i) == MODULESETTINGS_MEMORY_ADDRESS) {
+                        this.moduleSettings = data[i];
+                        OnOffType state = ((this.moduleSettings & 0x80) != 0x00) ? OnOffType.ON : OnOffType.OFF;
+                        updateState(screensaverChannel, state);
+                    }
+                }
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPOHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBGPOHandler.java
@@ -43,7 +43,7 @@ public class VelbusVMBGPOHandler extends VelbusMemoHandler {
     public static final int MODULESETTINGS_MEMORY_ADDRESS = 0x02F0;
     public static final int LAST_MEMORY_LOCATION_ADDRESS = 0x1A03;
 
-    private final ChannelUID screensaverChannel = new ChannelUID(thing.getUID(), "oledDisplay#SCREENSAVER");
+    private final ChannelUID screensaverChannel = new ChannelUID(thing.getUID(), "oledDisplay", "SCREENSAVER");
 
     private byte moduleSettings;
 

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBMeteoHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBMeteoHandler.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.handler;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.measure.quantity.Illuminance;
+import javax.measure.quantity.Length;
+import javax.measure.quantity.Speed;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.MetricPrefix;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusSensorReadoutRequestPacket;
+
+/**
+ * The {@link VelbusVMBMeteoHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusVMBMeteoHandler extends VelbusTemperatureSensorHandler {
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMBMETEO));
+
+    private static final byte RAIN_SENSOR_CHANNEL = 0x02;
+    private static final byte LIGHT_SENSOR_CHANNEL = 0x04;
+    private static final byte WIND_SENSOR_CHANNEL = 0x08;
+    private static final byte ALL_SENSOR_CHANNELS = RAIN_SENSOR_CHANNEL | LIGHT_SENSOR_CHANNEL | WIND_SENSOR_CHANNEL;
+
+    private ChannelUID rainfallChannel;
+    private ChannelUID illuminanceChannel;
+    private ChannelUID windspeedChannel;
+
+    public VelbusVMBMeteoHandler(Thing thing) {
+        super(thing, 0, new ChannelUID(thing.getUID(), "weatherStation#CH10"));
+
+        this.rainfallChannel = new ChannelUID(thing.getUID(), "weatherStation#CH11");
+        this.illuminanceChannel = new ChannelUID(thing.getUID(), "weatherStation#CH12");
+        this.windspeedChannel = new ChannelUID(thing.getUID(), "weatherStation#CH13");
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            logger.warn("Velbus bridge handler not found. Cannot handle command without bridge.");
+            return;
+        }
+
+        if (command instanceof RefreshType) {
+            if (channelUID.equals(rainfallChannel)) {
+                sendSensorReadoutRequest(velbusBridgeHandler, RAIN_SENSOR_CHANNEL);
+            } else if (channelUID.equals(illuminanceChannel)) {
+                sendSensorReadoutRequest(velbusBridgeHandler, LIGHT_SENSOR_CHANNEL);
+            } else if (channelUID.equals(windspeedChannel)) {
+                sendSensorReadoutRequest(velbusBridgeHandler, WIND_SENSOR_CHANNEL);
+            }
+        }
+    }
+
+    @Override
+    protected void sendSensorReadoutRequest(VelbusBridgeHandler velbusBridgeHandler) {
+        super.sendSensorReadoutRequest(velbusBridgeHandler);
+
+        sendSensorReadoutRequest(velbusBridgeHandler, ALL_SENSOR_CHANNELS);
+    }
+
+    protected void sendSensorReadoutRequest(VelbusBridgeHandler velbusBridgeHandler, byte channel) {
+        VelbusSensorReadoutRequestPacket packet = new VelbusSensorReadoutRequestPacket(getModuleAddress().getAddress(),
+                channel);
+
+        byte[] packetBytes = packet.getBytes();
+        velbusBridgeHandler.sendPacket(packetBytes);
+    }
+
+    @Override
+    protected int getClockAlarmAndProgramSelectionIndexInModuleStatus() {
+        return 8;
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if (command == COMMAND_SENSOR_RAW_DATA && packet.length >= 10) {
+                byte highByteCurrentRainValue = packet[5];
+                byte lowByteCurrentRainValue = packet[6];
+                byte highByteCurrentLightValue = packet[7];
+                byte lowByteCurrentLightValue = packet[8];
+                byte highByteCurrentWindValue = packet[9];
+                byte lowByteCurrentWindValue = packet[10];
+
+                double rainValue = (((highByteCurrentRainValue & 0xff) << 8) + (lowByteCurrentRainValue & 0xff)) / 10;
+                double lightValue = (((highByteCurrentLightValue & 0xff) << 8) + (lowByteCurrentLightValue & 0xff));
+                double windValue = (((highByteCurrentWindValue & 0xff) << 8) + (lowByteCurrentWindValue & 0xff)) / 10;
+
+                QuantityType<Length> rainValueState = new QuantityType<>(rainValue, MetricPrefix.MILLI(SIUnits.METRE));
+                QuantityType<Illuminance> lightValueState = new QuantityType<>(lightValue, SmartHomeUnits.LUX);
+                QuantityType<Speed> windValueState = new QuantityType<>(windValue, SIUnits.KILOMETRE_PER_HOUR);
+
+                updateState(rainfallChannel, rainValueState);
+                updateState(illuminanceChannel, lightValueState);
+                updateState(windspeedChannel, windValueState);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBMeteoHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBMeteoHandler.java
@@ -55,11 +55,11 @@ public class VelbusVMBMeteoHandler extends VelbusTemperatureSensorHandler {
     private ChannelUID windspeedChannel;
 
     public VelbusVMBMeteoHandler(Thing thing) {
-        super(thing, 0, new ChannelUID(thing.getUID(), "weatherStation#CH10"));
+        super(thing, 0, new ChannelUID(thing.getUID(), "weatherStation", "CH10"));
 
-        this.rainfallChannel = new ChannelUID(thing.getUID(), "weatherStation#CH11");
-        this.illuminanceChannel = new ChannelUID(thing.getUID(), "weatherStation#CH12");
-        this.windspeedChannel = new ChannelUID(thing.getUID(), "weatherStation#CH13");
+        this.rainfallChannel = new ChannelUID(thing.getUID(), "weatherStation", "CH11");
+        this.illuminanceChannel = new ChannelUID(thing.getUID(), "weatherStation", "CH12");
+        this.windspeedChannel = new ChannelUID(thing.getUID(), "weatherStation", "CH13");
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBPIROHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBPIROHandler.java
@@ -12,15 +12,26 @@
  */
 package org.openhab.binding.velbus.internal.handler;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.THING_TYPE_VMBPIRO;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.measure.quantity.Illuminance;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.velbus.internal.packets.VelbusLightValueRequestPacket;
+import org.openhab.binding.velbus.internal.packets.VelbusPacket;
 
 /**
  * The {@link VelbusVMBPIROHandler} is responsible for handling commands, which are
@@ -28,10 +39,56 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusVMBPIROHandler extends VelbusTemperatureSensorHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_VMBPIRO));
 
+    private ChannelUID illuminanceChannel;
+
     public VelbusVMBPIROHandler(Thing thing) {
-        super(thing, 0, new ChannelUID(thing.getUID(), "CH9"));
+        super(thing, 0, new ChannelUID(thing.getUID(), "input#CH9"));
+
+        this.illuminanceChannel = new ChannelUID(thing.getUID(), "input#LIGHT");
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        super.handleCommand(channelUID, command);
+
+        VelbusBridgeHandler velbusBridgeHandler = getVelbusBridgeHandler();
+        if (velbusBridgeHandler == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+
+        if (command instanceof RefreshType) {
+            if (channelUID.equals(illuminanceChannel)) {
+                VelbusLightValueRequestPacket packet = new VelbusLightValueRequestPacket(
+                        getModuleAddress().getAddress());
+
+                byte[] packetBytes = packet.getBytes();
+                velbusBridgeHandler.sendPacket(packetBytes);
+            }
+        }
+    }
+
+    @Override
+    public void onPacketReceived(byte[] packet) {
+        super.onPacketReceived(packet);
+
+        logger.trace("onPacketReceived() was called");
+
+        if (packet[0] == VelbusPacket.STX && packet.length >= 5) {
+            byte command = packet[4];
+
+            if (command == COMMAND_MODULE_STATUS && packet.length >= 6) {
+                byte highByteCurrentLightValue = packet[6];
+                byte lowByteCurrentLightValue = packet[7];
+
+                double lightValue = (((highByteCurrentLightValue & 0xff) << 8) + (lowByteCurrentLightValue & 0xff));
+                QuantityType<Illuminance> lightValueState = new QuantityType<>(lightValue, SmartHomeUnits.LUX);
+                updateState(illuminanceChannel, lightValueState);
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBPIROHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMBPIROHandler.java
@@ -46,9 +46,9 @@ public class VelbusVMBPIROHandler extends VelbusTemperatureSensorHandler {
     private ChannelUID illuminanceChannel;
 
     public VelbusVMBPIROHandler(Thing thing) {
-        super(thing, 0, new ChannelUID(thing.getUID(), "input#CH9"));
+        super(thing, 0, new ChannelUID(thing.getUID(), "input", "CH9"));
 
-        this.illuminanceChannel = new ChannelUID(thing.getUID(), "input#LIGHT");
+        this.illuminanceChannel = new ChannelUID(thing.getUID(), "input", "LIGHT");
     }
 
     @Override

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusBlindPositionPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusBlindPositionPacket.java
@@ -14,6 +14,7 @@ package org.openhab.binding.velbus.internal.packets;
 
 import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_BLIND_POS;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
@@ -22,6 +23,7 @@ import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusBlindPositionPacket extends VelbusPacket {
     private byte channel;
     private byte percentage;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusBlindUpDownPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusBlindUpDownPacket.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
@@ -20,6 +21,7 @@ import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusBlindUpDownPacket extends VelbusPacket {
     private final byte timeoutHighByte = 0x00;
     private final byte timeoutMidByte = 0x00;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusChannelNameRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusChannelNameRequestPacket.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_MODULE_NAME_REQUEST;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link VelbusChannelNameRequestPacket} represents a Velbus packet that can be used to
@@ -20,8 +22,8 @@ import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusChannelNameRequestPacket extends VelbusPacket {
-    private static final byte ALL_CHANNELS = (byte) 0xFF;
 
     public VelbusChannelNameRequestPacket(byte address) {
         super(address, PRIO_LOW);

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusCounterStatusRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusCounterStatusRequestPacket.java
@@ -12,29 +12,31 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SWITCH_BLIND_OFF;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_COUNTER_STATUS_REQUEST;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
- * The {@link VelbusBlindOffPacket} represents a Velbus packet that can be used to
- * stop a moving blind.
+ * The {@link VelbusCounterStatusRequestPacket} represents a Velbus packet that can be used to
+ * request the counter status of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusBlindOffPacket extends VelbusPacket {
+public class VelbusCounterStatusRequestPacket extends VelbusPacket {
     private byte channel;
 
-    public VelbusBlindOffPacket(VelbusChannelIdentifier velbusChannelIdentifier) {
-        super(velbusChannelIdentifier.getAddress(), PRIO_HI);
+    private final byte autosendTimeInterval = 0x00;
+
+    public VelbusCounterStatusRequestPacket(VelbusChannelIdentifier velbusChannelIdentifier) {
+        super(velbusChannelIdentifier.getAddress(), PRIO_LOW);
 
         this.channel = velbusChannelIdentifier.getChannelByte();
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SWITCH_BLIND_OFF, channel };
+        return new byte[] { COMMAND_COUNTER_STATUS_REQUEST, channel, autosendTimeInterval };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusDimmerPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusDimmerPacket.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
@@ -20,24 +21,38 @@ import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusDimmerPacket extends VelbusPacket {
-    private final byte dimspeedHighByte = 0x00;
-    private final byte dimspeedLowByte = 0x00;
+    private static final byte FIRST_GENERATION_DEVICE_FASTEST_DIMSPEED_HIGH_BYTE = (byte) 0xFF;
+    private static final byte FIRST_GENERATION_DEVICE_FASTEST_DIMSPEED_LOW_BYTE = (byte) 0xFF;
 
+    private Boolean isFirstGenerationDevice;
     private byte command;
     private byte channel;
     private byte percentage;
+    private int dimspeed;
 
-    public VelbusDimmerPacket(VelbusChannelIdentifier velbusChannelIdentifier, byte command, byte percentage) {
+    public VelbusDimmerPacket(VelbusChannelIdentifier velbusChannelIdentifier, byte command, byte percentage,
+            int dimspeed, Boolean isFirstGenerationDevice) {
         super(velbusChannelIdentifier.getAddress(), PRIO_HI);
 
         this.channel = velbusChannelIdentifier.getChannelByte();
         this.command = command;
         this.percentage = percentage;
+        this.dimspeed = dimspeed;
+        this.isFirstGenerationDevice = isFirstGenerationDevice;
     }
 
     @Override
     protected byte[] getDataBytes() {
+        byte dimspeedHighByte = (byte) ((dimspeed & 0xFF00) / 0x100);
+        byte dimspeedLowByte = (byte) (dimspeed & 0xFF);
+
+        if (dimspeed == 0 && isFirstGenerationDevice) {
+            dimspeedHighByte = FIRST_GENERATION_DEVICE_FASTEST_DIMSPEED_HIGH_BYTE;
+            dimspeedLowByte = FIRST_GENERATION_DEVICE_FASTEST_DIMSPEED_LOW_BYTE;
+        }
+
         return new byte[] { command, channel, percentage, dimspeedHighByte, dimspeedLowByte };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusFeedbackLEDPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusFeedbackLEDPacket.java
@@ -12,29 +12,29 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SWITCH_BLIND_OFF;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
- * The {@link VelbusBlindOffPacket} represents a Velbus packet that can be used to
- * stop a moving blind.
+ * The {@link VelbusFeedbackLEDPacket} represents a Velbus packet that can be used to
+ * set the feedback led (clear/set/slow blink/fast blink/very fast blink) of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusBlindOffPacket extends VelbusPacket {
+public class VelbusFeedbackLEDPacket extends VelbusPacket {
+    private byte command;
     private byte channel;
 
-    public VelbusBlindOffPacket(VelbusChannelIdentifier velbusChannelIdentifier) {
-        super(velbusChannelIdentifier.getAddress(), PRIO_HI);
+    public VelbusFeedbackLEDPacket(VelbusChannelIdentifier velbusChannelIdentifier, byte command) {
+        super(velbusChannelIdentifier.getAddress(), PRIO_LOW);
 
         this.channel = velbusChannelIdentifier.getChannelByte();
+        this.command = command;
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SWITCH_BLIND_OFF, channel };
+        return new byte[] { command, channel };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusLightValueRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusLightValueRequestPacket.java
@@ -12,29 +12,27 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SWITCH_BLIND_OFF;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_LIGHT_VALUE_REQUEST;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
- * The {@link VelbusBlindOffPacket} represents a Velbus packet that can be used to
- * stop a moving blind.
+ * The {@link VelbusLightValueRequestPacket} represents a Velbus packet that can be used to
+ * request the value of the light sensor of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusBlindOffPacket extends VelbusPacket {
-    private byte channel;
+public class VelbusLightValueRequestPacket extends VelbusPacket {
 
-    public VelbusBlindOffPacket(VelbusChannelIdentifier velbusChannelIdentifier) {
-        super(velbusChannelIdentifier.getAddress(), PRIO_HI);
+    private final byte autosendTimeInterval = 0x00;
 
-        this.channel = velbusChannelIdentifier.getChannelByte();
+    public VelbusLightValueRequestPacket(byte address) {
+        super(address, PRIO_LOW);
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SWITCH_BLIND_OFF, channel };
+        return new byte[] { COMMAND_LIGHT_VALUE_REQUEST, autosendTimeInterval };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusMemoTextPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusMemoTextPacket.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_TEXT;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusMemoTextPacket} represents a Velbus packet that can be used to
+ * set the mode (comfort/day/night/safe) of the given Velbus thermostat module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusMemoTextPacket extends VelbusPacket {
+    private byte textStartPosition;
+    private byte character1;
+    private byte character2;
+    private byte character3;
+    private byte character4;
+    private byte character5;
+
+    public VelbusMemoTextPacket(byte address, byte textStartPosition, char[] text) {
+        super(address, PRIO_LOW);
+
+        if (textStartPosition < 0 || textStartPosition > 63) {
+            throw new IllegalArgumentException("The text start position '" + textStartPosition
+                    + "' is invalid, because it should be between 0 and 63.");
+        }
+
+        if (text.length > 5) {
+            throw new IllegalArgumentException(
+                    "The text '" + text.toString() + "' is invalid, because it cannot be longer than 5 characters.");
+        }
+
+        this.textStartPosition = textStartPosition;
+        this.character1 = text.length > 0 ? (byte) text[0] : 0x00;
+        this.character2 = text.length > 1 ? (byte) text[1] : 0x00;
+        this.character3 = text.length > 2 ? (byte) text[2] : 0x00;
+        this.character4 = text.length > 3 ? (byte) text[3] : 0x00;
+        this.character5 = text.length > 4 ? (byte) text[4] : 0x00;
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_TEXT, 0x00, textStartPosition, character1, character2, character3, character4,
+                character5 };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusPacket.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link VelbusPacket} represents a base class for a Velbus packet and contains
  * functionality that is applicable to all Velbus packets.
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public abstract class VelbusPacket {
     public static final byte STX = 0x0F;
     public static final byte PRIO_HI = (byte) 0xF8;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusReadMemoryBlockPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusReadMemoryBlockPacket.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_READ_MEMORY_BLOCK;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusReadMemoryBlockPacket} represents a Velbus packet that can be used to
+ * request a block of 4 bytes from the memory of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusReadMemoryBlockPacket extends VelbusPacket {
+    private byte highMemoryAddress;
+    private byte lowMemoryAddress;
+
+    public VelbusReadMemoryBlockPacket(byte address, int memoryAddress) {
+        super(address, PRIO_LOW);
+
+        highMemoryAddress = (byte) ((memoryAddress >> 8) & 0xFF);
+        lowMemoryAddress = (byte) (memoryAddress & 0xFF);
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_READ_MEMORY_BLOCK, highMemoryAddress, lowMemoryAddress };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusReadMemoryPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusReadMemoryPacket.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_READ_DATA_FROM_MEMORY;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusReadMemoryPacket} represents a Velbus packet that can be used to
+ * request a byte from the memory of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusReadMemoryPacket extends VelbusPacket {
+    private byte highMemoryAddress;
+    private byte lowMemoryAddress;
+
+    public VelbusReadMemoryPacket(byte address, int memoryAddress) {
+        super(address, PRIO_LOW);
+
+        highMemoryAddress = (byte) ((memoryAddress >> 8) & 0xFF);
+        lowMemoryAddress = (byte) (memoryAddress & 0xFF);
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_READ_DATA_FROM_MEMORY, highMemoryAddress, lowMemoryAddress };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusRelayPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusRelayPacket.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
@@ -20,6 +21,7 @@ import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusRelayPacket extends VelbusPacket {
     private byte command;
     private byte channel;

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusScanPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusScanPacket.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link VelbusScanPacket} represents a Velbus packet that can be used to
  * check if a Velbus module exists on the given address and to request this module's
@@ -19,6 +21,7 @@ package org.openhab.binding.velbus.internal.packets;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusScanPacket extends VelbusPacket {
 
     public VelbusScanPacket(byte address) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSensorReadoutRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSensorReadoutRequestPacket.java
@@ -12,29 +12,31 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SWITCH_BLIND_OFF;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SENSOR_READOUT_REQUEST;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
- * The {@link VelbusBlindOffPacket} represents a Velbus packet that can be used to
- * stop a moving blind.
+ * The {@link VelbusSensorReadoutRequestPacket} represents a Velbus packet that can be used to
+ * request the value of a sensor channel of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusBlindOffPacket extends VelbusPacket {
+public class VelbusSensorReadoutRequestPacket extends VelbusPacket {
+
+    private final byte autosendTimeInterval = 0x00;
+
     private byte channel;
 
-    public VelbusBlindOffPacket(VelbusChannelIdentifier velbusChannelIdentifier) {
-        super(velbusChannelIdentifier.getAddress(), PRIO_HI);
+    public VelbusSensorReadoutRequestPacket(byte address, byte channel) {
+        super(address, PRIO_LOW);
 
-        this.channel = velbusChannelIdentifier.getChannelByte();
+        this.channel = channel;
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SWITCH_BLIND_OFF, channel };
+        return new byte[] { COMMAND_SENSOR_READOUT_REQUEST, channel, autosendTimeInterval };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSensorSettingsRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSensorSettingsRequestPacket.java
@@ -12,27 +12,24 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SENSOR_READOUT_REQUEST;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_TEMP_SENSOR_SETTINGS_REQUEST;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link VelbusSensorTemperatureRequestPacket} represents a Velbus packet that can be used to
- * request the value of the temperature sensor of the given Velbus module.
+ * The {@link VelbusSensorSettingsRequestPacket} represents a Velbus packet that can be used to
+ * request the sensor settings of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusSensorTemperatureRequestPacket extends VelbusPacket {
-
-    private final byte autosendTimeInterval = 0x00;
-
-    public VelbusSensorTemperatureRequestPacket(byte address) {
+public class VelbusSensorSettingsRequestPacket extends VelbusPacket {
+    public VelbusSensorSettingsRequestPacket(byte address) {
         super(address, PRIO_LOW);
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SENSOR_READOUT_REQUEST, autosendTimeInterval };
+        return new byte[] { COMMAND_TEMP_SENSOR_SETTINGS_REQUEST, 0x00 };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetDatePacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetDatePacket.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SET_REALTIME_DATE;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusSetDatePacket} represents a Velbus packet that can be used to
+ * set the date of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSetDatePacket extends VelbusPacket {
+    private ZonedDateTime zonedDateTime;
+
+    public VelbusSetDatePacket(byte address, ZonedDateTime zonedDateTime) {
+        super(address, PRIO_LOW);
+
+        this.zonedDateTime = zonedDateTime;
+    }
+
+    public byte getDay() {
+        return (byte) this.zonedDateTime.getDayOfMonth();
+    }
+
+    public byte getMonth() {
+        return (byte) this.zonedDateTime.getMonthValue();
+    }
+
+    public byte getYearHighByte() {
+        return (byte) ((zonedDateTime.getYear() & 0xff00) / 0x100);
+    }
+
+    public byte getYearLowByte() {
+        return (byte) (zonedDateTime.getYear() & 0xff);
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_SET_REALTIME_DATE, getDay(), getMonth(), getYearHighByte(), getYearLowByte() };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetDaylightSavingsStatusPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetDaylightSavingsStatusPacket.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_DAYLIGHT_SAVING_STATUS;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusSetDaylightSavingsStatusPacket} represents a Velbus packet that can be used to
+ * set the daylight saving status of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSetDaylightSavingsStatusPacket extends VelbusPacket {
+    private ZonedDateTime zonedDateTime;
+
+    public VelbusSetDaylightSavingsStatusPacket(byte address, ZonedDateTime zonedDateTime) {
+        super(address, PRIO_LOW);
+
+        this.zonedDateTime = zonedDateTime;
+    }
+
+    public boolean isDaylightSavings() {
+        return zonedDateTime.getZone().getRules().isDaylightSavings(zonedDateTime.toInstant());
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_DAYLIGHT_SAVING_STATUS, (byte) (isDaylightSavings() ? 0x01 : 0x00) };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetLocalClockAlarmPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetLocalClockAlarmPacket.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SET_ALARM_CLOCK;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.velbus.internal.VelbusClockAlarm;
+
+/**
+ * The {@link VelbusSetLocalClockAlarmPacket} represents a Velbus packet that can be used to
+ * set the value of the local clock alarm of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSetLocalClockAlarmPacket extends VelbusPacket {
+    private byte alarmNumber;
+    private VelbusClockAlarm alarmClock;
+
+    public VelbusSetLocalClockAlarmPacket(byte address, byte alarmNumber, VelbusClockAlarm alarmClock) {
+        super(address, PRIO_LOW);
+
+        this.alarmNumber = alarmNumber;
+        this.alarmClock = alarmClock;
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_SET_ALARM_CLOCK, alarmNumber, alarmClock.getWakeupHour(),
+                alarmClock.getWakeupMinute(), alarmClock.getBedtimeHour(), alarmClock.getBedtimeMinute(),
+                alarmClock.isEnabled() ? (byte) 0x01 : (byte) 0x00 };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetRealtimeClockPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetRealtimeClockPacket.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SET_REALTIME_CLOCK;
+
+import java.time.DayOfWeek;
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusSetRealtimeClockPacket} represents a Velbus packet that can be used to
+ * set the clock of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusSetRealtimeClockPacket extends VelbusPacket {
+    private ZonedDateTime zonedDateTime;
+
+    public VelbusSetRealtimeClockPacket(byte address, ZonedDateTime zonedDateTime) {
+        super(address, PRIO_LOW);
+
+        this.zonedDateTime = zonedDateTime;
+    }
+
+    public byte getHour() {
+        return (byte) this.zonedDateTime.getHour();
+    }
+
+    public byte getMinute() {
+        return (byte) this.zonedDateTime.getMinute();
+    }
+
+    public byte getWeekDay() {
+        DayOfWeek dayOfWeek = zonedDateTime.getDayOfWeek();
+        switch (dayOfWeek) {
+            case MONDAY:
+                return 0x00;
+            case TUESDAY:
+                return 0x01;
+            case WEDNESDAY:
+                return 0x02;
+            case THURSDAY:
+                return 0x03;
+            case FRIDAY:
+                return 0x04;
+            case SATURDAY:
+                return 0x05;
+            case SUNDAY:
+                return 0x06;
+            default:
+                throw new IllegalArgumentException("Day " + dayOfWeek + " is not a valid weekday.");
+        }
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_SET_REALTIME_CLOCK, this.getWeekDay(), getHour(), getMinute() };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetTemperaturePacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusSetTemperaturePacket.java
@@ -12,27 +12,31 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SENSOR_READOUT_REQUEST;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SET_TEMP;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link VelbusSensorTemperatureRequestPacket} represents a Velbus packet that can be used to
- * request the value of the temperature sensor of the given Velbus module.
+ * The {@link VelbusSetTemperaturePacket} represents a Velbus packet that can be used to
+ * set the value of a temperature variable of the given Velbus module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusSensorTemperatureRequestPacket extends VelbusPacket {
+public class VelbusSetTemperaturePacket extends VelbusPacket {
 
-    private final byte autosendTimeInterval = 0x00;
+    private byte temperatureVariable;
+    private byte temperature;
 
-    public VelbusSensorTemperatureRequestPacket(byte address) {
+    public VelbusSetTemperaturePacket(byte address, byte temperatureVariable, byte temperature) {
         super(address, PRIO_LOW);
+
+        this.temperatureVariable = temperatureVariable;
+        this.temperature = temperature;
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SENSOR_READOUT_REQUEST, autosendTimeInterval };
+        return new byte[] { COMMAND_SET_TEMP, temperatureVariable, temperature };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusStatusRequestPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusStatusRequestPacket.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_STATUS_REQUEST;
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.*;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
 
 /**
@@ -22,9 +23,8 @@ import org.openhab.binding.velbus.internal.VelbusChannelIdentifier;
  *
  * @author Cedric Boon - Initial contribution
  */
+@NonNullByDefault
 public class VelbusStatusRequestPacket extends VelbusPacket {
-    private static final byte ALL_CHANNELS = (byte) 0xFF;
-
     private byte channel;
 
     public VelbusStatusRequestPacket(byte address) {

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusThermostatModePacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusThermostatModePacket.java
@@ -12,27 +12,27 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SENSOR_READOUT_REQUEST;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link VelbusSensorTemperatureRequestPacket} represents a Velbus packet that can be used to
- * request the value of the temperature sensor of the given Velbus module.
+ * The {@link VelbusThermostatModePacket} represents a Velbus packet that can be used to
+ * set the mode (comfort/day/night/safe) of the given Velbus thermostat module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusSensorTemperatureRequestPacket extends VelbusPacket {
+public class VelbusThermostatModePacket extends VelbusPacket {
 
-    private final byte autosendTimeInterval = 0x00;
+    private byte commandByte;
 
-    public VelbusSensorTemperatureRequestPacket(byte address) {
+    public VelbusThermostatModePacket(byte address, byte commandByte) {
         super(address, PRIO_LOW);
+
+        this.commandByte = commandByte;
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SENSOR_READOUT_REQUEST, autosendTimeInterval };
+        return new byte[] { commandByte, 0x00, 0x00 };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusThermostatOperatingModePacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusThermostatOperatingModePacket.java
@@ -12,27 +12,27 @@
  */
 package org.openhab.binding.velbus.internal.packets;
 
-import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_SENSOR_READOUT_REQUEST;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link VelbusSensorTemperatureRequestPacket} represents a Velbus packet that can be used to
- * request the value of the temperature sensor of the given Velbus module.
+ * The {@link VelbusThermostatOperatingModePacket} represents a Velbus packet that can be used to
+ * set the operating mode (heating/cooling) of the given Velbus thermostat module.
  *
  * @author Cedric Boon - Initial contribution
  */
 @NonNullByDefault
-public class VelbusSensorTemperatureRequestPacket extends VelbusPacket {
+public class VelbusThermostatOperatingModePacket extends VelbusPacket {
 
-    private final byte autosendTimeInterval = 0x00;
+    private byte commandByte;
 
-    public VelbusSensorTemperatureRequestPacket(byte address) {
+    public VelbusThermostatOperatingModePacket(byte address, byte commandByte) {
         super(address, PRIO_LOW);
+
+        this.commandByte = commandByte;
     }
 
     @Override
     protected byte[] getDataBytes() {
-        return new byte[] { COMMAND_SENSOR_READOUT_REQUEST, autosendTimeInterval };
+        return new byte[] { commandByte, 0x00 };
     }
 }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusWriteMemoryPacket.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/packets/VelbusWriteMemoryPacket.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.velbus.internal.packets;
+
+import static org.openhab.binding.velbus.internal.VelbusBindingConstants.COMMAND_WRITE_DATA_TO_MEMORY;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VelbusWriteMemoryPacket} represents a Velbus packet that can be used to
+ * request a byte from the memory of the given Velbus module.
+ *
+ * @author Cedric Boon - Initial contribution
+ */
+@NonNullByDefault
+public class VelbusWriteMemoryPacket extends VelbusPacket {
+    private byte highMemoryAddress;
+    private byte lowMemoryAddress;
+    private byte data;
+
+    public VelbusWriteMemoryPacket(byte address, int memoryAddress, byte data) {
+        super(address, PRIO_LOW);
+
+        this.highMemoryAddress = (byte) ((memoryAddress >> 8) & 0xFF);
+        this.lowMemoryAddress = (byte) (memoryAddress & 0xFF);
+        this.data = data;
+    }
+
+    @Override
+    protected byte[] getDataBytes() {
+        return new byte[] { COMMAND_WRITE_DATA_TO_MEMORY, highMemoryAddress, lowMemoryAddress, data };
+    }
+}

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
@@ -12,6 +12,62 @@
 			<description>Select serial port (COM1, /dev/ttyS0, ...)</description>
 			<required>true</required>
 		</parameter>
+		<parameter name="timeUpdateInterval" type="integer">
+			<label>Time Update interval</label>
+			<description>The interval (in minutes) at which the realtime clock, date and daylight savings status of the modules
+				will be updated, default 360. If set to 0 or left empty, no refresh will be scheduled.</description>
+			<default>360</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="reconnectionInterval" type="integer">
+			<label>Reconnection interval</label>
+			<description>The interval (in seconds) at which reconnections should be reattempted in case of a communication
+				problem, default 15. If set to 0 or left empty, no reconnections will be attempted.</description>
+			<default>15</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="bridge-type:velbus:networkbridge">
+		<parameter name="address" type="text" required="true">
+			<context>network-address</context>
+			<label>IP Address or Hostname</label>
+			<description>IP Address or hostname of Velbus server</description>
+			<required>true</required>
+		</parameter>
+		<parameter name="port" type="integer" required="false">
+			<label>Port</label>
+			<description>Network port to communicate with Velbus server</description>
+			<required>true</required>
+		</parameter>
+		<parameter name="timeUpdateInterval" type="integer">
+			<label>Time Update interval</label>
+			<description>The interval (in minutes) at which the realtime clock, date and daylight savings status of the modules
+				will be updated, default 360. If set to 0 or left empty, no refresh will be scheduled.</description>
+			<default>360</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="reconnectionInterval" type="integer">
+			<label>Reconnection interval</label>
+			<description>The interval (in seconds) at which reconnections should be reattempted in case of a communication
+				problem, default 15. If set to 0 or left empty, no reconnections will be attempted.</description>
+			<default>15</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:velbus:temperatureSensorDevice">
+		<parameter name="address" type="text" required="true">
+			<label>Address</label>
+			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="refresh" type="integer">
+			<label>Refresh interval</label>
+			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
+				refresh will be scheduled.</description>
+			<default>300</default>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 
 	<config-description uri="thing-type:velbus:1channelDevice">
@@ -23,6 +79,25 @@
 			<label>CH1 Name</label>
 			<description>The name of CH1.</description>
 			<default>CH1</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:velbus:1channelDeviceWithDimspeed">
+		<parameter name="address" type="text" required="true">
+			<label>Address</label>
+			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="CH1" type="text">
+			<label>CH1 name</label>
+			<description>The name of CH1.</description>
+			<default>CH1</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="dimspeed" type="integer">
+			<label>Dimspeed</label>
+			<description>The time (in seconds) needed for dimming from 0 to 100%.</description>
+			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>
@@ -73,6 +148,43 @@
 			<label>CH4 Name</label>
 			<description>The name of CH4.</description>
 			<default>CH4</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:velbus:4channelDeviceWithDimspeed">
+		<parameter name="address" type="text" required="true">
+			<label>Address</label>
+			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="CH1" type="text">
+			<label>CH1 name</label>
+			<description>The name of CH1.</description>
+			<default>CH1</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH2" type="text">
+			<label>CH2 name</label>
+			<description>The name of CH2.</description>
+			<default>CH2</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH3" type="text">
+			<label>CH3 name</label>
+			<description>The name of CH3.</description>
+			<default>CH3</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH4" type="text">
+			<label>CH4 name</label>
+			<description>The name of CH4.</description>
+			<default>CH4</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="dimspeed" type="integer">
+			<label>Dimspeed</label>
+			<description>The time (in seconds) needed for dimming from 0 to 100%.</description>
+			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>
@@ -157,10 +269,165 @@
 		</parameter>
 	</config-description>
 
-	<config-description uri="thing-type:velbus:7channelDevice">
+	<config-description uri="thing-type:velbus:7channelDeviceWithCounters">
 		<parameter name="address" type="text" required="true">
 			<label>Address</label>
 			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="refresh" type="integer">
+			<label>Refresh interval</label>
+			<description>Refresh interval for the counters (in seconds), default 300. If set to 0 or left empty, no refresh will
+				be scheduled.</description>
+			<default>300</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH1" type="text">
+			<label>CH1 Name</label>
+			<description>The name of CH1.</description>
+			<default>CH1</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH2" type="text">
+			<label>CH2 Name</label>
+			<description>The name of CH2.</description>
+			<default>CH2</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH3" type="text">
+			<label>CH3 Name</label>
+			<description>The name of CH3.</description>
+			<default>CH3</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH4" type="text">
+			<label>CH4 Name</label>
+			<description>The name of CH4.</description>
+			<default>CH4</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH5" type="text">
+			<label>CH5 Name</label>
+			<description>The name of CH5.</description>
+			<default>CH5</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH6" type="text">
+			<label>CH6 Name</label>
+			<description>The name of CH6.</description>
+			<default>CH6</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH7" type="text">
+			<label>CH7 Name</label>
+			<description>The name of CH7.</description>
+			<default>CH7</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER1_UNIT" type="text">
+			<label>Counter 1 Unit</label>
+			<description>The unit for Counter 1.</description>
+			<default>kWh</default>
+			<options>
+				<option value="kWh">kWh</option>
+				<option value="liters">liters</option>
+				<option value="m³">m³</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER1_PULSE_MULTIPLIER" type="decimal">
+			<label>Counter 1 Pulse multiplier</label>
+			<description>The pulse multiplier for counter 1</description>
+			<default>1</default>
+			<options>
+				<option value="1">x1</option>
+				<option value="2.5">x2.5</option>
+				<option value="0.05">x0.05</option>
+				<option value="0.01">x0.01</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER2_UNIT" type="text">
+			<label>Counter 2 Unit</label>
+			<description>The unit for Counter 2.</description>
+			<default>kWh</default>
+			<options>
+				<option value="kWh">kWh</option>
+				<option value="liters">liters</option>
+				<option value="m³">m³</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER2_PULSE_MULTIPLIER" type="decimal">
+			<label>Counter 2 Pulse multiplier</label>
+			<description>The pulse multiplier for counter 2</description>
+			<default>1</default>
+			<options>
+				<option value="1">x1</option>
+				<option value="2.5">x2.5</option>
+				<option value="0.05">x0.05</option>
+				<option value="0.01">x0.01</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER3_UNIT" type="text">
+			<label>Counter 3 Unit</label>
+			<description>The unit for Counter 3.</description>
+			<default>kWh</default>
+			<options>
+				<option value="kWh">kWh</option>
+				<option value="liters">liters</option>
+				<option value="m³">m³</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER3_PULSE_MULTIPLIER" type="decimal">
+			<label>Counter 3 Pulse multiplier</label>
+			<description>The pulse multiplier for counter 3</description>
+			<default>1</default>
+			<options>
+				<option value="1">x1</option>
+				<option value="2.5">x2.5</option>
+				<option value="0.05">x0.05</option>
+				<option value="0.01">x0.01</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER4_UNIT" type="text">
+			<label>Counter 4 Unit</label>
+			<description>The unit for Counter 4.</description>
+			<default>kWh</default>
+			<options>
+				<option value="kWh">kWh</option>
+				<option value="liters">liters</option>
+				<option value="m³">m³</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="COUNTER4_PULSE_MULTIPLIER" type="decimal">
+			<label>Counter 4 Pulse multiplier</label>
+			<description>The pulse multiplier for counter 4</description>
+			<default>1</default>
+			<options>
+				<option value="1">x1</option>
+				<option value="2.5">x2.5</option>
+				<option value="0.05">x0.05</option>
+				<option value="0.01">x0.01</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:velbus:7channelDeviceWithTemperatureSensor">
+		<parameter name="address" type="text" required="true">
+			<label>Address</label>
+			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="refresh" type="integer">
+			<label>Refresh Interval</label>
+			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
+				refresh will be scheduled.</description>
+			<default>300</default>
+			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH1" type="text">
 			<label>CH1 Name</label>
@@ -325,6 +592,98 @@
 			<label>CH9 Name</label>
 			<description>The name of CH9 (temperature sensor channel).</description>
 			<default>Temperature</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:velbus:13channelDevice">
+		<parameter name="address" type="text" required="true">
+			<label>Address</label>
+			<description>The velbus address of the device</description>
+		</parameter>
+		<parameter name="refresh" type="integer">
+			<label>Refresh interval</label>
+			<description>Refresh interval for the sensors (in seconds), default 300. If set to 0 or left empty, no refresh will
+				be scheduled.</description>
+			<default>300</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH1" type="text">
+			<label>CH1 name</label>
+			<description>The name of CH1.</description>
+			<default>CH1</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH2" type="text">
+			<label>CH2 name</label>
+			<description>The name of CH2.</description>
+			<default>CH2</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH3" type="text">
+			<label>CH3 name</label>
+			<description>The name of CH3.</description>
+			<default>CH3</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH4" type="text">
+			<label>CH4 name</label>
+			<description>The name of CH4.</description>
+			<default>CH4</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH5" type="text">
+			<label>CH5 name</label>
+			<description>The name of CH5.</description>
+			<default>CH5</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH6" type="text">
+			<label>CH6 name</label>
+			<description>The name of CH6.</description>
+			<default>CH6</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH7" type="text">
+			<label>CH7 name</label>
+			<description>The name of CH7.</description>
+			<default>CH7</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH8" type="text">
+			<label>CH8 name</label>
+			<description>The name of CH8.</description>
+			<default>CH8</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH9" type="text">
+			<label>CH9 name</label>
+			<description>The name of CH9.</description>
+			<default>CH9</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH10" type="text">
+			<label>CH10 name</label>
+			<description>The name of CH10.</description>
+			<default>CH10</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH11" type="text">
+			<label>CH11 name</label>
+			<description>The name of CH11.</description>
+			<default>CH11</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH12" type="text">
+			<label>CH12 name</label>
+			<description>The name of CH12.</description>
+			<default>CH12</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="CH13" type="text">
+			<label>CH13 name</label>
+			<description>The name of CH13.</description>
+			<default>CH13</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
@@ -94,7 +94,7 @@
 			<default>CH1</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="dimspeed" type="integer">
+		<parameter name="dimspeed" type="integer" unit="s">
 			<label>Dimspeed</label>
 			<description>The time (in seconds) needed for dimming from 0 to 100%.</description>
 			<default>0</default>
@@ -181,7 +181,7 @@
 			<default>CH4</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="dimspeed" type="integer">
+		<parameter name="dimspeed" type="integer" unit="s">
 			<label>Dimspeed</label>
 			<description>The time (in seconds) needed for dimming from 0 to 100%.</description>
 			<default>0</default>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/config/config.xml
@@ -12,15 +12,15 @@
 			<description>Select serial port (COM1, /dev/ttyS0, ...)</description>
 			<required>true</required>
 		</parameter>
-		<parameter name="timeUpdateInterval" type="integer">
-			<label>Time Update interval</label>
+		<parameter name="timeUpdateInterval" type="integer" unit="min">
+			<label>Time Update Interval</label>
 			<description>The interval (in minutes) at which the realtime clock, date and daylight savings status of the modules
 				will be updated, default 360. If set to 0 or left empty, no refresh will be scheduled.</description>
 			<default>360</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="reconnectionInterval" type="integer">
-			<label>Reconnection interval</label>
+		<parameter name="reconnectionInterval" type="integer" unit="s">
+			<label>Reconnection Interval</label>
 			<description>The interval (in seconds) at which reconnections should be reattempted in case of a communication
 				problem, default 15. If set to 0 or left empty, no reconnections will be attempted.</description>
 			<default>15</default>
@@ -40,15 +40,15 @@
 			<description>Network port to communicate with Velbus server</description>
 			<required>true</required>
 		</parameter>
-		<parameter name="timeUpdateInterval" type="integer">
-			<label>Time Update interval</label>
+		<parameter name="timeUpdateInterval" type="integer" unit="min">
+			<label>Time Update Interval</label>
 			<description>The interval (in minutes) at which the realtime clock, date and daylight savings status of the modules
 				will be updated, default 360. If set to 0 or left empty, no refresh will be scheduled.</description>
 			<default>360</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="reconnectionInterval" type="integer">
-			<label>Reconnection interval</label>
+		<parameter name="reconnectionInterval" type="integer" unit="s">
+			<label>Reconnection Interval</label>
 			<description>The interval (in seconds) at which reconnections should be reattempted in case of a communication
 				problem, default 15. If set to 0 or left empty, no reconnections will be attempted.</description>
 			<default>15</default>
@@ -61,8 +61,8 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
-			<label>Refresh interval</label>
+		<parameter name="refresh" type="integer" unit="s">
+			<label>Refresh Interval</label>
 			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
 				refresh will be scheduled.</description>
 			<default>300</default>
@@ -89,7 +89,7 @@
 			<description>The velbus address of the device</description>
 		</parameter>
 		<parameter name="CH1" type="text">
-			<label>CH1 name</label>
+			<label>CH1 Name</label>
 			<description>The name of CH1.</description>
 			<default>CH1</default>
 			<advanced>true</advanced>
@@ -158,25 +158,25 @@
 			<description>The velbus address of the device</description>
 		</parameter>
 		<parameter name="CH1" type="text">
-			<label>CH1 name</label>
+			<label>CH1 Name</label>
 			<description>The name of CH1.</description>
 			<default>CH1</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH2" type="text">
-			<label>CH2 name</label>
+			<label>CH2 Name</label>
 			<description>The name of CH2.</description>
 			<default>CH2</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH3" type="text">
-			<label>CH3 name</label>
+			<label>CH3 Name</label>
 			<description>The name of CH3.</description>
 			<default>CH3</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH4" type="text">
-			<label>CH4 name</label>
+			<label>CH4 Name</label>
 			<description>The name of CH4.</description>
 			<default>CH4</default>
 			<advanced>true</advanced>
@@ -274,8 +274,8 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
-			<label>Refresh interval</label>
+		<parameter name="refresh" type="integer" unit="s">
+			<label>Refresh Interval</label>
 			<description>Refresh interval for the counters (in seconds), default 300. If set to 0 or left empty, no refresh will
 				be scheduled.</description>
 			<default>300</default>
@@ -323,7 +323,7 @@
 			<default>CH7</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER1_UNIT" type="text">
+		<parameter name="counter1Unit" type="text">
 			<label>Counter 1 Unit</label>
 			<description>The unit for Counter 1.</description>
 			<default>kWh</default>
@@ -334,8 +334,8 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER1_PULSE_MULTIPLIER" type="decimal">
-			<label>Counter 1 Pulse multiplier</label>
+		<parameter name="counter1PulseMultiplier" type="decimal">
+			<label>Counter 1 Pulse Multiplier</label>
 			<description>The pulse multiplier for counter 1</description>
 			<default>1</default>
 			<options>
@@ -346,7 +346,7 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER2_UNIT" type="text">
+		<parameter name="counter2Unit" type="text">
 			<label>Counter 2 Unit</label>
 			<description>The unit for Counter 2.</description>
 			<default>kWh</default>
@@ -357,8 +357,8 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER2_PULSE_MULTIPLIER" type="decimal">
-			<label>Counter 2 Pulse multiplier</label>
+		<parameter name="counter2PulseMultiplier" type="decimal">
+			<label>Counter 2 Pulse Multiplier</label>
 			<description>The pulse multiplier for counter 2</description>
 			<default>1</default>
 			<options>
@@ -369,7 +369,7 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER3_UNIT" type="text">
+		<parameter name="counter3Unit" type="text">
 			<label>Counter 3 Unit</label>
 			<description>The unit for Counter 3.</description>
 			<default>kWh</default>
@@ -380,8 +380,8 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER3_PULSE_MULTIPLIER" type="decimal">
-			<label>Counter 3 Pulse multiplier</label>
+		<parameter name="counter3PulseMultiplier" type="decimal">
+			<label>Counter 3 Pulse Multiplier</label>
 			<description>The pulse multiplier for counter 3</description>
 			<default>1</default>
 			<options>
@@ -392,7 +392,7 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER4_UNIT" type="text">
+		<parameter name="counter4Unit" type="text">
 			<label>Counter 4 Unit</label>
 			<description>The unit for Counter 4.</description>
 			<default>kWh</default>
@@ -403,8 +403,8 @@
 			</options>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="COUNTER4_PULSE_MULTIPLIER" type="decimal">
-			<label>Counter 4 Pulse multiplier</label>
+		<parameter name="counter4PulseMultiplier" type="decimal">
+			<label>Counter 4 Pulse Multiplier</label>
 			<description>The pulse multiplier for counter 4</description>
 			<default>1</default>
 			<options>
@@ -422,7 +422,7 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
+		<parameter name="refresh" type="integer" unit="s">
 			<label>Refresh Interval</label>
 			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
 				refresh will be scheduled.</description>
@@ -533,7 +533,7 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
+		<parameter name="refresh" type="integer" unit="s">
 			<label>Refresh Interval</label>
 			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
 				refresh will be scheduled.</description>
@@ -601,87 +601,87 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
-			<label>Refresh interval</label>
+		<parameter name="refresh" type="integer" unit="s">
+			<label>Refresh Interval</label>
 			<description>Refresh interval for the sensors (in seconds), default 300. If set to 0 or left empty, no refresh will
 				be scheduled.</description>
 			<default>300</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH1" type="text">
-			<label>CH1 name</label>
+			<label>CH1 Name</label>
 			<description>The name of CH1.</description>
 			<default>CH1</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH2" type="text">
-			<label>CH2 name</label>
+			<label>CH2 Name</label>
 			<description>The name of CH2.</description>
 			<default>CH2</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH3" type="text">
-			<label>CH3 name</label>
+			<label>CH3 Name</label>
 			<description>The name of CH3.</description>
 			<default>CH3</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH4" type="text">
-			<label>CH4 name</label>
+			<label>CH4 Name</label>
 			<description>The name of CH4.</description>
 			<default>CH4</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH5" type="text">
-			<label>CH5 name</label>
+			<label>CH5 Name</label>
 			<description>The name of CH5.</description>
 			<default>CH5</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH6" type="text">
-			<label>CH6 name</label>
+			<label>CH6 Name</label>
 			<description>The name of CH6.</description>
 			<default>CH6</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH7" type="text">
-			<label>CH7 name</label>
+			<label>CH7 Name</label>
 			<description>The name of CH7.</description>
 			<default>CH7</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH8" type="text">
-			<label>CH8 name</label>
+			<label>CH8 Name</label>
 			<description>The name of CH8.</description>
 			<default>CH8</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH9" type="text">
-			<label>CH9 name</label>
+			<label>CH9 Name</label>
 			<description>The name of CH9.</description>
 			<default>CH9</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH10" type="text">
-			<label>CH10 name</label>
+			<label>CH10 Name</label>
 			<description>The name of CH10.</description>
 			<default>CH10</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH11" type="text">
-			<label>CH11 name</label>
+			<label>CH11 Name</label>
 			<description>The name of CH11.</description>
 			<default>CH11</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH12" type="text">
-			<label>CH12 name</label>
+			<label>CH12 Name</label>
 			<description>The name of CH12.</description>
 			<default>CH12</default>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="CH13" type="text">
-			<label>CH13 name</label>
+			<label>CH13 Name</label>
 			<description>The name of CH13.</description>
 			<default>CH13</default>
 			<advanced>true</advanced>
@@ -693,7 +693,7 @@
 			<label>Address</label>
 			<description>The velbus address of the device</description>
 		</parameter>
-		<parameter name="refresh" type="integer">
+		<parameter name="refresh" type="integer" unit="s">
 			<label>Refresh Interval</label>
 			<description>Refresh interval for the temperature sensor (in seconds), default 300. If set to 0 or left empty, no
 				refresh will be scheduled.</description>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -129,6 +129,25 @@
 		<config-description-ref uri="thing-type:velbus:5channelDevice"/>
 	</thing-type>
 
+	<thing-type id="vmb1rys">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMB1RYS</label>
+		<description>1-channel relay module</description>
+		<channels>
+			<channel id="CH1" typeId="switch"/>
+			<channel id="CH2" typeId="switch"/>
+			<channel id="CH3" typeId="switch"/>
+			<channel id="CH4" typeId="switch"/>
+			<channel id="CH5" typeId="switch"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:velbus:5channelDevice"/>
+	</thing-type>
+
 	<thing-type id="vmb1ts">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -5,14 +5,36 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="bridge">
-		<label>Velbus Bridge</label>
+		<label>Velbus Serial Bridge</label>
 		<description>This bridge represents a Velbus Serial-interface</description>
 		<config-description-ref uri="bridge-type:velbus:bridge"/>
 	</bridge-type>
 
+	<bridge-type id="networkbridge">
+		<label>Velbus Network Bridge</label>
+		<description>This bridge represents a Velbus connection over TCP/IP</description>
+		<config-description-ref uri="bridge-type:velbus:networkbridge"/>
+	</bridge-type>
+
+	<thing-type id="vmb1bl">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMB1BL</label>
+		<description>1-channel blind control module for din rail</description>
+		<channels>
+			<channel id="CH1" typeId="rollershutter"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+	</thing-type>
+
 	<thing-type id="vmb1bls">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1BLS</label>
@@ -27,6 +49,7 @@
 	<thing-type id="vmb1dm">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1DM</label>
@@ -35,12 +58,13 @@
 			<channel id="CH1" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:1channelDeviceWithDimspeed"/>
 	</thing-type>
 
 	<thing-type id="vmb1led">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1LED</label>
@@ -49,12 +73,13 @@
 			<channel id="CH1" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:1channelDeviceWithDimspeed"/>
 	</thing-type>
 
 	<thing-type id="vmb1ry">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1RY</label>
@@ -69,6 +94,7 @@
 	<thing-type id="vmb1ryno">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1RYNO</label>
@@ -87,6 +113,7 @@
 	<thing-type id="vmb1rynos">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB1RYNOS</label>
@@ -102,9 +129,42 @@
 		<config-description-ref uri="thing-type:velbus:5channelDevice"/>
 	</thing-type>
 
+	<thing-type id="vmb1ts">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMB1TS</label>
+		<description>Temperature Sensor Module</description>
+		<channel-groups>
+			<channel-group id="input" typeId="1channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:temperatureSensorDevice"/>
+	</thing-type>
+
+	<thing-type id="vmb2bl">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMB2BL</label>
+		<description>2-channel blind control module</description>
+		<channels>
+			<channel id="CH1" typeId="rollershutter"/>
+			<channel id="CH2" typeId="rollershutter"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:velbus:2channelDevice"/>
+	</thing-type>
+
 	<thing-type id="vmb2ble">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB2BLE</label>
@@ -120,27 +180,40 @@
 	<thing-type id="vmb2pbn">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB2PBN</label>
 		<description>Push-button interface for Niko 1- or 2-fold push-buttons</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
-
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="feedback" typeId="2channelFeedbackModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
+	</thing-type>
+
+	<thing-type id="vmb4an">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMB4AN</label>
+		<description>Analog I/O module</description>
+		<channel-groups>
+			<channel-group id="alarm" typeId="8channelInputModule"/>
+			<channel-group id="analogInput" typeId="4channelAnalogInputModule"/>
+			<channel-group id="analogOutput" typeId="4channelAnalogOutputModule"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:13channelDevice"/>
 	</thing-type>
 
 	<thing-type id="vmb4dc">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB4DC</label>
@@ -152,12 +225,13 @@
 			<channel id="CH4" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:4channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:4channelDeviceWithDimspeed"/>
 	</thing-type>
 
 	<thing-type id="vmb4ry">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB4RY</label>
@@ -175,6 +249,7 @@
 	<thing-type id="vmb4ryld">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB4RYLD</label>
@@ -193,6 +268,7 @@
 	<thing-type id="vmb4ryno">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB4RYNO</label>
@@ -211,18 +287,14 @@
 	<thing-type id="vmb6in">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB6IN</label>
 		<description>6-channel input module</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="6channelInputModule"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:6channelDevice"/>
 	</thing-type>
@@ -230,20 +302,16 @@
 	<thing-type id="vmb6pbn">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB6PBN</label>
 		<description>Push-button interface module for Niko 4- or 6-fold push-button</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="feedback" typeId="6channelFeedbackModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
 	</thing-type>
@@ -251,41 +319,31 @@
 	<thing-type id="vmb7in">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB7IN</label>
 		<description>7-channel input module (potentialfree + pulse)</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="counter" typeId="4channelCounterModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
-		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:7channelDeviceWithCounters"/>
 	</thing-type>
 
 	<thing-type id="vmb8ir">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB8IR</label>
 		<description>Infrared remote control receiver module</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
 	</thing-type>
@@ -293,20 +351,15 @@
 	<thing-type id="vmb8pb">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB8PB</label>
 		<description>8-Channel Push Button module</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="feedback" typeId="8channelFeedbackModule"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
 	</thing-type>
@@ -314,20 +367,16 @@
 	<thing-type id="vmb8pbu">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMB8PBU</label>
 		<description>Push-button interface with 8 channels for universal mounting</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="feedback" typeId="8channelFeedbackModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
 	</thing-type>
@@ -335,6 +384,7 @@
 	<thing-type id="vmbdme">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBDME</label>
@@ -343,12 +393,13 @@
 			<channel id="CH1" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:1channelDeviceWithDimspeed"/>
 	</thing-type>
 
 	<thing-type id="vmbdmi">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBDMI</label>
@@ -357,12 +408,13 @@
 			<channel id="CH1" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:1channelDeviceWithDimspeed"/>
 	</thing-type>
 
 	<thing-type id="vmbdmir">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBDMI-R</label>
@@ -371,27 +423,114 @@
 			<channel id="CH1" typeId="brightness"/>
 		</channels>
 
-		<config-description-ref uri="thing-type:velbus:1channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:1channelDeviceWithDimspeed"/>
+	</thing-type>
+
+	<thing-type id="vmbel1">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBEL1</label>
+		<description>Edge-lit one touch button module</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="1channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbel2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBEL2</label>
+		<description>Edge-lit two touch buttons module</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="2channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbel4">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBEL4</label>
+		<description>Edge-lit four touch buttons module</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="4channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbelo">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBELO</label>
+		<description>Edge-lit touch panel with Oled display</description>
+		<channel-groups>
+			<channel-group id="input" typeId="33channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="32channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+			<channel-group id="oledDisplay" typeId="oledDisplay"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:33channelDeviceWithTemperatureSensor"/>
 	</thing-type>
 
 	<thing-type id="vmbgp1">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGP1</label>
 		<description>Glass control module with 1 touch key</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="1channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbgp1-2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBGP1-2</label>
+		<description>Glass control module with 1 touch key (Edition 2)</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="1channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
 	</thing-type>
@@ -399,21 +538,35 @@
 	<thing-type id="vmbgp2">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGP2</label>
 		<description>Glass control module with 2 touch keys</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="2channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbgp2-2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBGP2-2</label>
+		<description>Glass control module with 2 touch keys (Edition 2)</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="2channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
 	</thing-type>
@@ -421,21 +574,35 @@
 	<thing-type id="vmbgp4">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGP4</label>
 		<description>Glass control module with 4 touch keys</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="4channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbgp4-2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBGP4-2</label>
+		<description>Glass control module with 4 touch keys (Edition 2)</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="4channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
 	</thing-type>
@@ -443,21 +610,35 @@
 	<thing-type id="vmbgp4pir">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGP4PIR</label>
 		<description>Glass control module with 4 touch keys and built-in motion and twilight sensor</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="4channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbgp4pir-2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBGP4PIR-2</label>
+		<description>Glass control module with 4 touch keys and built-in motion and twilight sensor (Edition 2)</description>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="4channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
 	</thing-type>
@@ -465,45 +646,18 @@
 	<thing-type id="vmbgpo">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGPO</label>
 		<description>Glass control module with oled display</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="trigger-channel"/>
-			<channel id="CH10" typeId="trigger-channel"/>
-			<channel id="CH11" typeId="trigger-channel"/>
-			<channel id="CH12" typeId="trigger-channel"/>
-			<channel id="CH13" typeId="trigger-channel"/>
-			<channel id="CH14" typeId="trigger-channel"/>
-			<channel id="CH15" typeId="trigger-channel"/>
-			<channel id="CH16" typeId="trigger-channel"/>
-			<channel id="CH17" typeId="trigger-channel"/>
-			<channel id="CH18" typeId="trigger-channel"/>
-			<channel id="CH19" typeId="trigger-channel"/>
-			<channel id="CH20" typeId="trigger-channel"/>
-			<channel id="CH21" typeId="trigger-channel"/>
-			<channel id="CH22" typeId="trigger-channel"/>
-			<channel id="CH23" typeId="trigger-channel"/>
-			<channel id="CH24" typeId="trigger-channel"/>
-			<channel id="CH25" typeId="trigger-channel"/>
-			<channel id="CH26" typeId="trigger-channel"/>
-			<channel id="CH27" typeId="trigger-channel"/>
-			<channel id="CH28" typeId="trigger-channel"/>
-			<channel id="CH29" typeId="trigger-channel"/>
-			<channel id="CH30" typeId="trigger-channel"/>
-			<channel id="CH31" typeId="trigger-channel"/>
-			<channel id="CH32" typeId="trigger-channel"/>
-			<channel id="CH33" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="33channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="32channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+			<channel-group id="oledDisplay" typeId="oledDisplay"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:33channelDeviceWithTemperatureSensor"/>
 	</thing-type>
@@ -511,111 +665,176 @@
 	<thing-type id="vmbgpod">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBGPOD</label>
 		<description>Glass control module with oled display and temperature controller</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="trigger-channel"/>
-			<channel id="CH10" typeId="trigger-channel"/>
-			<channel id="CH11" typeId="trigger-channel"/>
-			<channel id="CH12" typeId="trigger-channel"/>
-			<channel id="CH13" typeId="trigger-channel"/>
-			<channel id="CH14" typeId="trigger-channel"/>
-			<channel id="CH15" typeId="trigger-channel"/>
-			<channel id="CH16" typeId="trigger-channel"/>
-			<channel id="CH17" typeId="trigger-channel"/>
-			<channel id="CH18" typeId="trigger-channel"/>
-			<channel id="CH19" typeId="trigger-channel"/>
-			<channel id="CH20" typeId="trigger-channel"/>
-			<channel id="CH21" typeId="trigger-channel"/>
-			<channel id="CH22" typeId="trigger-channel"/>
-			<channel id="CH23" typeId="trigger-channel"/>
-			<channel id="CH24" typeId="trigger-channel"/>
-			<channel id="CH25" typeId="trigger-channel"/>
-			<channel id="CH26" typeId="trigger-channel"/>
-			<channel id="CH27" typeId="trigger-channel"/>
-			<channel id="CH28" typeId="trigger-channel"/>
-			<channel id="CH29" typeId="trigger-channel"/>
-			<channel id="CH30" typeId="trigger-channel"/>
-			<channel id="CH31" typeId="trigger-channel"/>
-			<channel id="CH32" typeId="trigger-channel"/>
-			<channel id="CH33" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="33channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="32channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+			<channel-group id="oledDisplay" typeId="oledDisplay"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:33channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbgpod-2">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBGPOD-2</label>
+		<description>Glass control module with oled display and temperature controller (Edition 2)</description>
+		<channel-groups>
+			<channel-group id="input" typeId="33channelInputModuleWithTemperatureSensor"/>
+			<channel-group id="feedback" typeId="32channelFeedbackModule"/>
+			<channel-group id="thermostat" typeId="thermostat"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+			<channel-group id="oledDisplay" typeId="oledDisplay"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:33channelDeviceWithTemperatureSensor"/>
+	</thing-type>
+
+	<thing-type id="vmbmeteo">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBMETEO</label>
+		<description>Weather station with thermometer, anemometer, rain sensor and light sensor</description>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="weatherStation" typeId="weatherStation"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:13channelDevice"/>
 	</thing-type>
 
 	<thing-type id="vmbpirc">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBPIRC</label>
 		<description>Motion and twilight sensor for ceiling mounting</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="7channelInputModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
-		<config-description-ref uri="thing-type:velbus:7channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:7channelDeviceWithTemperatureSensor"/>
 	</thing-type>
 
 	<thing-type id="vmbpirm">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBPIRM</label>
 		<description>Mini motion and twilight sensor for recessed or surface mounting</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="7channelInputModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
-		<config-description-ref uri="thing-type:velbus:7channelDevice"/>
+		<config-description-ref uri="thing-type:velbus:7channelDeviceWithTemperatureSensor"/>
 	</thing-type>
 
 	<thing-type id="vmbpiro">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
 		</supported-bridge-type-refs>
 
 		<label>VMBPIRO</label>
 		<description>Outdoor motion, twilight and temperature sensor, Theben</description>
-		<channels>
-			<channel id="CH1" typeId="trigger-channel"/>
-			<channel id="CH2" typeId="trigger-channel"/>
-			<channel id="CH3" typeId="trigger-channel"/>
-			<channel id="CH4" typeId="trigger-channel"/>
-			<channel id="CH5" typeId="trigger-channel"/>
-			<channel id="CH6" typeId="trigger-channel"/>
-			<channel id="CH7" typeId="trigger-channel"/>
-			<channel id="CH8" typeId="trigger-channel"/>
-			<channel id="CH9" typeId="temperature"/>
-		</channels>
+		<channel-groups>
+			<channel-group id="input" typeId="9channelInputModuleWithTemperatureAndLightSensor"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
 
 		<config-description-ref uri="thing-type:velbus:9channelDeviceWithTemperatureSensor"/>
 	</thing-type>
 
+	<thing-type id="vmbrfr8s">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="networkbridge"/>
+		</supported-bridge-type-refs>
+
+		<label>VMBRFR8S</label>
+		<description>8 channel RF receiver module</description>
+		<channel-groups>
+			<channel-group id="input" typeId="8channelInputModule"/>
+			<channel-group id="feedback" typeId="8channelFeedbackModule"/>
+			<channel-group id="clockAlarm" typeId="clockAlarm"/>
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:velbus:8channelDevice"/>
+	</thing-type>
+
+	<channel-type id="heatingOperatingMode">
+		<item-type>String</item-type>
+		<label>Operating Mode</label>
+		<description>Operating mode (heating/cooling) for the thermostat in Velbus</description>
+		<state>
+			<options>
+				<option value="HEATING">Heating</option>
+				<option value="COOLING">Cooling</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="heatingMode">
+		<item-type>String</item-type>
+		<label>Mode</label>
+		<description>Mode (comfort/day/night/safe) for the thermostat in Velbus</description>
+		<state>
+			<options>
+				<option value="COMFORT">Comfort</option>
+				<option value="DAY">Day</option>
+				<option value="NIGHT">Night</option>
+				<option value="SAFE">Safe</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="ledFeedback">
+		<item-type>String</item-type>
+		<label>Feedback LED</label>
+		<description>Feedback LED for the push button in Velbus</description>
+		<state>
+			<options>
+				<option value="CLEAR_LED">Off</option>
+				<option value="SET_LED">On</option>
+				<option value="SLOW_BLINK_LED">Slow blink</option>
+				<option value="FAST_BLINK_LED">Fast blink</option>
+				<option value="VERY_FAST_BLINK_LED">Very fast blink</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="alarmType">
+		<item-type>String</item-type>
+		<label>Alarm Type</label>
+		<description>Type (local/global) of the alarm clock in Velbus</description>
+		<state>
+			<options>
+				<option value="LOCAL">Local</option>
+				<option value="GLOBAL">Global</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="text">
+		<item-type>String</item-type>
+		<label>Text</label>
+	</channel-type>
 	<channel-type id="switch">
 		<item-type>Switch</item-type>
 		<label>Switch</label>
@@ -642,6 +861,84 @@
 		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
 	</channel-type>
+	<channel-type id="hour">
+		<item-type>Number</item-type>
+		<label>Hour</label>
+		<state readOnly="false" min="0" max="23">
+		</state>
+	</channel-type>
+	<channel-type id="minute">
+		<item-type>Number</item-type>
+		<label>Minute</label>
+		<state readOnly="false" min="0" max="59">
+		</state>
+	</channel-type>
+	<channel-type id="counter">
+		<item-type>Number</item-type>
+		<label>Counter</label>
+		<state readOnly="false" min="0">
+		</state>
+	</channel-type>
+	<channel-type id="temperatureSetpoint">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature Setpoint</label>
+		<category>Temperature</category>
+		<state readOnly="false" min="-55" max="63.5" step="0.5" pattern="%.1f %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="voltage">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>Voltage</label>
+		<description>Currently measured voltage</description>
+		<category>Voltage</category>
+		<state readOnly="true" pattern="%.1f %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="current">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>Current</label>
+		<description>Currently measured current</description>
+		<category>Current</category>
+		<state readOnly="true" pattern="%.1f %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="percentage">
+		<item-type>Dimmer</item-type>
+		<label>Percentage</label>
+		<description>Current percentage</description>
+		<category>Percentage</category>
+	</channel-type>
+	<channel-type id="resistance">
+		<item-type>Number:ElectricResistance</item-type>
+		<label>Resistance</label>
+		<description>Currently measured resistance</description>
+		<category>Resistance</category>
+		<state readOnly="true" pattern="%.1f %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="rainfall">
+		<item-type>Number:Length</item-type>
+		<label>Rainfall</label>
+		<description>Currently measured quantity of rain</description>
+		<category>Rainfall</category>
+		<state readOnly="true" pattern="%.1f %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="illuminance">
+		<item-type>Number:Illuminance</item-type>
+		<label>Illuminance</label>
+		<description>Currently measured illuminance</description>
+		<category>Illuminance</category>
+		<state readOnly="true" pattern="%d %unit%">
+		</state>
+	</channel-type>
+	<channel-type id="windspeed">
+		<item-type>Number:Speed</item-type>
+		<label>Wind Speed</label>
+		<description>Currently measured wind speed</description>
+		<category>Wind</category>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
 	<channel-type id="trigger-channel">
 		<kind>trigger</kind>
 		<label>Trigger Channel</label>
@@ -653,4 +950,401 @@
 			</options>
 		</event>
 	</channel-type>
+	<channel-type id="thermostat-trigger-channel">
+		<kind>trigger</kind>
+		<label>Thermostat Trigger Channel</label>
+		<event>
+			<options>
+				<option value="PRESSED">pressed</option>
+				<option value="RELEASED">released</option>
+			</options>
+		</event>
+	</channel-type>
+	<channel-group-type id="1channelInputModuleWithTemperatureSensor">
+		<label>Input Module with Temperature sensor</label>
+		<description>This is a generic module with 8 input channels and a temperature sensor.</description>
+		<channels>
+			<channel id="CH1" typeId="temperature"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="4channelAnalogInputModule">
+		<label>Analog Input</label>
+		<description>
+			This is a generic analog module with 4 input channels.
+		</description>
+		<channels>
+			<channel id="CH9RAW" typeId="voltage"/>
+			<channel id="CH9" typeId="text"/>
+			<channel id="CH10RAW" typeId="voltage"/>
+			<channel id="CH10" typeId="text"/>
+			<channel id="CH11RAW" typeId="voltage"/>
+			<channel id="CH11" typeId="text"/>
+			<channel id="CH12RAW" typeId="voltage"/>
+			<channel id="CH12" typeId="text"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="4channelAnalogOutputModule">
+		<label>Analog Input</label>
+		<description>
+			This is a generic analog module with 4 output channels.
+		</description>
+		<channels>
+			<channel id="CH13" typeId="percentage"/>
+			<channel id="CH14" typeId="percentage"/>
+			<channel id="CH15" typeId="percentage"/>
+			<channel id="CH16" typeId="percentage"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="4channelCounterModule">
+		<label>Counters</label>
+		<description>This is a generic module with 4 counter channels.</description>
+		<channels>
+			<channel id="COUNTER1" typeId="counter"/>
+			<channel id="COUNTER1_CURRENT" typeId="counter"/>
+			<channel id="COUNTER2" typeId="counter"/>
+			<channel id="COUNTER2_CURRENT" typeId="counter"/>
+			<channel id="COUNTER3" typeId="counter"/>
+			<channel id="COUNTER3_CURRENT" typeId="counter"/>
+			<channel id="COUNTER4" typeId="counter"/>
+			<channel id="COUNTER4_CURRENT" typeId="counter"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="6channelInputModule">
+		<label>Input</label>
+		<description>This is a generic module with 6 input channels.</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="7channelInputModule">
+		<label>Input</label>
+		<description>This is a generic module with 7 input channels.</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+			<channel id="CH7" typeId="trigger-channel"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="8channelInputModule">
+		<label>Input</label>
+		<description>
+			This is a generic module with 8 input channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+			<channel id="CH7" typeId="trigger-channel"/>
+			<channel id="CH8" typeId="trigger-channel"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="9channelInputModuleWithTemperatureSensor">
+		<label>Input Module with Temperature sensor</label>
+		<description>This is a generic module with 8 input channels and a temperature sensor.</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+			<channel id="CH7" typeId="trigger-channel"/>
+			<channel id="CH8" typeId="trigger-channel"/>
+			<channel id="CH9" typeId="temperature"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="9channelInputModuleWithTemperatureAndLightSensor">
+		<label>Input Module with Temperature sensor</label>
+		<description>This is a generic module with 8 input channels, a temperature sensor and a light sensor.</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+			<channel id="CH7" typeId="trigger-channel"/>
+			<channel id="CH8" typeId="trigger-channel"/>
+			<channel id="CH9" typeId="temperature"/>
+			<channel id="LIGHT" typeId="illuminance"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="33channelInputModuleWithTemperatureSensor">
+		<label>Input Module with Temperature sensor</label>
+		<description>This is a generic module with 32 input channels and a temperature sensor.</description>
+		<channels>
+			<channel id="CH1" typeId="trigger-channel"/>
+			<channel id="CH2" typeId="trigger-channel"/>
+			<channel id="CH3" typeId="trigger-channel"/>
+			<channel id="CH4" typeId="trigger-channel"/>
+			<channel id="CH5" typeId="trigger-channel"/>
+			<channel id="CH6" typeId="trigger-channel"/>
+			<channel id="CH7" typeId="trigger-channel"/>
+			<channel id="CH8" typeId="trigger-channel"/>
+			<channel id="CH9" typeId="trigger-channel"/>
+			<channel id="CH10" typeId="trigger-channel"/>
+			<channel id="CH11" typeId="trigger-channel"/>
+			<channel id="CH12" typeId="trigger-channel"/>
+			<channel id="CH13" typeId="trigger-channel"/>
+			<channel id="CH14" typeId="trigger-channel"/>
+			<channel id="CH15" typeId="trigger-channel"/>
+			<channel id="CH16" typeId="trigger-channel"/>
+			<channel id="CH17" typeId="trigger-channel"/>
+			<channel id="CH18" typeId="trigger-channel"/>
+			<channel id="CH19" typeId="trigger-channel"/>
+			<channel id="CH20" typeId="trigger-channel"/>
+			<channel id="CH21" typeId="trigger-channel"/>
+			<channel id="CH22" typeId="trigger-channel"/>
+			<channel id="CH23" typeId="trigger-channel"/>
+			<channel id="CH24" typeId="trigger-channel"/>
+			<channel id="CH25" typeId="trigger-channel"/>
+			<channel id="CH26" typeId="trigger-channel"/>
+			<channel id="CH27" typeId="trigger-channel"/>
+			<channel id="CH28" typeId="trigger-channel"/>
+			<channel id="CH29" typeId="trigger-channel"/>
+			<channel id="CH30" typeId="trigger-channel"/>
+			<channel id="CH31" typeId="trigger-channel"/>
+			<channel id="CH32" typeId="trigger-channel"/>
+			<channel id="CH33" typeId="temperature"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="1channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 1 feedback channel.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="2channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 2 feedback channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+			<channel id="CH2" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="4channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 4 feedback channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+			<channel id="CH2" typeId="ledFeedback"/>
+			<channel id="CH3" typeId="ledFeedback"/>
+			<channel id="CH4" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="6channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 6 feedback channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+			<channel id="CH2" typeId="ledFeedback"/>
+			<channel id="CH3" typeId="ledFeedback"/>
+			<channel id="CH4" typeId="ledFeedback"/>
+			<channel id="CH5" typeId="ledFeedback"/>
+			<channel id="CH6" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="8channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 8 feedback channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+			<channel id="CH2" typeId="ledFeedback"/>
+			<channel id="CH3" typeId="ledFeedback"/>
+			<channel id="CH4" typeId="ledFeedback"/>
+			<channel id="CH5" typeId="ledFeedback"/>
+			<channel id="CH6" typeId="ledFeedback"/>
+			<channel id="CH7" typeId="ledFeedback"/>
+			<channel id="CH8" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="32channelFeedbackModule">
+		<label>Feedback</label>
+		<description>
+			This is a generic module with 32 feedback channels.
+		</description>
+		<channels>
+			<channel id="CH1" typeId="ledFeedback"/>
+			<channel id="CH2" typeId="ledFeedback"/>
+			<channel id="CH3" typeId="ledFeedback"/>
+			<channel id="CH4" typeId="ledFeedback"/>
+			<channel id="CH5" typeId="ledFeedback"/>
+			<channel id="CH6" typeId="ledFeedback"/>
+			<channel id="CH7" typeId="ledFeedback"/>
+			<channel id="CH8" typeId="ledFeedback"/>
+			<channel id="CH9" typeId="ledFeedback"/>
+			<channel id="CH10" typeId="ledFeedback"/>
+			<channel id="CH11" typeId="ledFeedback"/>
+			<channel id="CH12" typeId="ledFeedback"/>
+			<channel id="CH13" typeId="ledFeedback"/>
+			<channel id="CH14" typeId="ledFeedback"/>
+			<channel id="CH15" typeId="ledFeedback"/>
+			<channel id="CH16" typeId="ledFeedback"/>
+			<channel id="CH17" typeId="ledFeedback"/>
+			<channel id="CH18" typeId="ledFeedback"/>
+			<channel id="CH19" typeId="ledFeedback"/>
+			<channel id="CH20" typeId="ledFeedback"/>
+			<channel id="CH21" typeId="ledFeedback"/>
+			<channel id="CH22" typeId="ledFeedback"/>
+			<channel id="CH23" typeId="ledFeedback"/>
+			<channel id="CH24" typeId="ledFeedback"/>
+			<channel id="CH25" typeId="ledFeedback"/>
+			<channel id="CH26" typeId="ledFeedback"/>
+			<channel id="CH27" typeId="ledFeedback"/>
+			<channel id="CH28" typeId="ledFeedback"/>
+			<channel id="CH29" typeId="ledFeedback"/>
+			<channel id="CH30" typeId="ledFeedback"/>
+			<channel id="CH31" typeId="ledFeedback"/>
+			<channel id="CH32" typeId="ledFeedback"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="oledDisplay">
+		<label>O-LED Display</label>
+		<channels>
+			<channel id="MEMO" typeId="text">
+				<label>Memo</label>
+			</channel>
+			<channel id="SCREENSAVER" typeId="switch">
+				<label>Screensaver</label>
+			</channel>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="thermostat">
+		<label>Thermostat</label>
+		<description>This is a thermostat that supports heating/cooling and comfort/day/night/safe modes.</description>
+		<category>Temperatures</category>
+		<channels>
+			<channel id="CURRENTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Current Temperature Setpoint</label>
+			</channel>
+			<channel id="HEATINGMODECOMFORTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Heating Mode Comfort Temperature Setpoint</label>
+			</channel>
+			<channel id="HEATINGMODEDAYTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Heating Mode Day Temperature Setpoint</label>
+			</channel>
+			<channel id="HEATINGMODENIGHTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Heating Mode Night Temperature Setpoint</label>
+			</channel>
+			<channel id="HEATINGMODEANTIFROSTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Heating Mode Antifrost Temperature Setpoint</label>
+			</channel>
+			<channel id="COOLINGMODECOMFORTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Cooling Mode Comfort Temperature Setpoint</label>
+			</channel>
+			<channel id="COOLINGMODEDAYTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Cooling Mode Day Temperature Setpoint</label>
+			</channel>
+			<channel id="COOLINGMODENIGHTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Cooling Mode Night Temperature Setpoint</label>
+			</channel>
+			<channel id="COOLINGMODESAFETEMPERATURESETPOINT" typeId="temperatureSetpoint">
+				<label>Cooling Mode Safe Temperature Setpoint</label>
+			</channel>
+			<channel id="OPERATINGMODE" typeId="heatingOperatingMode"/>
+			<channel id="MODE" typeId="heatingMode"/>
+			<channel id="HEATER" typeId="thermostat-trigger-channel">
+				<label>Heater</label>
+			</channel>
+			<channel id="BOOST" typeId="thermostat-trigger-channel">
+				<label>Boost</label>
+			</channel>
+			<channel id="PUMP" typeId="thermostat-trigger-channel">
+				<label>Pump</label>
+			</channel>
+			<channel id="COOLER" typeId="thermostat-trigger-channel">
+				<label>Cooler</label>
+			</channel>
+			<channel id="ALARM1" typeId="thermostat-trigger-channel">
+				<label>Alarm 1</label>
+			</channel>
+			<channel id="ALARM2" typeId="thermostat-trigger-channel">
+				<label>Alarm 2</label>
+			</channel>
+			<channel id="ALARM3" typeId="thermostat-trigger-channel">
+				<label>Alarm 3</label>
+			</channel>
+			<channel id="ALARM4" typeId="thermostat-trigger-channel">
+				<label>Alarm 4</label>
+			</channel>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="weatherStation">
+		<label>Weather Station</label>
+		<description>This is a weather station with channels for temperature, rainfall, illuminance and windspeed.
+		</description>
+		<channels>
+			<channel id="CH10" typeId="temperature"/>
+			<channel id="CH11" typeId="rainfall"/>
+			<channel id="CH12" typeId="illuminance"/>
+			<channel id="CH13" typeId="windspeed"/>
+		</channels>
+	</channel-group-type>
+	<channel-group-type id="clockAlarm">
+		<label>Clock Alarm</label>
+		<description>This is a clock alarm with two configurable alarms that can be programmed with a wake up time and a bed
+			time.
+		</description>
+		<channels>
+			<channel id="CLOCKALARM1ENABLED" typeId="switch">
+				<label>Clock Alarm 1 Enabled</label>
+			</channel>
+			<channel id="CLOCKALARM1TYPE" typeId="alarmType">
+				<label>Clock Alarm 1 Type</label>
+			</channel>
+			<channel id="CLOCKALARM1WAKEUPHOUR" typeId="hour">
+				<label>Clock Alarm 1 Wakeup Hour</label>
+			</channel>
+			<channel id="CLOCKALARM1WAKEUPMINUTE" typeId="minute">
+				<label>Clock Alarm 1 Minute</label>
+			</channel>
+			<channel id="CLOCKALARM1BEDTIMEHOUR" typeId="hour">
+				<label>Clock Alarm 1 Bedtime Hour</label>
+			</channel>
+			<channel id="CLOCKALARM1BEDTIMEMINUTE" typeId="minute">
+				<label>Clock Alarm 1 Bedtime Minute</label>
+			</channel>
+			<channel id="CLOCKALARM2ENABLED" typeId="switch">
+				<label>Clock Alarm 2 Enabled</label>
+			</channel>
+			<channel id="CLOCKALARM2TYPE" typeId="alarmType">
+				<label>Clock Alarm 2 Type</label>
+			</channel>
+			<channel id="CLOCKALARM2WAKEUPHOUR" typeId="hour">
+				<label>Clock Alarm 2 Wakeup Hour</label>
+			</channel>
+			<channel id="CLOCKALARM2WAKEUPMINUTE" typeId="minute">
+				<label>Clock Alarm 2 Wakeup Minute</label>
+			</channel>
+			<channel id="CLOCKALARM2BEDTIMEHOUR" typeId="hour">
+				<label>Clock Alarm 2 Bedtime Hour</label>
+			</channel>
+			<channel id="CLOCKALARM2BEDTIMEMINUTE" typeId="minute">
+				<label>Clock Alarm 2 Bedtime Minute</label>
+			</channel>
+		</channels>
+	</channel-group-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -922,7 +922,7 @@
 		</state>
 	</channel-type>
 	<channel-type id="percentage">
-		<item-type>Dimmer</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Percentage</label>
 		<description>Current percentage</description>
 		<category>Percentage</category>
@@ -980,7 +980,7 @@
 		</event>
 	</channel-type>
 	<channel-group-type id="1channelInputModuleWithTemperatureSensor">
-		<label>Input Module with Temperature sensor</label>
+		<label>Input with Temperature Sensor</label>
 		<description>This is a generic module with 8 input channels and a temperature sensor.</description>
 		<channels>
 			<channel id="CH1" typeId="temperature"/>
@@ -1070,7 +1070,7 @@
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="9channelInputModuleWithTemperatureSensor">
-		<label>Input Module with Temperature sensor</label>
+		<label>Input with Temperature Sensor</label>
 		<description>This is a generic module with 8 input channels and a temperature sensor.</description>
 		<channels>
 			<channel id="CH1" typeId="trigger-channel"/>
@@ -1085,7 +1085,7 @@
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="9channelInputModuleWithTemperatureAndLightSensor">
-		<label>Input Module with Temperature sensor</label>
+		<label>Input with Temperature/Light Sensor</label>
 		<description>This is a generic module with 8 input channels, a temperature sensor and a light sensor.</description>
 		<channels>
 			<channel id="CH1" typeId="trigger-channel"/>
@@ -1101,7 +1101,7 @@
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="33channelInputModuleWithTemperatureSensor">
-		<label>Input Module with Temperature sensor</label>
+		<label>Input with Temperature Sensor</label>
 		<description>This is a generic module with 32 input channels and a temperature sensor.</description>
 		<channels>
 			<channel id="CH1" typeId="trigger-channel"/>

--- a/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -992,13 +992,13 @@
 			This is a generic analog module with 4 input channels.
 		</description>
 		<channels>
-			<channel id="CH9RAW" typeId="voltage"/>
+			<channel id="CH9Raw" typeId="voltage"/>
 			<channel id="CH9" typeId="text"/>
-			<channel id="CH10RAW" typeId="voltage"/>
+			<channel id="CH10Raw" typeId="voltage"/>
 			<channel id="CH10" typeId="text"/>
-			<channel id="CH11RAW" typeId="voltage"/>
+			<channel id="CH11Raw" typeId="voltage"/>
 			<channel id="CH11" typeId="text"/>
-			<channel id="CH12RAW" typeId="voltage"/>
+			<channel id="CH12Raw" typeId="voltage"/>
 			<channel id="CH12" typeId="text"/>
 		</channels>
 	</channel-group-type>
@@ -1018,14 +1018,14 @@
 		<label>Counters</label>
 		<description>This is a generic module with 4 counter channels.</description>
 		<channels>
-			<channel id="COUNTER1" typeId="counter"/>
-			<channel id="COUNTER1_CURRENT" typeId="counter"/>
-			<channel id="COUNTER2" typeId="counter"/>
-			<channel id="COUNTER2_CURRENT" typeId="counter"/>
-			<channel id="COUNTER3" typeId="counter"/>
-			<channel id="COUNTER3_CURRENT" typeId="counter"/>
-			<channel id="COUNTER4" typeId="counter"/>
-			<channel id="COUNTER4_CURRENT" typeId="counter"/>
+			<channel id="counter1" typeId="counter"/>
+			<channel id="counter1Current" typeId="counter"/>
+			<channel id="counter" typeId="counter"/>
+			<channel id="counter2Current" typeId="counter"/>
+			<channel id="counter3" typeId="counter"/>
+			<channel id="counter3Current" typeId="counter"/>
+			<channel id="counter4" typeId="counter"/>
+			<channel id="counter4Current" typeId="counter"/>
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="6channelInputModule">
@@ -1256,57 +1256,57 @@
 		<description>This is a thermostat that supports heating/cooling and comfort/day/night/safe modes.</description>
 		<category>Temperatures</category>
 		<channels>
-			<channel id="CURRENTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="currentTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Current Temperature Setpoint</label>
 			</channel>
-			<channel id="HEATINGMODECOMFORTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="heatingModeComfortTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Heating Mode Comfort Temperature Setpoint</label>
 			</channel>
-			<channel id="HEATINGMODEDAYTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="heatingModeDayTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Heating Mode Day Temperature Setpoint</label>
 			</channel>
-			<channel id="HEATINGMODENIGHTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="heatingModeNightTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Heating Mode Night Temperature Setpoint</label>
 			</channel>
-			<channel id="HEATINGMODEANTIFROSTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="heatingModeAntiFrostTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Heating Mode Antifrost Temperature Setpoint</label>
 			</channel>
-			<channel id="COOLINGMODECOMFORTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="coolingModeComfortTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Cooling Mode Comfort Temperature Setpoint</label>
 			</channel>
-			<channel id="COOLINGMODEDAYTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="coolingModeDayTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Cooling Mode Day Temperature Setpoint</label>
 			</channel>
-			<channel id="COOLINGMODENIGHTTEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="coolingModeNightTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Cooling Mode Night Temperature Setpoint</label>
 			</channel>
-			<channel id="COOLINGMODESAFETEMPERATURESETPOINT" typeId="temperatureSetpoint">
+			<channel id="coolingModeSafeTemperatureSetpoint" typeId="temperatureSetpoint">
 				<label>Cooling Mode Safe Temperature Setpoint</label>
 			</channel>
-			<channel id="OPERATINGMODE" typeId="heatingOperatingMode"/>
-			<channel id="MODE" typeId="heatingMode"/>
-			<channel id="HEATER" typeId="thermostat-trigger-channel">
+			<channel id="operatingMode" typeId="heatingOperatingMode"/>
+			<channel id="mode" typeId="heatingMode"/>
+			<channel id="heater" typeId="thermostat-trigger-channel">
 				<label>Heater</label>
 			</channel>
-			<channel id="BOOST" typeId="thermostat-trigger-channel">
+			<channel id="boost" typeId="thermostat-trigger-channel">
 				<label>Boost</label>
 			</channel>
-			<channel id="PUMP" typeId="thermostat-trigger-channel">
+			<channel id="pump" typeId="thermostat-trigger-channel">
 				<label>Pump</label>
 			</channel>
-			<channel id="COOLER" typeId="thermostat-trigger-channel">
+			<channel id="cooler" typeId="thermostat-trigger-channel">
 				<label>Cooler</label>
 			</channel>
-			<channel id="ALARM1" typeId="thermostat-trigger-channel">
+			<channel id="alarm1" typeId="thermostat-trigger-channel">
 				<label>Alarm 1</label>
 			</channel>
-			<channel id="ALARM2" typeId="thermostat-trigger-channel">
+			<channel id="alarm2" typeId="thermostat-trigger-channel">
 				<label>Alarm 2</label>
 			</channel>
-			<channel id="ALARM3" typeId="thermostat-trigger-channel">
+			<channel id="alarm3" typeId="thermostat-trigger-channel">
 				<label>Alarm 3</label>
 			</channel>
-			<channel id="ALARM4" typeId="thermostat-trigger-channel">
+			<channel id="alarm4" typeId="thermostat-trigger-channel">
 				<label>Alarm 4</label>
 			</channel>
 		</channels>
@@ -1328,40 +1328,40 @@
 			time.
 		</description>
 		<channels>
-			<channel id="CLOCKALARM1ENABLED" typeId="switch">
+			<channel id="clockAlarm1Enabled" typeId="switch">
 				<label>Clock Alarm 1 Enabled</label>
 			</channel>
-			<channel id="CLOCKALARM1TYPE" typeId="alarmType">
+			<channel id="clockAlarm1Type" typeId="alarmType">
 				<label>Clock Alarm 1 Type</label>
 			</channel>
-			<channel id="CLOCKALARM1WAKEUPHOUR" typeId="hour">
+			<channel id="clockAlarm1WakeupHour" typeId="hour">
 				<label>Clock Alarm 1 Wakeup Hour</label>
 			</channel>
-			<channel id="CLOCKALARM1WAKEUPMINUTE" typeId="minute">
+			<channel id="clockAlarm1WakeupMinute" typeId="minute">
 				<label>Clock Alarm 1 Minute</label>
 			</channel>
-			<channel id="CLOCKALARM1BEDTIMEHOUR" typeId="hour">
+			<channel id="clockAlarm1BedtimeHour" typeId="hour">
 				<label>Clock Alarm 1 Bedtime Hour</label>
 			</channel>
-			<channel id="CLOCKALARM1BEDTIMEMINUTE" typeId="minute">
+			<channel id="clockAlarm1BedtimeMinute" typeId="minute">
 				<label>Clock Alarm 1 Bedtime Minute</label>
 			</channel>
-			<channel id="CLOCKALARM2ENABLED" typeId="switch">
+			<channel id="clockAlarm2Enabled" typeId="switch">
 				<label>Clock Alarm 2 Enabled</label>
 			</channel>
-			<channel id="CLOCKALARM2TYPE" typeId="alarmType">
+			<channel id="clockAlarm2Type" typeId="alarmType">
 				<label>Clock Alarm 2 Type</label>
 			</channel>
-			<channel id="CLOCKALARM2WAKEUPHOUR" typeId="hour">
+			<channel id="clockAlarm2WakeupHour" typeId="hour">
 				<label>Clock Alarm 2 Wakeup Hour</label>
 			</channel>
-			<channel id="CLOCKALARM2WAKEUPMINUTE" typeId="minute">
+			<channel id="clockAlarm2WakeupMinute" typeId="minute">
 				<label>Clock Alarm 2 Wakeup Minute</label>
 			</channel>
-			<channel id="CLOCKALARM2BEDTIMEHOUR" typeId="hour">
+			<channel id="clockAlarm2BedtimeHour" typeId="hour">
 				<label>Clock Alarm 2 Bedtime Hour</label>
 			</channel>
-			<channel id="CLOCKALARM2BEDTIMEMINUTE" typeId="minute">
+			<channel id="clockAlarm2BedtimeMinute" typeId="minute">
 				<label>Clock Alarm 2 Bedtime Minute</label>
 			</channel>
 		</channels>


### PR DESCRIPTION
Signed-off-by: Cedric Boon <cedric.boon@hotmail.com>

[velbus] Added support for additional Velbus modules and module features.

This pull requests adds support for the following modules:
- A network bridge that can be used as an alternative to the serial bridge
- The VMB1BL blind module
- The VMB1RYS relay module
- The VMB1TS thermostat module
- The VMB2BL blind module
- The VMB4AN analog input/output module
- The VMBEL1, VMBEL2, VMBEL4 and VMBELO Edge lit glass button module
- The second edition of the VMBGP1, VMBGP2, VMBGP4, VMBGP4PIR and VMBGPOD glass button module
- The VMBMETEO weather station
- The VMBRFR8S RF receiver module

This pull request adds the following features to existing modules:
- Automatic reconnection by the bridges on connection loss
- Automatic update of the Velbus system's time, date and daylight savings status by the bridge
- Alarm clock functionality on the VMB2PBN, VMB6PBN, VMB7IN, VMB8PBU, VMBPIRC, VMBPIRM, VMBPIRO, VMBGP1, VMBGP2, VMBGP4, VMBGP4PIR, VMBGPO and VMBGPOD modules
- Thermostat functionality on the VMBGP1, VMBGP2, VMBGP4, VMBGP4PIR, VMBGPO and VMBGPOD modules
- Possibility to set the dim speed on the VMB1DM, VMB1LED, VMB4DC, VMBDME, VMBDMI and VMBDMIR dimmer modules
- Setting of a MEMO text on the OLED panel of the VMBGPO and VMBGPOD modules
- Setting of the feedback LED's on the VMB1TS, VMB2PBN, VMB6IN, VMB6PBN, VMB7IN, VMB8IR, VMB8PB, VMB8PBU, VMBGP1, VMBGP2, VMBGP4, VMBGP4PIR, VMBGPO, VMBGPOD, VMBPIRC, VMBPIRM and VMBPIRO modules
- Reading out the pulse counters of the VMB7IN module
- Reading out the illuminance value of the VMBPIRO module

To keep the thing-type definition file readable with the additional features, one breaking change has been introduced. The channel names of the VMB2PN, VMB6IN, VMB6PN, VMB7IN, VMB8IR, VMB8PB, VMB8PBU, VMBGP1, VMBGP2, VMBGP4, VMBGP4PIR, VMBGPO, VMBGPOD, VMBPIRC, VMBPIRM and VMBPIRO modules changed from "CHx" to "input:CHx".