### PR TITLE
[gree] Fix endless loop in command handler (previous PR)

### DIFF
--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/handler/GreeHandler.java
@@ -87,6 +87,7 @@ public class GreeHandler extends BaseThingHandler {
             String message = messages.get("thinginit.invconf");
             logger.warn("{}: {}", thingId, message);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, message);
+            return;
         }
 
         // set the thing status to UNKNOWN temporarily and let the background task decide for the real status.
@@ -128,7 +129,9 @@ public class GreeHandler extends BaseThingHandler {
             logger.warn("{}: {}", thingId, messages.get("thinginit.exception", "RuntimeException"), e);
         }
 
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, message);
+        if (getThing().getStatus() != ThingStatus.OFFLINE) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, message);
+        }
     }
 
     @Override
@@ -388,6 +391,7 @@ public class GreeHandler extends BaseThingHandler {
                     apiRetries++;
                     if (apiRetries > MAX_API_RETRIES) {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, message);
+                        apiRetries = 0;
                     }
                 }
             } catch (RuntimeException e) {


### PR DESCRIPTION
@Hilbrand This is a hotfix for the release. Due to a missing "return" it could get into an endless loop in the command handler. Shame on me :-)