### PR TITLE
[digitalSTROM] Change application Name for creating access token

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/config/Config.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/config/Config.java
@@ -25,7 +25,7 @@ public class Config {
     /**
      * The default application name to generate the application token.
      */
-    public static final String DEFAULT_APPLICATION_NAME = "ESH";
+    public static final String DEFAULT_APPLICATION_NAME = "openHAB";
     /**
      * Defines the used tread pool name to get a thread pool from {@link ThreadPoolManager}.
      */


### PR DESCRIPTION
While moving from eclipse smarthome, we should change the name of our application to identify against the digitalSTROM installation.

Signed-off-by: Hans-Jörg Merk <github@hmerk.de>