### PR TITLE
[pilight] Pilight Binding initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -173,6 +173,7 @@
 /bundles/org.openhab.binding.paradoxalarm/ @theater
 /bundles/org.openhab.binding.pentair/ @jsjames
 /bundles/org.openhab.binding.phc/ @gnlpfjh
+/bundles/org.openhab.binding.pilight/ @stefanroellin
 /bundles/org.openhab.binding.pioneeravr/ @Stratehm
 /bundles/org.openhab.binding.pixometer/ @Confectrician
 /bundles/org.openhab.binding.pjlinkdevice/ @nils

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -863,6 +863,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.pilight</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.pioneeravr</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.pilight/.classpath
+++ b/bundles/org.openhab.binding.pilight/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.binding.pilight/.project
+++ b/bundles/org.openhab.binding.pilight/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.pilight</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.binding.pilight/NOTICE
+++ b/bundles/org.openhab.binding.pilight/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.pilight/README.md
+++ b/bundles/org.openhab.binding.pilight/README.md
@@ -1,0 +1,96 @@
+# pilight Binding
+
+The pilight binding allows openHAB to communicate with a [pilight](http://www.pilight.org/) instance running pilight version 6.0 or greater.
+
+> pilight is a free open source full fledge domotica solution that runs on a Raspberry Pi, HummingBoard, BananaPi, Radxa, but also on *BSD and various linuxes (tested on Arch, Ubuntu and Debian). It's open source and freely available for anyone. pilight works with a great deal of devices and is frequency independent. Therefor, it can control devices working at 315Mhz, 433Mhz, 868Mhz etc. Support for these devices are dependent on community, because we as developers don't own them all.
+
+pilight is a cheap way to control 'Click On Click Off' devices. It started as an application for the Raspberry Pi (using the GPIO interface) but it's also possible now to connect it to any other PC using an Arduino Nano. You will need a cheap 433Mhz transceiver in both cases. See the [Pilight manual](https://manual.pilight.org/electronics/wiring.html) for more information.
+
+## Supported Things
+
+| Thing     | Type   | Description                                                                |
+|-----------|--------|----------------------------------------------------------------------------|
+| `bridge`  | Bridge | Pilight bridge required for the communication with the pilight daemon.     |
+| `contact` | Thing  | Pilight contact (read-only).                                               |
+| `dimmer`  | Thing  | Pilight dimmer.                                                            |
+| `switch`  | Thing  | Pilight switch.                                                            |
+| `generic` | Thing  | Pilight generic device for which you have to add the channels dynamically. |
+
+## Binding Configuration
+
+Things can be configured using Paper UI, or using a `.things` file.
+The configuration in this documentation explains the `.things` file, although you can find the same parameters from the Paper UI.
+
+### `bridge` Thing
+
+A `bridge` is required for the communication with a pilight daemon. Multiple pilight instances are supported by creating different pilight `bridge` things. 
+
+The `bridge` requires the following configuration parameters:
+
+| Parameter Label | Parameter ID | Description                                                                                                                                                                              | Required |
+|-----------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| IP Address      | ipAddress    | Host name or IP address of the pilight daemon                                                                                                                                            | yes      |
+| Port            | port         | Port number on which the pilight daemon is listening. Default: 5000                                                                                                                      | yes      |
+| Delay           | delay        | Delay (in millisecond) between consecutive commands.  Recommended value without band pass filter: 1000. Recommended value with band pass filter: somewhere between 200-500. Default: 500 | no       |
+
+Important: you must explicitly configure the port in the pilight daemon config or otherwise a random port will be used and the binding will not be able to connect.
+
+
+### `contact`, `dimmer`, `switch`, `generic` Things
+
+These things have alle one required parameter:
+
+| Parameter Label | Parameter ID | Description            | Required |
+|-----------------|--------------|------------------------|----------|
+| Name            | name         | Name of pilight device | yes      |
+
+
+## Channels
+
+The `bridge` thing has no channels.
+
+The `contact`, `dimmer` and `switch` things all have one channel:
+
+| Thing     | Channel  | Type    | Description             |
+|-----------|----------|---------|-------------------------|
+| `contact` | state    | Contact | State of the contact    |
+| `dimmer`  | dimlevel | Dimmer  | Dim level of the dimmer |
+| `switch`  | state    | Switch  | State of the switch     |
+
+The `generic` thing has no fixed channels and you have to add them manually. Currently, only String and Number channels are supported.
+
+## Examples
+
+things/pilight.things
+
+```
+Bridge pilight:bridge:raspi "Pilight Daemon raspi" [ ipAddress="192.168.1.1", port=5000 ] {
+        Thing switch office "Office" [ name="office" ]
+        Thing dimmer piano "Piano"  [ name="piano" ]
+        Thing generic weather "Weather"  [ name="weather" ] {
+            Channels:
+              State Number : temperature [ property="temperature"]
+              State Number : humidity [ property="humidity"]
+        }
+}
+```
+
+items/pilight.items
+
+```
+Switch office_switch "Büro" { channel="pilight:switch:raspi:office:state" }
+Dimmer piano_light "Klavier [%.0f %%]" { channel="pilight:dimmer:raspi:piano:dimlevel" }
+Number weather_temperature  "Aussentemperatur [%.1f °C]" <temperature>  { channel="pilight:generic:raspi:weather:temperature" }
+Number weather_humidity "Feuchtigkeit [%.0f %%]" <humidity> { channel="pilight:generic:raspi:weather:humidity" }
+
+```
+
+sitemaps/fragment.sitemap
+
+```
+Switch item=office_switch
+Slider item=piano_light
+Text item=weather_temperature 
+Text item=weather_humidity 
+```
+

--- a/bundles/org.openhab.binding.pilight/pom.xml
+++ b/bundles/org.openhab.binding.pilight/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>2.5.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.pilight</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Pilight Binding</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.4</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.binding.pilight/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.pilight-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-pilight" description="Pilight Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.pilight/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/IPilightCallback.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/IPilightCallback.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.openhab.binding.pilight.internal.dto.Config;
+import org.openhab.binding.pilight.internal.dto.Status;
+
+/**
+ * Callback interface to signal any listeners that an update was received from pilight
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+@NonNullByDefault
+public interface IPilightCallback {
+
+    /**
+     * Update thing status
+     *
+     * @param status status of thing
+     * @param statusDetail status detail of thing
+     * @param description description of thing status
+     */
+    void updateThingStatus(ThingStatus status, ThingStatusDetail statusDetail, @Nullable String description);
+
+    /**
+     * Update for one or more device received.
+     *
+     * @param allStatus list of Object containing list of devices that were updated and their current state
+     */
+    public void statusReceived(List<Status> allStatus);
+
+    /**
+     * Configuration received.
+     *
+     * @param config Object containing configuration of pilight
+     */
+    public void configReceived(Config config);
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBindingConstants.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBindingConstants.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link PilightBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightBindingConstants {
+
+    private static final String BINDING_ID = "pilight";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
+    public static final ThingTypeUID THING_TYPE_CONTACT = new ThingTypeUID(BINDING_ID, "contact");
+    public static final ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "dimmer");
+    public static final ThingTypeUID THING_TYPE_SWITCH = new ThingTypeUID(BINDING_ID, "switch");
+    public static final ThingTypeUID THING_TYPE_GENERIC = new ThingTypeUID(BINDING_ID, "generic");
+
+    // List of all Channel ids
+    public static final String CHANNEL_STATE = "state";
+    public static final String CHANNEL_DIMLEVEL = "dimlevel";
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBridgeConfiguration.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PilightBridgeConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightBridgeConfiguration {
+
+    private String ipAddress = "";
+    private Integer port = 0;
+    private Integer delay = 500;
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Integer getDelay() {
+        return delay;
+    }
+
+    public void setDelay(Integer delay) {
+        this.delay = delay;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightChannelConfiguration.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightChannelConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PilightChannelConfiguration} class contains fields mapping channel configuration parameters.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightChannelConfiguration {
+    private String property = "";
+
+    public String getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightConnector.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightConnector.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.AllStatus;
+import org.openhab.binding.pilight.internal.dto.Identification;
+import org.openhab.binding.pilight.internal.dto.Message;
+import org.openhab.binding.pilight.internal.dto.Options;
+import org.openhab.binding.pilight.internal.dto.Response;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This class listens for updates from the pilight daemon. It is also responsible for requesting
+ * and propagating the current pilight configuration.
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ *
+ */
+@NonNullByDefault
+public class PilightConnector extends Thread {
+
+    private static final Integer RECONNECT_DELAY_MSEC = 10 * 1000; // 10 seconds
+
+    private final Logger logger = LoggerFactory.getLogger(PilightConnector.class);
+
+    private final PilightBridgeConfiguration config;
+
+    private final IPilightCallback callback;
+
+    private final ObjectMapper inputMapper = new ObjectMapper(
+            new MappingJsonFactory().configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false));
+
+    private final ObjectMapper outputMapper = new ObjectMapper(
+            new MappingJsonFactory().configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false))
+                    .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+
+    private boolean running = true;
+
+    private @Nullable Socket socket;
+    private @Nullable PrintStream printStream;
+
+    private Date lastUpdate = new Date(0);
+
+    private ExecutorService delayedUpdateThreadPool = Executors.newSingleThreadExecutor();
+
+    public PilightConnector(PilightBridgeConfiguration config, IPilightCallback callback) {
+        this.config = config;
+        this.callback = callback;
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+        connect();
+
+        while (running) {
+            try {
+                final Socket socket = this.socket;
+                if (socket != null && !socket.isClosed()) {
+                    BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                    String line = in.readLine();
+                    while (running && line != null) {
+                        if (!line.isEmpty()) {
+                            logger.trace("Received from pilight: {}", line);
+                            if (line.startsWith("{\"message\":\"config\"")) {
+                                // Configuration received
+                                logger.info("Config received");
+                                callback.configReceived(inputMapper.readValue(line, Message.class).getConfig());
+                            } else if (line.startsWith("{\"message\":\"values\"")) {
+                                AllStatus status = inputMapper.readValue(line, AllStatus.class);
+                                callback.statusReceived(status.getValues());
+                            } else if (line.startsWith("{\"version\":")) {
+                                // version message - skip it
+                                logger.info("version received: {}", line);
+                            } else if (line.startsWith("{\"status\":")) {
+                                // Status message, we're not using this for now.
+                                Response response = inputMapper.readValue(line, Response.class);
+                                logger.trace("Response success: {}", response.isSuccess());
+                            } else if (line.equals("1")) {
+                                // pilight stopping
+                                throw new IOException("Connection to pilight lost");
+                            } else {
+                                Status status = inputMapper.readValue(line, Status.class);
+                                callback.statusReceived(Collections.singletonList(status));
+                            }
+                        }
+                        line = in.readLine();
+                    }
+                }
+            } catch (IOException e) {
+                if (running) {
+                    logger.debug("Error in pilight listener thread", e);
+                }
+            }
+
+            logger.info("Disconnected from pilight server at {}:{}", config.getIpAddress(), config.getPort());
+
+            if (running) {
+                callback.updateThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, null);
+                // empty line received (socket closed) or pilight stopped but binding
+                // is still running, try to reconnect
+                connect();
+            }
+        }
+    }
+
+    /**
+     * Tells the connector to refresh the configuration
+     */
+    public void refreshConfig() {
+        logger.trace("refreshConfig");
+        doSendAction(new Action(Action.ACTION_REQUEST_CONFIG));
+    }
+
+    /**
+     * Tells the connector to refresh the status of all devices
+     */
+    public void refreshStatus() {
+        logger.trace("refreshStatus");
+        doSendAction(new Action(Action.ACTION_REQUEST_VALUES));
+    }
+
+    /**
+     * Stops the listener
+     */
+    public void close() {
+        running = false;
+        disconnect();
+        interrupt();
+    }
+
+    private void disconnect() {
+        final PrintStream printStream = this.printStream;
+        if (printStream != null) {
+            printStream.close();
+            this.printStream = null;
+        }
+
+        final Socket socket = this.socket;
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                logger.debug("Error while closing pilight socket", e);
+            }
+            this.socket = null;
+        }
+    }
+
+    private boolean isConnected() {
+        final Socket socket = this.socket;
+        return socket != null && !socket.isClosed();
+    }
+
+    private void connect() {
+        disconnect();
+
+        int delay = 0;
+
+        while (!isConnected()) {
+            try {
+                logger.debug("pilight connecting to {}:{}", config.getIpAddress(), config.getPort());
+
+                Thread.sleep(delay);
+                Socket socket = new Socket(config.getIpAddress(), config.getPort());
+
+                Options options = new Options();
+                options.setConfig(true);
+
+                Identification identification = new Identification();
+                identification.setOptions(options);
+
+                // For some reason, directly using the outputMapper to write to the socket's OutputStream doesn't work.
+                PrintStream printStream = new PrintStream(socket.getOutputStream(), true);
+                printStream.println(outputMapper.writeValueAsString(identification));
+
+                Response response = inputMapper.readValue(socket.getInputStream(), Response.class);
+
+                if (response.getStatus().equals(Response.SUCCESS)) {
+                    logger.info("Established connection to pilight server at {}:{}", config.getIpAddress(),
+                            config.getPort());
+                    this.socket = socket;
+                    this.printStream = printStream;
+                    callback.updateThingStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
+                } else {
+                    socket.close();
+                    logger.debug("pilight client not accepted: {}", response.getStatus());
+                }
+            } catch (IOException e) {
+                logger.debug("connect failed", e);
+                callback.updateThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            } catch (InterruptedException e) {
+                logger.debug("connect interrupted", e);
+            }
+
+            delay = RECONNECT_DELAY_MSEC;
+        }
+    }
+
+    /**
+     * send action to pilight daemon
+     *
+     * @param action action to send
+     */
+    public synchronized void sendAction(Action action) {
+        DelayedUpdate delayed = new DelayedUpdate(action);
+        delayedUpdateThreadPool.execute(delayed);
+    }
+
+    private void doSendAction(Action action) {
+        final PrintStream printStream = this.printStream;
+        if (printStream != null) {
+            try {
+                printStream.println(outputMapper.writeValueAsString(action));
+            } catch (IOException e) {
+                logger.debug("Error while sending action '{}' to pilight server", action.getAction(), e);
+            }
+        } else {
+            logger.debug("Cannot send action '{}', not connected to pilight!", action.getAction());
+        }
+    }
+
+    /**
+     * Simple thread to allow calls to pilight to be throttled
+     */
+    private class DelayedUpdate implements Runnable {
+
+        private final Action action;
+
+        public DelayedUpdate(Action action) {
+            this.action = action;
+        }
+
+        @Override
+        public void run() {
+            long delayBetweenUpdates = config.getDelay();
+
+            long diff = new Date().getTime() - lastUpdate.getTime();
+            if (diff < delayBetweenUpdates) {
+                long delay = Math.min(delayBetweenUpdates - diff, config.getDelay());
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    logger.debug("Error while processing pilight throttling delay");
+                }
+            }
+
+            lastUpdate = new Date();
+            doSendAction(action);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightDeviceConfiguration.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightDeviceConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PilightDeviceConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightDeviceConfiguration {
+
+    private String name = "";
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightHandlerFactory.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightHandlerFactory.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal;
+
+import static org.openhab.binding.pilight.internal.PilightBindingConstants.*;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
+import org.openhab.binding.pilight.internal.handler.PilightBridgeHandler;
+import org.openhab.binding.pilight.internal.handler.PilightContactHandler;
+import org.openhab.binding.pilight.internal.handler.PilightDimmerHandler;
+import org.openhab.binding.pilight.internal.handler.PilightGenericHandler;
+import org.openhab.binding.pilight.internal.handler.PilightSwitchHandler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link PilightHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.pilight", service = ThingHandlerFactory.class)
+public class PilightHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .of(THING_TYPE_BRIDGE, THING_TYPE_CONTACT, THING_TYPE_DIMMER, THING_TYPE_GENERIC, THING_TYPE_SWITCH)
+            .collect(Collectors.toSet());
+
+    private final ChannelTypeRegistry channelTypeRegistry;
+
+    @Activate
+    public PilightHandlerFactory(@Reference ChannelTypeRegistry channelTypeRegistry) {
+        this.channelTypeRegistry = channelTypeRegistry;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_BRIDGE.equals(thingTypeUID)) {
+            return new PilightBridgeHandler((Bridge) thing);
+        }
+
+        if (THING_TYPE_CONTACT.equals(thingTypeUID)) {
+            return new PilightContactHandler(thing);
+        }
+
+        if (THING_TYPE_DIMMER.equals(thingTypeUID)) {
+            return new PilightDimmerHandler(thing);
+        }
+
+        if (THING_TYPE_GENERIC.equals(thingTypeUID)) {
+            return new PilightGenericHandler(thing, channelTypeRegistry);
+        }
+
+        if (THING_TYPE_SWITCH.equals(thingTypeUID)) {
+            return new PilightSwitchHandler(thing);
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Action.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Action.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * This message is sent when we want to change the state of a device or request the
+ * current configuration in pilight.
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Action {
+
+    public static final String ACTION_SEND = "send";
+
+    public static final String ACTION_CONTROL = "control";
+
+    public static final String ACTION_REQUEST_CONFIG = "request config";
+
+    public static final String ACTION_REQUEST_VALUES = "request values";
+
+    private String action;
+
+    private Code code;
+
+    private Options options;
+
+    public Action(String action) {
+        this.action = action;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public Code getCode() {
+        return code;
+    }
+
+    public void setCode(Code code) {
+        this.code = code;
+    }
+
+    public Options getOptions() {
+        return options;
+    }
+
+    public void setOptions(Options options) {
+        this.options = options;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/AllStatus.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/AllStatus.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * All status messages.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+public class AllStatus {
+
+    private String message;
+
+    private List<Status> values = new ArrayList<>();
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public List<Status> getValues() {
+        return values;
+    }
+
+    public void setValues(List<Status> values) {
+        this.values = values;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Code.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Code.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * Part of the {@link Action} message that is sent to pilight.
+ * This contains the desired state for a single device.
+ *
+ * {@link http://www.pilight.org/development/api/#sender}
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Code {
+
+    public static final String STATE_ON = "on";
+
+    public static final String STATE_OFF = "off";
+
+    private String device;
+
+    private String state;
+
+    private Values values;
+
+    public String getDevice() {
+        return device;
+    }
+
+    public void setDevice(String device) {
+        this.device = device;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public Values getValues() {
+        return values;
+    }
+
+    public void setValues(Values values) {
+        this.values = values;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Config.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Config.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * pilight configuration object
+ *
+ * {@link http://www.pilight.org/development/api/#controller}
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Config {
+
+    private Map<String, Device> devices;
+
+    public Map<String, Device> getDevices() {
+        return devices;
+    }
+
+    public void setDevices(Map<String, Device> devices) {
+        this.devices = devices;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Device.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Device.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class describing a device in pilight
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Device {
+
+    private String uuid;
+
+    private String origin;
+
+    private String timestamp;
+
+    private List<String> protocol;
+
+    private String state;
+
+    private Integer dimlevel = null;
+
+    // @SerializedName("dimlevel-maximum")
+    private Integer dimlevelMaximum = null;
+
+    private Integer dimlevelMinimum = null;
+
+    private List<Map<String, String>> id;
+
+    private Map<String, String> properties = new HashMap<String, String>();
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public List<String> getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(List<String> protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public Integer getDimlevel() {
+        return dimlevel;
+    }
+
+    public void setDimlevel(Integer dimlevel) {
+        this.dimlevel = dimlevel;
+    }
+
+    public Integer getDimlevelMaximum() {
+        return dimlevelMaximum;
+    }
+
+    @JsonProperty("dimlevel-maximum")
+    public void setDimlevelMaximum(Integer dimlevelMaximum) {
+        this.dimlevelMaximum = dimlevelMaximum;
+    }
+
+    public Integer getDimlevelMinimum() {
+        return dimlevelMinimum;
+    }
+
+    @JsonProperty("dimlevel-minimum")
+    public void setDimlevelMinimum(Integer dimlevelMinimum) {
+        this.dimlevelMinimum = dimlevelMinimum;
+    }
+
+    public List<Map<String, String>> getId() {
+        return id;
+    }
+
+    public void setId(List<Map<String, String>> id) {
+        this.id = id;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+        properties.put(name, value.toString());
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/DeviceType.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/DeviceType.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * Different types of devices in pilight
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class DeviceType {
+
+    public static final Integer SERVER = -1;
+
+    public static final Integer SWITCH = 1;
+
+    public static final Integer DIMMER = 2;
+
+    public static final Integer VALUE = 3;
+
+    public static final Integer CONTACT = 6;
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Identification.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Identification.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This object is sent to pilight right after the initial connection. It describes what kind of client we want to be.
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+@NonNullByDefault
+public class Identification {
+
+    public static final String ACTION_IDENTIFY = "identify";
+
+    private String action;
+
+    private Options options = new Options();
+
+    public Identification() {
+        this.action = ACTION_IDENTIFY;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public Options getOptions() {
+        return options;
+    }
+
+    public void setOptions(Options options) {
+        this.options = options;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Message.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Message.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * Wrapper for the {@code Config} object
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Message {
+
+    private Config config;
+
+    private String message;
+
+    public Config getConfig() {
+        return config;
+    }
+
+    public void setConfig(Config config) {
+        this.config = config;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Options.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Options.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import org.openhab.binding.pilight.internal.serializers.BooleanToIntegerSerializer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Options that can be set as a pilight client.
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Options {
+
+    public static final String MEDIA_ALL = "all";
+
+    public static final String MEDIA_WEB = "web";
+
+    public static final String MEDIA_MOBILE = "mobile";
+
+    public static final String MEDIA_DESKTOP = "desktop";
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonSerialize(using = BooleanToIntegerSerializer.class)
+    private Boolean core;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonSerialize(using = BooleanToIntegerSerializer.class)
+    private Boolean receiver;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonSerialize(using = BooleanToIntegerSerializer.class)
+    private Boolean config;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonSerialize(using = BooleanToIntegerSerializer.class)
+    private Boolean forward;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonSerialize(using = BooleanToIntegerSerializer.class)
+    private Boolean stats;
+
+    private String uuid;
+
+    private String media;
+
+    public Boolean getCore() {
+        return core;
+    }
+
+    public void setCore(Boolean core) {
+        this.core = core;
+    }
+
+    public Boolean getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(Boolean receiver) {
+        this.receiver = receiver;
+    }
+
+    public Boolean getConfig() {
+        return config;
+    }
+
+    public void setConfig(Boolean config) {
+        this.config = config;
+    }
+
+    public Boolean getForward() {
+        return forward;
+    }
+
+    public void setForward(Boolean forward) {
+        this.forward = forward;
+    }
+
+    public Boolean getStats() {
+        return stats;
+    }
+
+    public void setStats(Boolean stats) {
+        this.stats = stats;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getMedia() {
+        return media;
+    }
+
+    public void setMedia(String media) {
+        this.media = media;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Response.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Response.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * Response to a connection or state change request
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Response {
+
+    public static final String SUCCESS = "success";
+
+    public static final String FAILURE = "failure";
+
+    private String status;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public boolean isSuccess() {
+        return SUCCESS.equals(status);
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Status.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Status.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Status message is received when a device in pilight changes state.
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Status {
+
+    private String origin;
+
+    private Integer type;
+
+    private String uuid;
+
+    private List<String> devices = new ArrayList<>();
+
+    private Map<String, String> values = new HashMap<>();
+
+    public Status() {
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public List<String> getDevices() {
+        return devices;
+    }
+
+    public void setDevices(List<String> devices) {
+        this.devices = devices;
+    }
+
+    public Map<String, String> getValues() {
+        return values;
+    }
+
+    public void setValues(Map<String, String> values) {
+        this.values = values;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Values.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/dto/Values.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.dto;
+
+/**
+ * Describes the specific properties of a device
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public class Values {
+
+    private Integer dimlevel;
+
+    public Integer getDimlevel() {
+        return dimlevel;
+    }
+
+    public void setDimlevel(Integer dimlevel) {
+        this.dimlevel = dimlevel;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBaseHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBaseHandler.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.pilight.internal.PilightDeviceConfiguration;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Config;
+import org.openhab.binding.pilight.internal.dto.Device;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightBaseHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightBaseHandler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PilightBaseHandler.class);
+
+    private String name = "";
+
+    public PilightBaseHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            logger.debug("command refresh {}", name);
+            refreshConfigAndStatus();
+            return;
+        }
+
+        Action action = createUpdateCommand(channelUID, command);
+        if (action != null) {
+            sendAction(action);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        PilightDeviceConfiguration config = getConfigAs(PilightDeviceConfiguration.class);
+        name = config.getName();
+
+        logger.debug("initialize {}", name);
+
+        refreshConfigAndStatus();
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        logger.debug("bridge status changed to {}.", bridgeStatusInfo.getStatus());
+
+        if (bridgeStatusInfo.getStatus() != ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+    }
+
+    public void updateFromStatusIfMatches(Status status) {
+        String device = status.getDevices().get(0);
+
+        if (device != null && name.equals(device)) {
+            if (!ThingStatus.ONLINE.equals(getThing().getStatus())) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+            logger.trace("update '{}'", name);
+            updateFromStatus(status);
+        }
+    }
+
+    public void updateFromConfigIfMatches(Config config) {
+        Device device = config.getDevices().get(getName());
+        if (device != null) {
+            updateFromConfigDevice(device);
+        }
+    }
+
+    protected void updateFromStatus(Status status) {
+        // handled in derived class
+    }
+
+    protected void updateFromConfigDevice(Device device) {
+        // may be handled in derived class
+    }
+
+    protected @Nullable Action createUpdateCommand(ChannelUID channelUID, Command command) {
+        // handled in the derived class
+        return null;
+    }
+
+    protected String getName() {
+        return name;
+    }
+
+    private void sendAction(Action action) {
+        final PilightBridgeHandler handler = getPilightBridgeHandler();
+        if (handler != null) {
+            handler.sendAction(action);
+        } else {
+            logger.warn("No pilight bridge handler found to send action.");
+        }
+    }
+
+    private void refreshConfigAndStatus() {
+        final PilightBridgeHandler handler = getPilightBridgeHandler();
+        if (handler != null) {
+            handler.refreshConfigAndStatus();
+        } else {
+            logger.warn("No pilight bridge handler found to refresh config and status.");
+        }
+    }
+
+    private @Nullable PilightBridgeHandler getPilightBridgeHandler() {
+        final Bridge bridge = getBridge();
+        if (bridge != null) {
+            BridgeHandler handler = bridge.getHandler();
+            if (handler != null && handler instanceof PilightBridgeHandler) {
+                return (PilightBridgeHandler) handler;
+            }
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightBridgeHandler.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.pilight.internal.handler;
+
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.pilight.internal.IPilightCallback;
+import org.openhab.binding.pilight.internal.PilightBridgeConfiguration;
+import org.openhab.binding.pilight.internal.PilightConnector;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Config;
+import org.openhab.binding.pilight.internal.dto.DeviceType;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightBridgeHandler} is responsible dispatching commands for the child
+ * things to the Pilight daemon and sending status updates to the child things.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightBridgeHandler extends BaseBridgeHandler {
+
+    private static final Integer REFRESH_CONFIG_MSEC = 500;
+
+    private final Logger logger = LoggerFactory.getLogger(PilightBridgeHandler.class);
+
+    private @Nullable PilightConnector connector = null;
+
+    private @Nullable ScheduledFuture<?> refreshJob = null;
+
+    public PilightBridgeHandler(Bridge bridge) {
+        super(bridge);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("Pilight Bridge is read-only and does not handle commands.");
+    }
+
+    @Override
+    public void initialize() {
+        PilightBridgeConfiguration config = getConfigAs(PilightBridgeConfiguration.class);
+
+        PilightConnector connector = new PilightConnector(config, new IPilightCallback() {
+            @Override
+            public void updateThingStatus(ThingStatus status, ThingStatusDetail statusDetail,
+                    @Nullable String description) {
+                updateStatus(status, statusDetail, description);
+                if (status == ThingStatus.ONLINE) {
+                    refreshConfigAndStatus();
+                }
+            }
+
+            @Override
+            public void statusReceived(List<Status> allStatus) {
+                for (Status status : allStatus) {
+                    processStatus(status);
+                }
+            }
+
+            @Override
+            public void configReceived(Config config) {
+                processConfig(config);
+            }
+        });
+
+        updateStatus(ThingStatus.UNKNOWN);
+
+        connector.setName("OH-binding-" + getThing().getUID().getAsString());
+        connector.start();
+        this.connector = connector;
+    }
+
+    @Override
+    public void dispose() {
+        ScheduledFuture<?> future = this.refreshJob;
+        if (future != null) {
+            future.cancel(true);
+        }
+
+        final PilightConnector connector = this.connector;
+        if (connector != null) {
+            connector.close();
+            this.connector = null;
+        }
+    }
+
+    /**
+     * send action to pilight daemon
+     *
+     * @param action action to send
+     */
+    public void sendAction(Action action) {
+        final PilightConnector connector = this.connector;
+        if (connector != null) {
+            connector.sendAction(action);
+        }
+    }
+
+    /**
+     * refresh config and status by requesting config and all values from pilight daemon
+     */
+    public synchronized void refreshConfigAndStatus() {
+        if (thing.getStatus() == ThingStatus.ONLINE) {
+            final ScheduledFuture<?> refreshJob = this.refreshJob;
+            if (refreshJob == null || refreshJob.isCancelled() || refreshJob.isDone()) {
+                logger.debug("schedule refresh of config and status");
+                this.refreshJob = scheduler.schedule(this::doRefreshConfigAndStatus, REFRESH_CONFIG_MSEC,
+                        TimeUnit.MILLISECONDS);
+            }
+        } else {
+            logger.warn("Bridge is not online - ignoring refresh of config and status.");
+        }
+    }
+
+    private void doRefreshConfigAndStatus() {
+        logger.trace("do refresh config and status");
+        final PilightConnector connector = this.connector;
+        if (connector != null) {
+            // the config is required for dimmers to get the minimum and maximum dim levels
+            connector.refreshConfig();
+            connector.refreshStatus();
+        }
+    }
+
+    /**
+     * Processes a status update received from pilight
+     *
+     * @param status The new Status
+     */
+    private void processStatus(Status status) {
+        final Integer type = status.getType();
+        logger.trace("processStatus device '{}' type {}", status.getDevices().get(0), type);
+
+        if (!DeviceType.SERVER.equals(type)) {
+            for (Thing thing : getThing().getThings()) {
+                ThingHandler handler = thing.getHandler();
+                if (handler != null && handler instanceof PilightBaseHandler) {
+                    ((PilightBaseHandler) handler).updateFromStatusIfMatches(status);
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes a config received from pilight
+     *
+     * @param config The new config
+     */
+    private void processConfig(Config config) {
+        for (Thing thing : getThing().getThings()) {
+            ThingHandler handler = thing.getHandler();
+            if (handler != null && handler instanceof PilightBaseHandler) {
+                ((PilightBaseHandler) handler).updateFromConfigIfMatches(config);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightContactHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightContactHandler.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.handler;
+
+import static org.openhab.binding.pilight.internal.PilightBindingConstants.CHANNEL_STATE;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.openhab.binding.pilight.internal.types.PilightContactType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightContactHandler} is responsible for handling a pilight contact.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightContactHandler extends PilightBaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PilightContactHandler.class);
+
+    public PilightContactHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    protected void updateFromStatus(Status status) {
+        String state = status.getValues().get("state");
+        if (state != null) {
+            updateState(CHANNEL_STATE, PilightContactType.valueOf(state.toUpperCase()).toOpenClosedType());
+        }
+    }
+
+    @Override
+    protected @Nullable Action createUpdateCommand(ChannelUID channelUID, Command command) {
+        logger.warn("A contact is a read only device");
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightDimmerHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightDimmerHandler.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.handler;
+
+import static org.openhab.binding.pilight.internal.PilightBindingConstants.CHANNEL_DIMLEVEL;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Code;
+import org.openhab.binding.pilight.internal.dto.Device;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.openhab.binding.pilight.internal.dto.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightDimmerHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightDimmerHandler extends PilightBaseHandler {
+
+    private static final int MAX_DIM_LEVEL_DEFAULT = 15;
+
+    private final Logger logger = LoggerFactory.getLogger(PilightDimmerHandler.class);
+
+    private int maxDimLevel = MAX_DIM_LEVEL_DEFAULT;
+
+    public PilightDimmerHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    protected void updateFromStatus(Status status) {
+        BigDecimal dimLevel = BigDecimal.ZERO;
+        String dimLevelAsString = status.getValues().get("dimlevel");
+
+        if (dimLevelAsString != null) {
+            dimLevel = getPercentageFromDimLevel(dimLevelAsString);
+        } else {
+            // Dimmer items can can also be switched on or off in pilight.
+            // When this happens, the dimmer value is not reported. At least we know it's on or off.
+            String stateAsString = status.getValues().get("state");
+            if (stateAsString != null) {
+                State state = OnOffType.valueOf(stateAsString.toUpperCase());
+                dimLevel = state.equals(OnOffType.ON) ? new BigDecimal("100") : BigDecimal.ZERO;
+            }
+        }
+
+        State state = new PercentType(dimLevel);
+        updateState(CHANNEL_DIMLEVEL, state);
+    }
+
+    @Override
+    protected void updateFromConfigDevice(Device device) {
+        Integer max = device.getDimlevelMaximum();
+        logger.trace("updateFromConfigDevice {}", max);
+
+        if (max != null) {
+            maxDimLevel = max.intValue();
+        }
+    }
+
+    @Override
+    protected @Nullable Action createUpdateCommand(ChannelUID unused, Command command) {
+        Code code = new Code();
+        code.setDevice(getName());
+
+        if (command instanceof OnOffType) {
+            code.setState(((OnOffType) command).equals(OnOffType.ON) ? Code.STATE_ON : Code.STATE_OFF);
+        } else if (command instanceof PercentType) {
+            setDimmerValue((PercentType) command, code);
+        } else {
+            logger.warn("Only OnOffType and PercentType are supported by a dimmer.");
+            return null;
+        }
+
+        Action action = new Action(Action.ACTION_CONTROL);
+        action.setCode(code);
+        return action;
+    }
+
+    private BigDecimal getPercentageFromDimLevel(String string) {
+        return new BigDecimal(string).setScale(2).divide(new BigDecimal(maxDimLevel), RoundingMode.HALF_UP)
+                .multiply(new BigDecimal(100));
+    }
+
+    private void setDimmerValue(PercentType percent, Code code) {
+        if (BigDecimal.ZERO.equals(percent.toBigDecimal())) {
+            // pilight is not responding to commands that set both the dimlevel to 0 and state to off.
+            // So, we're only updating the state for now
+            code.setState(Code.STATE_OFF);
+        } else {
+            BigDecimal dimlevel = percent.toBigDecimal().setScale(2)
+                    .divide(BigDecimal.valueOf(100), RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(maxDimLevel))
+                    .setScale(0, RoundingMode.HALF_UP);
+
+            Values values = new Values();
+            values.setDimlevel(dimlevel.intValue());
+            code.setValues(values);
+            code.setState(dimlevel.compareTo(BigDecimal.ZERO) == 1 ? Code.STATE_ON : Code.STATE_OFF);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightGenericHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightGenericHandler.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.pilight.internal.PilightChannelConfiguration;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightGenericHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightGenericHandler extends PilightBaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PilightGenericHandler.class);
+
+    private final ChannelTypeRegistry channelTypeRegistry;
+
+    private final Map<ChannelUID, Boolean> channelReadOnlyMap = new HashMap<>();
+
+    public PilightGenericHandler(Thing thing, ChannelTypeRegistry channelTypeRegistry) {
+        super(thing);
+        this.channelTypeRegistry = channelTypeRegistry;
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        initializeReadOnlyChannels();
+    }
+
+    @Override
+    protected void updateFromStatus(Status status) {
+        for (Channel channel : thing.getChannels()) {
+            PilightChannelConfiguration config = channel.getConfiguration().as(PilightChannelConfiguration.class);
+            updateState(channel.getUID(),
+                    getDynamicChannelState(channel, status.getValues().get(config.getProperty())));
+        }
+    }
+
+    @Override
+    protected @Nullable Action createUpdateCommand(ChannelUID channelUID, Command command) {
+        if (isChannelReadOnly(channelUID)) {
+            logger.debug("Can't apply command '{}' to '{}' because channel is readonly.", command, channelUID.getId());
+            return null;
+        }
+
+        logger.debug("Create update command for '{}' not implemented.", channelUID.getId());
+
+        return null;
+    }
+
+    private State getDynamicChannelState(final Channel channel, final @Nullable String value) {
+        final String acceptedItemType = channel.getAcceptedItemType();
+
+        if (value == null || acceptedItemType == null) {
+            return UnDefType.UNDEF;
+        }
+
+        switch (acceptedItemType) {
+            case CoreItemFactory.NUMBER:
+                return new DecimalType(value);
+            case CoreItemFactory.STRING:
+                return StringType.valueOf(value);
+            case CoreItemFactory.SWITCH:
+                return OnOffType.from(value);
+            default:
+                logger.trace("Type '{}' for channel '{}' not implemented", channel.getAcceptedItemType(), channel);
+                return UnDefType.UNDEF;
+        }
+    }
+
+    private void initializeReadOnlyChannels() {
+        channelReadOnlyMap.clear();
+        for (Channel channel : thing.getChannels()) {
+            ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+            if (channelTypeUID != null) {
+                ChannelType channelType = channelTypeRegistry.getChannelType(channelTypeUID, null);
+
+                if (channelType != null) {
+                    logger.debug("initializeReadOnly {} {}", channelType, channelType.getState());
+                }
+
+                if (channelType != null && channelType.getState() != null) {
+                    channelReadOnlyMap.putIfAbsent(channel.getUID(), channelType.getState().isReadOnly());
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("null")
+    private boolean isChannelReadOnly(ChannelUID channelUID) {
+        Boolean isReadOnly = channelReadOnlyMap.get(channelUID);
+        return isReadOnly != null ? isReadOnly : true;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightSwitchHandler.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/handler/PilightSwitchHandler.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.handler;
+
+import static org.openhab.binding.pilight.internal.PilightBindingConstants.CHANNEL_STATE;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.pilight.internal.dto.Action;
+import org.openhab.binding.pilight.internal.dto.Code;
+import org.openhab.binding.pilight.internal.dto.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PilightSwitchHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Stefan Röllin - Initial contribution
+ */
+@NonNullByDefault
+public class PilightSwitchHandler extends PilightBaseHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(PilightSwitchHandler.class);
+
+    public PilightSwitchHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    protected void updateFromStatus(Status status) {
+        String state = status.getValues().get("state");
+        if (state != null) {
+            updateState(CHANNEL_STATE, OnOffType.valueOf(state.toUpperCase()));
+        }
+    }
+
+    @Override
+    protected @Nullable Action createUpdateCommand(ChannelUID unused, Command command) {
+        if (command instanceof OnOffType) {
+            Code code = new Code();
+            code.setDevice(getName());
+            code.setState(((OnOffType) command).equals(OnOffType.ON) ? Code.STATE_ON : Code.STATE_OFF);
+
+            Action action = new Action(Action.ACTION_CONTROL);
+            action.setCode(code);
+            return action;
+        }
+
+        logger.warn("A pilight switch only accepts OnOffType commands.");
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/serializers/BooleanToIntegerSerializer.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/serializers/BooleanToIntegerSerializer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.serializers;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Serializer to map boolean values to an integer (1 and 0).
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+@NonNullByDefault
+public class BooleanToIntegerSerializer extends JsonSerializer<Boolean> {
+
+    @Override
+    public void serialize(@Nullable Boolean bool, @Nullable JsonGenerator jsonGenerator,
+            @Nullable SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        if (bool != null && jsonGenerator != null) {
+            jsonGenerator.writeObject(bool ? 1 : 0);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/types/PilightContactType.java
+++ b/bundles/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/types/PilightContactType.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pilight.internal.types;
+
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+
+/**
+ * Enum to represent the state of a contact sensor in pilight
+ *
+ * @author Jeroen Idserda - Initial contribution
+ * @author Stefan Röllin - Port to openHAB 2 pilight binding
+ */
+public enum PilightContactType {
+    OPENED,
+    CLOSED;
+
+    public OpenClosedType toOpenClosedType() {
+        return this.equals(PilightContactType.OPENED) ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
+    }
+}

--- a/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="pilight" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Pilight Binding</name>
+	<description>This is the binding to communicate with a pilight daemon.</description>
+	<author>Stefan Röllin</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/config/config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+	https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:pilight:device">
+		<parameter name="name" type="text" required="true">
+			<label>Name of Device</label>
+			<description>The name of the pilight device.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/i18n/pilight_de.properties
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/i18n/pilight_de.properties
@@ -1,0 +1,38 @@
+# binding
+binding.pilight.name = Pilight Binding
+binding.pilight.description = Das Pilight Binding erlaubt es mit pilight daemons zu kommunizieren.
+
+# thing types
+thing-type.pilight.bridge.label = Pilight Bridge
+thing-type.pilight.bridge.description = Verbindung zwischen openHAB und einem pilight Daemon.
+
+thing-type.pilight.contact.label = Pilight Kontakt
+thing-type.pilight.contact.description = Pilight Kontakt
+
+thing-type.pilight.dimmer.label = Pilight Dimmer
+thing-type.pilight.dimmer.description = Pilight Dimmer
+
+thing-type.pilight.switch.label = Pilight Schalter
+thing-type.pilight.switch.description = Pilight Schalter
+
+thing-type.pilight.generic.label = Generisches pilight Gerät
+thing-type.pilight.generic.description = Gerät beim dem die Kanäle dynamisch hinzugefügt werden. 
+
+# thing type config description
+thing-type.config.pilight.bridge.ipAddress.label = IP-Adresse
+thing-type.config.pilight.bridge.ipAddress.description = Lokale IP-Adresse oder Hostname des pilight Daemons.
+thing-type.config.pilight.bridge.port.label = Port
+thing-type.config.pilight.bridge.port.description = Port des pilight Daemons.
+thing-type.config.pilight.bridge.delay.label = Verzögerung
+thing-type.config.pilight.bridge.delay.description = Verzögerung (in Millisekunden) zwischen zwei Kommandos. Empfohlener Wert ohne Bandpass filter: 1000 und mit Bandpass Filter zwischen 200 und 500. 
+
+thing-type.config.pilight.device.name.label = Name
+thing-type.config.pilight.device.name.description = Name des pilight Geräts 
+
+# channel types
+channel-type.pilight.contact-state.label = Status
+channel-type.pilight.contact-state.description = Status des pilight Kontakts
+channel-type.pilight.switch-state.label = Status
+channel-type.pilight.switch-state.description = Status des pilight Schalters
+channel-type.pilight.dimlevel.label = Dimerwert
+channel-type.pilight.dimlevel.description = Wert des pilight Dimmers

--- a/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/thing/bridge.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="pilight"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="bridge">
+		<label>Pilight Bridge</label>
+		<description>Pilight Bridge which connects to a Pilight instance.</description>
+
+		<config-description>
+			<parameter name="ipAddress" type="text" required="true">
+				<label>Network Address</label>
+				<description>The IP or host name of the Pilight instance.</description>
+				<context>network-address</context>
+			</parameter>
+			<parameter name="port" type="integer" required="true" min="1" max="65335">
+				<label>Port</label>
+				<description>Port of the Pilight daemon. You must explicitly configure the port in the Pilight daemon config or
+					otherwise a random port will be used and the binding will not be able to connect.
+				</description>
+				<default>5000</default>
+			</parameter>
+			<parameter name="delay" type="integer" required="false" min="1" max="65335">
+				<label>Delay between commands</label>
+				<description>Delay (in millisecond) between consecutive commands. Recommended value without band pass filter: 1000.
+					Recommended value with band pass filter: somewhere between 200-500.</description>
+				<default>500</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/thing/devices.xml
+++ b/bundles/org.openhab.binding.pilight/src/main/resources/ESH-INF/thing/devices.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="pilight"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="switch">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Pilight Switch</label>
+		<description>Pilight Switch</description>
+
+		<channels>
+			<channel id="state" typeId="switch-state"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:pilight:device"/>
+	</thing-type>
+
+	<thing-type id="contact">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Pilight Contact</label>
+		<description>Pilight Contact</description>
+
+		<channels>
+			<channel id="state" typeId="contact-state"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:pilight:device"/>
+	</thing-type>
+
+	<thing-type id="dimmer">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Pilight Dimmer</label>
+		<description>Pilight Dimmer</description>
+
+		<channels>
+			<channel id="dimlevel" typeId="dimlevel"/>
+		</channels>
+
+		<config-description-ref uri="thing-type:pilight:device"/>
+	</thing-type>
+
+	<thing-type id="generic" extensible="string,number">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Pilight Generic Device</label>
+		<description>Pilight Generic Device</description>
+
+		<config-description-ref uri="thing-type:pilight:device"/>
+	</thing-type>
+
+	<channel-type id="contact-state">
+		<item-type>Contact</item-type>
+		<label>State of contact</label>
+		<description>State of pilight contact.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dimlevel">
+		<item-type>Dimmer</item-type>
+		<label>Dim level</label>
+		<description>Dim level of pilight dimmer.</description>
+	</channel-type>
+
+	<channel-type id="switch-state">
+		<item-type>Switch</item-type>
+		<label>State of switch</label>
+		<description>State of pilight switch.</description>
+	</channel-type>
+
+	<channel-type id="string">
+		<item-type>String</item-type>
+		<label>Text Value</label>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="property" type="text">
+				<label>Property</label>
+				<description>The property of the device.</description>
+				<required>true</required>
+			</parameter>
+		</config-description>
+	</channel-type>
+
+	<channel-type id="number">
+		<item-type>Number</item-type>
+		<label>Number Value</label>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="property" type="text">
+				<label>Property</label>
+				<description>The property of the device.</description>
+				<required>true</required>
+			</parameter>
+		</config-description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -211,6 +211,7 @@
     <module>org.openhab.binding.paradoxalarm</module>
     <module>org.openhab.binding.pentair</module>
     <module>org.openhab.binding.phc</module>
+    <module>org.openhab.binding.pilight</module>
     <module>org.openhab.binding.pioneeravr</module>
     <module>org.openhab.binding.pixometer</module>
     <module>org.openhab.binding.pjlinkdevice</module>


### PR DESCRIPTION
Signed-off-by: Stefan Roellin <stefan@roellin-baumann.ch>

The Pilight binding allows openHAB to communicate with a [pilight](http://www.pilight.org/) instance running pilight version 6.0 or greater.
This pull request is meant to port the corresponding binding from openhab1-addons (https://www.openhab.org/addons/bindings/pilight1/) to openHAB 2.
