### PR TITLE
[teleinfo] Add rfc2217 support

### DIFF
--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/serial/TeleinfoSerialControllerHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/serial/TeleinfoSerialControllerHandler.java
@@ -149,8 +149,16 @@ public class TeleinfoSerialControllerHandler extends TeleinfoAbstractControllerH
             serialPort = commPort;
 
             commPort.setSerialPortParams(1200, SerialPort.DATABITS_7, SerialPort.STOPBITS_1, SerialPort.PARITY_EVEN);
-            commPort.enableReceiveThreshold(1);
-            commPort.enableReceiveTimeout(SERIAL_RECEIVE_TIMEOUT_MS);
+            try {
+                commPort.enableReceiveThreshold(1);
+            } catch (UnsupportedCommOperationException e) {
+                // rfc2217
+            }
+            try {
+                commPort.enableReceiveTimeout(SERIAL_RECEIVE_TIMEOUT_MS);
+            } catch (UnsupportedCommOperationException e) {
+                // rfc2217
+            }
             logger.debug("Starting receive thread");
             TeleinfoReceiveThread receiveThread = new TeleinfoReceiveThread(commPort, this,
                     config.autoRepairInvalidADPSgroupLine, scheduler);


### PR DESCRIPTION
This PR adds support for rfc2217 serial port in teleinfo binding.