### PR TITLE
[amazonechocontrol] Remove unused version which no longer parses due to type change

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
@@ -31,6 +31,5 @@ public class JsonPlaylists {
         public @Nullable String playlistId;
         public @Nullable String title;
         public int trackCount;
-        public int version;
     }
 }


### PR DESCRIPTION
Fixes #8491

As far as I can see the "version" field in the playlist is parsed, but never used.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>