### PR TITLE
Migrate tests to JUnit 5

### DIFF
--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/SunCalcTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/calc/SunCalcTest.java
@@ -12,15 +12,15 @@
  */
 package org.openhab.binding.astro.internal.calc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.astro.internal.model.Sun;
 import org.openhab.binding.astro.internal.model.SunPhaseName;
 
@@ -51,7 +51,7 @@ public class SunCalcTest {
 
     private SunCalc sunCalc;
 
-    @Before
+    @BeforeEach
     public void init() {
         sunCalc = new SunCalc();
     }
@@ -178,7 +178,7 @@ public class SunCalcTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testRangesForCoherenceBetweenNightEndAndAstroDawnStart() {
         Sun sun = sunCalc.getSunInfo(FEB_27_2019, AMSTERDAM_LATITUDE, AMSTERDAM_LONGITUDE, AMSTERDAM_ALTITUDE, false);
 

--- a/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/model/SunTest.java
+++ b/bundles/org.openhab.binding.astro/src/test/java/org/openhab/binding/astro/internal/model/SunTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.astro.internal.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.ZoneId;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.astro.internal.config.AstroChannelConfig;
 import org.openhab.binding.astro.internal.util.PropertyUtils;
 import org.openhab.core.library.types.StringType;
@@ -39,7 +39,7 @@ public class SunTest {
 
     private static ZoneId ZONE = ZoneId.systemDefault();
 
-    @Before
+    @BeforeEach
     public void init() {
         sun = new Sun();
         config = new AstroChannelConfig();
@@ -68,13 +68,14 @@ public class SunTest {
                 PropertyUtils.getState(new ChannelUID("astro:sun:home:phase#name"), config, sun, ZONE));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetStateWhenNullPhase() throws Exception {
         sun.setPhase(null);
 
         assertNull(sun.getPhase());
-        assertEquals(UnDefType.UNDEF,
-                PropertyUtils.getState(new ChannelUID("astro:sun:home:phase#name"), config, sun, ZONE));
+
+        assertThrows(NullPointerException.class, () -> assertEquals(UnDefType.UNDEF,
+                PropertyUtils.getState(new ChannelUID("astro:sun:home:phase#name"), config, sun, ZONE)));
     }
 
     @Test

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/actions/AVMFritzHeatingActionsTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/actions/AVMFritzHeatingActionsTest.java
@@ -12,11 +12,13 @@
  */
 package org.openhab.binding.avmfritz.actions;
 
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.avmfritz.internal.handler.AVMFritzHeatingActionsHandler;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingHandler;
@@ -26,6 +28,7 @@ import org.openhab.core.thing.binding.ThingHandler;
  *
  * @author Christoph Weitkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class AVMFritzHeatingActionsTest {
 
     private final ThingActions thingActionsStub = new ThingActions() {
@@ -43,32 +46,32 @@ public class AVMFritzHeatingActionsTest {
 
     private AVMFritzHeatingActions heatingActions;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
-
         heatingActions = new AVMFritzHeatingActions();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetBoostModeThingActionsIsNull() {
-        AVMFritzHeatingActions.setBoostMode(null, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class, () -> AVMFritzHeatingActions.setBoostMode(null, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetBoostModeThingActionsIsNotPushoverThingActions() {
-        AVMFritzHeatingActions.setBoostMode(thingActionsStub, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setBoostMode(thingActionsStub, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetBoostModeThingHandlerIsNull() {
-        AVMFritzHeatingActions.setBoostMode(heatingActions, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setBoostMode(heatingActions, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetBoostModeDurationNull() {
         heatingActions.setThingHandler(heatingActionsHandler);
-        AVMFritzHeatingActions.setBoostMode(heatingActions, null);
+        assertThrows(IllegalArgumentException.class, () -> AVMFritzHeatingActions.setBoostMode(heatingActions, null));
     }
 
     @Test
@@ -77,25 +80,29 @@ public class AVMFritzHeatingActionsTest {
         AVMFritzHeatingActions.setBoostMode(heatingActions, Long.valueOf(5L));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetWindowOpenModeThingActionsIsNull() {
-        AVMFritzHeatingActions.setWindowOpenMode(null, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setWindowOpenMode(null, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetWindowOpenModeThingActionsIsNotPushoverThingActions() {
-        AVMFritzHeatingActions.setWindowOpenMode(thingActionsStub, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setWindowOpenMode(thingActionsStub, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetWindowOpenModeThingHandlerIsNull() {
-        AVMFritzHeatingActions.setWindowOpenMode(heatingActions, Long.valueOf(5L));
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setWindowOpenMode(heatingActions, Long.valueOf(5L)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetWindowOpenModeDurationNull() {
         heatingActions.setThingHandler(heatingActionsHandler);
-        AVMFritzHeatingActions.setWindowOpenMode(heatingActions, null);
+        assertThrows(IllegalArgumentException.class,
+                () -> AVMFritzHeatingActions.setWindowOpenMode(heatingActions, null));
     }
 
     @Test

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzDeviceListModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzDeviceListModelTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.avmfritz.internal.dto;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 
 import java.io.StringReader;
@@ -23,8 +23,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.avmfritz.internal.util.JAXBUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ public class AVMFritzDeviceListModelTest {
 
     private @NonNullByDefault({}) DeviceListModel devices;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         //@formatter:off
         String xml =

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzTemplateListModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/AVMFritzTemplateListModelTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.avmfritz.internal.dto;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.util.Optional;
@@ -21,8 +21,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.avmfritz.internal.dto.templates.TemplateListModel;
 import org.openhab.binding.avmfritz.internal.dto.templates.TemplateModel;
 import org.openhab.binding.avmfritz.internal.util.JAXBUtils;
@@ -41,7 +41,7 @@ public class AVMFritzTemplateListModelTest {
 
     private @NonNullByDefault({}) TemplateListModel templates;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         //@formatter:off
         String xml =

--- a/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
+++ b/bundles/org.openhab.binding.avmfritz/src/test/java/org/openhab/binding/avmfritz/internal/dto/HeatingModelTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.avmfritz.internal.dto;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link HeatingModel} methods.

--- a/bundles/org.openhab.binding.bluetooth.airthings/src/test/java/org/openhab/binding/bluetooth/airthings/AirthingsWavePlusParserTest.java
+++ b/bundles/org.openhab.binding.bluetooth.airthings/src/test/java/org/openhab/binding/bluetooth/airthings/AirthingsWavePlusParserTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.bluetooth.airthings;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.airthings.internal.AirthingsParserException;
 import org.openhab.binding.bluetooth.airthings.internal.AirthingsWavePlusDataParser;
 
@@ -27,22 +27,22 @@ import org.openhab.binding.bluetooth.airthings.internal.AirthingsWavePlusDataPar
 @NonNullByDefault
 public class AirthingsWavePlusParserTest {
 
-    @Test(expected = AirthingsParserException.class)
-    public void testWrongVersion() throws AirthingsParserException {
+    @Test
+    public void testWrongVersion() {
         int[] data = { 5, 55, 51, 0, 122, 0, 61, 0, 119, 9, 11, 194, 169, 2, 46, 0, 0, 0, 4, 20 };
-        new AirthingsWavePlusDataParser(data);
+        assertThrows(AirthingsParserException.class, () -> new AirthingsWavePlusDataParser(data));
     }
 
-    @Test(expected = AirthingsParserException.class)
-    public void testEmptyData() throws AirthingsParserException {
+    @Test
+    public void testEmptyData() {
         int[] data = {};
-        new AirthingsWavePlusDataParser(data);
+        assertThrows(AirthingsParserException.class, () -> new AirthingsWavePlusDataParser(data));
     }
 
-    @Test(expected = AirthingsParserException.class)
+    @Test
     public void testWrongDataLen() throws AirthingsParserException {
         int[] data = { 1, 55, 51, 0, 122, 0, 61, 0, 119, 9, 11, 194, 169, 2, 46, 0, 0 };
-        new AirthingsWavePlusDataParser(data);
+        assertThrows(AirthingsParserException.class, () -> new AirthingsWavePlusDataParser(data));
     }
 
     @Test

--- a/bundles/org.openhab.binding.bluetooth.am43/src/test/java/org/openhab/binding/bluetooth/am43/CommandTest.java
+++ b/bundles/org.openhab.binding.bluetooth.am43/src/test/java/org/openhab/binding/bluetooth/am43/CommandTest.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.bluetooth.am43;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.am43.internal.command.ControlCommand;
 import org.openhab.binding.bluetooth.am43.internal.command.GetAllCommand;
 import org.openhab.binding.bluetooth.am43.internal.data.ControlAction;
@@ -31,7 +31,7 @@ public class CommandTest {
     public void findAllCommandTest() {
         byte[] expected = HexUtils.hexToBytes("00ff00009aa701013d");
         byte[] actual = new GetAllCommand().getRequest();
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 
     @Test
@@ -39,7 +39,7 @@ public class CommandTest {
         byte[] expected = HexUtils.hexToBytes("00ff00009a0a01cc5d");
         byte[] actual = new ControlCommand(ControlAction.STOP).getRequest();
 
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 
     @Test
@@ -47,6 +47,6 @@ public class CommandTest {
         byte[] expected = HexUtils.hexToBytes("00ff00009a0a01dd4c");
         byte[] actual = new ControlCommand(ControlAction.OPEN).getRequest();
 
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 }

--- a/bundles/org.openhab.binding.bluetooth.am43/src/test/java/org/openhab/binding/bluetooth/am43/CommandTest.java
+++ b/bundles/org.openhab.binding.bluetooth.am43/src/test/java/org/openhab/binding/bluetooth/am43/CommandTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.bluetooth.am43;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.am43.internal.command.ControlCommand;
 import org.openhab.binding.bluetooth.am43.internal.command.GetAllCommand;

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/test/java/org/openhab/binding/bluetooth/bluegiga/internal/attributeclient/BlueGigaFindInformationFoundEventTest.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/test/java/org/openhab/binding/bluetooth/bluegiga/internal/attributeclient/BlueGigaFindInformationFoundEventTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.bluetooth.bluegiga.internal.attributeclient;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.bluegiga.internal.command.attributeclient.BlueGigaFindInformationFoundEvent;
 
 /**

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/test/java/org/openhab/binding/bluetooth/bluegiga/internal/eir/EirRecordTest.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/test/java/org/openhab/binding/bluetooth/bluegiga/internal/eir/EirRecordTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.bluetooth.bluegiga.internal.eir;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link EirRecord}.

--- a/bundles/org.openhab.binding.bluetooth.daikinmadoka/src/test/java/org/openhab/binding/bluetooth/daikinmadoka/internal/MadokaMessageTest.java
+++ b/bundles/org.openhab.binding.bluetooth.daikinmadoka/src/test/java/org/openhab/binding/bluetooth/daikinmadoka/internal/MadokaMessageTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.bluetooth.daikinmadoka.internal;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bluetooth.daikinmadoka.internal.model.MadokaMessage;
 import org.openhab.binding.bluetooth.daikinmadoka.internal.model.MadokaValue;
 import org.openhab.binding.bluetooth.daikinmadoka.internal.model.commands.GetIndoorOutoorTemperatures;

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/BluetoothAddressTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/BluetoothAddressTest.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.binding.bluetooth;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link BluetoothAddress}.
@@ -21,14 +23,14 @@ import org.junit.Test;
  */
 public class BluetoothAddressTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithNullParam() {
-        new BluetoothAddress(null);
+        assertThrows(IllegalArgumentException.class, () -> new BluetoothAddress(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithoutColons() {
-        new BluetoothAddress("123456789ABC");
+        assertThrows(IllegalArgumentException.class, () -> new BluetoothAddress("123456789ABC"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryServiceTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -65,6 +66,7 @@ import org.slf4j.LoggerFactory;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
+@Disabled("Needs to be updated for OH3")
 public class BluetoothDiscoveryServiceTest {
 
     private static final int TIMEOUT = 2000;

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryServiceTest.java
@@ -13,6 +13,8 @@
 package org.openhab.binding.bluetooth.discovery.internal;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,16 +27,17 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.bluetooth.BluetoothAdapter;
 import org.openhab.binding.bluetooth.BluetoothAddress;
 import org.openhab.binding.bluetooth.BluetoothBindingConstants;
@@ -59,8 +62,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Connor Petty - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
-@RunWith(MockitoJUnitRunner.class)
 public class BluetoothDiscoveryServiceTest {
 
     private static final int TIMEOUT = 2000;
@@ -69,13 +73,10 @@ public class BluetoothDiscoveryServiceTest {
 
     private @NonNullByDefault({}) BluetoothDiscoveryService discoveryService;
 
-    @Spy
-    private @NonNullByDefault({}) MockDiscoveryParticipant participant1 = new MockDiscoveryParticipant();
+    private @Spy @NonNullByDefault({}) MockDiscoveryParticipant participant1 = new MockDiscoveryParticipant();
+    private @Mock @NonNullByDefault({}) DiscoveryListener mockDiscoveryListener;
 
-    @Mock
-    private @NonNullByDefault({}) DiscoveryListener mockDiscoveryListener;
-
-    @Before
+    @BeforeEach
     public void setup() {
         discoveryService = new BluetoothDiscoveryService();
         discoveryService.addDiscoveryListener(mockDiscoveryListener);
@@ -185,12 +186,12 @@ public class BluetoothDiscoveryServiceTest {
         DiscoveryResult result1 = results.get(0);
         DiscoveryResult result2 = results.get(1);
 
-        Assert.assertNotEquals(result1.getBridgeUID(), result2.getBridgeUID());
-        Assert.assertThat(result1.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(mockAdapter2.getUID())));
-        Assert.assertThat(result2.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(mockAdapter2.getUID())));
-        Assert.assertEquals(result1.getThingUID().getId(), result2.getThingUID().getId());
-        Assert.assertEquals(result1.getLabel(), result2.getLabel());
-        Assert.assertEquals(result1.getRepresentationProperty(), result2.getRepresentationProperty());
+        assertNotEquals(result1.getBridgeUID(), result2.getBridgeUID());
+        assertThat(result1.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(mockAdapter2.getUID())));
+        assertThat(result2.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(mockAdapter2.getUID())));
+        assertEquals(result1.getThingUID().getId(), result2.getThingUID().getId());
+        assertEquals(result1.getLabel(), result2.getLabel());
+        assertEquals(result1.getRepresentationProperty(), result2.getRepresentationProperty());
     }
 
     @Test
@@ -308,7 +309,7 @@ public class BluetoothDiscoveryServiceTest {
 
         DiscoveryResult result = resultCaptor.getValue();
 
-        Assert.assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
+        assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
 
         Mockito.verify(mockDiscoveryListener, Mockito.timeout(TIMEOUT).times(1)).thingRemoved(
                 ArgumentMatchers.same(discoveryService),
@@ -330,7 +331,7 @@ public class BluetoothDiscoveryServiceTest {
 
         DiscoveryResult result = resultCaptor.getValue();
 
-        Assert.assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
+        assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
 
         discoveryService.deviceRemoved(device);
 
@@ -382,7 +383,7 @@ public class BluetoothDiscoveryServiceTest {
 
         DiscoveryResult result = resultCaptor.getValue();
 
-        Assert.assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
+        assertEquals(BluetoothBindingConstants.THING_TYPE_BEACON, result.getThingTypeUID());
 
         device.setManufacturerId(10);
 
@@ -450,7 +451,7 @@ public class BluetoothDiscoveryServiceTest {
                 ArgumentMatchers.same(discoveryService),
                 ArgumentMatchers.argThat(arg -> arg.getThingTypeUID().equals(participant2.typeUID)));
 
-        Assert.assertEquals(1, callCount.get());
+        assertEquals(1, callCount.get());
     }
 
     @Test
@@ -471,12 +472,12 @@ public class BluetoothDiscoveryServiceTest {
         DiscoveryResult result1 = results.get(0);
         DiscoveryResult result2 = results.get(1);
 
-        Assert.assertNotEquals(result1.getBridgeUID(), result2.getBridgeUID());
-        Assert.assertThat(result1.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(roamingAdapter.getUID())));
-        Assert.assertThat(result2.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(roamingAdapter.getUID())));
-        Assert.assertEquals(result1.getThingUID().getId(), result2.getThingUID().getId());
-        Assert.assertEquals(result1.getLabel(), result2.getLabel());
-        Assert.assertEquals(result1.getRepresentationProperty(), result2.getRepresentationProperty());
+        assertNotEquals(result1.getBridgeUID(), result2.getBridgeUID());
+        assertThat(result1.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(roamingAdapter.getUID())));
+        assertThat(result2.getBridgeUID(), anyOf(is(mockAdapter1.getUID()), is(roamingAdapter.getUID())));
+        assertEquals(result1.getThingUID().getId(), result2.getThingUID().getId());
+        assertEquals(result1.getLabel(), result2.getLabel());
+        assertEquals(result1.getRepresentationProperty(), result2.getRepresentationProperty());
     }
 
     @Test
@@ -499,12 +500,12 @@ public class BluetoothDiscoveryServiceTest {
         ThingUID result1 = results.get(0);
         ThingUID result2 = results.get(1);
 
-        Assert.assertNotEquals(result1.getBridgeIds(), result2.getBridgeIds());
-        Assert.assertThat(result1.getBridgeIds().get(0),
+        assertNotEquals(result1.getBridgeIds(), result2.getBridgeIds());
+        assertThat(result1.getBridgeIds().get(0),
                 anyOf(is(mockAdapter1.getUID().getId()), is(roamingAdapter.getUID().getId())));
-        Assert.assertThat(result2.getBridgeIds().get(0),
+        assertThat(result2.getBridgeIds().get(0),
                 anyOf(is(mockAdapter1.getUID().getId()), is(roamingAdapter.getUID().getId())));
-        Assert.assertEquals(result1.getId(), result2.getId());
+        assertEquals(result1.getId(), result2.getId());
     }
 
     private class RoamingDiscoveryParticipant implements BluetoothDiscoveryParticipant {
@@ -555,7 +556,8 @@ public class BluetoothDiscoveryServiceTest {
 
         @Override
         public @NonNull ThingUID getThingUID(BluetoothDiscoveryDevice device) {
-            String id = device.getName() != null ? device.getName() : RandomStringUtils.randomAlphabetic(6);
+            String deviceName = device.getName();
+            String id = deviceName != null ? deviceName : RandomStringUtils.randomAlphabetic(6);
             return new ThingUID(typeUID, device.getAdapter().getUID(), id);
         }
     }

--- a/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/BsbLanHandlerFactoryTests.java
+++ b/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/BsbLanHandlerFactoryTests.java
@@ -12,11 +12,10 @@
  */
 package org.openhab.binding.bsblan.internal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**

--- a/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/api/BsbLanApiContentConverterTests.java
+++ b/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/api/BsbLanApiContentConverterTests.java
@@ -12,12 +12,10 @@
  */
 package org.openhab.binding.bsblan.internal.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterDTO;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterQueryResponseDTO;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterSetRequestDTO;

--- a/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
+++ b/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
@@ -12,13 +12,11 @@
  */
 package org.openhab.binding.bsblan.internal.helper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.bsblan.internal.BsbLanBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterDTO;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;

--- a/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
+++ b/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
@@ -217,10 +217,10 @@ public class BsbLanParameterConverterTests {
 
     @Test
     public void testGetValueForNumberValueChannel() {
-        assertNull("1", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.ON));
-        assertNull("0", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.OFF));
-        assertEquals("42", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(42)));
-        assertEquals("22.5", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(22.5)));
+        assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.ON), "1");
+        assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.OFF), "0");
+        assertEquals(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(42)), "42");
+        assertEquals(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(22.5)), "22.5");
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE,
                 new StringType("Not a number value")));
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new StringType("")));

--- a/bundles/org.openhab.binding.buienradar/src/test/java/org/openhab/binding/buienradar/BuienradarPredictionAPITest.java
+++ b/bundles/org.openhab.binding.buienradar/src/test/java/org/openhab/binding/buienradar/BuienradarPredictionAPITest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.buienradar;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.buienradar.internal.buienradarapi.BuienradarParseException;
 import org.openhab.binding.buienradar.internal.buienradarapi.BuienradarPredictionAPI;
 import org.openhab.binding.buienradar.internal.buienradarapi.Prediction;

--- a/bundles/org.openhab.binding.danfossairunit/src/test/java/org/openhab/binding/danfossairunit/internal/ValueCacheTest.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/test/java/org/openhab/binding/danfossairunit/internal/ValueCacheTest.java
@@ -12,11 +12,10 @@
  */
 package org.openhab.binding.danfossairunit.internal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 
 /**

--- a/bundles/org.openhab.binding.darksky/src/test/java/org/openhab/binding/darksky/internal/utils/ByteArrayFileCacheTest.java
+++ b/bundles/org.openhab.binding.darksky/src/test/java/org/openhab/binding/darksky/internal/utils/ByteArrayFileCacheTest.java
@@ -13,16 +13,16 @@
 package org.openhab.binding.darksky.internal.utils;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.ConfigConstants;
 
 /**
@@ -45,18 +45,18 @@ public class ByteArrayFileCacheTest {
 
     private ByteArrayFileCache subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new ByteArrayFileCache(SERVICE_PID);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         // delete all files
         subject.clear();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanUp() {
         // delete all folders
         SERVICE_CACHE_FOLDER.delete();

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/DeconzTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/DeconzTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.deconz;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,11 +23,14 @@ import java.time.ZonedDateTime;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.deconz.internal.Util;
 import org.openhab.binding.deconz.internal.discovery.ThingDiscoveryService;
 import org.openhab.binding.deconz.internal.dto.BridgeFullState;
@@ -49,23 +52,18 @@ import com.google.gson.GsonBuilder;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public class DeconzTest {
     private @NonNullByDefault({}) Gson gson;
 
-    @Mock
-    private @NonNullByDefault({}) DiscoveryListener discoveryListener;
+    private @Mock @NonNullByDefault({}) DiscoveryListener discoveryListener;
+    private @Mock @NonNullByDefault({}) DeconzBridgeHandler bridgeHandler;
+    private @Mock @NonNullByDefault({}) Bridge bridge;
 
-    @Mock
-    private @NonNullByDefault({}) DeconzBridgeHandler bridgeHandler;
-
-    @Mock
-    private @NonNullByDefault({}) Bridge bridge;
-
-    @Before
+    @BeforeEach
     public void initialize() {
-        initMocks(this);
-
         Mockito.doAnswer(answer -> bridge).when(bridgeHandler).getThing();
         Mockito.doAnswer(answer -> new ThingUID("deconz", "mybridge")).when(bridge).getUID();
 
@@ -78,9 +76,9 @@ public class DeconzTest {
     @Test
     public void discoveryTest() throws IOException {
         BridgeFullState bridgeFullState = getObjectFromJson("discovery.json", BridgeFullState.class, gson);
-        Assert.assertNotNull(bridgeFullState);
-        Assert.assertEquals(6, bridgeFullState.lights.size());
-        Assert.assertEquals(9, bridgeFullState.sensors.size());
+        assertNotNull(bridgeFullState);
+        assertEquals(6, bridgeFullState.lights.size());
+        assertEquals(9, bridgeFullState.sensors.size());
 
         ThingDiscoveryService discoveryService = new ThingDiscoveryService();
         discoveryService.setThingHandler(bridgeHandler);
@@ -98,10 +96,10 @@ public class DeconzTest {
     @Test
     public void dateTimeConversionTest() {
         DateTimeType dateTime = Util.convertTimestampToDateTime("2020-08-22T11:09Z");
-        Assert.assertEquals(new DateTimeType(ZonedDateTime.parse("2020-08-22T11:09:00Z")), dateTime);
+        assertEquals(new DateTimeType(ZonedDateTime.parse("2020-08-22T11:09:00Z")), dateTime);
 
         dateTime = Util.convertTimestampToDateTime("2020-08-22T11:09:47");
-        Assert.assertEquals(
-                new DateTimeType(ZonedDateTime.parse("2020-08-22T11:09:47Z")).toZone(ZoneId.systemDefault()), dateTime);
+        assertEquals(new DateTimeType(ZonedDateTime.parse("2020-08-22T11:09:47Z")).toZone(ZoneId.systemDefault()),
+                dateTime);
     }
 }

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/LightsTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/LightsTest.java
@@ -12,9 +12,8 @@
  */
 package org.openhab.binding.deconz;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.openhab.binding.deconz.internal.BindingConstants.*;
 
 import java.io.IOException;
@@ -23,11 +22,12 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.deconz.internal.StateDescriptionProvider;
 import org.openhab.binding.deconz.internal.dto.LightMessage;
 import org.openhab.binding.deconz.internal.handler.LightThingHandler;
@@ -53,20 +53,16 @@ import com.google.gson.GsonBuilder;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class LightsTest {
     private @NonNullByDefault({}) Gson gson;
 
-    @Mock
-    private @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
+    private @Mock @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
+    private @Mock @NonNullByDefault({}) StateDescriptionProvider stateDescriptionProvider;
 
-    @Mock
-    private @NonNullByDefault({}) StateDescriptionProvider stateDescriptionProvider;
-
-    @Before
+    @BeforeEach
     public void initialize() {
-        initMocks(this);
-
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(LightType.class, new LightTypeDeserializer());
         gsonBuilder.registerTypeAdapter(ThermostatMode.class, new ThermostatModeGsonTypeAdapter());
@@ -76,7 +72,7 @@ public class LightsTest {
     @Test
     public void colorTemperatureLightUpdateTest() throws IOException {
         LightMessage lightMessage = DeconzTest.getObjectFromJson("colortemperature.json", LightMessage.class, gson);
-        Assert.assertNotNull(lightMessage);
+        assertNotNull(lightMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "light");
         ChannelUID channelUID_bri = new ChannelUID(thingUID, CHANNEL_BRIGHTNESS);
@@ -122,7 +118,7 @@ public class LightsTest {
     @Test
     public void dimmableLightUpdateTest() throws IOException {
         LightMessage lightMessage = DeconzTest.getObjectFromJson("dimmable.json", LightMessage.class, gson);
-        Assert.assertNotNull(lightMessage);
+        assertNotNull(lightMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "light");
         ChannelUID channelUID_bri = new ChannelUID(thingUID, CHANNEL_BRIGHTNESS);
@@ -139,7 +135,7 @@ public class LightsTest {
     @Test
     public void dimmableLightOverrangeUpdateTest() throws IOException {
         LightMessage lightMessage = DeconzTest.getObjectFromJson("dimmable_overrange.json", LightMessage.class, gson);
-        Assert.assertNotNull(lightMessage);
+        assertNotNull(lightMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "light");
         ChannelUID channelUID_bri = new ChannelUID(thingUID, CHANNEL_BRIGHTNESS);
@@ -156,7 +152,7 @@ public class LightsTest {
     @Test
     public void dimmableLightUnderrangeUpdateTest() throws IOException {
         LightMessage lightMessage = DeconzTest.getObjectFromJson("dimmable_underrange.json", LightMessage.class, gson);
-        Assert.assertNotNull(lightMessage);
+        assertNotNull(lightMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "light");
         ChannelUID channelUID_bri = new ChannelUID(thingUID, CHANNEL_BRIGHTNESS);
@@ -173,7 +169,7 @@ public class LightsTest {
     @Test
     public void windowCoveringUpdateTest() throws IOException {
         LightMessage lightMessage = DeconzTest.getObjectFromJson("windowcovering.json", LightMessage.class, gson);
-        Assert.assertNotNull(lightMessage);
+        assertNotNull(lightMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "light");
         ChannelUID channelUID_pos = new ChannelUID(thingUID, CHANNEL_POSITION);

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/SensorsTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/SensorsTest.java
@@ -12,18 +12,19 @@
  */
 package org.openhab.binding.deconz;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.deconz.internal.BindingConstants.*;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.deconz.internal.dto.SensorMessage;
 import org.openhab.binding.deconz.internal.handler.SensorThermostatThingHandler;
 import org.openhab.binding.deconz.internal.handler.SensorThingHandler;
@@ -52,17 +53,15 @@ import com.google.gson.GsonBuilder;
  * @author Jan N. Klug - Initial contribution
  * @author Lukas Agethen - Added Thermostat
  */
+@ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class SensorsTest {
     private @NonNullByDefault({}) Gson gson;
 
-    @Mock
-    private @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
+    private @Mock @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
 
-    @Before
+    @BeforeEach
     public void initialize() {
-        initMocks(this);
-
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(LightType.class, new LightTypeDeserializer());
         gsonBuilder.registerTypeAdapter(ThermostatMode.class, new ThermostatModeGsonTypeAdapter());
@@ -72,7 +71,7 @@ public class SensorsTest {
     @Test
     public void carbonmonoxideSensorUpdateTest() throws IOException {
         SensorMessage sensorMessage = DeconzTest.getObjectFromJson("carbonmonoxide.json", SensorMessage.class, gson);
-        Assert.assertNotNull(sensorMessage);
+        assertNotNull(sensorMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "sensor");
         ChannelUID channelUID = new ChannelUID(thingUID, "carbonmonoxide");
@@ -88,7 +87,7 @@ public class SensorsTest {
     @Test
     public void thermostatSensorUpdateTest() throws IOException {
         SensorMessage sensorMessage = DeconzTest.getObjectFromJson("thermostat.json", SensorMessage.class, gson);
-        Assert.assertNotNull(sensorMessage);
+        assertNotNull(sensorMessage);
 
         ThingUID thingUID = new ThingUID("deconz", "sensor");
         ChannelUID channelValveUID = new ChannelUID(thingUID, "valve");

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/FadeActionTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/FadeActionTest.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.dmx.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.internal.action.ActionState;
 import org.openhab.binding.dmx.internal.action.FadeAction;
 import org.openhab.binding.dmx.internal.multiverse.DmxChannel;

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/UtilTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/UtilTest.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.dmx.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.internal.multiverse.DmxChannel;
 import org.openhab.core.library.types.PercentType;
 

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/ValueSetTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/ValueSetTest.java
@@ -13,11 +13,11 @@
 package org.openhab.binding.dmx.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases ValueSet

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ArtnetBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ArtnetBridgeHandlerTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
@@ -21,9 +22,9 @@ import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Bridge;
@@ -53,7 +54,7 @@ public class ArtnetBridgeHandlerTest extends JavaTest {
     private Bridge bridge;
     private ArtnetBridgeHandler bridgeHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bridgeProperties = new HashMap<>();
         bridgeProperties.put(CONFIG_ADDRESS, TEST_ADDRESS);
@@ -79,7 +80,7 @@ public class ArtnetBridgeHandlerTest extends JavaTest {
         bridgeHandler.initialize();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         bridgeHandler.dispose();
     }

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ChaserThingHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ChaserThingHandlerTest.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.dmx.internal.handler;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.test.AbstractDmxThingTestParent;
 import org.openhab.binding.dmx.test.TestBridgeHandler;
 import org.openhab.core.config.core.Configuration;
@@ -61,7 +61,7 @@ public class ChaserThingHandlerTest extends AbstractDmxThingTestParent {
     private TestBridgeHandler dmxBridgeHandler;
     private ChaserThingHandler chaserThingHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setup();
 

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ColorThingHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/ColorThingHandlerTest.java
@@ -12,17 +12,18 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.test.AbstractDmxThingTestParent;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DecimalType;
@@ -58,7 +59,7 @@ public class ColorThingHandlerTest extends AbstractDmxThingTestParent {
     private final ChannelUID CHANNEL_UID_BRIGHTNESS_G = new ChannelUID(THING_UID_DIMMER, CHANNEL_BRIGHTNESS_G);
     private final ChannelUID CHANNEL_UID_BRIGHTNESS_B = new ChannelUID(THING_UID_DIMMER, CHANNEL_BRIGHTNESS_B);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setup();
         thingProperties = new HashMap<>();

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/DimmerThingHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/DimmerThingHandlerTest.java
@@ -12,17 +12,18 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.test.AbstractDmxThingTestParent;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
@@ -51,7 +52,7 @@ public class DimmerThingHandlerTest extends AbstractDmxThingTestParent {
     private final ThingUID THING_UID_DIMMER = new ThingUID(THING_TYPE_DIMMER, "testdimmer");
     private final ChannelUID CHANNEL_UID_BRIGHTNESS = new ChannelUID(THING_UID_DIMMER, CHANNEL_BRIGHTNESS);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setup();
 

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/DmxBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/DmxBridgeHandlerTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
@@ -21,10 +22,10 @@ import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.dmx.internal.DmxBridgeHandler;
 import org.openhab.binding.dmx.internal.multiverse.BaseDmxChannel;
@@ -93,7 +94,7 @@ public class DmxBridgeHandlerTest extends JavaTest {
     private Bridge bridge;
     private DmxBridgeHandlerImpl bridgeHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bridgeProperties = new HashMap<>();
         bridge = BridgeBuilder.create(THING_TYPE_TEST_BRIDGE, "testbridge").withLabel("Test Bridge")
@@ -112,7 +113,7 @@ public class DmxBridgeHandlerTest extends JavaTest {
         bridgeHandler.initialize();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         bridgeHandler.dispose();
     }
@@ -122,13 +123,13 @@ public class DmxBridgeHandlerTest extends JavaTest {
         waitForAssert(() -> assertEquals(ThingStatus.ONLINE, bridge.getStatusInfo().getStatus()));
     }
 
-    @Ignore("https://github.com/eclipse/smarthome/issues/6015#issuecomment-411313627")
+    @Disabled("https://github.com/eclipse/smarthome/issues/6015#issuecomment-411313627")
     @Test
     public void assertSendDmxDataIsCalled() {
         Mockito.verify(bridgeHandler, after(500).atLeast(9)).sendDmxData();
     }
 
-    @Ignore("https://github.com/eclipse/smarthome/issues/6015")
+    @Disabled("https://github.com/eclipse/smarthome/issues/6015")
     @Test
     public void assertMuteChannelMutesOutput() {
         bridgeHandler.handleCommand(CHANNEL_UID_MUTE, OnOffType.ON);

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/Lib485BridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/Lib485BridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
@@ -20,9 +20,9 @@ import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Bridge;
@@ -51,7 +51,7 @@ public class Lib485BridgeHandlerTest extends JavaTest {
     private Bridge bridge;
     private Lib485BridgeHandler bridgeHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bridgeProperties = new HashMap<>();
         bridgeProperties.put(CONFIG_ADDRESS, TEST_ADDRESS);
@@ -76,7 +76,7 @@ public class Lib485BridgeHandlerTest extends JavaTest {
         bridgeHandler.initialize();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         bridgeHandler.dispose();
     }

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/SacnBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/SacnBridgeHandlerTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
@@ -21,9 +22,9 @@ import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Bridge;
@@ -52,7 +53,7 @@ public class SacnBridgeHandlerTest extends JavaTest {
     private Bridge bridge;
     private SacnBridgeHandler bridgeHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bridgeProperties = new HashMap<>();
         bridgeProperties.put(CONFIG_ADDRESS, TEST_ADDRESS);
@@ -79,7 +80,7 @@ public class SacnBridgeHandlerTest extends JavaTest {
         bridgeHandler.initialize();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         bridgeHandler.dispose();
     }

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/TunableWhiteThingHandlerTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/handler/TunableWhiteThingHandlerTest.java
@@ -12,17 +12,18 @@
  */
 package org.openhab.binding.dmx.internal.handler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dmx.test.AbstractDmxThingTestParent;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
@@ -54,7 +55,7 @@ public class TunableWhiteThingHandlerTest extends AbstractDmxThingTestParent {
     private final ChannelUID CHANNEL_UID_BRIGHTNESS_WW = new ChannelUID(THING_UID_DIMMER, CHANNEL_BRIGHTNESS_WW);
     private final ChannelUID CHANNEL_UID_COLOR_TEMP = new ChannelUID(THING_UID_DIMMER, CHANNEL_COLOR_TEMPERATURE);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setup();
 

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/multiverse/BaseChannelTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/multiverse/BaseChannelTest.java
@@ -13,11 +13,11 @@
 package org.openhab.binding.dmx.internal.multiverse;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for BaseChannel

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/multiverse/DmxChannelTest.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/internal/multiverse/DmxChannelTest.java
@@ -13,10 +13,10 @@
 package org.openhab.binding.dmx.internal.multiverse;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.openhab.binding.dmx.internal.action.FadeAction;
@@ -37,7 +37,7 @@ public class DmxChannelTest {
     DimmerThingHandler dimmerThingHandler;
     long currentTime;
 
-    @Before
+    @BeforeEach
     public void setup() {
         dimmerThingHandler = Mockito.mock(DimmerThingHandler.class);
         dmxChannel = new DmxChannel(0, 1, 0);

--- a/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/test/AbstractDmxThingTestParent.java
+++ b/bundles/org.openhab.binding.dmx/src/test/java/org/openhab/binding/dmx/test/AbstractDmxThingTestParent.java
@@ -12,9 +12,10 @@
  */
 package org.openhab.binding.dmx.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.dmx.test.TestBridgeHandler.THING_TYPE_TEST_BRIDGE;

--- a/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/DoorbirdInfoTest.java
+++ b/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/DoorbirdInfoTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.doorbird.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.doorbird.internal.api.DoorbirdInfo;
 
 /**

--- a/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/SipStatusTest.java
+++ b/bundles/org.openhab.binding.doorbird/src/test/java/org/openhab/binding/doorbird/internal/SipStatusTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.doorbird.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.doorbird.internal.api.SipStatus;
 
 /**

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/TelegramReaderUtil.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/TelegramReaderUtil.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.dsmr.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,9 +63,9 @@ public final class TelegramReaderUtil {
 
         parser.setLenientMode(true);
         parser.parse(telegram, telegram.length);
-        assertNotNull("Telegram state should have been set. (Missing newline at end of message?)", p1Telegram.get());
-        assertEquals("Expected TelegramState should be as expected", expectedTelegramState,
-                p1Telegram.get().getTelegramState());
+        assertNotNull(p1Telegram.get(), "Telegram state should have been set. (Missing newline at end of message?)");
+        assertEquals(expectedTelegramState, p1Telegram.get().getTelegramState(),
+                "Expected TelegramState should be as expected");
         return p1Telegram.get();
     }
 }

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,7 +47,6 @@ import org.openhab.core.io.transport.serial.SerialPortManager;
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @ExtendWith(MockitoExtension.class)
-@Disabled("Needs to be updated for OH3")
 public class DSMRSerialAutoDeviceTest {
 
     private static final String DUMMY_PORTNAME = "/dev/dummy-serial";
@@ -61,7 +59,7 @@ public class DSMRSerialAutoDeviceTest {
     private SerialPortManager serialPortManager = new SerialPortManager() {
         @Override
         public SerialPortIdentifier getIdentifier(String name) {
-            assertEquals("Expect the passed serial port name", DUMMY_PORTNAME, name);
+            assertEquals(DUMMY_PORTNAME, name, "Expect the passed serial port name");
             return mockIdentifier;
         }
 

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.dsmr.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,9 +24,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.dsmr.internal.DSMRBindingConstants;
 import org.openhab.binding.dsmr.internal.TelegramReaderUtil;
 import org.openhab.binding.dsmr.internal.device.DSMRSerialAutoDevice.DeviceState;
@@ -45,17 +46,15 @@ import org.openhab.core.io.transport.serial.SerialPortManager;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class DSMRSerialAutoDeviceTest {
 
     private static final String DUMMY_PORTNAME = "/dev/dummy-serial";
     private static final String TELEGRAM_NAME = "dsmr_50";
 
-    @Mock
-    private SerialPortIdentifier mockIdentifier;
-    @Mock
-    private ScheduledExecutorService scheduler;
-    @Mock
-    private SerialPort mockSerialPort;
+    private @Mock SerialPortIdentifier mockIdentifier;
+    private @Mock ScheduledExecutorService scheduler;
+    private @Mock SerialPort mockSerialPort;
 
     private SerialPortManager serialPortManager = new SerialPortManager() {
         @Override
@@ -71,9 +70,8 @@ public class DSMRSerialAutoDeviceTest {
     };
     private SerialPortEventListener serialPortEventListener;
 
-    @Before
+    @BeforeEach
     public void setUp() throws PortInUseException, TooManyListenersException {
-        initMocks(this);
         doAnswer(a -> {
             serialPortEventListener = a.getArgument(0);
             return null;
@@ -100,18 +98,18 @@ public class DSMRSerialAutoDeviceTest {
             DSMRSerialAutoDevice device = new DSMRSerialAutoDevice(serialPortManager, DUMMY_PORTNAME, listener,
                     new DSMRTelegramListener(), scheduler, 1);
             device.start();
-            assertSame("Expect to be starting discovery state", DeviceState.DISCOVER_SETTINGS, device.getState());
+            assertSame(DeviceState.DISCOVER_SETTINGS, device.getState(), "Expect to be starting discovery state");
             serialPortEventListener
                     .serialEvent(new MockSerialPortEvent(mockSerialPort, SerialPortEvent.BI, false, true));
-            assertSame("Expect to be still in discovery state", DeviceState.DISCOVER_SETTINGS, device.getState());
+            assertSame(DeviceState.DISCOVER_SETTINGS, device.getState(), "Expect to be still in discovery state");
             serialPortEventListener
                     .serialEvent(new MockSerialPortEvent(mockSerialPort, SerialPortEvent.DATA_AVAILABLE, false, true));
-            assertSame("Expect to be in normal state", DeviceState.NORMAL, device.getState());
+            assertSame(DeviceState.NORMAL, device.getState(), "Expect to be in normal state");
             device.restart();
-            assertSame("Expect not to start rediscovery when in normal state", DeviceState.NORMAL, device.getState());
+            assertSame(DeviceState.NORMAL, device.getState(), "Expect not to start rediscovery when in normal state");
             device.stop();
         }
-        assertNotNull("Expected to have read a telegram", telegramRef.get());
+        assertNotNull(telegramRef.get(), "Expected to have read a telegram");
     }
 
     @Test
@@ -137,19 +135,19 @@ public class DSMRSerialAutoDeviceTest {
             DSMRSerialAutoDevice device = new DSMRSerialAutoDevice(serialPortManager, DUMMY_PORTNAME, listener,
                     new DSMRTelegramListener(), scheduler, 1);
             device.start();
-            assertSame("Expected an error", DSMRConnectorErrorEvent.IN_USE, eventRef.get());
-            assertSame("Expect to be in error state", DeviceState.ERROR, device.getState());
+            assertSame(DSMRConnectorErrorEvent.IN_USE, eventRef.get(), "Expected an error");
+            assertSame(DeviceState.ERROR, device.getState(), "Expect to be in error state");
             // Trigger device to restart
             mockValidSerialPort();
             device.restart();
-            assertSame("Expect to be starting discovery state", DeviceState.DISCOVER_SETTINGS, device.getState());
+            assertSame(DeviceState.DISCOVER_SETTINGS, device.getState(), "Expect to be starting discovery state");
             // Trigger device to go into error stage with port doesn't exist.
             mockIdentifier = null;
             device = new DSMRSerialAutoDevice(serialPortManager, DUMMY_PORTNAME, listener, new DSMRTelegramListener(),
                     scheduler, 1);
             device.start();
-            assertSame("Expected an error", DSMRConnectorErrorEvent.DONT_EXISTS, eventRef.get());
-            assertSame("Expect to be in error state", DeviceState.ERROR, device.getState());
+            assertSame(DSMRConnectorErrorEvent.DONT_EXISTS, eventRef.get(), "Expected an error");
+            assertSame(DeviceState.ERROR, device.getState(), "Expect to be in error state");
         }
     }
 

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/DSMRSerialAutoDeviceTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -47,6 +48,7 @@ import org.openhab.core.io.transport.serial.SerialPortManager;
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @ExtendWith(MockitoExtension.class)
+@Disabled("Needs to be updated for OH3")
 public class DSMRSerialAutoDeviceTest {
 
     private static final String DUMMY_PORTNAME = "/dev/dummy-serial";

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/SmartyDecrypterTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/SmartyDecrypterTest.java
@@ -13,13 +13,13 @@
 package org.openhab.binding.dsmr.internal.device;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dsmr.internal.TelegramReaderUtil;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1TelegramListener;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1TelegramParser;

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/p1telegram/P1TelegramParserTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/device/p1telegram/P1TelegramParserTest.java
@@ -12,16 +12,13 @@
  */
 package org.openhab.binding.dsmr.internal.device.p1telegram;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.binding.dsmr.internal.TelegramReaderUtil;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1Telegram.TelegramState;
 
@@ -30,11 +27,9 @@ import org.openhab.binding.dsmr.internal.device.p1telegram.P1Telegram.TelegramSt
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
-@RunWith(value = Parameterized.class)
 public class P1TelegramParserTest {
 
     // @formatter:off
-    @Parameters(name = "{0}")
     public static final List<Object[]> data() {
         return Arrays.asList(new Object[][] {
             { "ace4000", 59, },
@@ -52,17 +47,13 @@ public class P1TelegramParserTest {
     }
     // @formatter:on
 
-    @Parameter(0)
-    public String telegramName;
-
-    @Parameter(1)
-    public int numberOfCosemObjects;
-
-    @Test
-    public void testParsing() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testParsing(final String telegramName, final int numberOfCosemObjects) {
         P1Telegram telegram = TelegramReaderUtil.readTelegram(telegramName, TelegramState.OK);
-        assertEquals("Should not have any unknown cosem objects", 0, telegram.getUnknownCosemObjects().size());
-        assertEquals("Expected number of objects", numberOfCosemObjects,
-                telegram.getCosemObjects().stream().mapToInt(co -> co.getCosemValues().size()).sum());
+        assertEquals(0, telegram.getUnknownCosemObjects().size(), "Should not have any unknown cosem objects");
+        assertEquals(numberOfCosemObjects,
+                telegram.getCosemObjects().stream().mapToInt(co -> co.getCosemValues().size()).sum(),
+                "Expected number of objects");
     }
 }

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/discovery/DSMRMeterDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/discovery/DSMRMeterDiscoveryServiceTest.java
@@ -12,24 +12,23 @@
  */
 package org.openhab.binding.dsmr.internal.discovery;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.dsmr.internal.meter.DSMRMeterType.*;
 
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.TooManyListenersException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.dsmr.internal.TelegramReaderUtil;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1Telegram;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1Telegram.TelegramState;
@@ -37,7 +36,6 @@ import org.openhab.binding.dsmr.internal.handler.DSMRBridgeHandler;
 import org.openhab.binding.dsmr.internal.handler.DSMRMeterHandler;
 import org.openhab.binding.dsmr.internal.meter.DSMRMeterDescriptor;
 import org.openhab.binding.dsmr.internal.meter.DSMRMeterType;
-import org.openhab.core.io.transport.serial.PortInUseException;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 
@@ -46,22 +44,15 @@ import org.openhab.core.thing.ThingUID;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class DSMRMeterDiscoveryServiceTest {
 
     private static final String EXPECTED_CONFIGURED_TELEGRAM = "dsmr_50";
     private static final String UNREGISTERED_METER_TELEGRAM = "unregistered_meter";
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private DSMRBridgeHandler bridge;
-    @Mock
-    private Thing thing;
-    @Mock
-    private DSMRMeterHandler meterHandler;
-
-    @Before
-    public void setUp() throws PortInUseException, TooManyListenersException {
-        initMocks(this);
-    }
+    private @Mock(answer = Answers.RETURNS_DEEP_STUBS) DSMRBridgeHandler bridge;
+    private @Mock Thing thing;
+    private @Mock DSMRMeterHandler meterHandler;
 
     /**
      * Test if discovery reports when the user has incorrectly configured the binding with the wrong meter types.
@@ -100,12 +91,12 @@ public class DSMRMeterDiscoveryServiceTest {
         when(bridge.getThing().getThings()).thenReturn(things);
 
         service.telegramReceived(expected);
-        assertNotNull("Should have invalid configured meters", invalidConfiguredRef.get());
-        assertTrue("Should have found specific invalid meter",
-                invalidConfiguredRef.get().contains(DSMRMeterType.ELECTRICITY_V4_2));
-        assertNotNull("Should have undetected meters", unconfiguredRef.get());
-        assertTrue("Should have found specific undetected meter",
-                unconfiguredRef.get().contains(DSMRMeterType.ELECTRICITY_V5_0));
+        assertNotNull(invalidConfiguredRef.get(), "Should have invalid configured meters");
+        assertTrue(invalidConfiguredRef.get().contains(DSMRMeterType.ELECTRICITY_V4_2),
+                "Should have found specific invalid meter");
+        assertNotNull(unconfiguredRef.get(), "Should have undetected meters");
+        assertTrue(unconfiguredRef.get().contains(DSMRMeterType.ELECTRICITY_V5_0),
+                "Should have found specific undetected meter");
     }
 
     /**
@@ -128,6 +119,6 @@ public class DSMRMeterDiscoveryServiceTest {
         when(bridge.getThing().getThings()).thenReturn(Collections.emptyList());
 
         service.telegramReceived(telegram);
-        assertTrue("Should have found an unregistered meter", unregisteredMeter.get());
+        assertTrue(unregisteredMeter.get(), "Should have found an unregistered meter");
     }
 }

--- a/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/meter/DSMRMeterTest.java
+++ b/bundles/org.openhab.binding.dsmr/src/test/java/org/openhab/binding/dsmr/internal/meter/DSMRMeterTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.dsmr.internal.meter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.dsmr.internal.TelegramReaderUtil;
 import org.openhab.binding.dsmr.internal.device.cosem.CosemObject;
 import org.openhab.binding.dsmr.internal.device.p1telegram.P1Telegram.TelegramState;
@@ -40,7 +40,7 @@ public class DSMRMeterTest {
 
         List<CosemObject> filterMeterValues = meter
                 .filterMeterValues(TelegramReaderUtil.readTelegram("dsmr_50", TelegramState.OK).getCosemObjects());
-        assertEquals("Filter should return all required objects", DSMRMeterType.DEVICE_V5.requiredCosemObjects.length,
-                filterMeterValues.size());
+        assertEquals(DSMRMeterType.DEVICE_V5.requiredCosemObjects.length, filterMeterValues.size(),
+                "Filter should return all required objects");
     }
 }

--- a/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/DwdUnwetterHandlerTest.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/DwdUnwetterHandlerTest.java
@@ -13,10 +13,9 @@
 package org.openhab.binding.dwdunwetter;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.InputStream;
 import java.util.List;
@@ -26,10 +25,14 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.dwdunwetter.internal.DwdUnwetterBindingConstants;
 import org.openhab.binding.dwdunwetter.internal.handler.DwdUnwetterHandler;
 import org.openhab.core.config.core.Configuration;
@@ -51,19 +54,17 @@ import org.w3c.dom.NodeList;
  *
  * @author Martin Koehler - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class DwdUnwetterHandlerTest extends JavaTest {
 
     private ThingHandler handler;
 
-    @Mock
-    private ThingHandlerCallback callback;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Thing thing;
 
-    @Mock
-    private Thing thing;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
         handler = new DwdUnwetterHandler(thing);
         handler.setCallback(callback);
         // mock getConfiguration to prevent NPEs

--- a/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningCacheTest.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningCacheTest.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.dwdunwetter.internal.data;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Instant;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DwdWarningCache}
@@ -29,7 +29,7 @@ public class DwdWarningCacheTest {
 
     private DwdWarningCache cache;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cache = new DwdWarningCache();
     }

--- a/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningsDataTest.java
+++ b/bundles/org.openhab.binding.dwdunwetter/src/test/java/org/openhab/binding/dwdunwetter/internal/data/DwdWarningsDataTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.dwdunwetter.internal.data;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -23,8 +23,8 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.UnDefType;
@@ -47,7 +47,7 @@ public class DwdWarningsDataTest {
     private TestDataProvider testDataProvider;
     private DwdWarningsData warningsData;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         this.testDataProvider = new TestDataProvider();
         loadXmlFromFile();

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/actions/Enigma2ActionsTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/actions/Enigma2ActionsTest.java
@@ -12,14 +12,15 @@
  */
 package org.openhab.binding.enigma2.actions;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.enigma2.handler.Enigma2Handler;
 import org.openhab.binding.enigma2.internal.Enigma2BindingConstants;
 
@@ -37,7 +38,7 @@ public class Enigma2ActionsTest {
     private Enigma2Handler enigma2Handler;
     public static final String SOME_TEXT = "some Text";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enigma2Handler = mock(Enigma2Handler.class);
         enigma2Actions = new Enigma2Actions();
@@ -109,9 +110,9 @@ public class Enigma2ActionsTest {
         verify(enigma2Handler).sendRcCommand("KEY_1");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSendRcCommandStaticWithException() {
-        Enigma2Actions.sendRcCommand(null, "KEY_1");
+        assertThrows(IllegalArgumentException.class, () -> Enigma2Actions.sendRcCommand(null, "KEY_1"));
     }
 
     @Test
@@ -126,9 +127,9 @@ public class Enigma2ActionsTest {
         verify(enigma2Handler).sendInfo(10, SOME_TEXT);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSendInfoStaticWithException() {
-        Enigma2Actions.sendInfo(null, SOME_TEXT);
+        assertThrows(IllegalArgumentException.class, () -> Enigma2Actions.sendInfo(null, SOME_TEXT));
     }
 
     @Test
@@ -143,9 +144,9 @@ public class Enigma2ActionsTest {
         verify(enigma2Handler).sendError(10, SOME_TEXT);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSendErrorStaticWithException() {
-        Enigma2Actions.sendError(null, SOME_TEXT);
+        assertThrows(IllegalArgumentException.class, () -> Enigma2Actions.sendError(null, SOME_TEXT));
     }
 
     @Test
@@ -160,9 +161,9 @@ public class Enigma2ActionsTest {
         verify(enigma2Handler).sendWarning(10, SOME_TEXT);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSendWarningStaticWithException() {
-        Enigma2Actions.sendWarning(null, SOME_TEXT);
+        assertThrows(IllegalArgumentException.class, () -> Enigma2Actions.sendWarning(null, SOME_TEXT));
     }
 
     @Test
@@ -177,8 +178,8 @@ public class Enigma2ActionsTest {
         verify(enigma2Handler).sendQuestion(10, SOME_TEXT);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSendQuestionStaticWithException() {
-        Enigma2Actions.sendQuestion(null, SOME_TEXT);
+        assertThrows(IllegalArgumentException.class, () -> Enigma2Actions.sendQuestion(null, SOME_TEXT));
     }
 }

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/handler/Enigma2HandlerTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/handler/Enigma2HandlerTest.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.enigma2.handler;
 
 import static org.eclipse.jdt.annotation.Checks.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -23,15 +23,20 @@ import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.enigma2.actions.Enigma2Actions;
 import org.openhab.binding.enigma2.internal.Enigma2BindingConstants;
 import org.openhab.binding.enigma2.internal.Enigma2Client;
 import org.openhab.binding.enigma2.internal.Enigma2Configuration;
 import org.openhab.binding.enigma2.internal.Enigma2RemoteKey;
 import org.openhab.core.config.core.Configuration;
-import org.openhab.core.library.types.*;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.NextPreviousType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
@@ -58,7 +63,7 @@ public class Enigma2HandlerTest {
     @Nullable
     private ThingHandlerCallback callback;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enigma2Client = mock(Enigma2Client.class);
         thing = mock(Thing.class);

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2ClientTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2ClientTest.java
@@ -13,8 +13,9 @@
 package org.openhab.binding.enigma2.internal;
 
 import static org.eclipse.jdt.annotation.Checks.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -22,8 +23,8 @@ import java.time.LocalDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * The {@link Enigma2ClientTest} class is responsible for testing {@link Enigma2Client}.
@@ -41,7 +42,7 @@ public class Enigma2ClientTest {
     @Nullable
     private Enigma2HttpClient enigma2HttpClient;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         enigma2HttpClient = mock(Enigma2HttpClient.class);
         enigma2Client = spy(new Enigma2Client("localhost:8080", "user", "password", 5));

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2HandlerFactoryTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2HandlerFactoryTest.java
@@ -13,15 +13,14 @@
 package org.openhab.binding.enigma2.internal;
 
 import static org.eclipse.jdt.annotation.Checks.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.openhab.binding.enigma2.internal.Enigma2BindingConstants.THING_TYPE_DEVICE;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2RemoteKeyTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/Enigma2RemoteKeyTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.enigma2.internal;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The {@link Enigma2RemoteKeyTest} class is responsible for testing {@link Enigma2RemoteKey}.

--- a/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/discovery/Enigma2DiscoveryParticipantTest.java
+++ b/bundles/org.openhab.binding.enigma2/src/test/java/org/openhab/binding/enigma2/internal/discovery/Enigma2DiscoveryParticipantTest.java
@@ -13,10 +13,9 @@
 package org.openhab.binding.enigma2.internal.discovery;
 
 import static org.eclipse.jdt.annotation.Checks.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -25,8 +24,8 @@ import javax.jmdns.ServiceInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.enigma2.internal.Enigma2BindingConstants;
 import org.openhab.binding.enigma2.internal.Enigma2HttpClient;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -47,7 +46,7 @@ public class Enigma2DiscoveryParticipantTest {
     @Nullable
     private Enigma2DiscoveryParticipant enigma2DiscoveryParticipant;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enigma2HttpClient = mock(Enigma2HttpClient.class);
         serviceInfo = mock(ServiceInfo.class);

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/AbstractFMIResponseParsingTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/AbstractFMIResponseParsingTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.fmiweather;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -30,7 +30,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.openhab.binding.fmiweather.internal.client.Client;
 import org.openhab.binding.fmiweather.internal.client.Data;
 import org.openhab.binding.fmiweather.internal.client.FMIResponse;
@@ -47,7 +47,7 @@ public class AbstractFMIResponseParsingTest {
     @NonNullByDefault({})
     protected Client client;
 
-    @Before
+    @BeforeEach
     public void setUpClient() {
         client = new Client();
     }

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIRequestTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIRequestTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.math.BigDecimal;
 import java.util.AbstractMap;
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.FMISID;
 import org.openhab.binding.fmiweather.internal.client.ForecastRequest;
 import org.openhab.binding.fmiweather.internal.client.LatLon;

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingEmptyTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingEmptyTest.java
@@ -13,12 +13,13 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Path;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.Client;
 import org.openhab.binding.fmiweather.internal.client.FMIResponse;
 
@@ -33,7 +34,7 @@ public class FMIResponseParsingEmptyTest extends AbstractFMIResponseParsingTest 
 
     private FMIResponse observationsResponse;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new Client();
         try {

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingExceptionReportTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingExceptionReportTest.java
@@ -13,12 +13,13 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.exception.FMIResponseException;
 
 /**

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingInvalidOrUnexpectedXmlTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingInvalidOrUnexpectedXmlTest.java
@@ -12,11 +12,12 @@
  */
 package org.openhab.binding.fmiweather;
 
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.nio.file.Path;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.exception.FMIResponseException;
 import org.xml.sax.SAXParseException;
 
@@ -30,13 +31,15 @@ public class FMIResponseParsingInvalidOrUnexpectedXmlTest extends AbstractFMIRes
 
     private Path observations1 = getTestResource("observations_single_place.xml");
 
-    @Test(expected = SAXParseException.class)
-    public void testInvalidXml() throws IOException, Throwable {
-        parseMultiPointCoverageXml(readTestResourceUtf8(observations1).replace("276.0", "<<"));
+    @Test
+    public void testInvalidXml() {
+        assertThrows(SAXParseException.class,
+                () -> parseMultiPointCoverageXml(readTestResourceUtf8(observations1).replace("276.0", "<<")));
     }
 
-    @Test(expected = FMIResponseException.class)
-    public void testUnexpectedXml() throws IOException, Throwable {
-        parseMultiPointCoverageXml(readTestResourceUtf8(observations1).replace("276.0", "<foo>4</foo>"));
+    @Test
+    public void testUnexpectedXml() {
+        assertThrows(FMIResponseException.class,
+                () -> parseMultiPointCoverageXml(readTestResourceUtf8(observations1).replace("276.0", "<foo>4</foo>")));
     }
 }

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingMultiplePlacesTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingMultiplePlacesTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
@@ -21,8 +21,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.Data;
 import org.openhab.binding.fmiweather.internal.client.FMIResponse;
 import org.openhab.binding.fmiweather.internal.client.Location;
@@ -60,7 +60,7 @@ public class FMIResponseParsingMultiplePlacesTest extends AbstractFMIResponsePar
     private Location pointWithNoName = new Location("19.9,61.0973", "61.09726,19.90000", new BigDecimal("61.09726"),
             new BigDecimal("19.90000"));
 
-    @Before
+    @BeforeEach
     public void setUp() {
         try {
             observationsMultiplePlacesResponse = parseMultiPointCoverageXml(

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingSinglePlaceTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/FMIResponseParsingSinglePlaceTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
@@ -21,8 +22,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.Data;
 import org.openhab.binding.fmiweather.internal.client.FMIResponse;
 import org.openhab.binding.fmiweather.internal.client.Location;
@@ -46,7 +47,7 @@ public class FMIResponseParsingSinglePlaceTest extends AbstractFMIResponseParsin
     private Location emasalo = new Location("Porvoo Emäsalo", "101023", new BigDecimal("60.20382"),
             new BigDecimal("25.62546"));
 
-    @Before
+    @BeforeEach
     public void setUp() {
         try {
             observationsResponse1 = parseMultiPointCoverageXml(readTestResourceUtf8(observations1));

--- a/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/ParsingStationsTest.java
+++ b/bundles/org.openhab.binding.fmiweather/src/test/java/org/openhab/binding/fmiweather/ParsingStationsTest.java
@@ -13,14 +13,15 @@
 package org.openhab.binding.fmiweather;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.fmiweather.internal.client.Location;
 
 /**

--- a/bundles/org.openhab.binding.foobot/src/test/java/org/openhab/binding/foobot/internal/handler/FoobotAccountHandlerTest.java
+++ b/bundles/org.openhab.binding.foobot/src/test/java/org/openhab/binding/foobot/internal/handler/FoobotAccountHandlerTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.foobot.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.openhab.binding.foobot.internal.FoobotApiConnector;
 import org.openhab.binding.foobot.internal.FoobotApiException;
@@ -50,7 +50,7 @@ public class FoobotAccountHandlerTest {
     public void testSensorDataToState() throws IOException, FoobotApiException {
         final List<FoobotDevice> deviceList = handler.getDeviceList();
 
-        assertFalse("Device list should not return empty", deviceList.isEmpty());
-        assertEquals("1234567890ABCDEF", deviceList.get(0).getUuid());
+        assertFalse(deviceList.isEmpty(), "Device list should not return empty");
+        assertEquals(deviceList.get(0).getUuid(), "1234567890ABCDEF");
     }
 }

--- a/bundles/org.openhab.binding.foobot/src/test/java/org/openhab/binding/foobot/internal/handler/FoobotDeviceHandlerTest.java
+++ b/bundles/org.openhab.binding.foobot/src/test/java/org/openhab/binding/foobot/internal/handler/FoobotDeviceHandlerTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.foobot.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.openhab.binding.foobot.internal.FoobotApiConnector;
 import org.openhab.binding.foobot.internal.FoobotApiException;
@@ -52,7 +52,7 @@ public class FoobotDeviceHandlerTest {
     public void testSensorDataToState() throws IOException, FoobotApiException {
         final FoobotJsonData sensorData = connector.getSensorData("1234");
 
-        assertNotNull("No sensor data read", sensorData);
+        assertNotNull(sensorData, "No sensor data read");
         assertEquals(handler.sensorDataToState("temperature", sensorData), new QuantityType(12.345, SIUnits.CELSIUS));
         assertEquals(handler.sensorDataToState("gpi", sensorData), new DecimalType(5.6789012));
     }

--- a/bundles/org.openhab.binding.freebox/src/test/java/org/openhab/binding/freebox/internal/api/FreeboxApiManagerTest.java
+++ b/bundles/org.openhab.binding.freebox/src/test/java/org/openhab/binding/freebox/internal/api/FreeboxApiManagerTest.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.freebox.internal.api;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -27,6 +27,6 @@ public class FreeboxApiManagerTest {
     public void hmacSha1Test() throws Exception {
         String expected = "25dad1bb5604321f12b755cc9d755d1480cf7989";
         String actual = FreeboxApiManager.hmacSha1("Token1234", "Challenge");
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/bundles/org.openhab.binding.freebox/src/test/java/org/openhab/binding/freebox/internal/api/FreeboxApiManagerTest.java
+++ b/bundles/org.openhab.binding.freebox/src/test/java/org/openhab/binding/freebox/internal/api/FreeboxApiManagerTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.freebox.internal.api;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioDiscoveryParticipantJavaTest.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioDiscoveryParticipantJavaTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.fsinternetradio.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ManufacturerDetails;
@@ -80,7 +80,7 @@ public class FSInternetRadioDiscoveryParticipantJavaTest {
     String DEFAULT_RADIO_THING_UID = String.format("%s:%s:%s", RADIO_BINDING_ID, RADIO_THING_TYPE_ID,
             DEFAULT_RADIO_SERIAL_NUMBER);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         discoveryParticipant = new FSInternetRadioDiscoveryParticipant();
     }

--- a/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioHandlerJavaTest.java
+++ b/bundles/org.openhab.binding.fsinternetradio/src/test/java/org/openhab/binding/fsinternetradio/test/FSInternetRadioHandlerJavaTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.fsinternetradio.test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.fsinternetradio.internal.FSInternetRadioBindingConstants.*;
@@ -29,11 +30,10 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.binding.fsinternetradio.internal.FSInternetRadioBindingConstants;
 import org.openhab.binding.fsinternetradio.internal.handler.FSInternetRadioHandler;
@@ -124,7 +124,7 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
     private static final String DEFAULT_CONFIG_PROPERTY_REFRESH = "1";
     private static final Configuration DEFAULT_COMPLETE_CONFIGURATION = createDefaultConfiguration();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception {
         ServletHolder holder = new ServletHolder(radioServiceDummy);
         server = new TestServer(DEFAULT_CONFIG_PROPERTY_IP, DEFAULT_CONFIG_PROPERTY_PORT, TIMEOUT, holder);
@@ -134,12 +134,12 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
         httpClient.start();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         createThePowerChannel();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         server.stopServer();
         httpClient.stop();
@@ -147,13 +147,13 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
 
     private static @NonNull Channel getChannel(final @NonNull Thing thing, final @NonNull String channelId) {
         final Channel channel = thing.getChannel(channelId);
-        Assert.assertNotNull(channel);
+        assertNotNull(channel);
         return channel;
     }
 
     private static @NonNull ChannelUID getChannelUID(final @NonNull Thing thing, final @NonNull String channelId) {
         final ChannelUID channelUID = getChannel(thing, channelId).getUID();
-        Assert.assertNotNull(channelUID);
+        assertNotNull(channelUID);
         return channelUID;
     }
 
@@ -290,15 +290,15 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
 
         radioHandler.handleCommand(powerChannelUID, OnOffType.ON);
         waitForAssert(() -> {
-            assertTrue("We should be able to turn on the radio",
-                    radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER));
+            assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER),
+                    "We should be able to turn on the radio");
             radioServiceDummy.clearRequestParameters();
         });
 
         radioHandler.handleCommand(powerChannelUID, OnOffType.OFF);
         waitForAssert(() -> {
-            assertTrue("We should be able to turn off the radio",
-                    radioServiceDummy.containsRequestParameter(0, CHANNEL_POWER));
+            assertTrue(radioServiceDummy.containsRequestParameter(0, CHANNEL_POWER),
+                    "We should be able to turn off the radio");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -308,8 +308,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
          */
         radioHandler.handleCommand(powerChannelUID, OnOffType.ON);
         waitForAssert(() -> {
-            assertTrue("We should be able to turn on the radio",
-                    radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER));
+            assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER),
+                    "We should be able to turn on the radio");
             radioServiceDummy.clearRequestParameters();
         });
     }
@@ -333,15 +333,15 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
 
         radioHandler.handleCommand(muteChannelUID, OnOffType.ON);
         waitForAssert(() -> {
-            assertTrue("We should be able to mute the radio",
-                    radioServiceDummy.containsRequestParameter(1, CHANNEL_MUTE));
+            assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_MUTE),
+                    "We should be able to mute the radio");
             radioServiceDummy.clearRequestParameters();
         });
 
         radioHandler.handleCommand(muteChannelUID, OnOffType.OFF);
         waitForAssert(() -> {
-            assertTrue("We should be able to unmute the radio",
-                    radioServiceDummy.containsRequestParameter(0, CHANNEL_MUTE));
+            assertTrue(radioServiceDummy.containsRequestParameter(0, CHANNEL_MUTE),
+                    "We should be able to unmute the radio");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -370,8 +370,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
 
         radioHandler.handleCommand(modeChannelUID, DecimalType.valueOf("1"));
         waitForAssert(() -> {
-            assertTrue("We should be able to update the mode channel correctly",
-                    radioServiceDummy.containsRequestParameter(1, CHANNEL_MODE));
+            assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_MODE),
+                    "We should be able to update the mode channel correctly");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -381,8 +381,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
          */
         radioHandler.handleCommand(modeChannelUID, DecimalType.valueOf("3"));
         waitForAssert(() -> {
-            assertTrue("We should be able to update the mode channel correctly",
-                    radioServiceDummy.containsRequestParameter(3, CHANNEL_MODE));
+            assertTrue(radioServiceDummy.containsRequestParameter(3, CHANNEL_MODE),
+                    "We should be able to update the mode channel correctly");
             radioServiceDummy.clearRequestParameters();
         });
     }
@@ -450,8 +450,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
         radioHandler.handleCommand(absoluteVolumeChannelUID, DecimalType.valueOf("36"));
 
         waitForAssert(() -> {
-            assertTrue("The volume should not exceed the maximum value",
-                    radioServiceDummy.containsRequestParameter(32, VOLUME));
+            assertTrue(radioServiceDummy.containsRequestParameter(32, VOLUME),
+                    "The volume should not exceed the maximum value");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -459,8 +459,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
         radioHandler.handleCommand(absoluteVolumeChannelUID, IncreaseDecreaseType.INCREASE);
 
         waitForAssert(() -> {
-            assertTrue("The volume should not be increased above the maximum value",
-                    radioServiceDummy.areRequestParametersEmpty());
+            assertTrue(radioServiceDummy.areRequestParametersEmpty(),
+                    "The volume should not be increased above the maximum value");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -468,16 +468,16 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
         radioHandler.handleCommand(absoluteVolumeChannelUID, UpDownType.UP);
 
         waitForAssert(() -> {
-            assertTrue("The volume should not be increased above the maximum value",
-                    radioServiceDummy.areRequestParametersEmpty());
+            assertTrue(radioServiceDummy.areRequestParametersEmpty(),
+                    "The volume should not be increased above the maximum value");
             radioServiceDummy.clearRequestParameters();
         });
 
         // Trying to set a value that is lower than the minimum volume value
         radioHandler.handleCommand(absoluteVolumeChannelUID, DecimalType.valueOf("-10"));
         waitForAssert(() -> {
-            assertTrue("The volume should not be decreased below 0",
-                    radioServiceDummy.containsRequestParameter(0, VOLUME));
+            assertTrue(radioServiceDummy.containsRequestParameter(0, VOLUME),
+                    "The volume should not be decreased below 0");
             radioServiceDummy.clearRequestParameters();
         });
 
@@ -489,8 +489,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
         // trying to set the volume
         radioHandler.handleCommand(absoluteVolumeChannelUID, DecimalType.valueOf("15"));
         waitForAssert(() -> {
-            assertTrue("We should be able to set the volume correctly",
-                    radioServiceDummy.containsRequestParameter(15, VOLUME));
+            assertTrue(radioServiceDummy.containsRequestParameter(15, VOLUME),
+                    "We should be able to set the volume correctly");
             radioServiceDummy.clearRequestParameters();
         });
     }
@@ -586,16 +586,16 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
          */
         radioHandler.handleCommand(percentVolumeChannelUID, PercentType.valueOf("50"));
         waitForAssert(() -> {
-            assertTrue("We should be able to set the volume correctly using percentages.",
-                    radioServiceDummy.containsRequestParameter(16, VOLUME));
+            assertTrue(radioServiceDummy.containsRequestParameter(16, VOLUME),
+                    "We should be able to set the volume correctly using percentages.");
             radioServiceDummy.clearRequestParameters();
         });
 
         radioHandler.handleCommand(percentVolumeChannelUID, PercentType.valueOf("15"));
 
         waitForAssert(() -> {
-            assertTrue("We should be able to set the volume correctly using percentages.",
-                    radioServiceDummy.containsRequestParameter(4, VOLUME));
+            assertTrue(radioServiceDummy.containsRequestParameter(4, VOLUME),
+                    "We should be able to set the volume correctly using percentages.");
             radioServiceDummy.clearRequestParameters();
         });
     }
@@ -605,31 +605,31 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
             // First we have to make sure that the item state is 0
             radioHandler.handleCommand(channelUID, DecimalType.valueOf("0"));
             waitForAssert(() -> {
-                assertTrue("We should be able to turn on the radio",
-                        radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER));
+                assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER),
+                        "We should be able to turn on the radio");
                 radioServiceDummy.clearRequestParameters();
             });
 
             radioHandler.handleCommand(channelUID, IncreaseDecreaseType.INCREASE);
 
             waitForAssert(() -> {
-                assertTrue("We should be able to increase the volume correctly",
-                        radioServiceDummy.containsRequestParameter(1, VOLUME));
+                assertTrue(radioServiceDummy.containsRequestParameter(1, VOLUME),
+                        "We should be able to increase the volume correctly");
                 radioServiceDummy.clearRequestParameters();
             });
 
             radioHandler.handleCommand(channelUID, IncreaseDecreaseType.DECREASE);
             waitForAssert(() -> {
-                assertTrue("We should be able to increase the volume correctly",
-                        radioServiceDummy.containsRequestParameter(0, VOLUME));
+                assertTrue(radioServiceDummy.containsRequestParameter(0, VOLUME),
+                        "We should be able to increase the volume correctly");
                 radioServiceDummy.clearRequestParameters();
             });
 
             // Trying to decrease one more time
             radioHandler.handleCommand(channelUID, IncreaseDecreaseType.DECREASE);
             waitForAssert(() -> {
-                assertFalse("We should be able to decrease the volume correctly",
-                        radioServiceDummy.containsRequestParameter(0, VOLUME));
+                assertFalse(radioServiceDummy.containsRequestParameter(0, VOLUME),
+                        "We should be able to decrease the volume correctly");
                 radioServiceDummy.clearRequestParameters();
             });
         }
@@ -640,30 +640,30 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
             // First we have to make sure that the item state is 0
             radioHandler.handleCommand(channelUID, DecimalType.valueOf("0"));
             waitForAssert(() -> {
-                assertTrue("We should be able to turn on the radio",
-                        radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER));
+                assertTrue(radioServiceDummy.containsRequestParameter(1, CHANNEL_POWER),
+                        "We should be able to turn on the radio");
                 radioServiceDummy.clearRequestParameters();
             });
 
             radioHandler.handleCommand(channelUID, UpDownType.UP);
             waitForAssert(() -> {
-                assertTrue("We should be able to increase the volume correctly",
-                        radioServiceDummy.containsRequestParameter(1, VOLUME));
+                assertTrue(radioServiceDummy.containsRequestParameter(1, VOLUME),
+                        "We should be able to increase the volume correctly");
                 radioServiceDummy.clearRequestParameters();
             });
 
             radioHandler.handleCommand(channelUID, UpDownType.DOWN);
             waitForAssert(() -> {
-                assertTrue("We should be able to decrease the volume correctly",
-                        radioServiceDummy.containsRequestParameter(0, VOLUME));
+                assertTrue(radioServiceDummy.containsRequestParameter(0, VOLUME),
+                        "We should be able to decrease the volume correctly");
                 radioServiceDummy.clearRequestParameters();
             });
 
             // Trying to decrease one more time
             radioHandler.handleCommand(channelUID, UpDownType.DOWN);
             waitForAssert(() -> {
-                assertTrue("We shouldn't be able to decrease the volume below 0",
-                        radioServiceDummy.areRequestParametersEmpty());
+                assertTrue(radioServiceDummy.areRequestParametersEmpty(),
+                        "We shouldn't be able to decrease the volume below 0");
                 radioServiceDummy.clearRequestParameters();
             });
         }
@@ -687,8 +687,8 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
 
         radioHandler.handleCommand(presetChannelUID, DecimalType.valueOf("100"));
         waitForAssert(() -> {
-            assertTrue("We should be able to set value to the preset",
-                    radioServiceDummy.containsRequestParameter(100, PRESET));
+            assertTrue(radioServiceDummy.containsRequestParameter(100, PRESET),
+                    "We should be able to set value to the preset");
             radioServiceDummy.clearRequestParameters();
         });
     }

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.hdpowerview;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.hdpowerview.internal.api.ActuatorClass.*;
 import static org.openhab.binding.hdpowerview.internal.api.CoordinateSystem.*;
 
@@ -28,7 +28,7 @@ import javax.ws.rs.client.ClientBuilder;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.hdpowerview.internal.HDPowerViewWebTargets;
 import org.openhab.binding.hdpowerview.internal.HubMaintenanceException;
 import org.openhab.binding.hdpowerview.internal.api.CoordinateSystem;

--- a/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/HeosJsonParserEventTest.java
+++ b/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/HeosJsonParserEventTest.java
@@ -13,10 +13,10 @@
 package org.openhab.binding.heos.internal.json;
 
 import static java.lang.Long.valueOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.heos.internal.json.dto.HeosCommunicationAttribute;
 import org.openhab.binding.heos.internal.json.dto.HeosEvent;
 import org.openhab.binding.heos.internal.json.dto.HeosEventObject;

--- a/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/HeosJsonParserResponseTest.java
+++ b/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/HeosJsonParserResponseTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.heos.internal.json;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.heos.internal.json.dto.HeosCommunicationAttribute.*;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.heos.internal.json.dto.HeosCommand;
 import org.openhab.binding.heos.internal.json.dto.HeosCommandGroup;
 import org.openhab.binding.heos.internal.json.dto.HeosErrorCode;

--- a/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/dto/HeosCommandTupleTest.java
+++ b/bundles/org.openhab.binding.heos/src/test/java/org/openhab/binding/heos/internal/json/dto/HeosCommandTupleTest.java
@@ -12,13 +12,12 @@
  */
 package org.openhab.binding.heos.internal.json.dto;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.heos.internal.json.dto.HeosCommand.*;
 import static org.openhab.binding.heos.internal.json.dto.HeosCommandGroup.SYSTEM;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests to validate the functioning of the HeosCommandTuple

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/client/RpcClientTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/client/RpcClientTest.java
@@ -20,8 +20,8 @@ import static org.openhab.binding.homematic.test.util.RpcClientMockImpl.*;
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.communicator.message.RpcRequest;
 import org.openhab.binding.homematic.internal.communicator.message.XmlRpcRequest;
 import org.openhab.binding.homematic.internal.model.HmChannel;
@@ -36,7 +36,7 @@ public class RpcClientTest extends JavaTest {
 
     private RpcClientMockImpl rpcClient;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         this.rpcClient = new RpcClientMockImpl();
     }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
@@ -17,8 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.misc.HomematicClientException;
 import org.openhab.binding.homematic.internal.misc.HomematicConstants;
 import org.openhab.binding.homematic.internal.misc.MiscUtils;
@@ -44,7 +44,7 @@ public class ButtonDatapointTest extends JavaTest {
     private MockEventReceiver mockEventReceiver;
     private final ButtonVirtualDatapointHandler bvdpHandler = new ButtonVirtualDatapointHandler();
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         this.mockEventReceiver = new MockEventReceiver();
     }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/BaseConverterTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.homematic.internal.converter;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmDevice;
@@ -34,7 +34,7 @@ public class BaseConverterTest {
     protected final HmDatapoint integerQuantityDp = new HmDatapoint("floatIntegerDp", "", HmValueType.INTEGER, null,
             false, HmParamsetType.VALUES);
 
-    @Before
+    @BeforeEach
     public void setup() {
         HmChannel stubChannel = new HmChannel("stubChannel", 0);
         stubChannel.setDevice(new HmDevice("LEQ123456", HmInterface.RF, "HM-STUB-DEVICE", "", "", ""));

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertFromBindingTest.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.homematic.internal.converter;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.converter.type.AbstractTypeConverter;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.core.library.types.DecimalType;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertToBindingTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConvertToBindingTest.java
@@ -14,8 +14,9 @@ package org.openhab.binding.homematic.internal.converter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.converter.type.AbstractTypeConverter;
 import org.openhab.binding.homematic.internal.converter.type.DecimalTypeConverter;
 import org.openhab.binding.homematic.internal.converter.type.QuantityTypeConverter;
@@ -99,15 +100,15 @@ public class ConvertToBindingTest extends BaseConverterTest {
         assertThat(convertedValue, is(42));
     }
 
-    @Test(expected = ConverterException.class)
-    public void testQuantityTypeConverterFailsToConvertDecimalType() throws ConverterException {
+    @Test
+    public void testQuantityTypeConverterFailsToConvertDecimalType() {
         QuantityTypeConverter converter = new QuantityTypeConverter();
-        converter.convertToBinding(new DecimalType(99.9), floatDp);
+        assertThrows(ConverterException.class, () -> converter.convertToBinding(new DecimalType(99.9), floatDp));
     }
 
-    @Test(expected = ConverterException.class)
-    public void testDecimalTypeConverterFailsToConvertQuantityType() throws ConverterException {
+    @Test
+    public void testDecimalTypeConverterFailsToConvertQuantityType() {
         DecimalTypeConverter converter = new DecimalTypeConverter();
-        converter.convertToBinding(new QuantityType<>("99.9 %"), floatDp);
+        assertThrows(ConverterException.class, () -> converter.convertToBinding(new QuantityType<>("99.9 %"), floatDp));
     }
 }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConverterFactoryTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/converter/ConverterFactoryTest.java
@@ -15,7 +15,7 @@ package org.openhab.binding.homematic.internal.converter;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.converter.type.DecimalTypeConverter;
 import org.openhab.binding.homematic.internal.converter.type.OnOffTypeConverter;
 import org.openhab.binding.homematic.internal.converter.type.OpenClosedTypeConverter;

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/discovery/HomematicDeviceDiscoveryServiceTest.java
@@ -21,8 +21,8 @@ import static org.openhab.binding.homematic.test.util.DimmerHelper.createDimmerH
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.communicator.HomematicGateway;
 import org.openhab.binding.homematic.internal.handler.HomematicBridgeHandler;
 import org.openhab.binding.homematic.internal.model.HmDevice;
@@ -46,7 +46,7 @@ public class HomematicDeviceDiscoveryServiceTest extends JavaTest {
     private HomematicDeviceDiscoveryService homematicDeviceDiscoveryService;
     private HomematicBridgeHandler homematicBridgeHandler;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         this.homematicBridgeHandler = mockHomematicBridgeHandler();
         this.homematicDeviceDiscoveryService = new HomematicDeviceDiscoveryService();

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/handler/SimplePortPoolTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/handler/SimplePortPoolTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link org.openhab.binding.homematic.internal.handler.SimplePortPool}.
@@ -31,7 +31,7 @@ public class SimplePortPoolTest {
 
     private SimplePortPool simplePortPool;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.simplePortPool = new SimplePortPool();
     }

--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/type/UidUtilsTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/type/UidUtilsTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openhab.binding.homematic.test.util.BridgeHelper.createHomematicBridge;
 import static org.openhab.binding.homematic.test.util.DimmerHelper.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.model.HmChannel;
 import org.openhab.binding.homematic.internal.model.HmDatapoint;
 import org.openhab.binding.homematic.internal.model.HmDatapointInfo;

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/ApiVersionTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/ApiVersionTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.hue.internal;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/HueBridgeTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/HueBridgeTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.hue.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.hue.internal.HttpClient.Result;
 import org.openhab.binding.hue.internal.exceptions.ApiException;

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/LightStateConverterTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/LightStateConverterTest.java
@@ -13,9 +13,10 @@
 package org.openhab.binding.hue.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.hue.internal.State.ColorMode;
 import org.openhab.binding.hue.internal.handler.LightStateConverter;
 import org.openhab.core.library.types.DecimalType;

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/SceneTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/SceneTest.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.hue.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author HJiang - initial contribution

--- a/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
+++ b/bundles/org.openhab.binding.hue/src/test/java/org/openhab/binding/hue/internal/handler/HueLightHandlerTest.java
@@ -12,15 +12,15 @@
  */
 package org.openhab.binding.hue.internal.handler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.binding.hue.internal.FullConfig;
 import org.openhab.binding.hue.internal.FullLight;
@@ -65,7 +65,7 @@ public class HueLightHandlerTest {
 
     private Gson gson;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         gson = new Gson();
     }

--- a/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
+++ b/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
@@ -12,15 +12,15 @@
  */
 package org.openhab.binding.icalendar.internal.logic;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
@@ -45,7 +45,7 @@ public class BiweeklyPresentableCalendarTest {
     private AbstractPresentableCalendar calendar2;
     private AbstractPresentableCalendar calendar3;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, CalendarException {
         calendar = new BiweeklyPresentableCalendar(new FileInputStream("src/test/resources/test.ics"));
         calendar2 = new BiweeklyPresentableCalendar(new FileInputStream("src/test/resources/test2.ics"));

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ButtonPressDurationDetectorTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ButtonPressDurationDetectorTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.ihc.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for IHC / ELKO binding

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/SignalLevelConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/SignalLevelConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for IHC / ELKO binding

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DateTimeTypeWSDateValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DateTimeTypeWSDateValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSDateValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DateTimeTypeWSTimeValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DateTimeTypeWSTimeValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSTimeValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSBooleanValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSBooleanValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSEnumValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSEnumValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSEnumValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSFloatingPointValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSFloatingPointValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSFloatingPointValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
@@ -42,16 +42,18 @@ public class DecimalTypeWSFloatingPointValueConverterTest {
         assertEquals(new DecimalType(2.54), type);
     }
 
-    @Test(expected = ConversionException.class)
-    public void testMinExceed() throws ConversionException {
+    @Test
+    public void testMinExceed() {
         WSFloatingPointValue val = new WSFloatingPointValue(12345, 0, -100, 100);
-        val = convertFromOHType(val, new DecimalType(-101.5), new ConverterAdditionalInfo(null, false, null));
+        assertThrows(ConversionException.class,
+                () -> convertFromOHType(val, new DecimalType(-101.5), new ConverterAdditionalInfo(null, false, null)));
     }
 
-    @Test(expected = ConversionException.class)
-    public void testMaxExceed() throws ConversionException {
+    @Test
+    public void testMaxExceed() {
         WSFloatingPointValue val = new WSFloatingPointValue(12345, 0, -100, 100);
-        val = convertFromOHType(val, new DecimalType(101.5), new ConverterAdditionalInfo(null, false, null));
+        assertThrows(ConversionException.class,
+                () -> convertFromOHType(val, new DecimalType(101.5), new ConverterAdditionalInfo(null, false, null)));
     }
 
     private WSFloatingPointValue convertFromOHType(WSFloatingPointValue IHCvalue, Type OHval,

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSIntegerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSIntegerValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSIntegerValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
@@ -42,16 +42,18 @@ public class DecimalTypeWSIntegerValueConverterTest {
         assertEquals(new DecimalType(2), type);
     }
 
-    @Test(expected = ConversionException.class)
-    public void testMinExceed() throws ConversionException {
+    @Test
+    public void testMinExceed() {
         WSIntegerValue val = new WSIntegerValue(12345, 0, -100, 100);
-        val = convertFromOHType(val, new DecimalType(-101.5), new ConverterAdditionalInfo(null, false, null));
+        assertThrows(ConversionException.class,
+                () -> convertFromOHType(val, new DecimalType(-101.5), new ConverterAdditionalInfo(null, false, null)));
     }
 
-    @Test(expected = ConversionException.class)
-    public void testMaxExceed() throws ConversionException {
+    @Test
+    public void testMaxExceed() {
         WSIntegerValue val = new WSIntegerValue(12345, 0, -100, 100);
-        val = convertFromOHType(val, new DecimalType(101.5), new ConverterAdditionalInfo(null, false, null));
+        assertThrows(ConversionException.class,
+                () -> convertFromOHType(val, new DecimalType(101.5), new ConverterAdditionalInfo(null, false, null)));
     }
 
     private WSIntegerValue convertFromOHType(WSIntegerValue IHCvalue, Type OHval,

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSTimerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSTimerValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSTimerValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSWeekdayValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/DecimalTypeWSWeekdayValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSWeekdayValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OnOffTypeWSBooleanValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OnOffTypeWSBooleanValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OnOffTypeWSIntegerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OnOffTypeWSIntegerValueConverterTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSIntegerValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
@@ -69,15 +69,15 @@ public class OnOffTypeWSIntegerValueConverterTest {
         assertEquals(OnOffType.ON, type);
     }
 
-    @Test(expected = ConversionException.class)
-    public void testOnLevelledError() throws ConversionException {
+    @Test
+    public void testOnLevelledError() {
         WSIntegerValue val = new WSIntegerValue(12345, 0, -100, 100);
 
         Map<Command, Object> commandLevels = new HashMap<>();
         commandLevels.put(OnOffType.ON, "70");
 
-        val = convertFromOHType(val, OnOffType.ON,
-                new ConverterAdditionalInfo(null, false, Collections.unmodifiableMap(commandLevels)));
+        assertThrows(ConversionException.class, () -> convertFromOHType(val, OnOffType.ON,
+                new ConverterAdditionalInfo(null, false, Collections.unmodifiableMap(commandLevels))));
     }
 
     @Test

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OpenClosedTypeWSBooleanValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OpenClosedTypeWSBooleanValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OpenClosedTypeWSIntegerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/OpenClosedTypeWSIntegerValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSIntegerValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/PercentTypeWSIntegerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/PercentTypeWSIntegerValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSIntegerValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/StringTypeWSEnumValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/StringTypeWSEnumValueConverterTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.projectfile.IhcEnumValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSEnumValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/UpDownTypeWSBooleanValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/UpDownTypeWSBooleanValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/UpDownTypeWSIntegerValueConverterTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/converters/UpDownTypeWSIntegerValueConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.ihc.internal.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSIntegerValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/IhcClientTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/IhcClientTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.ihc.internal.ws;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.UnsupportedEncodingException;
 import java.net.SocketTimeoutException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSFile;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSProjectInfo;
@@ -34,7 +34,7 @@ public class IhcClientTest {
 
     private IhcClient ihcClient;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcClient = spy(new IhcClient("test1", "test2", "test3"));
         WSProjectInfo projectInfo = new WSProjectInfo();

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/ResourceFileUtils.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/ResourceFileUtils.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcAirlinkManagementServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcAirlinkManagementServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSRFDevice;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
@@ -42,7 +42,7 @@ public class IhcAirlinkManagementServiceTest {
     private String query;
     private final int timeout = 100;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcAirlinkManagementService = spy(new IhcAirlinkManagementService(host, timeout, new IhcConnectionPool()));
 

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcAuthenticationServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcAuthenticationServiceTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.net.SocketTimeoutException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSLoginResult;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
@@ -37,7 +37,7 @@ public class IhcAuthenticationServiceTest {
     private final String url = "https://1.1.1.1/ws/AuthenticationService";
     private final int timeout = 100;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcAuthenticationService = spy(new IhcAuthenticationService(host, timeout, new IhcConnectionPool()));
 

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcConfigurationServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcConfigurationServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -22,8 +22,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSSystemInfo;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
@@ -43,7 +43,7 @@ public class IhcConfigurationServiceTest {
     private Map<String, String> requestProps = new HashMap<>();
     private final int timeout = 100;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcConfigurationService = spy(new IhcConfigurationService(host, timeout, new IhcConnectionPool()));
         requestProps.clear();

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcControllerServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcControllerServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.IhcClient;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSControllerState;
@@ -45,7 +45,7 @@ public class IhcControllerServiceTest {
     private String query;
     private final int timeout = 100;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcControllerService = spy(new IhcControllerService(host, timeout, new IhcConnectionPool()));
 
@@ -138,6 +138,6 @@ public class IhcControllerServiceTest {
         final byte[] expectedResult = "LvVF4VWSi0WqRKps7lGH6U....OBCl1gwKGbvYM1SDh".getBytes();
         final WSFile result = ihcControllerService.getProjectSegment(1, 1001, 2002);
 
-        assertTrue("Result bytes doesn't match to expected bytes", Arrays.equals(expectedResult, result.getData()));
+        assertTrue(Arrays.equals(expectedResult, result.getData()), "Result bytes doesn't match to expected bytes");
     }
 }

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcResourceInteractionServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcResourceInteractionServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -20,8 +20,8 @@ import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
 import org.openhab.binding.ihc.internal.ws.http.IhcConnectionPool;
@@ -46,7 +46,7 @@ public class IhcResourceInteractionServiceTest {
     private final String host = "1.1.1.1";
     private final String url = "https://1.1.1.1/ws/ResourceInteractionService";
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcResourceInteractionService = spy(new IhcResourceInteractionService(host, 0, new IhcConnectionPool()));
 

--- a/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcTimeServiceTest.java
+++ b/bundles/org.openhab.binding.ihc/src/test/java/org/openhab/binding/ihc/internal/ws/services/IhcTimeServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.ihc.internal.ws.services;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -22,8 +22,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.ihc.internal.ws.ResourceFileUtils;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSTimeManagerSettings;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
@@ -42,7 +42,7 @@ public class IhcTimeServiceTest {
     private Map<String, String> requestProps = new HashMap<>();
     private final int timeout = 100;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IhcExecption, SocketTimeoutException {
         ihcTimeService = spy(new IhcTimeService(host, timeout, new IhcConnectionPool()));
 

--- a/bundles/org.openhab.binding.innogysmarthome/src/test/java/org/openhab/binding/innogysmarthome/internal/InnogyWebSocketTest.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/test/java/org/openhab/binding/innogysmarthome/internal/InnogyWebSocketTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.innogysmarthome.internal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
@@ -22,8 +22,8 @@ import java.util.concurrent.Future;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.innogysmarthome.internal.listener.EventListener;
 
 /**
@@ -36,7 +36,7 @@ public class InnogyWebSocketTest {
     private WebSocketClient webSocketClientMock;
     private Session sessionMock;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         sessionMock = mock(Session.class);
 

--- a/bundles/org.openhab.binding.innogysmarthome/src/test/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.innogysmarthome/src/test/java/org/openhab/binding/innogysmarthome/internal/handler/InnogyBridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.innogysmarthome.internal.handler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.net.ConnectException;
@@ -23,8 +23,8 @@ import java.util.concurrent.ScheduledFuture;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jetty.client.HttpClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.innogysmarthome.internal.InnogyBindingConstants;
 import org.openhab.binding.innogysmarthome.internal.InnogyWebSocket;
 import org.openhab.binding.innogysmarthome.internal.client.InnogyClient;
@@ -47,7 +47,7 @@ public class InnogyBridgeHandlerTest {
     private Bridge bridgeMock;
     private InnogyWebSocket webSocketMock;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         bridgeMock = mock(Bridge.class);
         when(bridgeMock.getUID()).thenReturn(new ThingUID("innogysmarthome", "bridge"));

--- a/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTypeTest.java
+++ b/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/channel/KNXChannelTypeTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.knx.internal.channel;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -30,7 +30,7 @@ public class KNXChannelTypeTest {
 
     private KNXChannelType ct;
 
-    @Before
+    @BeforeEach
     public void setup() {
         ct = new MyKNXChannelType("");
     }

--- a/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.openhab.binding.knx/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.knx.internal.dpt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 
 /**

--- a/bundles/org.openhab.binding.kodi/src/test/java/org/openhab/binding/kodi/internal/utils/ByteArrayFileCacheTest.java
+++ b/bundles/org.openhab.binding.kodi/src/test/java/org/openhab/binding/kodi/internal/utils/ByteArrayFileCacheTest.java
@@ -13,16 +13,16 @@
 package org.openhab.binding.kodi.internal.utils;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.ConfigConstants;
 
 /**
@@ -45,18 +45,18 @@ public class ByteArrayFileCacheTest {
 
     private ByteArrayFileCache subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new ByteArrayFileCache(SERVICE_PID);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         // delete all files
         subject.clear();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanUp() {
         // delete all folders
         SERVICE_CACHE_FOLDER.delete();

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/LocalTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/LocalTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.lametrictime.api.common.impl.typeadapters.imported;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link LocalTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class LocalTimeTypeAdapter extends TemporalTypeAdapter<LocalTime> {
 
-  public LocalTimeTypeAdapter() {
-    super(LocalTime::parse);
-  }
+    public LocalTimeTypeAdapter() {
+        super(LocalTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/OffsetDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/OffsetDateTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.lametrictime.api.common.impl.typeadapters.imported;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link OffsetDateTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class OffsetDateTimeTypeAdapter extends DateTimeTypeAdapter<OffsetDateTime> {
 
-  public OffsetDateTimeTypeAdapter() {
-    super(OffsetDateTime::parse);
-  }
+    public OffsetDateTimeTypeAdapter() {
+        super(OffsetDateTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/OffsetTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/OffsetTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.lametrictime.api.common.impl.typeadapters.imported;
 
 import java.time.OffsetTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link OffsetTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class OffsetTimeTypeAdapter extends TemporalTypeAdapter<OffsetTime> {
 
-  public OffsetTimeTypeAdapter() {
-    super(OffsetTime::parse);
-  }
+    public OffsetTimeTypeAdapter() {
+        super(OffsetTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/ZonedDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/java/org/openhab/binding/lametrictime/api/common/impl/typeadapters/imported/ZonedDateTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.lametrictime.api.common.impl.typeadapters.imported;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link ZonedDateTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class ZonedDateTimeTypeAdapter extends DateTimeTypeAdapter<ZonedDateTime> {
 
-  public ZonedDateTimeTypeAdapter() {
-    super(ZonedDateTime::parse);
-  }
+    public ZonedDateTimeTypeAdapter() {
+        super(ZonedDateTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/impl/FileIconTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/impl/FileIconTest.java
@@ -15,9 +15,9 @@
  */
 package org.openhab.binding.lametrictime.api.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
 public class FileIconTest extends AbstractTest

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/impl/LaMetricTimeLocalImplIT.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/impl/LaMetricTimeLocalImplIT.java
@@ -15,6 +15,8 @@
  */
 package org.openhab.binding.lametrictime.api.local.impl;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -22,9 +24,9 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.local.ApplicationActionException;
 import org.openhab.binding.lametrictime.api.local.ApplicationActivationException;
 import org.openhab.binding.lametrictime.api.local.ApplicationNotFoundException;
@@ -62,14 +64,14 @@ import org.openhab.binding.lametrictime.api.test.TestUtil;
  * integration-test'.
  * </p>
  */
-@Ignore
+@Disabled
 public class LaMetricTimeLocalImplIT {
     private static final String PROP_HOST = "host";
     private static final String PROP_API_KEY = "apiKey";
 
     private static LaMetricTimeLocalImpl local;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         File file = TestUtil.getTestDataPath(LaMetricTimeLocalImplIT.class, "device.properties").toFile();
         if (!file.exists()) {
@@ -126,9 +128,9 @@ public class LaMetricTimeLocalImplIT {
         local.getNotifications();
     }
 
-    @Test(expected = NotificationNotFoundException.class)
-    public void testGetInvalidNotification() throws NotificationNotFoundException {
-        local.getNotification("invalid");
+    @Test
+    public void testGetInvalidNotification() {
+        assertThrows(NotificationNotFoundException.class, () -> local.getNotification("invalid"));
     }
 
     @Test
@@ -202,9 +204,9 @@ public class LaMetricTimeLocalImplIT {
         local.getApplication(CoreApps.weather().getPackageName());
     }
 
-    @Test(expected = ApplicationNotFoundException.class)
-    public void testGetInvalidApplication() throws ApplicationNotFoundException {
-        local.getApplication("invalid");
+    @Test
+    public void testGetInvalidApplication() {
+        assertThrows(ApplicationNotFoundException.class, () -> local.getApplication("invalid"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/ActionTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/ActionTest.java
@@ -15,15 +15,15 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Iterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -33,7 +33,7 @@ public class ActionTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/ApplicationTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/ApplicationTest.java
@@ -15,15 +15,15 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Iterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -33,7 +33,7 @@ public class ApplicationTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/AudioTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/AudioTest.java
@@ -15,12 +15,12 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -30,7 +30,7 @@ public class AudioTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/BluetoothTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/BluetoothTest.java
@@ -15,12 +15,12 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -30,7 +30,7 @@ public class BluetoothTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/FrameTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/FrameTest.java
@@ -15,13 +15,13 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Arrays;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -31,7 +31,7 @@ public class FrameTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/GoalDataTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/GoalDataTest.java
@@ -15,12 +15,12 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -30,7 +30,7 @@ public class GoalDataTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/UpdateActionTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/UpdateActionTest.java
@@ -15,45 +15,40 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.TreeMap;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class UpdateActionTest extends AbstractTest
-{
+public class UpdateActionTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
     @SuppressWarnings("serial")
-    public void testSerialize() throws Exception
-    {
+    public void testSerialize() throws Exception {
         UpdateAction action = new UpdateAction().withId("countdown.configure")
-                                                // @formatter:off
+        // @formatter:off
                                                 .withParameters(new TreeMap<String, Parameter>(){{put("duration", new IntegerParameter().withValue(30));}});
                                                 // @formatter:on
         assertEquals(readJson("update-action.json"), gson.toJson(action));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testDeserialize() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("update-action.json")))
-        {
-            gson.fromJson(reader, UpdateAction.class);
+    @Test
+    public void testDeserialize() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("update-action.json"))) {
+            assertThrows(UnsupportedOperationException.class, () -> gson.fromJson(reader, UpdateAction.class));
         }
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/WidgetTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/WidgetTest.java
@@ -15,13 +15,13 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.HashMap;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -32,7 +32,7 @@ public class WidgetTest extends AbstractTest
 {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass()
     {
         gson = GsonGenerator.create(true);

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/WidgetUpdatesTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/local/model/WidgetUpdatesTest.java
@@ -15,15 +15,15 @@
  */
 package org.openhab.binding.lametrictime.api.local.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lametrictime.api.common.impl.GsonGenerator;
 import org.openhab.binding.lametrictime.api.test.AbstractTest;
 
@@ -32,7 +32,7 @@ import com.google.gson.Gson;
 public class WidgetUpdatesTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/BrightnessModeTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/BrightnessModeTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.BrightnessMode;
+import org.junit.jupiter.api.Test;
 
-public class BrightnessModeTest
-{
+public class BrightnessModeTest {
     @Test
-    public void testConversion()
-    {
-        for (BrightnessMode value : BrightnessMode.values())
-        {
+    public void testConversion() {
+        for (BrightnessMode value : BrightnessMode.values()) {
             assertEquals(value, BrightnessMode.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(BrightnessMode.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(BrightnessMode.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/DisplayTypeTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/DisplayTypeTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.DisplayType;
+import org.junit.jupiter.api.Test;
 
-public class DisplayTypeTest
-{
+public class DisplayTypeTest {
     @Test
-    public void testConversion()
-    {
-        for (DisplayType value : DisplayType.values())
-        {
+    public void testConversion() {
+        for (DisplayType value : DisplayType.values()) {
             assertEquals(value, DisplayType.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(DisplayType.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(DisplayType.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/IconTypeTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/IconTypeTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.IconType;
+import org.junit.jupiter.api.Test;
 
-public class IconTypeTest
-{
+public class IconTypeTest {
     @Test
-    public void testConversion()
-    {
-        for (IconType value : IconType.values())
-        {
+    public void testConversion() {
+        for (IconType value : IconType.values()) {
             assertEquals(value, IconType.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(IconType.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(IconType.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/IpModeTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/IpModeTest.java
@@ -15,31 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IpModeTest
-{
+public class IpModeTest {
     @Test
-    public void testConversion()
-    {
-        for (IpMode value : IpMode.values())
-        {
+    public void testConversion() {
+        for (IpMode value : IpMode.values()) {
             assertEquals(value, IpMode.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(IpMode.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(IpMode.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/PriorityTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/PriorityTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.Priority;
+import org.junit.jupiter.api.Test;
 
-public class PriorityTest
-{
+public class PriorityTest {
     @Test
-    public void testConversion()
-    {
-        for (Priority value : Priority.values())
-        {
+    public void testConversion() {
+        for (Priority value : Priority.values()) {
             assertEquals(value, Priority.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(Priority.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(Priority.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/SoundCategoryTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/SoundCategoryTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.SoundCategory;
+import org.junit.jupiter.api.Test;
 
-public class SoundCategoryTest
-{
+public class SoundCategoryTest {
     @Test
-    public void testConversion()
-    {
-        for (SoundCategory value : SoundCategory.values())
-        {
+    public void testConversion() {
+        for (SoundCategory value : SoundCategory.values()) {
             assertEquals(value, SoundCategory.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(SoundCategory.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(SoundCategory.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/SoundTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/SoundTest.java
@@ -15,32 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.openhab.binding.lametrictime.api.model.enums.Sound;
+import org.junit.jupiter.api.Test;
 
-public class SoundTest
-{
+public class SoundTest {
     @Test
-    public void testConversion()
-    {
-        for (Sound value : Sound.values())
-        {
+    public void testConversion() {
+        for (Sound value : Sound.values()) {
             assertEquals(value, Sound.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(Sound.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(Sound.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/WifiEncryptionTest.java
+++ b/bundles/org.openhab.binding.lametrictime/src/3rdparty/test/org/openhab/binding/lametrictime/api/model/enums/WifiEncryptionTest.java
@@ -15,31 +15,25 @@
  */
 package org.openhab.binding.lametrictime.api.model.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class WifiEncryptionTest
-{
+public class WifiEncryptionTest {
     @Test
-    public void testConversion()
-    {
-        for (WifiEncryption value : WifiEncryption.values())
-        {
+    public void testConversion() {
+        for (WifiEncryption value : WifiEncryption.values()) {
             assertEquals(value, WifiEncryption.toEnum(value.toRaw()));
         }
     }
 
     @Test
-    public void testInvalidRawValue()
-    {
+    public void testInvalidRawValue() {
         assertNull(WifiEncryption.toEnum("invalid raw value"));
     }
 
     @Test
-    public void testNullRawValue()
-    {
+    public void testNullRawValue() {
         assertNull(WifiEncryption.toEnum(null));
     }
 }

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/ModuleActionsTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/ModuleActionsTest.java
@@ -12,19 +12,20 @@
  */
 package org.openhab.binding.lcn.internal;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.nio.ByteBuffer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.lcn.internal.common.LcnDefs;
 import org.openhab.binding.lcn.internal.common.LcnException;
 
@@ -33,6 +34,7 @@ import org.openhab.binding.lcn.internal.common.LcnException;
  *
  * @author Fabian Wolter - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class ModuleActionsTest {
     private LcnModuleActions a = new LcnModuleActions();
@@ -40,9 +42,8 @@ public class ModuleActionsTest {
     @Captor
     private @NonNullByDefault({}) ArgumentCaptor<byte[]> byteBufferCaptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         a = new LcnModuleActions();
         a.setThingHandler(handler);
     }

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryServiceTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.lcn.internal.pchkdiscovery;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link LcnPchkDiscoveryService}.
@@ -30,7 +30,7 @@ public class LcnPchkDiscoveryServiceTest {
     private ServicesResponse r = s.xmlToServiceResponse(RESPONSE);
     private static final String RESPONSE = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><ServicesResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"servicesresponse.xsd\"><Version major=\"1\" minor=\"0\" /><Server requestId=\"1548\" machineId=\"b8:27:eb:fe:a4:bb\" machineName=\"raspberrypi\" osShort=\"Unix/Linux\" osLong=\"Unix/Linux\">LCN-PCHK 3.2.2 running on Unix/Linux</Server><Services /><ExtServices><ExtService name=\"LcnPchkBus\" major=\"1\" minor=\"0\" prot=\"TCP\" localPort=\"4114\">PCHK 3.2.2 bus</ExtService></ExtServices></ServicesResponse>";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         s = new LcnPchkDiscoveryService();
         r = s.xmlToServiceResponse(RESPONSE);

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/AbstractTestLcnModuleSubHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/AbstractTestLcnModuleSubHandler.java
@@ -15,8 +15,11 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.lcn.internal.LcnModuleHandler;
 import org.openhab.binding.lcn.internal.connection.ModInfo;
 
@@ -25,19 +28,15 @@ import org.openhab.binding.lcn.internal.connection.ModInfo;
  *
  * @author Fabian Wolter - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public class AbstractTestLcnModuleSubHandler {
-    @Mock
-    protected @NonNullByDefault({}) LcnModuleHandler handler;
-    @Mock
-    protected @NonNullByDefault({}) ModInfo info;
 
-    public AbstractTestLcnModuleSubHandler() {
-        setUp();
-    }
+    protected @Mock @NonNullByDefault({}) LcnModuleHandler handler;
+    protected @Mock @NonNullByDefault({}) ModInfo info;
 
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(handler.isMyAddress("000", "005")).thenReturn(true);
     }
 }

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleBinarySensorSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleBinarySensorSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.core.library.types.OpenClosedType;
 
@@ -30,7 +30,7 @@ public class LcnModuleBinarySensorSubHandlerTest extends AbstractTestLcnModuleSu
     private @NonNullByDefault({}) LcnModuleBinarySensorSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleHostCommandSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleHostCommandSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 
 /**
@@ -29,7 +29,7 @@ public class LcnModuleHostCommandSubHandlerTest extends AbstractTestLcnModuleSub
     private @NonNullByDefault({}) LcnModuleHostCommandSubHandler subHandler;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleKeyLockTableSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleKeyLockTableSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.core.library.types.OnOffType;
@@ -31,7 +31,7 @@ public class LcnModuleKeyLockTableSubHandlerTest extends AbstractTestLcnModuleSu
     private @NonNullByDefault({}) LcnModuleKeyLockTableSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleLedSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleLedSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnDefs;
 import org.openhab.binding.lcn.internal.common.LcnException;
@@ -33,7 +33,7 @@ public class LcnModuleLedSubHandlerTest extends AbstractTestLcnModuleSubHandler 
     private @NonNullByDefault({}) LcnModuleLedSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleLogicSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleLogicSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.core.library.types.StringType;
 
@@ -37,7 +37,7 @@ public class LcnModuleLogicSubHandlerTest extends AbstractTestLcnModuleSubHandle
     private @NonNullByDefault({}) LcnModuleLogicSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleOutputSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleOutputSubHandlerTest.java
@@ -17,8 +17,8 @@ import static org.mockito.Mockito.verify;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.DimmerOutputCommand;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnDefs;
@@ -36,7 +36,7 @@ public class LcnModuleOutputSubHandlerTest extends AbstractTestLcnModuleSubHandl
     private @NonNullByDefault({}) LcnModuleOutputSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRelaySubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRelaySubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.core.library.types.OnOffType;
@@ -32,7 +32,7 @@ public class LcnModuleRelaySubHandlerTest extends AbstractTestLcnModuleSubHandle
     private @NonNullByDefault({}) LcnModuleRelaySubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRollershutterOutputSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRollershutterOutputSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.core.library.types.StopMoveType;
@@ -32,7 +32,7 @@ public class LcnModuleRollershutterOutputSubHandlerTest extends AbstractTestLcnM
     private @NonNullByDefault({}) LcnModuleRollershutterOutputSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRollershutterRelaySubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRollershutterRelaySubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.core.library.types.StopMoveType;
@@ -32,7 +32,7 @@ public class LcnModuleRollershutterRelaySubHandlerTest extends AbstractTestLcnMo
     private @NonNullByDefault({}) LcnModuleRollershutterRelaySubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRvarLockSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRvarLockSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.core.library.types.OnOffType;
@@ -31,7 +31,7 @@ public class LcnModuleRvarLockSubHandlerTest extends AbstractTestLcnModuleSubHan
     private @NonNullByDefault({}) LcnModuleRvarLockSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRvarSetpointSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleRvarSetpointSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.binding.lcn.internal.common.Variable;
@@ -34,7 +34,7 @@ public class LcnModuleRvarSetpointSubHandlerTest extends AbstractTestLcnModuleSu
     private @NonNullByDefault({}) LcnModuleRvarSetpointSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleS0CounterSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleS0CounterSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.core.library.types.DecimalType;
 
@@ -30,7 +30,7 @@ public class LcnModuleS0CounterSubHandlerTest extends AbstractTestLcnModuleSubHa
     private @NonNullByDefault({}) LcnModuleS0CounterSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleThresholdSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleThresholdSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.binding.lcn.internal.common.Variable;
@@ -32,7 +32,7 @@ public class LcnModuleThresholdSubHandlerTest extends AbstractTestLcnModuleSubHa
     private @NonNullByDefault({}) LcnModuleThresholdSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleVariableSubHandlerTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/subhandler/LcnModuleVariableSubHandlerTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.lcn.internal.subhandler;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.lcn.internal.common.LcnChannelGroup;
 import org.openhab.binding.lcn.internal.common.LcnException;
 import org.openhab.binding.lcn.internal.common.Variable;
@@ -33,7 +33,7 @@ public class LcnModuleVariableSubHandlerTest extends AbstractTestLcnModuleSubHan
     private @NonNullByDefault({}) LcnModuleVariableSubHandler l;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
 

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlAlarmNoPresenceTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlAlarmNoPresenceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -20,8 +20,8 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -50,7 +50,7 @@ public class LxControlAlarmNoPresenceTest extends LxControlTest {
     private static final String numberChannels[] = { NEXT_LEVEL_CHANNEL, NEXT_LEVEL_DELAY_CHANNEL,
             NEXT_LEVEL_DELAY_TOTAL_CHANNEL, LEVEL_CHANNEL, ARMED_DELAY_CHANNEL, ARMED_TOTAL_DELAY_CHANNEL };
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("233d5db0-0333-5865-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Burglar Alarm No Presence");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlAlarmWithPresenceTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlAlarmWithPresenceTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 
 /**
@@ -26,7 +26,7 @@ public class LxControlAlarmWithPresenceTest extends LxControlAlarmNoPresenceTest
     private static final String MOTION_SENSORS_CHANNEL = " / Motion Sensors";
 
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("133d5db0-0333-5865-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Burglar Alarm With Presence");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlDimmerTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlDimmerTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -26,7 +26,7 @@ import org.openhab.core.library.types.StopMoveType;
  *
  */
 public class LxControlDimmerTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("131b19cd-03c0-640f-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Dimmer Control");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlIRoomControllerV2Test.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlIRoomControllerV2Test.java
@@ -15,8 +15,8 @@ package org.openhab.binding.loxone.internal.controls;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 
@@ -41,7 +41,7 @@ public class LxControlIRoomControllerV2Test extends LxControlTest {
     private static final String FROST_PROTECT_TEMPERATURE_CHANNEL = "/ Frost Protect Temperature";
     private static final String HEAT_PROTECT_TEMPERATURE_CHANNEL = "/ Heat Protect Temperature";
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("14328f8a-21c9-7c0d-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Intelligent Room Controller");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTempTagTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTempTagTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.loxone.internal.controls;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for (@link LxControlInfoOnlyAnalog} - check tags for temperature category
@@ -24,7 +24,7 @@ import org.junit.Test;
  *
  */
 public class LxControlInfoOnlyAnalogTempTagTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("0fec5dc3-003e-8800-ffff555fb0c34b9e", "0fe3a451-0283-2afa-ffff403fb0c34b9e",
                 "0fb99a98-02df-46f1-ffff403fb0c34b9e", "Info Only Analog Temperature");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyAnalogTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.types.UnDefType;
 
@@ -24,7 +24,7 @@ import org.openhab.core.types.UnDefType;
  *
  */
 public class LxControlInfoOnlyAnalogTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("0fec5dc3-003e-8800-ffff403fb0c34b9e", "0fe3a451-0283-2afa-ffff403fb0c34b9e",
                 "0fe665f4-0161-4773-ffff403fb0c34b9e", "Info Only Analog");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyDigitalTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlInfoOnlyDigitalTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.UnDefType;
 
@@ -24,7 +24,7 @@ import org.openhab.core.types.UnDefType;
  *
  */
 public class LxControlInfoOnlyDigitalTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("101b50f7-0306-98fb-ffff403fb0c34b9e", "0e368d32-014f-4604-ffff403fb0c34b9e",
                 "101b563d-0302-78bd-ffff403fb0c34b9e", "Info Only Digital");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlJalousieTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlJalousieTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.loxone.internal.controls;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -35,7 +35,7 @@ public class LxControlJalousieTest extends LxControlTest {
     private static final String SHADE_CHANNEL = " / Shade";
     private static final String AUTO_SHADE_CHANNEL = " / Auto Shade";
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("0e367c09-0161-e2c1-ffff403fb0c34b9e", "0e368d32-014f-4604-ffff403fb0c34b9e",
                 "0b734138-033e-02d8-ffff403fb0c34b9e", "Window Blinds");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLeftRightAnalogTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLeftRightAnalogTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test class for (@link LxControlLeftRightAnalog}
@@ -22,7 +22,7 @@ import org.junit.Before;
  */
 public class LxControlLeftRightAnalogTest extends LxControlUpDownAnalogTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         min = 1072.123;
         max = 1123.458;

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLeftRightDigitalTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLeftRightDigitalTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for (@link LxControlLeftRightDigital}
@@ -23,7 +23,7 @@ import org.junit.Test;
  */
 public class LxControlLeftRightDigitalTest extends LxControlUpDownDigitalTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         upChannel = " / Left";
         downChannel = " / Right";

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlLightControllerV2Test.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.loxone.internal.controls;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -24,8 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.loxone.internal.types.LxUuid;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -40,7 +41,7 @@ import org.openhab.core.types.UnDefType;
  *
  */
 public class LxControlLightControllerV2Test extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("1076668f-0101-7076-ffff403fb0c34b9e", "0b734138-03ac-03f0-ffff403fb0c34b9e",
                 "0b734138-033e-02d4-ffff403fb0c34b9e", "Lighting controller");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlMeterTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlMeterTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 
@@ -28,7 +28,7 @@ public class LxControlMeterTest extends LxControlTest {
     private static final String TOTAL_VALUE_CHANNEL = " / Total";
     private static final String RESET_CHANNEL = " / Reset";
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("13b3ea27-00fc-6f1b-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Energy Meter");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlPushbuttonTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlPushbuttonTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.loxone.internal.controls;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -28,7 +28,7 @@ import org.openhab.core.library.types.StringType;
  */
 public class LxControlPushbuttonTest extends LxControlSwitchTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("0e3684cc-026e-28e0-ffff403fb0c34b9e", "0b734138-038c-035e-ffff403fb0c34b9e",
                 "0b734138-033e-02d8-ffff403fb0c34b9e", "Kitchen All Blinds Up");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlRadioTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlRadioTest.java
@@ -16,8 +16,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -30,7 +30,7 @@ import org.openhab.core.types.StateOption;
  *
  */
 public class LxControlRadioTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("4255054f-0355-af47-ffff403fb0c34b9e", "11d68cf4-0080-7697-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Sprinkler 1");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlRadioTest2.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlRadioTest2.java
@@ -16,8 +16,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.StateOption;
@@ -30,7 +30,7 @@ import org.openhab.core.types.StateOption;
  */
 public class LxControlRadioTest2 extends LxControlRadioTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("1255054f-0355-af47-ffff403fb0c34b9e", "11d68cf4-0080-7697-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Sprinkler 2");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSliderTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSliderTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for (@link LxControlSlider} - this is actually the same control as up down analog
@@ -23,7 +23,7 @@ import org.junit.Test;
  */
 public class LxControlSliderTest extends LxControlUpDownAnalogTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         min = 120.0;
         max = 450.0;

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSwitchTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlSwitchTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.loxone.internal.controls;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -28,7 +28,7 @@ import org.openhab.core.types.UnDefType;
  *
  */
 public class LxControlSwitchTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("0f2f6b5d-0349-83b1-ffff403fb0c34b9e", "0b734138-038c-0382-ffff403fb0c34b9e",
                 "0b734138-033e-02d4-ffff403fb0c34b9e", "Switch Button");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTextStateTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTextStateTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.StringType;
 
 /**
@@ -23,7 +23,7 @@ import org.openhab.core.library.types.StringType;
  *
  */
 public class LxControlTextStateTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("106bed36-016d-6dd8-ffffffe6109fb656", "0b734138-038c-0386-ffff403fb0c34b9e",
                 "0fe665f4-0161-4773-ffff403fb0c34b9e", "Gate");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTimedSwitchTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTimedSwitchTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.loxone.internal.controls;
 import java.math.BigDecimal;
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 
@@ -29,7 +29,7 @@ import org.openhab.core.library.types.OnOffType;
 public class LxControlTimedSwitchTest extends LxControlTest {
     private static final String DELAY_CHANNEL = " / Deactivation Delay";
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("1326771c-030e-3a7c-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Stairwell Light Switch");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTrackerTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlTrackerTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.StringType;
 
 /**
@@ -23,7 +23,7 @@ import org.openhab.core.library.types.StringType;
  *
  */
 public class LxControlTrackerTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("132aa43b-01d4-56ea-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Tracker Control");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlUpDownAnalogTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlUpDownAnalogTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.loxone.internal.controls;
 
 import java.math.BigDecimal;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.types.UnDefType;
 
@@ -31,7 +31,7 @@ public class LxControlUpDownAnalogTest extends LxControlTest {
     Double step;
     String format;
 
-    @Before
+    @BeforeEach
     public void setup() {
         min = 50.0;
         max = 150.0;

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlUpDownDigitalTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlUpDownDigitalTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 
 /**
@@ -26,7 +26,7 @@ public class LxControlUpDownDigitalTest extends LxControlTest {
     String upChannel;
     String downChannel;
 
-    @Before
+    @BeforeEach
     public void setup() {
         upChannel = " / Up";
         downChannel = " / Down";

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlValueSelectorIncrTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlValueSelectorIncrTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.PercentType;
 
@@ -25,7 +25,7 @@ import org.openhab.core.library.types.PercentType;
  */
 public class LxControlValueSelectorIncrTest extends LxControlValueSelectorTest {
     @Override
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("132a7b7e-0022-3aac-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Selection Switch Increase Only");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlValueSelectorTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlValueSelectorTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.loxone.internal.controls;
 
 import java.math.BigDecimal;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
@@ -31,7 +31,7 @@ import org.openhab.core.library.types.StopMoveType;
 public class LxControlValueSelectorTest extends LxControlTest {
     private static final String NUMBER_CHANNEL = " / Number";
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("432a7b7e-0022-3aac-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Selection Switch");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlWebPageTest.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxControlWebPageTest.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.StringType;
 
 /**
@@ -23,7 +23,7 @@ import org.openhab.core.library.types.StringType;
  *
  */
 public class LxControlWebPageTest extends LxControlTest {
-    @Before
+    @BeforeEach
     public void setup() {
         setupControl("132d2791-00f8-d532-ffff403fb0c34b9e", "0b734138-037d-034e-ffff403fb0c34b9e",
                 "0fe650c2-0004-d446-ffff504f9410790f", "Webpage 1");

--- a/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
+++ b/bundles/org.openhab.binding.loxone/src/test/java/org/openhab/binding/loxone/internal/controls/LxServerHandlerDummy.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.loxone.internal.controls;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/ConditionHandlerTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/ConditionHandlerTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.handler.BaseSensorHandler.UpdateStatus;
 import org.openhab.binding.luftdateninfo.internal.mock.ConditionHandlerExtension;
 import org.openhab.binding.luftdateninfo.internal.mock.ThingMock;
@@ -47,11 +47,11 @@ public class ConditionHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/condition-result-no-pressure.json");
         if (pmJson != null) {
             UpdateStatus result = condHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.OK, result);
-            assertEquals("Temperature", QuantityType.valueOf(22.7, SIUnits.CELSIUS), condHandler.getTemperature());
-            assertEquals("Humidity", QuantityType.valueOf(61.0, SmartHomeUnits.PERCENT), condHandler.getHumidity());
-            assertEquals("Pressure", QuantityType.valueOf(-1, SIUnits.PASCAL), condHandler.getPressure());
-            assertEquals("Pressure Sea", QuantityType.valueOf(-1, SIUnits.PASCAL), condHandler.getPressureSea());
+            assertEquals(UpdateStatus.OK, result, "Valid update");
+            assertEquals(QuantityType.valueOf(22.7, SIUnits.CELSIUS), condHandler.getTemperature(), "Temperature");
+            assertEquals(QuantityType.valueOf(61.0, SmartHomeUnits.PERCENT), condHandler.getHumidity(), "Humidity");
+            assertEquals(QuantityType.valueOf(-1, SIUnits.PASCAL), condHandler.getPressure(), "Pressure");
+            assertEquals(QuantityType.valueOf(-1, SIUnits.PASCAL), condHandler.getPressureSea(), "Pressure Sea");
         } else {
             assertTrue(false);
         }
@@ -70,11 +70,11 @@ public class ConditionHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/condition-result-plus-pressure.json");
         if (pmJson != null) {
             UpdateStatus result = condHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.OK, result);
-            assertEquals("Temperature", QuantityType.valueOf(21.5, SIUnits.CELSIUS), condHandler.getTemperature());
-            assertEquals("Humidity", QuantityType.valueOf(58.5, SmartHomeUnits.PERCENT), condHandler.getHumidity());
-            assertEquals("Pressure", QuantityType.valueOf(100200.0, SIUnits.PASCAL), condHandler.getPressure());
-            assertEquals("Pressure Sea", QuantityType.valueOf(101968.7, SIUnits.PASCAL), condHandler.getPressureSea());
+            assertEquals(UpdateStatus.OK, result, "Valid update");
+            assertEquals(QuantityType.valueOf(21.5, SIUnits.CELSIUS), condHandler.getTemperature(), "Temperature");
+            assertEquals(QuantityType.valueOf(58.5, SmartHomeUnits.PERCENT), condHandler.getHumidity(), "Humidity");
+            assertEquals(QuantityType.valueOf(100200.0, SIUnits.PASCAL), condHandler.getPressure(), "Pressure");
+            assertEquals(QuantityType.valueOf(101968.7, SIUnits.PASCAL), condHandler.getPressureSea(), "Pressure Sea");
         } else {
             assertTrue(false);
         }
@@ -93,7 +93,7 @@ public class ConditionHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/noise-result.json");
         if (pmJson != null) {
             UpdateStatus result = condHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.VALUE_ERROR, result);
+            assertEquals(UpdateStatus.VALUE_ERROR, result, "Valid update");
         } else {
             assertTrue(false);
         }
@@ -110,7 +110,7 @@ public class ConditionHandlerTest {
 
         ConditionHandlerExtension condHandler = new ConditionHandlerExtension(t);
         UpdateStatus result = condHandler.updateChannels("[]");
-        assertEquals("Valid update", UpdateStatus.VALUE_EMPTY, result);
+        assertEquals(UpdateStatus.VALUE_EMPTY, result, "Valid update");
     }
 
     @Test
@@ -124,6 +124,6 @@ public class ConditionHandlerTest {
 
         ConditionHandlerExtension condHandler = new ConditionHandlerExtension(t);
         UpdateStatus result = condHandler.updateChannels(null);
-        assertEquals("Valid update", UpdateStatus.CONNECTION_ERROR, result);
+        assertEquals(UpdateStatus.CONNECTION_ERROR, result, "Valid update");
     }
 }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/DTOTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/DTOTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.dto.SensorData;
 import org.openhab.binding.luftdateninfo.internal.dto.SensorDataValue;
 import org.openhab.binding.luftdateninfo.internal.handler.HTTPHandler;
@@ -39,7 +39,7 @@ public class DTOTest {
         Gson gson = new Gson();
         SensorData[] valueArray = gson.fromJson(result, SensorData[].class);
         // System.out.println(valueArray.length);
-        assertEquals("Array size", 2, valueArray.length);
+        assertEquals(2, valueArray.length, "Array size");
 
         SensorData d = valueArray[0];
         // Assure latest data is taken
@@ -52,9 +52,9 @@ public class DTOTest {
         assertNotNull(d);
         sensorDataVaueList.forEach(v -> {
             if (v.getValueType().equals(HTTPHandler.TEMPERATURE)) {
-                assertEquals("Temperature", "22.70", v.getValue());
+                assertEquals("22.70", v.getValue(), "Temperature");
             } else if (v.getValueType().equals(HTTPHandler.HUMIDITY)) {
-                assertEquals("Humidity", "61.00", v.getValue());
+                assertEquals("61.00", v.getValue(), "Humidity");
             }
         });
     }
@@ -65,7 +65,7 @@ public class DTOTest {
         Gson gson = new Gson();
         SensorData[] valueArray = gson.fromJson(result, SensorData[].class);
         // System.out.println(valueArray.length);
-        assertEquals("Array size", 2, valueArray.length);
+        assertEquals(2, valueArray.length, "Array size");
 
         SensorData d = valueArray[0];
         // Assure latest data is taken

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/HTTPHandlerEvalTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/HTTPHandlerEvalTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.dto.SensorDataValue;
 import org.openhab.binding.luftdateninfo.internal.handler.HTTPHandler;
 import org.openhab.binding.luftdateninfo.internal.util.FileReader;
@@ -37,7 +37,7 @@ public class HTTPHandlerEvalTest {
     private @Nullable List<SensorDataValue> noise;
     private HTTPHandler http = new HTTPHandler();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         String conditionsStr = FileReader.readFileInString("src/test/resources/condition-result-no-pressure.json");
         assertNotNull(conditionsStr);

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/HTTPHandlerValueTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/HTTPHandlerValueTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.dto.SensorDataValue;
 import org.openhab.binding.luftdateninfo.internal.handler.HTTPHandler;
 import org.openhab.binding.luftdateninfo.internal.util.FileReader;
@@ -57,9 +57,9 @@ public class HTTPHandlerValueTest {
 
     private void testSensorValue(SensorDataValue s) {
         if (s.getValueType().equals(HTTPHandler.TEMPERATURE)) {
-            assertEquals("Temperature resource 1", "22.70", s.getValue());
+            assertEquals("22.70", s.getValue(), "Temperature resource 1");
         } else if (s.getValueType().equals(HTTPHandler.HUMIDITY)) {
-            assertEquals("Humidity resource 1", "61.00", s.getValue());
+            assertEquals("61.00", s.getValue(), "Humidity resource 1");
         } else {
             assertTrue(false);
         }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/NoiseHandlerTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/NoiseHandlerTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.handler.BaseSensorHandler.UpdateStatus;
 import org.openhab.binding.luftdateninfo.internal.mock.NoiseHandlerExtension;
 import org.openhab.binding.luftdateninfo.internal.mock.ThingMock;
@@ -46,13 +46,13 @@ public class NoiseHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/noise-result.json");
         if (pmJson != null) {
             UpdateStatus result = noiseHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.OK, result);
-            assertEquals("Noise EQ", QuantityType.valueOf(51.0, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseEQCache());
-            assertEquals("Noise Min", QuantityType.valueOf(47.2, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseMinCache());
-            assertEquals("Noise Max", QuantityType.valueOf(57.0, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseMaxCache());
+            assertEquals(UpdateStatus.OK, result, "Valid update");
+            assertEquals(QuantityType.valueOf(51.0, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseEQCache(),
+                    "Noise EQ");
+            assertEquals(QuantityType.valueOf(47.2, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseMinCache(),
+                    "Noise Min");
+            assertEquals(QuantityType.valueOf(57.0, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseMaxCache(),
+                    "Noise Max");
         } else {
             assertTrue(false);
         }
@@ -71,13 +71,13 @@ public class NoiseHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/condition-result-no-pressure.json");
         if (pmJson != null) {
             UpdateStatus result = noiseHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.VALUE_ERROR, result);
-            assertEquals("Values undefined", QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseEQCache());
-            assertEquals("Values undefined", QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseMinCache());
-            assertEquals("Values undefined", QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL),
-                    noiseHandler.getNoiseMaxCache());
+            assertEquals(UpdateStatus.VALUE_ERROR, result, "Valid update");
+            assertEquals(QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseEQCache(),
+                    "Values undefined");
+            assertEquals(QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseMinCache(),
+                    "Values undefined");
+            assertEquals(QuantityType.valueOf(-1, SmartHomeUnits.DECIBEL), noiseHandler.getNoiseMaxCache(),
+                    "Values undefined");
         } else {
             assertTrue(false);
         }
@@ -94,7 +94,7 @@ public class NoiseHandlerTest {
 
         NoiseHandlerExtension noiseHandler = new NoiseHandlerExtension(t);
         UpdateStatus result = noiseHandler.updateChannels("[]");
-        assertEquals("Valid update", UpdateStatus.VALUE_EMPTY, result);
+        assertEquals(UpdateStatus.VALUE_EMPTY, result, "Valid update");
     }
 
     @Test
@@ -108,6 +108,6 @@ public class NoiseHandlerTest {
 
         NoiseHandlerExtension noiseHandler = new NoiseHandlerExtension(t);
         UpdateStatus result = noiseHandler.updateChannels(null);
-        assertEquals("Valid update", UpdateStatus.CONNECTION_ERROR, result);
+        assertEquals(UpdateStatus.CONNECTION_ERROR, result, "Valid update");
     }
 }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/NumberTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/NumberTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.utils.NumberUtils;
 
 /**
@@ -30,32 +30,32 @@ public class NumberTest {
     public void testRoundingUp() {
         double d1 = 1.95;
         double d1r2 = NumberUtils.round(d1, 2);
-        assertEquals("Double 1.95, 2 places ", "1.95", Double.toString(d1r2));
+        assertEquals("1.95", Double.toString(d1r2), "Double 1.95, 2 places");
         // System.out.println("D1R2 " + d1r2);
         double d1r1 = NumberUtils.round(d1, 1);
         // System.out.println("D1R1 " + d1r1);
-        assertEquals("Double 1.95, 1 place ", "2.0", Double.toString(d1r1));
+        assertEquals("2.0", Double.toString(d1r1), "Double 1.95, 1 place");
     }
 
     @Test
     public void testRoundingDown() {
         double d1 = 1.94;
         double d1r2 = NumberUtils.round(d1, 2);
-        assertEquals("Double 1.94, 2 places ", "1.94", Double.toString(d1r2));
+        assertEquals("1.94", Double.toString(d1r2), "Double 1.94, 2 places");
         // System.out.println("D1R2 " + d1r2);
         double d1r1 = NumberUtils.round(d1, 1);
         // System.out.println("D1R1 " + d1r1);
-        assertEquals("Double 1.94, 1 place ", "1.9", Double.toString(d1r1));
+        assertEquals("1.9", Double.toString(d1r1), "Double 1.94, 1 place");
     }
 
     @Test
     public void testStringNumbers() {
         String d1 = "1.94";
         double d1r2 = NumberUtils.round(d1, 2);
-        assertEquals("Double 1.94, 2 places ", "1.94", Double.toString(d1r2));
+        assertEquals("1.94", Double.toString(d1r2), "Double 1.94, 2 places");
         // System.out.println("D1R2 " + d1r2);
         double d1r1 = NumberUtils.round(d1, 1);
         // System.out.println("D1R1 " + d1r1);
-        assertEquals("Double 1.94, 1 place ", "1.9", Double.toString(d1r1));
+        assertEquals("1.9", Double.toString(d1r1), "Double 1.94, 1 place");
     }
 }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/PMHandlerTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/PMHandlerTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.luftdateninfo.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.handler.BaseSensorHandler.ConfigStatus;
 import org.openhab.binding.luftdateninfo.internal.handler.BaseSensorHandler.LifecycleStatus;
 import org.openhab.binding.luftdateninfo.internal.handler.BaseSensorHandler.UpdateStatus;
@@ -64,7 +64,7 @@ public class PMHandlerTest {
          * Test if config status is 0 = CONFIG_OK for valid configuration. Take real int for comparison instead of
          * BaseHandler constants - in case of change test needs to be adapted
          */
-        assertEquals("Handler Configuration status", ConfigStatus.OK, pmHandler.getConfigStatus());
+        assertEquals(ConfigStatus.OK, pmHandler.getConfigStatus(), "Handler Configuration status");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class PMHandlerTest {
          * Test if config status is 3 = CONFIG_SENSOR_NUMBER for invalid configuration with non-number sensorid. Take
          * real int for comparison instead of BaseHandler constants - in case of change test needs to be adapted
          */
-        assertEquals("Handler Configuration status", ConfigStatus.SENSOR_ID_NEGATIVE, pmHandler.getConfigStatus());
+        assertEquals(ConfigStatus.SENSOR_ID_NEGATIVE, pmHandler.getConfigStatus(), "Handler Configuration status");
     }
 
     @Test
@@ -110,11 +110,11 @@ public class PMHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/pm-result.json");
         if (pmJson != null) {
             UpdateStatus result = pmHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.OK, result);
-            assertEquals("PM25", QuantityType.valueOf(2.9, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE),
-                    pmHandler.getPM25Cache());
-            assertEquals("PM100", QuantityType.valueOf(5.2, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE),
-                    pmHandler.getPM100Cache());
+            assertEquals(UpdateStatus.OK, result, "Valid update");
+            assertEquals(QuantityType.valueOf(2.9, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE), pmHandler.getPM25Cache(),
+                    "PM25");
+            assertEquals(QuantityType.valueOf(5.2, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE), pmHandler.getPM100Cache(),
+                    "PM100");
         } else {
             assertTrue(false);
         }
@@ -133,11 +133,11 @@ public class PMHandlerTest {
         String pmJson = FileReader.readFileInString("src/test/resources/noise-result.json");
         if (pmJson != null) {
             UpdateStatus result = pmHandler.updateChannels(pmJson);
-            assertEquals("Valid update", UpdateStatus.VALUE_ERROR, result);
-            assertEquals("Values undefined", QuantityType.valueOf(-1, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE),
-                    pmHandler.getPM25Cache());
-            assertEquals("Values undefined", QuantityType.valueOf(-1, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE),
-                    pmHandler.getPM100Cache());
+            assertEquals(UpdateStatus.VALUE_ERROR, result, "Valid update");
+            assertEquals(QuantityType.valueOf(-1, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE), pmHandler.getPM25Cache(),
+                    "Values undefined");
+            assertEquals(QuantityType.valueOf(-1, SmartHomeUnits.MICROGRAM_PER_CUBICMETRE), pmHandler.getPM100Cache(),
+                    "Values undefined");
         } else {
             assertTrue(false);
         }
@@ -154,7 +154,7 @@ public class PMHandlerTest {
 
         PMHandlerExtension pmHandler = new PMHandlerExtension(t);
         UpdateStatus result = pmHandler.updateChannels("[]");
-        assertEquals("Valid update", UpdateStatus.VALUE_EMPTY, result);
+        assertEquals(UpdateStatus.VALUE_EMPTY, result, "Valid update");
     }
 
     @Test
@@ -168,6 +168,6 @@ public class PMHandlerTest {
 
         PMHandlerExtension pmHandler = new PMHandlerExtension(t);
         UpdateStatus result = pmHandler.updateChannels(null);
-        assertEquals("Valid update", UpdateStatus.CONNECTION_ERROR, result);
+        assertEquals(UpdateStatus.CONNECTION_ERROR, result, "Valid update");
     }
 }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/util/DateTimeTest.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/util/DateTimeTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.luftdateninfo.internal.util;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.luftdateninfo.internal.utils.DateTimeUtils;
 
 /**
@@ -34,12 +34,12 @@ public class DateTimeTest {
         String jsonDateString = "2020-08-14 14:53:21";
         try {
             LocalDateTime dt = LocalDateTime.from(DateTimeUtils.DTF.parse(jsonDateString));
-            assertEquals("Day ", 14, dt.getDayOfMonth());
-            assertEquals("Month ", 8, dt.getMonthValue());
-            assertEquals("Year ", 2020, dt.getYear());
+            assertEquals(14, dt.getDayOfMonth(), "Day");
+            assertEquals(8, dt.getMonthValue(), "Month");
+            assertEquals(2020, dt.getYear(), "Year");
 
             String s = dt.format(DateTimeUtils.DTF);
-            assertEquals("String ", jsonDateString, s);
+            assertEquals(jsonDateString, s, "String");
         } catch (DateTimeParseException e) {
             assertFalse(true);
         }

--- a/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/util/FileReader.java
+++ b/bundles/org.openhab.binding.luftdateninfo/src/test/java/org/openhab/binding/luftdateninfo/internal/util/FileReader.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.luftdateninfo.internal.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;

--- a/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
+++ b/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.mail;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -26,7 +27,7 @@ import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
 import org.apache.commons.mail.MultiPartEmail;
 import org.apache.commons.mail.SimpleEmail;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.mail.internal.MailBuilder;
 
 /**
@@ -40,19 +41,20 @@ public class MailBuilderTest {
     private static final String TEST_STRING = "test";
     private static final String TEST_EMAIL = "foo@bar.zinga";
 
-    @Test(expected = AddressException.class)
-    public void illegalToAddressThrowsException() throws AddressException {
-        MailBuilder builder = new MailBuilder("foo bar.zinga");
+    @Test
+    public void illegalToAddressThrowsException() {
+        assertThrows(AddressException.class, () -> new MailBuilder("foo bar.zinga"));
     }
 
-    @Test(expected = EmailException.class)
-    public void illegalFromAddressThrowsException() throws AddressException, EmailException {
-        Email mail = new MailBuilder("TEST_EMAIL").withSender("foo bar.zinga").build();
+    @Test
+    public void illegalFromAddressThrowsException() {
+        assertThrows(EmailException.class, () -> new MailBuilder("TEST_EMAIL").withSender("foo bar.zinga").build());
     }
 
-    @Test(expected = MalformedURLException.class)
-    public void illegalURLThrowsException() throws AddressException, MalformedURLException {
-        MailBuilder builder = new MailBuilder("TEST_EMAIL").withURLAttachment("foo bar.zinga");
+    @Test
+    public void illegalURLThrowsException() {
+        assertThrows(MalformedURLException.class,
+                () -> new MailBuilder("TEST_EMAIL").withURLAttachment("foo bar.zinga"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/FCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/FCommandTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for {@link FCommand}.

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/MCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/MCommandTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.DeviceConfiguration;
 import org.openhab.binding.max.internal.device.RoomInformation;

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/SCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/SCommandTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.Utils;
 import org.openhab.binding.max.internal.device.ThermostatModeType;
 

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/SConfigCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/SConfigCommandTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.command.SConfigCommand.ConfigCommandType;
 
 /**

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/TCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/TCommandTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Base64;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.Utils;
 
 /**

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/ZCommandTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/command/ZCommandTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.command;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for {@link ZCommand}.

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/CMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/CMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.DeviceType;
 
 /**

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/ConfigurationTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/ConfigurationTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.DeviceConfiguration;
 import org.openhab.binding.max.internal.device.DeviceType;
 
@@ -35,7 +35,7 @@ public class ConfigurationTest {
     private final CMessage message = new CMessage(RAW_DATA);
     private @Nullable DeviceConfiguration configuration;
 
-    @Before
+    @BeforeEach
     public void before() {
         configuration = DeviceConfiguration.create(message);
     }

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/FMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/FMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for {@link FMessage}.

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/HMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/HMessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.Utils;
 
 /**

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/LMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/LMessageTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.Device;
 import org.openhab.binding.max.internal.device.DeviceConfiguration;
 import org.openhab.binding.max.internal.device.DeviceInformation;
@@ -46,7 +46,7 @@ public class LMessageTest {
     private final LMessage message = new LMessage(RAWDATA);
     private final List<DeviceConfiguration> configurations = new ArrayList<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         createTestDevices();
     }
@@ -90,10 +90,10 @@ public class LMessageTest {
     @Test
     public void allDevicesCreatedFromMessage() {
         Collection<? extends Device> devices = message.getDevices(configurations);
-        assertEquals("Incorrect number of devices created", testDevices.size(), devices.size());
+        assertEquals(testDevices.size(), devices.size(), "Incorrect number of devices created");
         for (Device device : devices) {
-            assertTrue("Unexpected device created: " + device.getRFAddress(),
-                    testDevices.containsKey(device.getRFAddress()));
+            assertTrue(testDevices.containsKey(device.getRFAddress()),
+                    "Unexpected device created: " + device.getRFAddress());
         }
     }
 
@@ -101,7 +101,7 @@ public class LMessageTest {
     public void isCorrectErrorState() {
         for (Device device : message.getDevices(configurations)) {
             Device testDevice = testDevices.get(device.getRFAddress());
-            assertEquals("Error set incorrectly in Device", testDevice.isError(), device.isError());
+            assertEquals(testDevice.isError(), device.isError(), "Error set incorrectly in Device");
         }
     }
 }

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/MMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/MMessageTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.DeviceInformation;
 import org.openhab.binding.max.internal.device.DeviceType;
 import org.openhab.binding.max.internal.device.RoomInformation;

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/MessageProcessorTest.java
@@ -12,9 +12,10 @@
  */
 package org.openhab.binding.max.internal.message;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.exceptions.IncompleteMessageException;
 import org.openhab.binding.max.internal.exceptions.IncorrectMultilineIndexException;
 import org.openhab.binding.max.internal.exceptions.MessageIsWaitingException;
@@ -31,12 +32,12 @@ public class MessageProcessorTest {
     private final MessageProcessor processor = new MessageProcessor();
 
     private void commonMessageTest(String line, Message expectedMessage) throws Exception {
-        Assert.assertTrue(this.processor.addReceivedLine(line));
-        Assert.assertTrue(this.processor.isMessageAvailable());
+        assertTrue(this.processor.addReceivedLine(line));
+        assertTrue(this.processor.isMessageAvailable());
         Message message = this.processor.pull();
-        Assert.assertNotNull(message);
-        Assert.assertEquals(message.getClass().getName(), expectedMessage.getClass().getName());
-        Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
+        assertNotNull(message);
+        assertEquals(message.getClass().getName(), expectedMessage.getClass().getName());
+        assertEquals(expectedMessage.getPayload(), message.getPayload());
     }
 
     @Test
@@ -101,12 +102,12 @@ public class MessageProcessorTest {
         String expectedString = line1 + line2_part2;
         MMessage expectedMessage = new MMessage(expectedString);
 
-        Assert.assertFalse(this.processor.addReceivedLine(line1));
-        Assert.assertTrue(this.processor.addReceivedLine(line2));
+        assertFalse(this.processor.addReceivedLine(line1));
+        assertTrue(this.processor.addReceivedLine(line2));
         Message message = this.processor.pull();
-        Assert.assertNotNull(message);
-        Assert.assertEquals(message.getClass().getName(), MMessage.class.getName());
-        Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
+        assertNotNull(message);
+        assertEquals(message.getClass().getName(), MMessage.class.getName());
+        assertEquals(expectedMessage.getPayload(), message.getPayload());
     }
 
     @Test
@@ -116,16 +117,16 @@ public class MessageProcessorTest {
 
         try {
             this.processor.addReceivedLine(line2);
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (IncorrectMultilineIndexException e) {
             // OK, correct Exception was thrown
         }
 
         try {
             this.processor.reset();
-            Assert.assertFalse(this.processor.addReceivedLine(line1));
+            assertFalse(this.processor.addReceivedLine(line1));
             this.processor.addReceivedLine(line2);
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (IncorrectMultilineIndexException e) {
             // OK, correct Exception was thrown
         }
@@ -137,20 +138,20 @@ public class MessageProcessorTest {
         String line2 = "M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
 
         try {
-            Assert.assertTrue(this.processor.addReceivedLine(line1));
+            assertTrue(this.processor.addReceivedLine(line1));
             this.processor.addReceivedLine(line2);
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (MessageIsWaitingException e) {
             // OK, correct Exception was thrown
         }
 
         Message message = this.processor.pull();
-        Assert.assertNotNull(message);
-        Assert.assertEquals(message.getClass().getName(), HMessage.class.getName());
+        assertNotNull(message);
+        assertEquals(message.getClass().getName(), HMessage.class.getName());
         this.processor.addReceivedLine(line2);
         message = this.processor.pull();
-        Assert.assertNotNull(message);
-        Assert.assertEquals(message.getClass().getName(), MMessage.class.getName());
+        assertNotNull(message);
+        assertEquals(message.getClass().getName(), MMessage.class.getName());
     }
 
     @Test
@@ -159,9 +160,9 @@ public class MessageProcessorTest {
         String line2 = "H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
 
         try {
-            Assert.assertFalse(this.processor.addReceivedLine(line1));
+            assertFalse(this.processor.addReceivedLine(line1));
             this.processor.addReceivedLine(line2);
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (IncompleteMessageException e) {
             // OK, correct Exception was thrown
         }
@@ -172,8 +173,8 @@ public class MessageProcessorTest {
         String rawData = "X:0ff1bc,EQ/xvAQJEAJMRVEwNzk0MDA3";
 
         try {
-            Assert.assertFalse(this.processor.addReceivedLine(rawData));
-            Assert.fail("Expected exception was not thrown.");
+            assertFalse(this.processor.addReceivedLine(rawData));
+            fail("Expected exception was not thrown.");
         } catch (UnsupportedMessageTypeException e) {
             // OK, correct Exception was thrown
         }
@@ -187,7 +188,7 @@ public class MessageProcessorTest {
 
         try {
             this.processor.pull();
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (NoMessageAvailableException e) {
             // OK, correct Exception was thrown
         }
@@ -199,7 +200,7 @@ public class MessageProcessorTest {
 
         try {
             this.processor.addReceivedLine(line1);
-            Assert.fail("Expected exception was not thrown.");
+            fail("Expected exception was not thrown.");
         } catch (UnprocessableMessageException e) {
             // OK, correct Exception was thrown
         }

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/NMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/NMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.device.DeviceType;
 
 /**

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/SMessageTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/SMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for {@link FMessage}.

--- a/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/UtilsTest.java
+++ b/bundles/org.openhab.binding.max/src/test/java/org/openhab/binding/max/internal/message/UtilsTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.max.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Date;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.max.internal.Utils;
 
 /**

--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ActionConditionTest.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ActionConditionTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.miio.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.miio.internal.basic.ActionConditions;
 import org.openhab.binding.miio.internal.basic.MiIoDeviceActionCondition;
 

--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.openhab.binding.miio.internal.basic.MiIoBasicChannel;
 import org.openhab.binding.miio.internal.basic.MiIoBasicDevice;
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ public class ReadmeHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReadmeHelper.class);
     private static final String BASEFILE = "./README.base.md";
 
-    @Ignore
+    @Disabled
     public static void main(String[] args) {
         ReadmeHelper rm = new ReadmeHelper();
         LOGGER.info("## Creating device list");

--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/RoboMapViewer.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/RoboMapViewer.java
@@ -45,7 +45,7 @@ import javax.swing.filechooser.FileSystemView;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.openhab.binding.miio.internal.robot.RRMapDraw;
 import org.openhab.binding.miio.internal.robot.RRMapFileParser;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ public class RoboMapViewer extends JFrame {
     protected MapPoint fromLocation = new MapPoint();
     private static final long serialVersionUID = 2623447051590306992L;
 
-    @Ignore
+    @Disabled
     public static void main(String args[]) {
         System.setProperty("swing.defaultlaf", "javax.swing.plaf.metal.MetalLookAndFeel");
         RoboMapViewer vc = new RoboMapViewer(args);

--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/UtilsTest.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/UtilsTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.miio.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Utils}

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/DataBlockTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/DataBlockTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.modbus.e3dc.dto;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.modbus.e3dc.internal.dto.EmergencyBlock;
 import org.openhab.binding.modbus.e3dc.internal.dto.PowerBlock;
 import org.openhab.binding.modbus.e3dc.internal.dto.StringBlock;
@@ -36,7 +36,7 @@ import org.openhab.core.library.types.OnOffType;
 public class DataBlockTest {
     private Parser mc;
 
-    @Before
+    @BeforeEach
     public void setup() {
         byte[] dataBlock = new byte[] { 0, -14, 0, 0, -2, -47, -1, -1, 2, 47, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 99, 99, 0, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
@@ -50,10 +50,10 @@ public class DataBlockTest {
         Optional<Data> dataOpt = mc.parse(DataType.POWER);
         assertTrue(dataOpt.isPresent());
         PowerBlock b = (PowerBlock) dataOpt.get();
-        assertEquals("PV Supply", "242.0 W", b.pvPowerSupply.toString());
-        assertEquals("Grid Supply", "14.0 W", b.gridPowerSupply.toString());
-        assertEquals("Grid Consumption", "0.0 W", b.gridPowerConsumpition.toString());
-        assertEquals("Battery Supply", "303.0 W", b.batteryPowerSupply.toString());
+        assertEquals("242.0 W", b.pvPowerSupply.toString(), "PV Supply");
+        assertEquals("14.0 W", b.gridPowerSupply.toString(), "Grid Supply");
+        assertEquals("0.0 W", b.gridPowerConsumpition.toString(), "Grid Consumption");
+        assertEquals("303.0 W", b.batteryPowerSupply.toString(), "Battery Supply");
     }
 
     @Test
@@ -65,10 +65,10 @@ public class DataBlockTest {
         Optional<WallboxBlock> o = a.getWallboxBlock(0);
         WallboxBlock b = o.get();
         assertNotNull(b);
-        assertEquals("Wallbox available", OnOffType.ON, b.wbAvailable);
-        assertEquals("Wallbox Sunmode", OnOffType.ON, b.wbSunmode);
-        assertEquals("Wallbox 1phase", OnOffType.OFF, b.wb1phase);
-        assertEquals("Wallbox charging", OnOffType.OFF, b.wbCharging);
+        assertEquals(OnOffType.ON, b.wbAvailable, "Wallbox available");
+        assertEquals(OnOffType.ON, b.wbSunmode, "Wallbox Sunmode");
+        assertEquals(OnOffType.OFF, b.wb1phase, "Wallbox 1phase");
+        assertEquals(OnOffType.OFF, b.wbCharging, "Wallbox charging");
     }
 
     @Test
@@ -76,14 +76,14 @@ public class DataBlockTest {
         Optional<Data> dataOpt = mc.parse(DataType.EMERGENCY);
         assertTrue(dataOpt.isPresent());
         EmergencyBlock b = (EmergencyBlock) dataOpt.get();
-        assertEquals("EMS Status", EmergencyBlock.EP_NOT_SUPPORTED, b.epStatus.toFullString());
-        assertEquals("Battery charging locked", OnOffType.OFF, b.batteryChargingLocked);
-        assertEquals("Battery discharging locked", OnOffType.OFF, b.batteryDischargingLocked);
-        assertEquals("EP possible", OnOffType.OFF, b.epPossible);
-        assertEquals("Weather Predicted charging", OnOffType.OFF, b.weatherPredictedCharging);
-        assertEquals("Regulation Status", OnOffType.OFF, b.regulationStatus);
-        assertEquals("Charge Lock Time", OnOffType.OFF, b.chargeLockTime);
-        assertEquals("Discharge Lock Time", OnOffType.OFF, b.dischargeLockTime);
+        assertEquals(EmergencyBlock.EP_NOT_SUPPORTED, b.epStatus.toFullString(), "EMS Status");
+        assertEquals(OnOffType.OFF, b.batteryChargingLocked, "Battery charging locked");
+        assertEquals(OnOffType.OFF, b.batteryDischargingLocked, "Battery discharging locked");
+        assertEquals(OnOffType.OFF, b.epPossible, "EP possible");
+        assertEquals(OnOffType.OFF, b.weatherPredictedCharging, "Weather Predicted charging");
+        assertEquals(OnOffType.OFF, b.regulationStatus, "Regulation Status");
+        assertEquals(OnOffType.OFF, b.chargeLockTime, "Charge Lock Time");
+        assertEquals(OnOffType.OFF, b.dischargeLockTime, "Discharge Lock Time");
     }
 
     @Test
@@ -91,26 +91,26 @@ public class DataBlockTest {
         Optional<Data> dataOpt = mc.parse(DataType.STRINGS);
         assertTrue(dataOpt.isPresent());
         StringBlock b = (StringBlock) dataOpt.get();
-        assertEquals("String 1 V", 381, b.string1Volt.intValue());
-        assertEquals("String 1 V", "V", b.string1Volt.getUnit().toString());
-        assertEquals("String 2 V", 533, b.string2Volt.intValue());
-        assertEquals("String 1 V", "V", b.string2Volt.getUnit().toString());
-        assertEquals("String 3 V", 0, b.string3Volt.intValue());
-        assertEquals("String 1 V", "V", b.string3Volt.getUnit().toString());
+        assertEquals(381, b.string1Volt.intValue(), "String 1 V");
+        assertEquals("V", b.string1Volt.getUnit().toString(), "String 1 V");
+        assertEquals(533, b.string2Volt.intValue(), "String 2 V");
+        assertEquals("V", b.string2Volt.getUnit().toString(), "String 1 V");
+        assertEquals(0, b.string3Volt.intValue(), "String 3 V");
+        assertEquals("V", b.string3Volt.getUnit().toString(), "String 1 V");
 
-        assertEquals("String 1 A", 0.27, b.string1Ampere.doubleValue(), 0.01);
-        assertEquals("String 1 A", "A", b.string1Ampere.getUnit().toString());
-        assertEquals("String 2 A", 0.26, b.string2Ampere.doubleValue(), 0.01);
-        assertEquals("String 2 A", "A", b.string2Ampere.getUnit().toString());
-        assertEquals("String 3 A", 0, b.string3Ampere.doubleValue(), 0.01);
-        assertEquals("String 3 A", "A", b.string3Ampere.getUnit().toString());
+        assertEquals(0.27, b.string1Ampere.doubleValue(), 0.01, "String 1 A");
+        assertEquals("A", b.string1Ampere.getUnit().toString(), "String 1 A");
+        assertEquals(0.26, b.string2Ampere.doubleValue(), 0.01, "String 2 A");
+        assertEquals("A", b.string2Ampere.getUnit().toString(), "String 2 A");
+        assertEquals(0, b.string3Ampere.doubleValue(), 0.01, "String 3 A");
+        assertEquals("A", b.string3Ampere.getUnit().toString(), "String 3 A");
 
-        assertEquals("String 1 W", 103, b.string1Watt.intValue());
-        assertEquals("String 1 W", "W", b.string1Watt.getUnit().toString());
-        assertEquals("String 2 W", 139, b.string2Watt.intValue());
-        assertEquals("String 2 W", "W", b.string2Watt.getUnit().toString());
-        assertEquals("String 3 W", 0, b.string3Watt.intValue());
-        assertEquals("String 3 W", "W", b.string3Watt.getUnit().toString());
+        assertEquals(103, b.string1Watt.intValue(), "String 1 W");
+        assertEquals("W", b.string1Watt.getUnit().toString(), "String 1 W");
+        assertEquals(139, b.string2Watt.intValue(), "String 2 W");
+        assertEquals("W", b.string2Watt.getUnit().toString(), "String 2 W");
+        assertEquals(0, b.string3Watt.intValue(), "String 3 W");
+        assertEquals("W", b.string3Watt.getUnit().toString(), "String 3 W");
     }
 
     @Test

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/InfoTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/InfoTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.modbus.e3dc.dto;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.modbus.e3dc.internal.dto.InfoBlock;
 import org.openhab.binding.modbus.e3dc.internal.modbus.Data;
 import org.openhab.binding.modbus.e3dc.internal.modbus.Data.DataType;
@@ -31,7 +31,7 @@ import org.openhab.binding.modbus.e3dc.internal.modbus.Parser;
 public class InfoTest {
     private Parser mc;
 
-    @Before
+    @BeforeEach
     public void setup() {
         byte[] infoBlock = new byte[] { -29, -36, 1, 2, 0, -120, 69, 51, 47, 68, 67, 32, 71, 109, 98, 72, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 49, 48, 32, 69, 32, 65, 73, 79, 0, 0, 0, 0, 0, 0,

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/InfoTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/dto/InfoTest.java
@@ -48,10 +48,10 @@ public class InfoTest {
         assertTrue(infoOpt.isPresent());
         InfoBlock b = (InfoBlock) infoOpt.get();
         assertNotNull(b);
-        assertEquals("MagicByte", "E3DC", b.modbusId.toString());
-        assertEquals("Model", "S10 E AIO", b.modelName.toString());
-        assertEquals("Firmware", "S10_2020_04", b.firmware.toString());
-        assertEquals("Manufacturer", "E3/DC GmbH", b.manufacturer.toString());
+        assertEquals("E3DC", b.modbusId.toString(), "MagicByte");
+        assertEquals("S10 E AIO", b.modelName.toString(), "Model");
+        assertEquals("S10_2020_04", b.firmware.toString(), "Firmware");
+        assertEquals("E3/DC GmbH", b.manufacturer.toString(), "Manufacturer");
     }
 
     @Test

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/internal/handler/E3DCHandlerStateTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/internal/handler/E3DCHandlerStateTest.java
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/modbus/ParserNameTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/modbus/ParserNameTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.modbus.e3dc.modbus;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -30,11 +30,11 @@ public class ParserNameTest {
     @Test
     public void testDebugNames() {
         Parser mcInfo = new Parser(DataType.INFO);
-        assertEquals("Debug Name Info", "org.openhab.binding.modbus.e3dc.internal.modbus.Parser:INFO",
-                mcInfo.toString());
+        assertEquals("org.openhab.binding.modbus.e3dc.internal.modbus.Parser:INFO", mcInfo.toString(),
+                "Debug Name Info");
 
         Parser mcPower = new Parser(DataType.DATA);
-        assertEquals("Debug Name Power", "org.openhab.binding.modbus.e3dc.internal.modbus.Parser:DATA",
-                mcPower.toString());
+        assertEquals("org.openhab.binding.modbus.e3dc.internal.modbus.Parser:DATA", mcPower.toString(),
+                "Debug Name Power");
     }
 }

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/modbus/ParserNameTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/modbus/ParserNameTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.modbus.e3dc.modbus;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.modbus.e3dc.internal.modbus.Data.DataType;
 import org.openhab.binding.modbus.e3dc.internal.modbus.Parser;
 

--- a/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/util/DataConverterTest.java
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/test/java/org/openhab/binding/modbus/e3dc/util/DataConverterTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.modbus.e3dc.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.modbus.e3dc.internal.dto.DataConverter;
 
 /**
@@ -34,28 +34,28 @@ public class DataConverterTest {
         // Reg 69 value 65098 bytes [-2, 74]
         // Reg 70 value 65535 bytes [-1, -1]
         byte[] b = new byte[] { -2, -74, -1, -1 };
-        assertEquals("Negative Value", -330, DataConverter.getInt32Swap(ByteBuffer.wrap(b)));
+        assertEquals(-330, DataConverter.getInt32Swap(ByteBuffer.wrap(b)), "Negative Value");
     }
 
     @Test
     public void testBitset() {
         byte[] b = new byte[] { 3, 16 };
         BitSet s = BitSet.valueOf(b);
-        assertEquals("Bit0", true, s.get(0));
-        assertEquals("Bit1", true, s.get(1));
-        assertEquals("Bit2", false, s.get(2));
-        assertEquals("Bit3", false, s.get(3));
-        assertEquals("Bit4", false, s.get(4));
-        assertEquals("Bit5", false, s.get(5));
-        assertEquals("Bit6", false, s.get(6));
-        assertEquals("Bit7", false, s.get(7));
-        assertEquals("Bit8", false, s.get(8));
-        assertEquals("Bit9", false, s.get(9));
-        assertEquals("Bit10", false, s.get(10));
-        assertEquals("Bit11", false, s.get(11));
-        assertEquals("Bit12", true, s.get(12));
-        assertEquals("Bit13", false, s.get(13));
-        assertEquals("Bit14", false, s.get(14));
-        assertEquals("Bit15", false, s.get(15));
+        assertEquals(true, s.get(0), "Bit0");
+        assertEquals(true, s.get(1), "Bit1");
+        assertEquals(false, s.get(2), "Bit2");
+        assertEquals(false, s.get(3), "Bit3");
+        assertEquals(false, s.get(4), "Bit4");
+        assertEquals(false, s.get(5), "Bit5");
+        assertEquals(false, s.get(6), "Bit6");
+        assertEquals(false, s.get(7), "Bit7");
+        assertEquals(false, s.get(8), "Bit8");
+        assertEquals(false, s.get(9), "Bit9");
+        assertEquals(false, s.get(10), "Bit10");
+        assertEquals(false, s.get(11), "Bit11");
+        assertEquals(true, s.get(12), "Bit12");
+        assertEquals(false, s.get(13), "Bit13");
+        assertEquals(false, s.get(14), "Bit14");
+        assertEquals(false, s.get(15), "Bit15");
     }
 }

--- a/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/AtomicStampedKeyValueTest.java
+++ b/bundles/org.openhab.binding.modbus/src/test/java/org/openhab/binding/modbus/internal/AtomicStampedKeyValueTest.java
@@ -13,21 +13,19 @@
 package org.openhab.binding.modbus.internal;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Sami Salonen - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
 public class AtomicStampedKeyValueTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testInitWithNullValue() {
-        new AtomicStampedValue<>(0, null);
+        assertThrows(NullPointerException.class, () -> new AtomicStampedValue<>(0, null));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTests.java
@@ -13,11 +13,11 @@
 package org.openhab.binding.mqtt.generic;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -31,11 +31,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 import org.openhab.binding.mqtt.generic.values.ColorValue;
 import org.openhab.binding.mqtt.generic.values.DateTimeValue;
@@ -55,26 +59,21 @@ import org.openhab.core.thing.ChannelUID;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class ChannelStateTests {
-    @Mock
-    private MqttBrokerConnection connection;
 
-    @Mock
-    private ChannelStateUpdateListener channelStateUpdateListener;
-
-    @Mock
-    private ChannelUID channelUID;
-
-    @Spy
-    private TextValue textValue;
+    private @Mock MqttBrokerConnection connection;
+    private @Mock ChannelStateUpdateListener channelStateUpdateListener;
+    private @Mock ChannelUID channelUID;
+    private @Spy TextValue textValue;
 
     private ScheduledExecutorService scheduler;
 
     private ChannelConfig config = ChannelConfigBuilder.create("state", "command").build();
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
         CompletableFuture<Void> voidFutureComplete = new CompletableFuture<>();
         voidFutureComplete.complete(null);
         doReturn(voidFutureComplete).when(connection).unsubscribeAll();
@@ -87,7 +86,7 @@ public class ChannelStateTests {
         scheduler = new ScheduledThreadPoolExecutor(1);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         scheduler.shutdownNow();
     }
@@ -308,8 +307,8 @@ public class ChannelStateTests {
         subject.processMessage("state", datetime.getBytes());
 
         String channelState = value.getChannelState().toString();
-        assertTrue("Expected '" + channelState + "' to start with '" + datetime + "'",
-                channelState.startsWith(datetime));
+        assertTrue(channelState.startsWith(datetime),
+                "Expected '" + channelState + "' to start with '" + datetime + "'");
         assertThat(value.getMQTTpublishValue(null), is(datetime));
     }
 

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTransformationTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/ChannelStateTransformationTests.java
@@ -13,19 +13,22 @@
 package org.openhab.binding.mqtt.generic;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.mqtt.generic.internal.handler.ThingChannelConstants.*;
 
 import java.util.concurrent.CompletableFuture;
 
 import javax.naming.ConfigurationException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.internal.handler.GenericMQTTThingHandler;
 import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
 import org.openhab.core.config.core.Configuration;
@@ -44,32 +47,21 @@ import org.openhab.core.transform.TransformationService;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class ChannelStateTransformationTests {
 
-    @Mock
-    private TransformationService jsonPathService;
-
-    @Mock
-    private TransformationServiceProvider transformationServiceProvider;
-
-    @Mock
-    private ThingHandlerCallback callback;
-
-    @Mock
-    private Thing thing;
-
-    @Mock
-    private AbstractBrokerHandler bridgeHandler;
-
-    @Mock
-    private MqttBrokerConnection connection;
+    private @Mock TransformationService jsonPathService;
+    private @Mock TransformationServiceProvider transformationServiceProvider;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Thing thing;
+    private @Mock AbstractBrokerHandler bridgeHandler;
+    private @Mock MqttBrokerConnection connection;
 
     private GenericMQTTThingHandler thingHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() throws ConfigurationException, MqttException {
-        initMocks(this);
-
         ThingStatusInfo thingStatus = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
 
         // Mock the thing: We need the thingUID and the bridgeUID

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -13,17 +13,21 @@
 package org.openhab.binding.mqtt.generic.internal.handler;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.mqtt.generic.internal.handler.ThingChannelConstants.*;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.ChannelConfig;
 import org.openhab.binding.mqtt.generic.ChannelConfigBuilder;
 import org.openhab.binding.mqtt.generic.ChannelState;
@@ -51,26 +55,21 @@ import org.openhab.core.types.RefreshType;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class GenericThingHandlerTests {
-    @Mock
-    private ThingHandlerCallback callback;
 
-    @Mock
-    private Thing thing;
-
-    @Mock
-    private AbstractBrokerHandler bridgeHandler;
-
-    @Mock
-    private MqttBrokerConnection connection;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Thing thing;
+    private @Mock AbstractBrokerHandler bridgeHandler;
+    private @Mock MqttBrokerConnection connection;
 
     private GenericMQTTThingHandler thingHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ThingStatusInfo thingStatus = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
 
-        MockitoAnnotations.initMocks(this);
         // Mock the thing: We need the thingUID and the bridgeUID
         when(thing.getUID()).thenReturn(testGenericThing);
         when(thing.getChannels()).thenReturn(thingChannelList);
@@ -100,11 +99,12 @@ public class GenericThingHandlerTests {
         doReturn(thingStatus).when(thingHandler).getBridgeStatus();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initializeWithUnknownThingUID() {
         ChannelConfig config = textConfiguration().as(ChannelConfig.class);
-        thingHandler.createChannelState(config, new ChannelUID(testGenericThing, "test"),
-                ValueFactory.createValueState(config, unknownChannel.getId()));
+        assertThrows(IllegalArgumentException.class,
+                () -> thingHandler.createChannelState(config, new ChannelUID(testGenericThing, "test"),
+                        ValueFactory.createValueState(config, unknownChannel.getId())));
     }
 
     @Test

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/mapping/MqttTopicClassMapperTests.java
@@ -14,7 +14,8 @@ package org.openhab.binding.mqtt.generic.mapping;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -29,12 +30,15 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass.AttributeChanged;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 
@@ -53,6 +57,8 @@ import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class MqttTopicClassMapperTests {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ FIELD })
@@ -113,9 +119,8 @@ public class MqttTopicClassMapperTests {
     // A completed future is returned for a subscribe call to the attributes
     final CompletableFuture<Boolean> future = CompletableFuture.completedFuture(true);
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         doReturn(CompletableFuture.completedFuture(true)).when(connection).subscribe(any(), any());
         doReturn(CompletableFuture.completedFuture(true)).when(connection).unsubscribe(any(), any());
         injectedFields = (int) Stream.of(countInjectedFields.getClass().getDeclaredFields())
@@ -189,7 +194,7 @@ public class MqttTopicClassMapperTests {
 
             // Check each value if the assignment worked
             if (!f.field.getType().isArray()) {
-                assertNotNull(f.field.getName() + " is null", f.field.get(attributes));
+                assertNotNull(f.field.get(attributes), f.field.getName() + " is null");
                 // Consider if a mapToField was used that would manipulate the received value
                 MQTTvalueTransform mapToField = f.field.getAnnotation(MQTTvalueTransform.class);
                 String prefix = mapToField != null ? mapToField.prefix() : "";

--- a/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/test/java/org/openhab/binding/mqtt/generic/values/ValueTests.java
@@ -13,11 +13,12 @@
 package org.openhab.binding.mqtt.generic.values;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.mqtt.generic.mapping.ColorMode;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -45,10 +46,10 @@ public class ValueTests {
         return TypeParser.parseCommand(v.getSupportedCommandTypes(), str);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalTextStateUpdate() {
         TextValue v = new TextValue("one,two".split(","));
-        v.update(p(v, "three"));
+        assertThrows(IllegalArgumentException.class, () -> v.update(p(v, "three")));
     }
 
     public void textStateUpdate() {
@@ -71,34 +72,34 @@ public class ValueTests {
         assertThat(((HSBType) v.getChannelState()).getBrightness().intValue(), is(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalColorUpdate() {
         ColorValue v = new ColorValue(ColorMode.RGB, null, null, 10);
-        v.update(p(v, "255,255,abc"));
+        assertThrows(IllegalArgumentException.class, () -> v.update(p(v, "255,255,abc")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalNumberCommand() {
         NumberValue v = new NumberValue(null, null, null, null);
-        v.update(OnOffType.OFF);
+        assertThrows(IllegalArgumentException.class, () -> v.update(OnOffType.OFF));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void illegalPercentCommand() {
         PercentageValue v = new PercentageValue(null, null, null, null, null);
-        v.update(new StringType("demo"));
+        assertThrows(IllegalStateException.class, () -> v.update(new StringType("demo")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalOnOffCommand() {
         OnOffValue v = new OnOffValue(null, null);
-        v.update(new DecimalType(101.0));
+        assertThrows(IllegalArgumentException.class, () -> v.update(new DecimalType(101.0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalPercentUpdate() {
         PercentageValue v = new PercentageValue(null, null, null, null, null);
-        v.update(new DecimalType(101.0));
+        assertThrows(IllegalArgumentException.class, () -> v.update(new DecimalType(101.0)));
     }
 
     @Test
@@ -309,10 +310,10 @@ public class ValueTests {
         assertEquals(((PercentType) v.getChannelState()).floatValue(), 100.0f, 0.01f);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void percentCalcInvalid() {
         PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), null,
                 null);
-        v.update(new DecimalType(9.0));
+        assertThrows(IllegalArgumentException.class, () -> v.update(new DecimalType(9.0)));
     }
 }

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HAConfigurationTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HAConfigurationTests.java
@@ -13,8 +13,8 @@
 package org.openhab.binding.mqtt.homeassistant.internal;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.mqtt.homeassistant.internal.BaseChannelConfiguration.Connection;
 
 import com.google.gson.Gson;

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/test/java/org/openhab/binding/mqtt/homeassistant/internal/HaIDTests.java
@@ -13,13 +13,13 @@
 package org.openhab.binding.mqtt.homeassistant.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
 
 /**

--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/generic/internal/mapping/HomieChildMapTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/generic/internal/mapping/HomieChildMapTests.java
@@ -13,18 +13,20 @@
 package org.openhab.binding.mqtt.homie.generic.internal.mapping;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.tools.ChildMap;
 import org.openhab.binding.mqtt.homie.internal.handler.ThingChannelConstants;
 import org.openhab.binding.mqtt.homie.internal.homie300.DeviceCallback;
@@ -36,6 +38,8 @@ import org.openhab.binding.mqtt.homie.internal.homie300.NodeAttributes;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class HomieChildMapTests {
     private @Mock DeviceCallback callback;
 
@@ -57,11 +61,6 @@ public class HomieChildMapTests {
 
     private void removedNode(Node node) {
         callback.nodeRemoved(node);
-    }
-
-    @Before
-    public void setUp() {
-        initMocks(this);
     }
 
     public static class AddedAction implements Function<Node, CompletableFuture<Void>> {

--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.mqtt.homie.internal.handler;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.mqtt.homie.internal.handler.ThingChannelConstants.TEST_HOMIE_THING;
@@ -30,11 +31,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.generic.ChannelState;
 import org.openhab.binding.mqtt.generic.MqttChannelTypeProvider;
 import org.openhab.binding.mqtt.generic.mapping.AbstractMqttAttributeClass;
@@ -75,26 +79,18 @@ import org.openhab.core.types.TypeParser;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class HomieThingHandlerTests {
-    @Mock
-    private ThingHandlerCallback callback;
 
     private Thing thing;
 
-    @Mock
-    private AbstractBrokerHandler bridgeHandler;
-
-    @Mock
-    private MqttBrokerConnection connection;
-
-    @Mock
-    private ScheduledExecutorService scheduler;
-
-    @Mock
-    private ScheduledFuture<?> scheduledFuture;
-
-    @Mock
-    private ThingTypeRegistry thingTypeRegistry;
+    private @Mock AbstractBrokerHandler bridgeHandler;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock MqttBrokerConnection connection;
+    private @Mock ScheduledExecutorService scheduler;
+    private @Mock ScheduledFuture<?> scheduledFuture;
+    private @Mock ThingTypeRegistry thingTypeRegistry;
 
     private HomieThingHandler thingHandler;
 
@@ -104,13 +100,11 @@ public class HomieThingHandlerTests {
     private final String deviceTopic = "homie/" + deviceID;
 
     // A completed future is returned for a subscribe call to the attributes
-    CompletableFuture<@Nullable Void> future = CompletableFuture.completedFuture(null);
+    private CompletableFuture<@Nullable Void> future = CompletableFuture.completedFuture(null);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final ThingStatusInfo thingStatus = new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null);
-
-        MockitoAnnotations.initMocks(this);
 
         final Configuration config = new Configuration();
         config.put("basetopic", "homie");

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandlerTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/handler/AbstractBrokerHandlerTest.java
@@ -13,16 +13,20 @@
 package org.openhab.binding.mqtt.handler;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.internal.MqttThingID;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -38,24 +42,20 @@ import org.osgi.service.cm.ConfigurationException;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class AbstractBrokerHandlerTest {
     private final String HOST = "tcp://123.1.2.3";
     private final int PORT = 80;
     private SystemBrokerHandler handler;
     int stateChangeCounter = 0;
 
-    @Mock
-    private ThingHandlerCallback callback;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Bridge thing;
+    private @Mock MqttService service;
 
-    @Mock
-    private Bridge thing;
-
-    @Mock
-    private MqttService service;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         doReturn(MqttThingID.getThingUID(HOST, PORT)).when(thing).getUID();
         doReturn(new Configuration(Collections.singletonMap("brokerid", MqttThingID.getThingUID(HOST, PORT).getId())))
                 .when(thing).getConfiguration();

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/discovery/ServiceDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/discovery/ServiceDiscoveryServiceTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.mqtt.internal.discovery;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -23,11 +23,14 @@ import java.util.TreeMap;
 
 import javax.naming.ConfigurationException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.mqtt.MqttBindingConstants;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -39,16 +42,15 @@ import org.openhab.core.io.transport.mqtt.MqttService;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class ServiceDiscoveryServiceTest {
-    @Mock
-    private MqttService service;
 
-    @Mock
-    private DiscoveryListener discoverListener;
+    private @Mock MqttService service;
+    private @Mock DiscoveryListener discoverListener;
 
-    @Before
+    @BeforeEach
     public void initMocks() throws ConfigurationException {
-        MockitoAnnotations.initMocks(this);
         Map<String, MqttBrokerConnection> brokers = new TreeMap<>();
         brokers.put("testname", new MqttBrokerConnection("tcp://123.123.123.123", null, false, null));
         brokers.put("textual", new MqttBrokerConnection("tcp://123.123.123.123", null, true, null));

--- a/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/ssl/PinningSSLContextProviderTest.java
+++ b/bundles/org.openhab.binding.mqtt/src/test/java/org/openhab/binding/mqtt/internal/ssl/PinningSSLContextProviderTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.mqtt.internal.ssl;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -26,7 +26,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.util.HexUtils;
 
 /**

--- a/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/LayoutTest.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/LayoutTest.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.nanoleaf.internal;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nanoleaf.internal.model.Layout;
 
 import com.google.gson.Gson;
@@ -36,7 +36,7 @@ public class LayoutTest {
     String layout1Json = "";
     String layoutInconsistentPanelNoJson = "";
 
-    @Before
+    @BeforeEach
     public void setup() {
         layout1Json = "{\"numPanels\":14,\"sideLength\":100,\"positionData\":[{\"panelId\":41451,\"x\":350,\"y\":0,\"o\":0,\"shapeType\":3},{\"panelId\":8134,\"x\":350,\"y\":150,\"o\":0,\"shapeType\":2},{\"panelId\":58086,\"x\":200,\"y\":100,\"o\":270,\"shapeType\":2},{\"panelId\":38724,\"x\":300,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":48111,\"x\":200,\"y\":200,\"o\":270,\"shapeType\":2},{\"panelId\":56093,\"x\":100,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":55836,\"x\":0,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":31413,\"x\":100,\"y\":300,\"o\":90,\"shapeType\":2},{\"panelId\":9162,\"x\":300,\"y\":300,\"o\":90,\"shapeType\":2},{\"panelId\":13276,\"x\":400,\"y\":300,\"o\":90,\"shapeType\":2},{\"panelId\":17870,\"x\":400,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":5164,\"x\":500,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":64279,\"x\":600,\"y\":200,\"o\":0,\"shapeType\":2},{\"panelId\":39755,\"x\":500,\"y\":100,\"o\":90,\"shapeType\":2}]}";
         // panel number is not consistent to returned panels in array but it should still work

--- a/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/TouchTest.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/TouchTest.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.nanoleaf.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nanoleaf.internal.model.TouchEvent;
 import org.openhab.binding.nanoleaf.internal.model.TouchEvents;
 

--- a/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandlerTest.java
+++ b/bundles/org.openhab.binding.nanoleaf/src/test/java/org/openhab/binding/nanoleaf/internal/handler/NanoleafControllerHandlerTest.java
@@ -12,13 +12,12 @@
  */
 package org.openhab.binding.nanoleaf.internal.handler;
 
-import static java.nio.file.Files.*;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nanoleaf.internal.model.ControllerInfo;
 import org.openhab.binding.nanoleaf.internal.model.State;
 import org.openhab.core.library.types.OnOffType;
@@ -38,7 +37,7 @@ public class NanoleafControllerHandlerTest {
 
     private String controllerInfoJSON = "";
 
-    @Before
+    @BeforeEach
     public void setup() {
     }
 

--- a/bundles/org.openhab.binding.neohub/src/test/java/org/openhab/binding/neohub/test/NeoHubTestData.java
+++ b/bundles/org.openhab.binding.neohub/src/test/java/org/openhab/binding/neohub/test/NeoHubTestData.java
@@ -12,12 +12,7 @@
  */
 package org.openhab.binding.neohub.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.neohub.internal.NeoHubBindingConstants.*;
 
 import java.io.BufferedReader;
@@ -27,7 +22,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.neohub.internal.NeoHubAbstractDeviceData;
 import org.openhab.binding.neohub.internal.NeoHubAbstractDeviceData.AbstractRecord;
 import org.openhab.binding.neohub.internal.NeoHubGetEngineersData;

--- a/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.netatmo.internal.discovery;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -21,16 +21,18 @@ import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.netatmo.internal.handler.NetatmoBridgeHandler;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.netatmo.internal.handler.NetatmoBridgeHandler;
 
 import io.swagger.client.model.NAMain;
 import io.swagger.client.model.NAStationDataBody;
@@ -39,13 +41,14 @@ import io.swagger.client.model.NAStationModule;
 /**
  * @author Sven Strohschein - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class NetatmoModuleDiscoveryServiceTest {
 
     private NetatmoModuleDiscoveryServiceAccessible service;
     private NetatmoBridgeHandler bridgeHandlerSpy;
 
-    @Before
+    @BeforeEach
     public void before() {
         Bridge bridgeMock = mock(Bridge.class);
         when(bridgeMock.getUID()).thenReturn(new ThingUID("netatmo", "bridge"));

--- a/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/presence/NAPresenceCameraHandlerTest.java
+++ b/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/presence/NAPresenceCameraHandlerTest.java
@@ -12,13 +12,21 @@
  */
 package org.openhab.binding.netatmo.internal.presence;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.netatmo.internal.NetatmoBindingConstants;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -29,29 +37,22 @@ import org.openhab.core.thing.internal.ThingImpl;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.netatmo.internal.NetatmoBindingConstants;
 
 import io.swagger.client.model.NAWelcomeCamera;
 
 /**
  * @author Sven Strohschein - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class NAPresenceCameraHandlerTest {
 
     private static final String DUMMY_VPN_URL = "https://dummytestvpnaddress.net/restricted/10.255.89.96/9826069dc689e8327ac3ed2ced4ff089/MTU5MTgzMzYwMDrQ7eHHhG0_OJ4TgmPhGlnK7QQ5pZ,,";
     private static final String DUMMY_LOCAL_URL = "http://192.168.178.76/9826069dc689e8327ac3ed2ced4ff089";
     private static final Optional<String> DUMMY_PING_RESPONSE = createPingResponseContent(DUMMY_LOCAL_URL);
 
-    @Mock
-    private RequestExecutor requestExecutorMock;
-    @Mock
-    private TimeZoneProvider timeZoneProviderMock;
+    private @Mock RequestExecutor requestExecutorMock;
+    private @Mock TimeZoneProvider timeZoneProviderMock;
 
     private Thing presenceCameraThing;
     private NAWelcomeCamera presenceCamera;
@@ -60,7 +61,7 @@ public class NAPresenceCameraHandlerTest {
     private ChannelUID floodlightAutoModeChannelUID;
     private NAPresenceCameraHandlerAccessible handler;
 
-    @Before
+    @BeforeEach
     public void before() {
         presenceCameraThing = new ThingImpl(new ThingTypeUID("netatmo", "NOC"), "1");
         presenceCamera = new NAWelcomeCamera();

--- a/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandlerTest.java
+++ b/bundles/org.openhab.binding.netatmo/src/test/java/org/openhab/binding/netatmo/internal/welcome/NAWelcomeHomeHandlerTest.java
@@ -12,28 +12,33 @@
  */
 package org.openhab.binding.netatmo.internal.welcome;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.netatmo.internal.NetatmoBindingConstants;
+import org.openhab.binding.netatmo.internal.handler.NetatmoBridgeHandler;
+import org.openhab.binding.netatmo.internal.webhook.NAWebhookCameraEvent;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.internal.ThingImpl;
 import org.openhab.core.types.UnDefType;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.netatmo.internal.NetatmoBindingConstants;
-import org.openhab.binding.netatmo.internal.handler.NetatmoBridgeHandler;
-import org.openhab.binding.netatmo.internal.webhook.NAWebhookCameraEvent;
 
 import io.swagger.client.model.NAWelcomeEvent;
 import io.swagger.client.model.NAWelcomeHome;
@@ -43,18 +48,18 @@ import io.swagger.client.model.NAWelcomeSubEvent;
 /**
  * @author Sven Strohschein - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class NAWelcomeHomeHandlerTest {
 
     private static final String DUMMY_HOME_ID = "1";
 
-    @Mock
-    private TimeZoneProvider timeZoneProviderMock;
     private NAWelcomeHomeHandlerAccessible handler;
-    @Mock
-    private NetatmoBridgeHandler bridgeHandlerMock;
 
-    @Before
+    private @Mock NetatmoBridgeHandler bridgeHandlerMock;
+    private @Mock TimeZoneProvider timeZoneProviderMock;
+
+    @BeforeEach
     public void before() {
         Thing welcomeHomeThing = new ThingImpl(new ThingTypeUID("netatmo", "NAWelcomeHome"), "1");
         handler = new NAWelcomeHomeHandlerAccessible(welcomeHomeThing);
@@ -283,10 +288,9 @@ public class NAWelcomeHomeHandlerTest {
 
     @Test
     public void testMatchDetectedObjectEnums() {
-        assertArrayEquals(
-                "The detected object enums aren't equal anymore, that could lead to a bug! Please check the usages!",
-                Arrays.stream(NAWelcomeEvent.CategoryEnum.values()).map(Enum::name).toArray(),
-                Arrays.stream(NAWelcomeSubEvent.TypeEnum.values()).map(Enum::name).toArray());
+        assertArrayEquals(Arrays.stream(NAWelcomeEvent.CategoryEnum.values()).map(Enum::name).toArray(),
+                Arrays.stream(NAWelcomeSubEvent.TypeEnum.values()).map(Enum::name).toArray(),
+                "The detected object enums aren't equal anymore, that could lead to a bug! Please check the usages!");
     }
 
     private NAWelcomeHome initHome() {

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.network.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -25,12 +26,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.network.internal.toberemoved.cache.ExpiringCacheAsync;
 import org.openhab.binding.network.internal.toberemoved.cache.ExpiringCacheHelper;
 import org.openhab.binding.network.internal.utils.NetworkUtils;
@@ -43,26 +47,20 @@ import org.openhab.binding.network.internal.utils.PingResult;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class PresenceDetectionTest {
-    static long CACHETIME = 2000L;
-    @Mock
-    NetworkUtils networkUtils;
+    private static final long CACHETIME = 2000L;
 
-    @Mock
-    PresenceDetectionListener listener;
+    private PresenceDetection subject;
 
-    @Mock
-    ExecutorService executorService;
+    private @Mock Consumer<PresenceDetectionValue> callback;
+    private @Mock ExecutorService executorService;
+    private @Mock PresenceDetectionListener listener;
+    private @Mock NetworkUtils networkUtils;
 
-    @Mock
-    Consumer<PresenceDetectionValue> callback;
-
-    PresenceDetection subject;
-
-    @Before
+    @BeforeEach
     public void setUp() throws UnknownHostException {
-        MockitoAnnotations.initMocks(this);
-
         // Mock an interface
         when(networkUtils.getInterfaceNames()).thenReturn(Collections.singleton("TESTinterface"));
         doReturn(ArpPingUtilEnum.IPUTILS_ARPING).when(networkUtils).determineNativeARPpingMethod(anyString());
@@ -86,7 +84,7 @@ public class PresenceDetectionTest {
         assertThat(subject.pingMethod, is(IpPingMethodEnum.WINDOWS_PING));
     }
 
-    @After
+    @AfterEach
     public void shutDown() {
         subject.waitForPresenceDetection();
     }

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionValuesTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/PresenceDetectionValuesTest.java
@@ -13,9 +13,10 @@
 package org.openhab.binding.network.internal;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests cases for {@see PresenceDetectionValue}

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/WakeOnLanPacketSenderTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/WakeOnLanPacketSenderTest.java
@@ -13,12 +13,15 @@
 package org.openhab.binding.network.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.binding.network.internal.WakeOnLanPacketSender.*;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.openhab.core.util.HexUtils;
 
 /**
@@ -26,6 +29,7 @@ import org.openhab.core.util.HexUtils;
  *
  * @author Wouter Born - Initial contribution
  */
+@Timeout(value = 10, unit = TimeUnit.SECONDS)
 public class WakeOnLanPacketSenderTest {
 
     private void assertValidMagicPacket(byte[] macBytes, byte[] packet) {
@@ -75,23 +79,23 @@ public class WakeOnLanPacketSenderTest {
         assertValidMagicPacket(HexUtils.hexToBytes("6f70656e4841"), actualPacket);
     }
 
-    @Test(expected = IllegalStateException.class, timeout = 10000)
+    @Test
     public void sendWithEmptyMacAddressThrowsException() {
-        new WakeOnLanPacketSender("").sendPacket();
+        assertThrows(IllegalStateException.class, () -> new WakeOnLanPacketSender("").sendPacket());
     }
 
-    @Test(expected = IllegalStateException.class, timeout = 10000)
+    @Test
     public void sendWithTooShortMacAddressThrowsException() {
-        new WakeOnLanPacketSender("6f:70:65:6e:48").sendPacket();
+        assertThrows(IllegalStateException.class, () -> new WakeOnLanPacketSender("6f:70:65:6e:48").sendPacket());
     }
 
-    @Test(expected = IllegalStateException.class, timeout = 10000)
+    @Test
     public void sendWithTooLongMacAddressThrowsException() {
-        new WakeOnLanPacketSender("6f:70:65:6e:48:41:42").sendPacket();
+        assertThrows(IllegalStateException.class, () -> new WakeOnLanPacketSender("6f:70:65:6e:48:41:42").sendPacket());
     }
 
-    @Test(expected = IllegalStateException.class, timeout = 10000)
+    @Test
     public void sendWithUnsupportedSeparatorInMacAddressThrowsException() {
-        new WakeOnLanPacketSender("6f=70=65=6e=48=41").sendPacket();
+        assertThrows(IllegalStateException.class, () -> new WakeOnLanPacketSender("6f=70=65=6e=48=41").sendPacket());
     }
 }

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/dhcp/DHCPTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/dhcp/DHCPTest.java
@@ -13,16 +13,16 @@
 package org.openhab.binding.network.internal.dhcp;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.SocketException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.network.internal.dhcp.DHCPPacket.BadPacketException;
 
 /**

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/discovery/DiscoveryTest.java
@@ -13,17 +13,20 @@
 package org.openhab.binding.network.internal.discovery;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Collections;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.network.internal.NetworkBindingConstants;
 import org.openhab.binding.network.internal.PresenceDetectionValue;
 import org.openhab.core.config.discovery.DiscoveryListener;
@@ -34,18 +37,16 @@ import org.openhab.core.config.discovery.DiscoveryResult;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class DiscoveryTest {
     private final String ip = "127.0.0.1";
 
-    @Mock
-    PresenceDetectionValue value;
+    private @Mock PresenceDetectionValue value;
+    private @Mock DiscoveryListener listener;
 
-    @Mock
-    DiscoveryListener listener;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
         when(value.getHostAddress()).thenReturn(ip);
         when(value.getLowestLatency()).thenReturn(10.0);
         when(value.isReachable()).thenReturn(true);
@@ -65,8 +66,8 @@ public class DiscoveryTest {
         d.partialDetectionResult(value);
         verify(listener).thingDiscovered(any(), result.capture());
         DiscoveryResult dresult = result.getValue();
-        Assert.assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createPingUID(ip)));
-        Assert.assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_HOSTNAME), is(ip));
+        assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createPingUID(ip)));
+        assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_HOSTNAME), is(ip));
     }
 
     @Test
@@ -83,8 +84,8 @@ public class DiscoveryTest {
         d.partialDetectionResult(value);
         verify(listener).thingDiscovered(any(), result.capture());
         DiscoveryResult dresult = result.getValue();
-        Assert.assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createServiceUID(ip, 1010)));
-        Assert.assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_HOSTNAME), is(ip));
-        Assert.assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_PORT), is(1010));
+        assertThat(dresult.getThingUID(), is(NetworkDiscoveryService.createServiceUID(ip, 1010)));
+        assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_HOSTNAME), is(ip));
+        assertThat(dresult.getProperties().get(NetworkBindingConstants.PARAMETER_PORT), is(1010));
     }
 }

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/handler/NetworkHandlerTest.java
@@ -13,17 +13,20 @@
 package org.openhab.binding.network.internal.handler;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.network.internal.NetworkBindingConfiguration;
 import org.openhab.binding.network.internal.NetworkBindingConstants;
 import org.openhab.binding.network.internal.PresenceDetection;
@@ -45,17 +48,16 @@ import org.openhab.core.thing.binding.ThingHandlerCallback;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class NetworkHandlerTest extends JavaTest {
     private ThingUID thingUID = new ThingUID("network", "ttype", "ping");
-    @Mock
-    private ThingHandlerCallback callback;
 
-    @Mock
-    private Thing thing;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Thing thing;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
         when(thing.getUID()).thenReturn(thingUID);
     }
 
@@ -91,7 +93,7 @@ public class NetworkHandlerTest extends JavaTest {
     public void tcpDeviceInitTests() {
         NetworkBindingConfiguration config = new NetworkBindingConfiguration();
         NetworkHandler handler = spy(new NetworkHandler(thing, true, config));
-        Assert.assertThat(handler.isTCPServiceDevice(), is(true));
+        assertThat(handler.isTCPServiceDevice(), is(true));
         handler.setCallback(callback);
         // Port is missing, should make the device OFFLINE
         when(thing.getConfiguration()).thenAnswer(a -> {
@@ -103,9 +105,8 @@ public class NetworkHandlerTest extends JavaTest {
         // Check that we are offline
         ArgumentCaptor<ThingStatusInfo> statusInfoCaptor = ArgumentCaptor.forClass(ThingStatusInfo.class);
         verify(callback).statusUpdated(eq(thing), statusInfoCaptor.capture());
-        Assert.assertThat(statusInfoCaptor.getValue().getStatus(), is(equalTo(ThingStatus.OFFLINE)));
-        Assert.assertThat(statusInfoCaptor.getValue().getStatusDetail(),
-                is(equalTo(ThingStatusDetail.CONFIGURATION_ERROR)));
+        assertThat(statusInfoCaptor.getValue().getStatus(), is(equalTo(ThingStatus.OFFLINE)));
+        assertThat(statusInfoCaptor.getValue().getStatusDetail(), is(equalTo(ThingStatusDetail.CONFIGURATION_ERROR)));
     }
 
     @Test

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/toberemoved/cache/ExpiringCacheAsyncTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/toberemoved/cache/ExpiringCacheAsyncTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.network.internal.toberemoved.cache;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.binding.network.internal.toberemoved.cache.ExpiringCacheAsync.ExpiringCacheUpdate;
 
@@ -27,18 +27,17 @@ import org.openhab.binding.network.internal.toberemoved.cache.ExpiringCacheAsync
  * @author David Graeff - Initial contribution
  */
 public class ExpiringCacheAsyncTest {
-    @SuppressWarnings("unused")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWrongCacheTime() {
+        assertThrows(IllegalArgumentException.class, () ->
         // Fail if cache time is <= 0
         new ExpiringCacheAsync<>(0, () -> {
-        });
+        }));
     }
 
-    @SuppressWarnings("unused")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNoRefrehCommand() {
-        new ExpiringCacheAsync<>(2000, null);
+        assertThrows(IllegalArgumentException.class, () -> new ExpiringCacheAsync<>(2000, null));
     }
 
     @Test

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.network.internal.utils;
 
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the parser which extracts latency values from the output of the ping command.
@@ -34,8 +34,8 @@ public class LatencyParserTest {
         Optional<Double> resultLatency = latencyParser.parseLatency(input);
 
         // Assert
-        Assert.assertTrue(resultLatency.isPresent());
-        Assert.assertEquals(1.225, resultLatency.get(), 0);
+        assertTrue(resultLatency.isPresent());
+        assertEquals(1.225, resultLatency.get(), 0);
     }
 
     @Test
@@ -54,7 +54,7 @@ public class LatencyParserTest {
             Optional<Double> resultLatency = latencyParser.parseLatency(inputLine);
 
             // Assert
-            Assert.assertFalse(resultLatency.isPresent());
+            assertFalse(resultLatency.isPresent());
         }
     }
 }

--- a/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
+++ b/bundles/org.openhab.binding.network/src/test/java/org/openhab/binding/network/internal/utils/LatencyParserTest.java
@@ -12,9 +12,10 @@
  */
 package org.openhab.binding.network.internal.utils;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/NutNameChannelsTest.java
+++ b/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/NutNameChannelsTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.binding.networkupstools.internal;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.CoreItemFactory;
 
 /**
@@ -75,7 +76,7 @@ public class NutNameChannelsTest {
         for (final Entry<NutName, String> entry : readMeNutNames.entrySet()) {
             final Matcher matcher = README_PATTERN.matcher(entry.getValue());
 
-            assertNotNull("Could not find NutName in readme for : " + entry.getValue(), entry.getKey());
+            assertNotNull(entry.getKey(), "Could not find NutName in readme for : " + entry.getValue());
             if (matcher.find()) {
                 list.add(String.format(TEMPLATE_CHANNEL, entry.getKey().getChannelId(),
                         nutNameToChannelType(entry.getKey())));
@@ -145,10 +146,10 @@ public class NutNameChannelsTest {
 
     private NutName lineToNutName(final String line) {
         final Matcher matcher = README_PATTERN.matcher(line);
-        assertTrue("Could not match readme line: " + line, matcher.find());
+        assertTrue(matcher.find(), "Could not match readme line: " + line);
         final String name = matcher.group(1);
         final NutName channelIdToNutName = NutName.channelIdToNutName(name);
-        assertNotNull("Name should not match null: '" + name + "' ->" + line, channelIdToNutName);
+        assertNotNull(channelIdToNutName, "Name should not match null: '" + name + "' ->" + line);
         return channelIdToNutName;
     }
 

--- a/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/NutNameTest.java
+++ b/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/NutNameTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.networkupstools.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class to check the validity of the {@link NutName} enum.
@@ -38,12 +38,12 @@ public class NutNameTest {
         for (final NutName nn : NutName.values()) {
             final Matcher matcher = CHANNEL_PATTERN.matcher(nn.getName());
 
-            assertTrue("NutName name '" + nn + "' could not be matched with expected pattern.", matcher.find());
+            assertTrue(matcher.find(), "NutName name '" + nn + "' could not be matched with expected pattern.");
             final String expectedChannelId = matcher.group(1)
                     + StringUtils.capitalize(Optional.ofNullable(matcher.group(2)).orElse(""))
                     + StringUtils.capitalize(Optional.ofNullable(matcher.group(3)).orElse(""))
                     + StringUtils.capitalize(Optional.ofNullable(matcher.group(4)).orElse(""));
-            assertEquals("Channel name not correct", expectedChannelId, nn.getChannelId());
+            assertEquals(expectedChannelId, nn.getChannelId(), "Channel name not correct");
         }
     }
 }

--- a/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/nut/NutApiTest.java
+++ b/bundles/org.openhab.binding.networkupstools/src/test/java/org/openhab/binding/networkupstools/internal/nut/NutApiTest.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.networkupstools.internal.nut;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,24 +26,25 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit test to test the {@link NutApi} using a mock Socket connection.
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class NutApiTest {
 
-    @Mock
-    private Socket socket;
+    private @Mock Socket socket;
     private NutConnector connector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
-        initMocks(this);
         connector = new NutConnector("localhost", 0, "test", "pwd") {
             @Override
             protected Socket newSocket() {

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerCommand2NibeTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerCommand2NibeTest.java
@@ -12,19 +12,19 @@
  */
 package org.openhab.binding.nibeheatpump.internal.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.nibeheatpump.internal.models.PumpModel;
 import org.openhab.binding.nibeheatpump.internal.models.VariableInformation;
 import org.openhab.core.io.transport.serial.SerialPortManager;
@@ -38,7 +38,7 @@ import org.openhab.core.types.Command;
  *
  * @author Jevgeni Kiski - Initial contribution
  */
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class NibeHeatPumpHandlerCommand2NibeTest {
     private NibeHeatPumpHandler product; // the class under test
     private Method m;
@@ -46,13 +46,8 @@ public class NibeHeatPumpHandlerCommand2NibeTest {
     private Class<?>[] parameterTypes;
     private Object[] parameters;
 
-    private int fCoilAddress;
-    private Command fCommand;
-    private int fExpected;
-
     private @Mock SerialPortManager serialPortManager;
 
-    @Parameterized.Parameters(name = "{index}: f({0}, {1})={2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] { { 47028, new DecimalType("-1"), (byte) 0xFF },
                 { 48132, new DecimalType("0"), 0 }, { 48132, new StringType("0"), 0 },
@@ -63,16 +58,8 @@ public class NibeHeatPumpHandlerCommand2NibeTest {
                 { 47371, OnOffType.from(true), 0x1 }, { 47371, OnOffType.from(false), 0x0 }, });
     }
 
-    public NibeHeatPumpHandlerCommand2NibeTest(final int coilAddress, final Command command, final int expected) {
-        this.fCoilAddress = coilAddress;
-        this.fCommand = command;
-        this.fExpected = expected;
-    }
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
-
         product = new NibeHeatPumpHandler(null, PumpModel.F1X55, serialPortManager);
         parameterTypes = new Class[2];
         parameterTypes[0] = VariableInformation.class;
@@ -82,13 +69,15 @@ public class NibeHeatPumpHandlerCommand2NibeTest {
         parameters = new Object[2];
     }
 
-    @Test
-    public void convertNibeValueToStateTest() throws InvocationTargetException, IllegalAccessException {
-        VariableInformation varInfo = VariableInformation.getVariableInfo(PumpModel.F1X55, fCoilAddress);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void convertNibeValueToStateTest(final int coilAddress, final Command command, final int expected)
+            throws InvocationTargetException, IllegalAccessException {
+        VariableInformation varInfo = VariableInformation.getVariableInfo(PumpModel.F1X55, coilAddress);
         parameters[0] = varInfo;
-        parameters[1] = fCommand;
+        parameters[1] = command;
         int value = (int) m.invoke(product, parameters);
 
-        assertEquals(fExpected, value);
+        assertEquals(expected, value);
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerNibe2StateTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/handler/NibeHeatPumpHandlerNibe2StateTest.java
@@ -12,8 +12,7 @@
  */
 package org.openhab.binding.nibeheatpump.internal.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -21,11 +20,12 @@ import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.nibeheatpump.internal.models.PumpModel;
 import org.openhab.binding.nibeheatpump.internal.models.VariableInformation;
 import org.openhab.core.io.transport.serial.SerialPortManager;
@@ -36,7 +36,7 @@ import org.openhab.core.types.State;
  *
  * @author Jevgeni Kiski - Initial contribution
  */
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class NibeHeatPumpHandlerNibe2StateTest {
 
     // we need to get the decimal separator of the default locale for our tests
@@ -47,15 +47,9 @@ public class NibeHeatPumpHandlerNibe2StateTest {
     private Method m;
     private Class<?>[] parameterTypes;
     private Object[] parameters;
-    private int fCoilAddress;
-    private int fValue;
-    private String fFormat;
-    private String fType;
-    private String fExpected;
 
     private @Mock SerialPortManager serialPortManager;
 
-    @Parameterized.Parameters(name = "{index}: f({0}, {1}, {3})={4}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] { //
                 { 47028, 0xFF, "%d", "Number", "-1" }, //
@@ -87,19 +81,8 @@ public class NibeHeatPumpHandlerNibe2StateTest {
         });
     }
 
-    public NibeHeatPumpHandlerNibe2StateTest(final int coilAddress, final int value, final String format,
-            final String type, final String expected) {
-        this.fCoilAddress = coilAddress;
-        this.fValue = value;
-        this.fFormat = format;
-        this.fType = type;
-        this.fExpected = expected;
-    }
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
-
         product = new NibeHeatPumpHandler(null, PumpModel.F1X55, serialPortManager);
         parameterTypes = new Class[3];
         parameterTypes[0] = VariableInformation.class;
@@ -110,14 +93,16 @@ public class NibeHeatPumpHandlerNibe2StateTest {
         parameters = new Object[3];
     }
 
-    @Test
-    public void convertNibeValueToStateTest() throws InvocationTargetException, IllegalAccessException {
-        VariableInformation varInfo = VariableInformation.getVariableInfo(PumpModel.F1X55, fCoilAddress);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void convertNibeValueToStateTest(final int coilAddress, final int value, final String format,
+            final String type, final String expected) throws InvocationTargetException, IllegalAccessException {
+        VariableInformation varInfo = VariableInformation.getVariableInfo(PumpModel.F1X55, coilAddress);
         parameters[0] = varInfo;
-        parameters[1] = fValue;
-        parameters[2] = fType;
+        parameters[1] = value;
+        parameters[2] = type;
         State state = (State) m.invoke(product, parameters);
 
-        assertEquals(fExpected, state.format(fFormat));
+        assertEquals(expected, state.format(format));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusDataReadOutMessageTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusDataReadOutMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nibeheatpump.internal.NibeHeatPumpException;
 import org.openhab.core.util.HexUtils;
 
@@ -182,20 +182,20 @@ public class ModbusDataReadOutMessageTest {
         checkRegisters(message, expectedValues);
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void badCrcTest() throws NibeHeatPumpException {
+    @Test
+    public void badCrcTest() {
         final String message = "5C0020685001A81F0100A86400FDA7D003449C1E004F9CA000509C7800519C0301529C1B01879C14014E9CC601479C010115B9B0FF3AB94B00C9AF0000489C0D014C9CE7004B9C0000FFFF0000FFFF0000FFFF000044";
 
         final byte[] msg = HexUtils.hexToBytes(message);
-        MessageFactory.getMessage(msg);
+        assertThrows(NibeHeatPumpException.class, () -> MessageFactory.getMessage(msg));
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void notModbusDataReadOutMessageTest() throws NibeHeatPumpException {
+    @Test
+    public void notModbusDataReadOutMessageTest() {
         final String message = "519C0301529C1B01879C14014E9CC601479C010115B9B0FF3AB94B00C9AF0000489C0D014C9CE7004B9C0000FFFF0000FFFF0000FFFF000044";
 
         final byte[] msg = HexUtils.hexToBytes(message);
-        new ModbusDataReadOutMessage(msg);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusDataReadOutMessage(msg));
     }
 
     private void checkRegisters(final String message, final ArrayList<ModbusValue> expectedRegs)

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusReadRequestMessageTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusReadRequestMessageTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nibeheatpump.internal.NibeHeatPumpException;
 import org.openhab.core.util.HexUtils;
 
@@ -42,17 +42,17 @@ public class ModbusReadRequestMessageTest {
         assertEquals(coilAddress, m.getCoilAddress());
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void badCrcTest() throws NibeHeatPumpException {
+    @Test
+    public void badCrcTest() {
         final String strMessage = "C069023930A1";
         final byte[] msg = HexUtils.hexToBytes(strMessage);
-        new ModbusReadRequestMessage(msg);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusReadRequestMessage(msg));
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void notReadRequestMessageTest() throws NibeHeatPumpException {
+    @Test
+    public void notReadRequestMessageTest() {
         final String strMessage = "C169023930A2";
         final byte[] byteMessage = HexUtils.hexToBytes(strMessage);
-        new ModbusReadRequestMessage(byteMessage);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusReadRequestMessage(byteMessage));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusReadResponseMessageTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusReadResponseMessageTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nibeheatpump.internal.NibeHeatPumpException;
 import org.openhab.core.util.HexUtils;
 
@@ -45,17 +45,17 @@ public class ModbusReadResponseMessageTest {
         assertEquals(value, m.getValue());
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void badCrcTest() throws NibeHeatPumpException {
+    @Test
+    public void badCrcTest() {
         final String strMessage = "5C00206A060102030405064C";
         final byte[] byteMessage = HexUtils.hexToBytes(strMessage);
-        MessageFactory.getMessage(byteMessage);
+        assertThrows(NibeHeatPumpException.class, () -> MessageFactory.getMessage(byteMessage));
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void notReadResponseMessageTest() throws NibeHeatPumpException {
+    @Test
+    public void notReadResponseMessageTest() {
         final String strMessage = "5C00206B060102030405064A";
         final byte[] byteMessage = HexUtils.hexToBytes(strMessage);
-        new ModbusReadResponseMessage(byteMessage);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusReadResponseMessage(byteMessage));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusWriteRequestMessageTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusWriteRequestMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nibeheatpump.internal.NibeHeatPumpException;
 import org.openhab.core.util.HexUtils;
 
@@ -26,7 +26,7 @@ import org.openhab.core.util.HexUtils;
  */
 public class ModbusWriteRequestMessageTest {
 
-    @Before
+    @BeforeEach
     public void Before() {
     }
 
@@ -50,17 +50,17 @@ public class ModbusWriteRequestMessageTest {
         assertEquals(value, m.getValue());
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void badCrcTest() throws NibeHeatPumpException {
+    @Test
+    public void badCrcTest() {
         final String strMessage = "C06B06393006120F00BA";
         final byte[] msg = HexUtils.hexToBytes(strMessage);
-        new ModbusWriteRequestMessage(msg);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusWriteRequestMessage(msg));
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void notWriteRequestMessageTest() throws NibeHeatPumpException {
+    @Test
+    public void notWriteRequestMessageTest() {
         final String strMessage = "C06A06393006120F00BF";
         final byte[] byteMessage = HexUtils.hexToBytes(strMessage);
-        new ModbusWriteRequestMessage(byteMessage);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusWriteRequestMessage(byteMessage));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusWriteResponseMessageTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/ModbusWriteResponseMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.nibeheatpump.internal.NibeHeatPumpException;
 import org.openhab.core.util.HexUtils;
 
@@ -26,7 +26,7 @@ import org.openhab.core.util.HexUtils;
  */
 public class ModbusWriteResponseMessageTest {
 
-    @Before
+    @BeforeEach
     public void Before() {
     }
 
@@ -62,17 +62,17 @@ public class ModbusWriteResponseMessageTest {
         assertEquals(false, m.isSuccessfull());
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void badCrcTest() throws NibeHeatPumpException {
+    @Test
+    public void badCrcTest() {
         final String strMessage = "5C00206C01004A";
         final byte[] msg = HexUtils.hexToBytes(strMessage);
-        new ModbusWriteResponseMessage(msg);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusWriteResponseMessage(msg));
     }
 
-    @Test(expected = NibeHeatPumpException.class)
-    public void notWriteResponseMessageTest() throws NibeHeatPumpException {
+    @Test
+    public void notWriteResponseMessageTest() {
         final String strMessage = "5C00206B060102030405064A";
         final byte[] byteMessage = HexUtils.hexToBytes(strMessage);
-        new ModbusWriteResponseMessage(byteMessage);
+        assertThrows(NibeHeatPumpException.class, () -> new ModbusWriteResponseMessage(byteMessage));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/NibeHeatPumpProtocolTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/message/NibeHeatPumpProtocolTest.java
@@ -12,15 +12,16 @@
  */
 package org.openhab.binding.nibeheatpump.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.openhab.binding.nibeheatpump.internal.protocol.NibeHeatPumpProtocolContext;
 import org.openhab.binding.nibeheatpump.internal.protocol.NibeHeatPumpProtocolDefaultContext;
 import org.openhab.core.util.HexUtils;
@@ -63,7 +64,7 @@ public class NibeHeatPumpProtocolTest {
         }
     };
 
-    @Before
+    @BeforeEach
     public void Before() {
         ackRequestCount = 0;
         nakRequestCount = 0;
@@ -74,7 +75,8 @@ public class NibeHeatPumpProtocolTest {
         mockupContext.msg().clear();
     }
 
-    @Test(timeout = 1000)
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
     public void test() {
         //@formatter:off
         final String strTestData =
@@ -132,24 +134,24 @@ public class NibeHeatPumpProtocolTest {
         String expect;
 
         expect = "5C001962189600E1010200000000800000000000020914340001000005B8";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(0));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(0));
 
         expect = "5C00206850449C9600489C88014C9C2D014E9CCF004D9CE0014F9C3200509C0400519C8201529C6B02569C3E00C9AF000001A8F600FDA77E02FAA90F0098A9DC27FFFF0000A0A93A04FFFF00009CA9FD19FFFF000081";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(1));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(1));
 
         expect = "5C001962189600DF01020000000080000000000002091434000100000586";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(2));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(2));
 
         expect = "5C0019600079";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(3));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(3));
 
         expect = "5C00206851449C2500489CFC004C9CF1004E9CC7014D9C0B024F9C2500509C3300519C0B01529C5C5C01569C3100C9AF000001A80C01FDA716FAFAA9070098A91B1BFFFF0000A0A9CA02FFFF00009CA99212FFFF0000BE";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(4));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(4));
 
         expect = "5C00206852449C2500489CFE004C9CF2004E9CD4014D9CFB014F9C2500509C3700519C0D01529C5C5C01569C3200C9AF000001A80C01FDA712FAFAA9070098A95C5C1BFFFF0000A0A9D102FFFF00009CA9B412FFFF00007F";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(5));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(5));
 
         expect = "5C00206850449C2600489CF6004C9CF1004E9CD6014D9C0C024F9C4500509C3F00519CF100529C0401569CD500C9AF000001A80C01FDA799FAFAA9020098A91A1BFFFF0000A0A9CA02FFFF00009CA99212FFFF0000C5";
-        Assert.assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(6));
+        assertArrayEquals(HexUtils.hexToBytes(expect), receivedMsgs.get(6));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/models/PumpModelTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/models/PumpModelTest.java
@@ -12,17 +12,17 @@
  */
 package org.openhab.binding.nibeheatpump.internal.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pauli Anttila - Initial contribution
  */
 public class PumpModelTest {
 
-    @Before
+    @BeforeEach
     public void Before() {
     }
 
@@ -54,8 +54,8 @@ public class PumpModelTest {
         assertEquals(PumpModel.F470, pumpModel);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void badPumpModelTest() {
-        PumpModel.getPumpModel("XXXX");
+        assertThrows(IllegalArgumentException.class, () -> PumpModel.getPumpModel("XXXX"));
     }
 }

--- a/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/models/VariableInformationTest.java
+++ b/bundles/org.openhab.binding.nibeheatpump/src/test/java/org/openhab/binding/nibeheatpump/internal/models/VariableInformationTest.java
@@ -12,17 +12,17 @@
  */
 package org.openhab.binding.nibeheatpump.internal.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pauli Anttila - Initial contribution
  */
 public class VariableInformationTest {
 
-    @Before
+    @BeforeEach
     public void Before() {
     }
 

--- a/bundles/org.openhab.binding.omnikinverter/src/test/java/org/openhab/binding/omnikinverter/internal/test/OmnikInverterMessageTest.java
+++ b/bundles/org.openhab.binding.omnikinverter/src/test/java/org/openhab/binding/omnikinverter/internal/test/OmnikInverterMessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.omnikinverter.internal.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.omnikinverter.internal.OmnikInverterMessage;
 
 /**
@@ -29,7 +29,7 @@ public class OmnikInverterMessageTest {
 
     private OmnikInverterMessage message;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         File file = new File("src/test/resources/omnik.output");
         message = new OmnikInverterMessage(Files.readAllBytes(file.toPath()));

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/CompletenessTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/CompletenessTest.java
@@ -12,18 +12,27 @@
  */
 package org.openhab.binding.onewire;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.onewire.internal.OwBindingConstants;
 import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.device.OwSensorType;
-import org.openhab.binding.onewire.internal.handler.*;
+import org.openhab.binding.onewire.internal.handler.AdvancedMultisensorThingHandler;
+import org.openhab.binding.onewire.internal.handler.BAE091xSensorThingHandler;
+import org.openhab.binding.onewire.internal.handler.BasicMultisensorThingHandler;
+import org.openhab.binding.onewire.internal.handler.BasicThingHandler;
+import org.openhab.binding.onewire.internal.handler.EDSSensorThingHandler;
 
 /**
  * Tests cases for binding completeness
@@ -48,7 +57,7 @@ public class CompletenessTest {
         for (OwSensorType sensorType : EnumSet.allOf(OwSensorType.class)) {
             if (!OwBindingConstants.THING_TYPE_MAP.containsKey(sensorType)
                     && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
-                Assert.fail("missing thing type map for sensor type " + sensorType.name());
+                fail("missing thing type map for sensor type " + sensorType.name());
             }
         }
     }
@@ -58,7 +67,7 @@ public class CompletenessTest {
         for (OwSensorType sensorType : EnumSet.allOf(OwSensorType.class)) {
             if (!OwBindingConstants.SENSOR_TYPE_CHANNEL_MAP.containsKey(sensorType)
                     && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
-                Assert.fail("missing channel configuration map for sensor type " + sensorType.name());
+                fail("missing channel configuration map for sensor type " + sensorType.name());
             }
         }
     }
@@ -67,7 +76,7 @@ public class CompletenessTest {
     public void allSensorsSupportedByThingHandlers() {
         for (OwSensorType sensorType : EnumSet.allOf(OwSensorType.class)) {
             if (!THINGHANDLER_SENSOR_TYPES.contains(sensorType) && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
-                Assert.fail("missing thing handler for sensor type " + sensorType.name());
+                fail("missing thing handler for sensor type " + sensorType.name());
             }
         }
     }
@@ -77,7 +86,7 @@ public class CompletenessTest {
         for (OwSensorType sensorType : EnumSet.allOf(OwSensorType.class)) {
             if (!OwBindingConstants.THING_LABEL_MAP.containsKey(sensorType)
                     && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
-                Assert.fail("missing label for sensor type " + sensorType.name());
+                fail("missing label for sensor type " + sensorType.name());
             }
         }
     }
@@ -90,14 +99,14 @@ public class CompletenessTest {
                     try {
                         return (String) f.get(null);
                     } catch (IllegalAccessException e) {
-                        Assert.fail("unexpected");
+                        fail("unexpected");
                         return null;
                     }
                 }).collect(Collectors.toList());
 
         for (String channel : channels) {
             if (!OwBindingConstants.ACCEPTED_ITEM_TYPES_MAP.containsKey(channel)) {
-                Assert.fail("missing accepted item type for channel " + channel);
+                fail("missing accepted item type for channel " + channel);
             }
         }
     }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/OwserverDeviceParameterTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/OwserverDeviceParameterTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.onewire;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.onewire.internal.SensorId;
 import org.openhab.binding.onewire.internal.owserver.OwserverDeviceParameter;
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/SensorIdTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/SensorIdTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.onewire;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.onewire.internal.SensorId;
 
 /**

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/UtilTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/UtilTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.onewire;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.onewire.internal.Util;
 import org.openhab.core.library.dimension.Density;
 import org.openhab.core.library.types.QuantityType;

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/BAE0910Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/BAE0910Test.java
@@ -12,16 +12,18 @@
  */
 package org.openhab.binding.onewire.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -42,7 +44,7 @@ import org.openhab.core.types.State;
  */
 @NonNullByDefault
 public class BAE0910Test extends DeviceTestParent<BAE0910> {
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BAE091X, BAE0910.class);
     }
@@ -50,54 +52,49 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
     // pin 1: counter
 
     @Test
-    public void counter() {
+    public void counter() throws OwException {
         addChannel(CHANNEL_COUNTER, "Number");
         final BAE0910 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(
-                    mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter("/counter"))))
-                    .thenReturn(new DecimalType(34567));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter("/counter"))))
+                .thenReturn(new DecimalType(34567));
 
-            testDevice.enableChannel(CHANNEL_COUNTER);
-            testDevice.configureChannels(mockBridgeHandler);
+        testDevice.enableChannel(CHANNEL_COUNTER);
+        testDevice.configureChannels(mockBridgeHandler);
 
-            // refresh
-            ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
-            testDevice.refresh(mockBridgeHandler, true);
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter("/counter")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_COUNTER), stateArgumentCaptor.capture());
-            assertEquals(new DecimalType(34567), stateArgumentCaptor.getValue());
+        // refresh
+        ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
+        testDevice.refresh(mockBridgeHandler, true);
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
+                eq(new OwserverDeviceParameter("/counter")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_COUNTER), stateArgumentCaptor.capture());
+        assertEquals(new DecimalType(34567), stateArgumentCaptor.getValue());
 
-            // write
-            assertFalse(testDevice.writeChannel(mockBridgeHandler, CHANNEL_COUNTER, new DecimalType(12345)));
+        // write
+        assertFalse(testDevice.writeChannel(mockBridgeHandler, CHANNEL_COUNTER, new DecimalType(12345)));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     // pin 2: digital2 or pwm1
 
     @Test
-    public void digitalOut2() {
+    public void digitalOut2() throws OwException {
         addChannel(CHANNEL_DIGITAL2, "Switch");
         digitalBaseChannel(CHANNEL_DIGITAL2, bitSet(3, 4), 0, "/out", bitSet(0), true);
     }
 
     @Test
-    public void pwm4() {
+    public void pwm4() throws OwException {
         pwmBaseChannel(CHANNEL_PWM_FREQ2, CHANNEL_PWM_DUTY4, "/period2", "/duty4", 2);
     }
 
     // pin 6: pio or pwm 3
 
     @Test
-    public void digital6PioIn() {
+    public void digital6PioIn() throws OwException {
         Map<String, Object> channelConfig = new HashMap<>();
         channelConfig.put("pulldevice", "pulldown");
         channelConfig.put("mode", "input");
@@ -106,7 +103,7 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
     }
 
     @Test
-    public void digital6PioOut() {
+    public void digital6PioOut() throws OwException {
         Map<String, Object> channelConfig = new HashMap<>();
         channelConfig.put("mode", "output");
         addChannel(CHANNEL_DIGITAL6, "Switch", new Configuration(channelConfig));
@@ -114,14 +111,14 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
     }
 
     @Test
-    public void pwm3() {
+    public void pwm3() throws OwException {
         pwmBaseChannel(CHANNEL_PWM_FREQ1, CHANNEL_PWM_DUTY3, "/period1", "/duty3", 1);
     }
 
     // pin 7: analog, output, pwm2
 
     @Test
-    public void analog() {
+    public void analog() throws OwException {
         Map<String, Object> channelConfig = new HashMap<>();
         channelConfig.put("hires", "true");
         addChannel(CHANNEL_VOLTAGE, "Number:ElectricPotential", new Configuration(channelConfig));
@@ -129,61 +126,56 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
         final BAE0910 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter("/adc"))))
-                    .thenReturn(new DecimalType(5.2));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter("/adc"))))
+                .thenReturn(new DecimalType(5.2));
 
-            testDevice.enableChannel(CHANNEL_VOLTAGE);
-            testDevice.configureChannels(mockBridgeHandler);
+        testDevice.enableChannel(CHANNEL_VOLTAGE);
+        testDevice.configureChannels(mockBridgeHandler);
 
-            // test configuration
-            assertEquals(bitSet(3, 4), checkConfiguration(2));
+        // test configuration
+        assertEquals(bitSet(3, 4), checkConfiguration(2));
 
-            // refresh
-            ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
-            testDevice.refresh(mockBridgeHandler, true);
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter("/adc")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_VOLTAGE), stateArgumentCaptor.capture());
-            assertEquals(new QuantityType<>("5.2 V"), stateArgumentCaptor.getValue());
+        // refresh
+        ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
+        testDevice.refresh(mockBridgeHandler, true);
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter("/adc")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_VOLTAGE), stateArgumentCaptor.capture());
+        assertEquals(new QuantityType<>("5.2 V"), stateArgumentCaptor.getValue());
 
-            // write (should fail)
-            assertFalse(testDevice.writeChannel(mockBridgeHandler, CHANNEL_VOLTAGE, new QuantityType<>("3 V")));
+        // write (should fail)
+        assertFalse(testDevice.writeChannel(mockBridgeHandler, CHANNEL_VOLTAGE, new QuantityType<>("3 V")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void digitalOut7() {
+    public void digitalOut7() throws OwException {
         addChannel(CHANNEL_DIGITAL7, "Switch");
         digitalBaseChannel(CHANNEL_DIGITAL7, bitSet(4), 4, "/tpm2c", bitSet(4, 7), true);
     }
 
     @Test
-    public void pwm2() {
+    public void pwm2() throws OwException {
         pwmBaseChannel(CHANNEL_PWM_FREQ2, CHANNEL_PWM_DUTY2, "/period2", "/duty2", 2);
     }
 
     // pin 8: digital in, digital out or pwm
 
     @Test
-    public void digitalIn8() {
+    public void digitalIn8() throws OwException {
         addChannel(CHANNEL_DIGITAL8, "Switch", new ChannelTypeUID(BINDING_ID, "bae-in"));
         digitalBaseChannel(CHANNEL_DIGITAL8, bitSet(4, 5), 3, "/tpm1c", bitSet(4, 5, 7), false);
     }
 
     @Test
-    public void digitalOut8() {
+    public void digitalOut8() throws OwException {
         addChannel(CHANNEL_DIGITAL8, "Switch");
         digitalBaseChannel(CHANNEL_DIGITAL8, bitSet(4), 3, "/tpm1c", bitSet(4, 7), true);
     }
 
     @Test
-    public void pwm1() {
+    public void pwm1() throws OwException {
         pwmBaseChannel(CHANNEL_PWM_FREQ1, CHANNEL_PWM_DUTY1, "/period1", "/duty1", 1);
     }
 
@@ -198,44 +190,39 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
      * @param isOutput if this channel is an output
      */
     private void digitalBaseChannel(String channel, BitSet configBitSet, int configRegister, String channelParam,
-            BitSet returnBitSet, boolean isOutput) {
+            BitSet returnBitSet, boolean isOutput) throws OwException {
         final BAE0910 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), eq(new OwserverDeviceParameter(channelParam))))
-                    .thenReturn(returnBitSet);
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), eq(new OwserverDeviceParameter(channelParam))))
+                .thenReturn(returnBitSet);
 
-            testDevice.enableChannel(channel);
-            testDevice.configureChannels(mockBridgeHandler);
+        testDevice.enableChannel(channel);
+        testDevice.configureChannels(mockBridgeHandler);
 
-            // test configuration
-            assertEquals(configBitSet, checkConfiguration(configRegister));
+        // test configuration
+        assertEquals(configBitSet, checkConfiguration(configRegister));
 
-            // refresh
-            ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
-            testDevice.refresh(mockBridgeHandler, true);
-            inOrder.verify(mockBridgeHandler).readBitSet(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(channelParam)));
-            inOrder.verify(mockThingHandler).postUpdate(eq(channel), stateArgumentCaptor.capture());
-            assertEquals(OnOffType.ON, stateArgumentCaptor.getValue());
+        // refresh
+        ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
+        testDevice.refresh(mockBridgeHandler, true);
+        inOrder.verify(mockBridgeHandler).readBitSet(eq(testSensorId), eq(new OwserverDeviceParameter(channelParam)));
+        inOrder.verify(mockThingHandler).postUpdate(eq(channel), stateArgumentCaptor.capture());
+        assertEquals(OnOffType.ON, stateArgumentCaptor.getValue());
 
-            // write
-            if (isOutput) {
-                ArgumentCaptor<BitSet> bitSetArgumentCaptor = ArgumentCaptor.forClass(BitSet.class);
-                assertTrue(testDevice.writeChannel(mockBridgeHandler, channel, OnOffType.ON));
-                inOrder.verify(mockBridgeHandler).writeBitSet(eq(testSensorId),
-                        eq(new OwserverDeviceParameter(channelParam)), bitSetArgumentCaptor.capture());
-                assertEquals(returnBitSet, bitSetArgumentCaptor.getValue());
-            } else {
-                assertFalse(testDevice.writeChannel(mockBridgeHandler, channel, OnOffType.ON));
-            }
-
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
+        // write
+        if (isOutput) {
+            ArgumentCaptor<BitSet> bitSetArgumentCaptor = ArgumentCaptor.forClass(BitSet.class);
+            assertTrue(testDevice.writeChannel(mockBridgeHandler, channel, OnOffType.ON));
+            inOrder.verify(mockBridgeHandler).writeBitSet(eq(testSensorId),
+                    eq(new OwserverDeviceParameter(channelParam)), bitSetArgumentCaptor.capture());
+            assertEquals(returnBitSet, bitSetArgumentCaptor.getValue());
+        } else {
+            assertFalse(testDevice.writeChannel(mockBridgeHandler, channel, OnOffType.ON));
         }
+
+        inOrder.verifyNoMoreInteractions();
     }
 
     /**
@@ -248,7 +235,7 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
      * @param registerIndex index for TPM configuration register
      */
     private void pwmBaseChannel(String freqChannel, String dutyChannel, String freqParam, String dutyParam,
-            int registerIndex) {
+            int registerIndex) throws OwException {
         Map<String, Object> channelConfig = new HashMap<>();
         channelConfig.put("prescaler", 5);
         addChannel(freqChannel, "Number:Frequency", new Configuration(channelConfig));
@@ -257,51 +244,42 @@ public class BAE0910Test extends DeviceTestParent<BAE0910> {
         final BAE0910 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(
-                    mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(freqParam))))
-                    .thenReturn(new DecimalType(32768));
-            Mockito.when(
-                    mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(dutyParam))))
-                    .thenReturn(new DecimalType(16384));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(freqParam))))
+                .thenReturn(new DecimalType(32768));
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(dutyParam))))
+                .thenReturn(new DecimalType(16384));
 
-            testDevice.enableChannel(freqChannel);
-            testDevice.enableChannel(dutyChannel);
-            testDevice.configureChannels(mockBridgeHandler);
+        testDevice.enableChannel(freqChannel);
+        testDevice.enableChannel(dutyChannel);
+        testDevice.configureChannels(mockBridgeHandler);
 
-            // test configuration
-            assertEquals(bitSet(0, 2), checkConfiguration(registerIndex + 2));
+        // test configuration
+        assertEquals(bitSet(0, 2), checkConfiguration(registerIndex + 2));
 
-            // refresh
-            ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
-            testDevice.refresh(mockBridgeHandler, true);
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(freqParam)));
-            inOrder.verify(mockThingHandler).postUpdate(eq(freqChannel), stateArgumentCaptor.capture());
-            assertEquals(new QuantityType<>("15.2587890625 Hz"), stateArgumentCaptor.getValue());
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(dutyParam)));
-            inOrder.verify(mockThingHandler).postUpdate(eq(dutyChannel), stateArgumentCaptor.capture());
-            assertEquals(new QuantityType<>("50 %"), stateArgumentCaptor.getValue());
+        // refresh
+        ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
+        testDevice.refresh(mockBridgeHandler, true);
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(freqParam)));
+        inOrder.verify(mockThingHandler).postUpdate(eq(freqChannel), stateArgumentCaptor.capture());
+        assertEquals(new QuantityType<>("15.2587890625 Hz"), stateArgumentCaptor.getValue());
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(dutyParam)));
+        inOrder.verify(mockThingHandler).postUpdate(eq(dutyChannel), stateArgumentCaptor.capture());
+        assertEquals(new QuantityType<>("50 %"), stateArgumentCaptor.getValue());
 
-            // write
-            ArgumentCaptor<DecimalType> decimalTypeArgumentCaptor = ArgumentCaptor.forClass(DecimalType.class);
-            assertTrue(testDevice.writeChannel(mockBridgeHandler, freqChannel, new QuantityType<>("50000 Hz")));
-            inOrder.verify(mockBridgeHandler).writeDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(freqParam)), decimalTypeArgumentCaptor.capture());
-            assertEquals(new DecimalType(10), decimalTypeArgumentCaptor.getValue());
-            testDevice.writeChannel(mockBridgeHandler, dutyChannel, new QuantityType<>("25 %"));
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(freqParam)));
-            inOrder.verify(mockBridgeHandler).writeDecimalType(eq(testSensorId),
-                    eq(new OwserverDeviceParameter(dutyParam)), decimalTypeArgumentCaptor.capture());
-            assertEquals(new DecimalType(8192), decimalTypeArgumentCaptor.getValue());
+        // write
+        ArgumentCaptor<DecimalType> decimalTypeArgumentCaptor = ArgumentCaptor.forClass(DecimalType.class);
+        assertTrue(testDevice.writeChannel(mockBridgeHandler, freqChannel, new QuantityType<>("50000 Hz")));
+        inOrder.verify(mockBridgeHandler).writeDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(freqParam)),
+                decimalTypeArgumentCaptor.capture());
+        assertEquals(new DecimalType(10), decimalTypeArgumentCaptor.getValue());
+        testDevice.writeChannel(mockBridgeHandler, dutyChannel, new QuantityType<>("25 %"));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(freqParam)));
+        inOrder.verify(mockBridgeHandler).writeDecimalType(eq(testSensorId), eq(new OwserverDeviceParameter(dutyParam)),
+                decimalTypeArgumentCaptor.capture());
+        assertEquals(new DecimalType(8192), decimalTypeArgumentCaptor.getValue());
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     /**

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS18x20Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS18x20Test.java
@@ -12,8 +12,7 @@
  */
 package org.openhab.binding.onewire.device;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
@@ -21,9 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -41,7 +39,7 @@ import org.openhab.core.library.types.QuantityType;
 @NonNullByDefault
 public class DS18x20Test extends DeviceTestParent<DS18x20> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS18x20.class);
 
@@ -51,42 +49,34 @@ public class DS18x20Test extends DeviceTestParent<DS18x20> {
     }
 
     @Test
-    public void temperatureTest() {
+    public void temperatureTest() throws OwException {
         final DS18x20 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(15.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(15.0));
 
-            testDevice.enableChannel(CHANNEL_TEMPERATURE);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_TEMPERATURE);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(1)).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("15.0 °C")));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(mockBridgeHandler, times(1)).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("15.0 °C")));
     }
 
     @Test
-    public void temperatureIgnorePORTest() {
+    public void temperatureIgnorePORTest() throws OwException {
         final DS18x20 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(85.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(85.0));
 
-            testDevice.enableChannel(CHANNEL_TEMPERATURE);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_TEMPERATURE);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(1)).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler, times(0)).postUpdate(eq(CHANNEL_TEMPERATURE), any());
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(mockBridgeHandler, times(1)).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler, times(0)).postUpdate(eq(CHANNEL_TEMPERATURE), any());
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS1923Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS1923Test.java
@@ -17,9 +17,8 @@ import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -36,7 +35,7 @@ import org.openhab.core.library.types.QuantityType;
  */
 @NonNullByDefault
 public class DS1923Test extends DeviceTestParent<DS1923> {
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_MS_TX, DS1923.class);
 
@@ -47,52 +46,44 @@ public class DS1923Test extends DeviceTestParent<DS1923> {
     }
 
     @Test
-    public void temperatureChannel() {
+    public void temperatureChannel() throws OwException {
         final DS1923 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_TEMPERATURE);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_TEMPERATURE);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void humidityChannel() {
+    public void humidityChannel() throws OwException {
         final DS1923 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_DEWPOINT);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_DEWPOINT);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
-                    eq(new QuantityType<>("0.9381970824113001000 g/m³")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
-                    eq(new QuantityType<>("-20.31395053870025 °C")));
+        inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
+                eq(new QuantityType<>("0.9381970824113001000 g/m³")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
+                eq(new QuantityType<>("-20.31395053870025 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2401Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2401Test.java
@@ -15,8 +15,9 @@ package org.openhab.binding.onewire.device;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.THING_TYPE_BASIC;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.device.DS2401;
 import org.openhab.core.library.types.OnOffType;
 
@@ -28,18 +29,18 @@ import org.openhab.core.library.types.OnOffType;
 @NonNullByDefault
 public class DS2401Test extends DeviceTestParent<DS2401> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS2401.class);
     }
 
     @Test
-    public void presenceTestOn() {
+    public void presenceTestOn() throws OwException {
         presenceTest(OnOffType.ON);
     }
 
     @Test
-    public void presenceTestOff() {
+    public void presenceTestOff() throws OwException {
         presenceTest(OnOffType.OFF);
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2405Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2405Test.java
@@ -19,9 +19,8 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 import java.util.BitSet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -36,7 +35,7 @@ import org.openhab.core.library.types.OnOffType;
 @NonNullByDefault
 public class DS2405Test extends DeviceTestParent<DS2405> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS2405.class);
 
@@ -44,12 +43,12 @@ public class DS2405Test extends DeviceTestParent<DS2405> {
     }
 
     @Test
-    public void digitalChannel() {
+    public void digitalChannel() throws OwException {
         digitalChannelTest(OnOffType.ON, 0);
         digitalChannelTest(OnOffType.OFF, 0);
     }
 
-    private void digitalChannelTest(OnOffType state, int channelNo) {
+    private void digitalChannelTest(OnOffType state, int channelNo) throws OwException {
         final DS2405 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
@@ -58,18 +57,14 @@ public class DS2405Test extends DeviceTestParent<DS2405> {
             returnValue.flip(0, 7);
         }
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
     }
 
     private String channelName(int channelNo) {

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2406_DS2413Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2406_DS2413Test.java
@@ -19,9 +19,8 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 import java.util.BitSet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -36,7 +35,7 @@ import org.openhab.core.library.types.OnOffType;
 @NonNullByDefault
 public class DS2406_DS2413Test extends DeviceTestParent<DS2406_DS2413> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS2406_DS2413.class);
 
@@ -46,14 +45,14 @@ public class DS2406_DS2413Test extends DeviceTestParent<DS2406_DS2413> {
     }
 
     @Test
-    public void digitalChannel() {
+    public void digitalChannel() throws OwException {
         for (int i = 0; i < 2; i++) {
             digitalChannelTest(OnOffType.ON, i);
             digitalChannelTest(OnOffType.OFF, i);
         }
     }
 
-    private void digitalChannelTest(OnOffType state, int channelNo) {
+    private void digitalChannelTest(OnOffType state, int channelNo) throws OwException {
         final DS2406_DS2413 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
@@ -62,18 +61,14 @@ public class DS2406_DS2413Test extends DeviceTestParent<DS2406_DS2413> {
             returnValue.flip(0, 7);
         }
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
     }
 
     private String channelName(int channelNo) {

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2408Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2408Test.java
@@ -19,9 +19,8 @@ import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 import java.util.BitSet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -36,7 +35,7 @@ import org.openhab.core.library.types.OnOffType;
 @NonNullByDefault
 public class DS2408Test extends DeviceTestParent<DS2408> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS2408.class);
 
@@ -46,14 +45,14 @@ public class DS2408Test extends DeviceTestParent<DS2408> {
     }
 
     @Test
-    public void digitalChannel() {
+    public void digitalChannel() throws OwException {
         for (int i = 0; i < 8; i++) {
             digitalChannelTest(OnOffType.ON, i);
             digitalChannelTest(OnOffType.OFF, i);
         }
     }
 
-    private void digitalChannelTest(OnOffType state, int channelNo) {
+    private void digitalChannelTest(OnOffType state, int channelNo) throws OwException {
         final DS2408 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
@@ -62,18 +61,14 @@ public class DS2408Test extends DeviceTestParent<DS2408> {
             returnValue.flip(0, 8);
         }
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
     }
 
     private String channelName(int channelNo) {

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2423Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2423Test.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.onewire.device;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
@@ -20,9 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -39,7 +39,7 @@ import org.openhab.core.types.State;
 @NonNullByDefault
 public class DS2423Test extends DeviceTestParent<DS2423> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_BASIC, DS2423.class);
 
@@ -68,7 +68,7 @@ public class DS2423Test extends DeviceTestParent<DS2423> {
             inOrder.verify(mockThingHandler).postUpdate(eq(channelName(0)), eq(returnValue.get(0)));
             inOrder.verify(mockThingHandler).postUpdate(eq(channelName(1)), eq(returnValue.get(1)));
         } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
+            fail("caught unexpected OwException");
         }
     }
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2438Test.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/DS2438Test.java
@@ -17,9 +17,8 @@ import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -37,7 +36,7 @@ import org.openhab.core.library.types.QuantityType;
 @NonNullByDefault
 public class DS2438Test extends DeviceTestParent<DS2438> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_MS_TX, DS2438.class);
 
@@ -52,173 +51,145 @@ public class DS2438Test extends DeviceTestParent<DS2438> {
     }
 
     @Test
-    public void temperatureChannel() {
+    public void temperatureChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_TEMPERATURE);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_TEMPERATURE);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void humidityChannel() {
+    public void humidityChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_DEWPOINT);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_DEWPOINT);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
-                    eq(new QuantityType<>("0.9381970824113001000 g/m³")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
-                    eq(new QuantityType<>("-20.31395053870025 °C")));
+        inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
+                eq(new QuantityType<>("0.9381970824113001000 g/m³")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
+                eq(new QuantityType<>("-20.31395053870025 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void voltageChannel() {
+    public void voltageChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.enableChannel(CHANNEL_VOLTAGE);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_VOLTAGE);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_VOLTAGE), eq(new QuantityType<>("2.0 V")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_VOLTAGE), eq(new QuantityType<>("2.0 V")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void currentChannel() {
+    public void currentChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
 
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.enableChannel(CHANNEL_CURRENT);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_CURRENT);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_CURRENT), eq(new QuantityType<>("2.0 mA")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_CURRENT), eq(new QuantityType<>("2.0 mA")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void lightChannel() {
+    public void lightChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(0.1));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(0.1));
 
-            testDevice.enableChannel(CHANNEL_LIGHT);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.setLightSensorType(LightSensorType.ELABNET_V1);
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_LIGHT);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.setLightSensorType(LightSensorType.ELABNET_V1);
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("97442 lx")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("97442 lx")));
 
-            testDevice.setLightSensorType(LightSensorType.ELABNET_V2);
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.setLightSensorType(LightSensorType.ELABNET_V2);
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("134 lx")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("134 lx")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void supplyVoltageChannel() {
+    public void supplyVoltageChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.enableChannel(CHANNEL_SUPPLYVOLTAGE);
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_SUPPLYVOLTAGE);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_SUPPLYVOLTAGE), eq(new QuantityType<>("2.0 V")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_SUPPLYVOLTAGE), eq(new QuantityType<>("2.0 V")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void noChannel() {
+    public void noChannel() throws OwException {
         final DS2438 testDevice = instantiateDevice();
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.configureChannels();
-            inOrder.verify(mockThingHandler).getThing();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.configureChannels();
+        inOrder.verify(mockThingHandler).getThing();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/EDS006xTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/device/EDS006xTest.java
@@ -17,9 +17,8 @@ import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.openhab.binding.onewire.internal.OwException;
@@ -37,7 +36,7 @@ import org.openhab.core.library.types.QuantityType;
 @NonNullByDefault
 public class EDS006xTest extends DeviceTestParent<EDS006x> {
 
-    @Before
+    @BeforeEach
     public void setupMocks() {
         setupMocks(THING_TYPE_EDS_ENV, EDS006x.class);
 
@@ -50,114 +49,94 @@ public class EDS006xTest extends DeviceTestParent<EDS006x> {
     }
 
     @Test
-    public void temperatureChannel() {
+    public void temperatureChannel() throws OwException {
         final EDS006x testDevice = instantiateDevice(OwSensorType.EDS0068);
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_TEMPERATURE);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_TEMPERATURE);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_TEMPERATURE), eq(new QuantityType<>("10.0 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void humidityChannel() {
+    public void humidityChannel() throws OwException {
         final EDS006x testDevice = instantiateDevice(OwSensorType.EDS0068);
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(10.0));
 
-            testDevice.enableChannel(CHANNEL_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
-            testDevice.enableChannel(CHANNEL_DEWPOINT);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);
+        testDevice.enableChannel(CHANNEL_DEWPOINT);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
-                    eq(new QuantityType<>("0.9381970824113001000 g/m³")));
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
-                    eq(new QuantityType<>("-20.31395053870025 °C")));
+        inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_HUMIDITY), eq(new QuantityType<>("10.0 %")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_ABSOLUTE_HUMIDITY),
+                eq(new QuantityType<>("0.9381970824113001000 g/m³")));
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_DEWPOINT),
+                eq(new QuantityType<>("-20.31395053870025 °C")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void pressureChannel() {
+    public void pressureChannel() throws OwException {
         final EDS006x testDevice = instantiateDevice(OwSensorType.EDS0068);
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.enableChannel(CHANNEL_PRESSURE);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_PRESSURE);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_PRESSURE), eq(new QuantityType<>("2.0 mbar")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_PRESSURE), eq(new QuantityType<>("2.0 mbar")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void lightChannel() {
+    public void lightChannel() throws OwException {
         final EDS006x testDevice = instantiateDevice(OwSensorType.EDS0068);
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(100));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(100));
 
-            testDevice.enableChannel(CHANNEL_LIGHT);
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.enableChannel(CHANNEL_LIGHT);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
-            inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("100 lx")));
+        inOrder.verify(mockBridgeHandler).readDecimalType(eq(testSensorId), any());
+        inOrder.verify(mockThingHandler).postUpdate(eq(CHANNEL_LIGHT), eq(new QuantityType<>("100 lx")));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void noChannel() {
+    public void noChannel() throws OwException {
         final EDS006x testDevice = instantiateDevice(OwSensorType.EDS0068);
         final InOrder inOrder = Mockito.inOrder(mockThingHandler, mockBridgeHandler);
 
-        try {
-            Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
+        Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
+        Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(new DecimalType(2.0));
 
-            testDevice.configureChannels();
-            testDevice.refresh(mockBridgeHandler, true);
+        testDevice.configureChannels();
+        testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/BasicThingHandlerTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/BasicThingHandlerTest.java
@@ -12,21 +12,17 @@
  */
 package org.openhab.binding.onewire.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
-import static org.openhab.binding.onewire.internal.OwBindingConstants.CONFIG_ID;
-import static org.openhab.binding.onewire.internal.OwBindingConstants.THING_TYPE_BASIC;
+import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.openhab.binding.onewire.internal.device.OwSensorType;
 import org.openhab.binding.onewire.internal.handler.BasicThingHandler;
 import org.openhab.binding.onewire.internal.handler.OwBaseThingHandler;
@@ -47,15 +43,13 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 public class BasicThingHandlerTest extends AbstractThingHandlerTest {
     private static final String TEST_ID = "00.000000000000";
 
-    @Before
+    @BeforeEach
     public void setup() throws OwException {
-        MockitoAnnotations.initMocks(this);
-
         initializeBridge();
 
         final Bridge bridge = this.bridge;
         if (bridge == null) {
-            Assert.fail("bridge is null");
+            fail("bridge is null");
             return;
         }
 
@@ -67,7 +61,7 @@ public class BasicThingHandlerTest extends AbstractThingHandlerTest {
 
         final Thing thing = this.thing;
         if (thing == null) {
-            Assert.fail("thing is null");
+            fail("thing is null");
             return;
         }
 
@@ -85,7 +79,7 @@ public class BasicThingHandlerTest extends AbstractThingHandlerTest {
     public void testInitializationEndsWithUnknown() throws OwException {
         final ThingHandler thingHandler = this.thingHandler;
         if (thingHandler == null) {
-            Assert.fail("thingHandler is null");
+            fail("thingHandler is null");
             return;
         }
 
@@ -103,7 +97,7 @@ public class BasicThingHandlerTest extends AbstractThingHandlerTest {
         final OwBaseThingHandler thingHandler = this.thingHandler;
         final InOrder inOrder = this.inOrder;
         if (thingHandler == null || inOrder == null) {
-            Assert.fail("prerequisite is null");
+            fail("prerequisite is null");
             return;
         }
 
@@ -127,7 +121,7 @@ public class BasicThingHandlerTest extends AbstractThingHandlerTest {
         final OwBaseThingHandler thingHandler = this.thingHandler;
         final InOrder inOrder = this.inOrder;
         if (thingHandler == null || inOrder == null) {
-            Assert.fail("prerequisite is null");
+            fail("prerequisite is null");
             return;
         }
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/EDSSensorThingHandlerTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/EDSSensorThingHandlerTest.java
@@ -12,25 +12,26 @@
  */
 package org.openhab.binding.onewire.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.openhab.binding.onewire.internal.handler.EDSSensorThingHandler;
 import org.openhab.binding.onewire.internal.handler.OwBaseThingHandler;
 import org.openhab.binding.onewire.test.AbstractThingHandlerTest;
 import org.openhab.core.config.core.Configuration;
-import org.openhab.core.thing.*;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
@@ -50,15 +51,13 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
             CHANNEL_ABSOLUTE_HUMIDITY);
     private static final ChannelUID CHANNEL_UID_DEWPOINT = new ChannelUID(THING_UID, CHANNEL_DEWPOINT);
 
-    @Before
+    @BeforeEach
     public void setup() throws OwException {
-        MockitoAnnotations.initMocks(this);
-
         initializeBridge();
 
         final Bridge bridge = this.bridge;
         if (bridge == null) {
-            Assert.fail("bridge is null");
+            fail("bridge is null");
             return;
         }
 
@@ -75,7 +74,7 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
 
         final Thing thing = this.thing;
         if (thing == null) {
-            Assert.fail("thing is null");
+            fail("thing is null");
             return;
         }
 
@@ -97,7 +96,7 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
     public void testInitializationEndsWithUnknown() {
         final ThingHandler thingHandler = this.thingHandler;
         if (thingHandler == null) {
-            Assert.fail("thingHandler is null");
+            fail("thingHandler is null");
             return;
         }
 
@@ -111,7 +110,7 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
         final OwBaseThingHandler thingHandler = this.thingHandler;
         final InOrder inOrder = this.inOrder;
         if (thingHandler == null || inOrder == null) {
-            Assert.fail("prerequisite is null");
+            fail("prerequisite is null");
             return;
         }
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/MultisensorThingHandlerTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/MultisensorThingHandlerTest.java
@@ -12,21 +12,17 @@
  */
 package org.openhab.binding.onewire.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
-import static org.openhab.binding.onewire.internal.OwBindingConstants.CONFIG_ID;
-import static org.openhab.binding.onewire.internal.OwBindingConstants.THING_TYPE_MS_TX;
+import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.openhab.binding.onewire.internal.device.OwSensorType;
 import org.openhab.binding.onewire.internal.handler.BasicMultisensorThingHandler;
 import org.openhab.binding.onewire.internal.handler.OwBaseThingHandler;
@@ -47,15 +43,13 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
     private static final String TEST_ID = "00.000000000000";
 
-    @Before
+    @BeforeEach
     public void setup() throws OwException {
-        MockitoAnnotations.initMocks(this);
-
         initializeBridge();
 
         final Bridge bridge = this.bridge;
         if (bridge == null) {
-            Assert.fail("bridge is null");
+            fail("bridge is null");
             return;
         }
 
@@ -67,7 +61,7 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
 
         final Thing thing = this.thing;
         if (thing == null) {
-            Assert.fail("thing is null");
+            fail("thing is null");
             return;
         }
 
@@ -95,7 +89,7 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
     public void testInitializationEndsWithUnknown() {
         final ThingHandler thingHandler = this.thingHandler;
         if (thingHandler == null) {
-            Assert.fail("thingHandler is null");
+            fail("thingHandler is null");
             return;
         }
         thingHandler.initialize();
@@ -108,7 +102,7 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
         final OwBaseThingHandler thingHandler = this.thingHandler;
         final InOrder inOrder = this.inOrder;
         if (thingHandler == null || inOrder == null) {
-            Assert.fail("prerequisite is null");
+            fail("prerequisite is null");
             return;
         }
         thingHandler.initialize();

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/OwserverBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/internal/OwserverBridgeHandlerTest.java
@@ -13,11 +13,10 @@
 package org.openhab.binding.onewire.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.*;
 
 import java.util.HashMap;
@@ -25,13 +24,14 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.onewire.internal.handler.OwserverBridgeHandler;
 import org.openhab.binding.onewire.internal.owserver.OwserverConnection;
 import org.openhab.binding.onewire.internal.owserver.OwserverConnectionState;
@@ -49,6 +49,7 @@ import org.openhab.core.thing.binding.builder.BridgeBuilder;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class OwserverBridgeHandlerTest extends JavaTest {
 
@@ -56,23 +57,16 @@ public class OwserverBridgeHandlerTest extends JavaTest {
     private static final int TEST_PORT = 4711;
     Map<String, Object> bridgeProperties = new HashMap<>();
 
-    @Mock
-    @NonNullByDefault({})
-    private OwserverConnection owserverConnection;
-
-    @Mock
-    @NonNullByDefault({})
-    private ThingHandlerCallback thingHandlerCallback;
+    private @Mock @NonNullByDefault({}) OwserverConnection owserverConnection;
+    private @Mock @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
 
     private @Nullable OwserverBridgeHandler bridgeHandler;
     private @Nullable Bridge bridge;
 
-    @Before
+    @BeforeEach
     public void setup() {
         bridgeProperties.put(CONFIG_ADDRESS, TEST_HOST);
         bridgeProperties.put(CONFIG_PORT, TEST_PORT);
-
-        initMocks(this);
 
         bridge = BridgeBuilder.create(THING_TYPE_OWSERVER, "owserver").withLabel("owserver")
                 .withConfiguration(new Configuration(bridgeProperties)).build();
@@ -85,7 +79,7 @@ public class OwserverBridgeHandlerTest extends JavaTest {
         final Bridge bridge = this.bridge;
 
         if (bridge == null) {
-            Assert.fail("bridge is null");
+            fail("bridge is null");
             return;
         }
 
@@ -95,7 +89,7 @@ public class OwserverBridgeHandlerTest extends JavaTest {
         this.bridgeHandler = bridgeHandler;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         final OwserverBridgeHandler bridgeHandler = this.bridgeHandler;
         if (bridgeHandler != null) {
@@ -107,7 +101,7 @@ public class OwserverBridgeHandlerTest extends JavaTest {
     public void testInitializationStartsConnectionWithOptions() {
         final OwserverBridgeHandler bridgeHandler = this.bridgeHandler;
         if (bridgeHandler == null) {
-            Assert.fail("bridgeHandler is null");
+            fail("bridgeHandler is null");
             return;
         }
 
@@ -123,7 +117,7 @@ public class OwserverBridgeHandlerTest extends JavaTest {
     public void testInitializationReportsRefreshableOnSuccessfullConnection() {
         final OwserverBridgeHandler bridgeHandler = this.bridgeHandler;
         if (bridgeHandler == null) {
-            Assert.fail("bridgeHandler is null");
+            fail("bridgeHandler is null");
             return;
         }
 
@@ -148,7 +142,7 @@ public class OwserverBridgeHandlerTest extends JavaTest {
     public void testInitializationReportsNotRefreshableOnFailedConnection() {
         final OwserverBridgeHandler bridgeHandler = this.bridgeHandler;
         if (bridgeHandler == null) {
-            Assert.fail("bridgeHandler is null");
+            fail("bridgeHandler is null");
             return;
         }
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/owserver/OwserverConnectionTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/owserver/OwserverConnectionTest.java
@@ -12,9 +12,8 @@
  */
 package org.openhab.binding.onewire.owserver;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,12 +21,13 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.OwPageBuffer;
 import org.openhab.binding.onewire.internal.SensorId;
@@ -46,6 +46,7 @@ import org.openhab.core.types.State;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 @NonNullByDefault
 public class OwserverConnectionTest extends JavaTest {
     private static final String TEST_HOST = "127.0.0.1";
@@ -53,15 +54,12 @@ public class OwserverConnectionTest extends JavaTest {
     private @Nullable OwserverTestServer testServer;
     private @Nullable OwserverConnection owserverConnection;
 
-    @Mock
-    private @NonNullByDefault({}) OwserverBridgeHandler bridgeHandler;
+    private @Mock @NonNullByDefault({}) OwserverBridgeHandler bridgeHandler;
 
     private int testPort;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
-
         CompletableFuture<Boolean> serverStarted = new CompletableFuture<>();
         testPort = TestPortUtil.findFreePort();
         try {
@@ -80,7 +78,7 @@ public class OwserverConnectionTest extends JavaTest {
         serverStarted.get(); // wait for the server thread to start
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         try {
             final OwserverTestServer testServer = this.testServer;
@@ -96,7 +94,7 @@ public class OwserverConnectionTest extends JavaTest {
     public void successfullConnectionReportedToBridgeHandler() {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
@@ -108,7 +106,7 @@ public class OwserverConnectionTest extends JavaTest {
     public void failedConnectionReportedToBridgeHandler() {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.setPort(1);
@@ -119,30 +117,27 @@ public class OwserverConnectionTest extends JavaTest {
     }
 
     @Test
-    public void testGetDirectory() {
+    public void testGetDirectory() throws OwException {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
-        try {
-            List<SensorId> directory = owserverConnection.getDirectory("/");
 
-            assertEquals(3, directory.size());
-            assertEquals(new SensorId("/00.0123456789ab"), directory.get(0));
-            assertEquals(new SensorId("/00.0123456789ac"), directory.get(1));
-            assertEquals(new SensorId("/00.0123456789ad"), directory.get(2));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        List<SensorId> directory = owserverConnection.getDirectory("/");
+
+        assertEquals(3, directory.size());
+        assertEquals(new SensorId("/00.0123456789ab"), directory.get(0));
+        assertEquals(new SensorId("/00.0123456789ac"), directory.get(1));
+        assertEquals(new SensorId("/00.0123456789ad"), directory.get(2));
     }
 
     @Test
     public void testCheckPresence() {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
@@ -154,71 +149,58 @@ public class OwserverConnectionTest extends JavaTest {
     }
 
     @Test
-    public void testReadDecimalType() {
+    public void testReadDecimalType() throws OwException {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
-        try {
-            DecimalType number = (DecimalType) owserverConnection.readDecimalType("testsensor/decimal");
 
-            assertEquals(17.4, number.doubleValue(), 0.01);
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        DecimalType number = (DecimalType) owserverConnection.readDecimalType("testsensor/decimal");
+
+        assertEquals(17.4, number.doubleValue(), 0.01);
     }
 
     @Test
-    public void testReadDecimalTypeArray() {
+    public void testReadDecimalTypeArray() throws OwException {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
-        try {
-            List<State> numbers = owserverConnection.readDecimalTypeArray("testsensor/decimalarray");
 
-            assertEquals(3834, ((DecimalType) numbers.get(0)).intValue());
-            assertEquals(0, ((DecimalType) numbers.get(1)).intValue());
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        List<State> numbers = owserverConnection.readDecimalTypeArray("testsensor/decimalarray");
+
+        assertEquals(3834, ((DecimalType) numbers.get(0)).intValue());
+        assertEquals(0, ((DecimalType) numbers.get(1)).intValue());
     }
 
     @Test
-    public void testGetPages() {
+    public void testGetPages() throws OwException {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
-        try {
-            OwPageBuffer pageBuffer = owserverConnection.readPages("testsensor");
 
-            assertEquals(31, pageBuffer.getByte(5, 7));
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        OwPageBuffer pageBuffer = owserverConnection.readPages("testsensor");
+        assertEquals(31, pageBuffer.getByte(5, 7));
     }
 
     @Test
-    public void testWriteDecimalType() {
+    public void testWriteDecimalType() throws OwException {
         final OwserverConnection owserverConnection = this.owserverConnection;
         if (owserverConnection == null) {
-            Assert.fail("connection is null");
+            fail("connection is null");
             return;
         }
         owserverConnection.start();
-        try {
-            owserverConnection.writeDecimalType("testsensor/decimal", new DecimalType(2009));
 
-            Mockito.verify(bridgeHandler, never()).reportConnectionState(OwserverConnectionState.FAILED);
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        owserverConnection.writeDecimalType("testsensor/decimal", new DecimalType(2009));
+
+        Mockito.verify(bridgeHandler, never()).reportConnectionState(OwserverConnectionState.FAILED);
     }
 }

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/test/AbstractThingHandlerTest.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/test/AbstractThingHandlerTest.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.onewire.test;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.openhab.binding.onewire.internal.OwBindingConstants.THING_TYPE_OWSERVER;
 
@@ -23,11 +24,14 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.handler.OwBaseThingHandler;
@@ -48,6 +52,8 @@ import org.openhab.core.thing.binding.builder.BridgeBuilder;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public abstract class AbstractThingHandlerTest extends JavaTest {
 
@@ -56,25 +62,11 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
     protected Map<String, Object> thingConfiguration = new HashMap<>();
     protected Map<String, Object> channelProperties = new HashMap<>();
 
-    @Mock
-    @NonNullByDefault({})
-    protected ThingHandlerCallback thingHandlerCallback;
-
-    @Mock
-    @NonNullByDefault({})
-    protected OwDynamicStateDescriptionProvider stateProvider;
-
-    @Mock
-    @NonNullByDefault({})
-    protected ThingHandlerCallback bridgeHandlerCallback;
-
-    @Mock
-    @NonNullByDefault({})
-    protected OwserverBridgeHandler bridgeHandler;
-
-    @Mock
-    @NonNullByDefault({})
-    protected OwserverBridgeHandler secondBridgeHandler;
+    protected @Mock @NonNullByDefault({}) ThingHandlerCallback thingHandlerCallback;
+    protected @Mock @NonNullByDefault({}) OwDynamicStateDescriptionProvider stateProvider;
+    protected @Mock @NonNullByDefault({}) ThingHandlerCallback bridgeHandlerCallback;
+    protected @Mock @NonNullByDefault({}) OwserverBridgeHandler bridgeHandler;
+    protected @Mock @NonNullByDefault({}) OwserverBridgeHandler secondBridgeHandler;
 
     protected List<Channel> channels = new ArrayList<>();
 
@@ -84,7 +76,7 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
 
     protected @Nullable InOrder inOrder;
 
-    @After
+    @AfterEach
     public void tearDown() {
         final ThingHandler thingHandler = this.thingHandler;
         if (thingHandler != null) {
@@ -95,7 +87,7 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
     protected void initializeHandlerMocks() {
         final ThingHandler thingHandler = this.thingHandler;
         if (thingHandler == null) {
-            Assert.fail("thingHandler is null");
+            fail("thingHandler is null");
             return;
         }
 
@@ -131,7 +123,7 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
         Mockito.doAnswer(answer -> {
             final OwBaseThingHandler thingHandler = this.thingHandler;
             if (thingHandler == null) {
-                Assert.fail("thingHandler is null");
+                fail("thingHandler is null");
                 return null;
             }
 

--- a/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/test/OwserverTestServer.java
+++ b/bundles/org.openhab.binding.onewire/src/test/java/org/openhab/binding/onewire/test/OwserverTestServer.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.onewire.test;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -22,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
 import org.openhab.binding.onewire.internal.OwException;
 import org.openhab.binding.onewire.internal.OwPageBuffer;
 import org.openhab.binding.onewire.internal.owserver.OwserverPacket;
@@ -78,7 +79,7 @@ public class OwserverTestServer {
                 } catch (IOException e) {
                     logger.error("I/O Error: {}", e.getMessage());
                 } catch (OwException e) {
-                    Assert.fail("caught unexpected OwException");
+                    fail("caught unexpected OwException");
                 }
             }
         }.start();

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestCreateCommandPayload.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestCreateCommandPayload.java
@@ -13,6 +13,7 @@
 package tests;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.CommandPayload;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.PartitionCommand;

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestCreateCommandPayload.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestCreateCommandPayload.java
@@ -12,8 +12,8 @@
  */
 package tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.CommandPayload;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.PartitionCommand;
 import org.openhab.binding.paradoxalarm.internal.util.ParadoxUtil;
@@ -41,9 +41,9 @@ public class TestCreateCommandPayload {
         int payloadIndexOfByteToCheck = 6 + (partitionNumber - 1) / 2;
         byte byteValue = bytes[payloadIndexOfByteToCheck];
         if ((partitionNumber - 1) % 2 == 0) {
-            Assert.assertTrue(ParadoxUtil.getHighNibble(byteValue) == command.getCommand());
+            assertTrue(ParadoxUtil.getHighNibble(byteValue) == command.getCommand());
         } else {
-            Assert.assertTrue(ParadoxUtil.getLowNibble(byteValue) == command.getCommand());
+            assertTrue(ParadoxUtil.getLowNibble(byteValue) == command.getCommand());
         }
     }
 }

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestEncryptionHandler.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestEncryptionHandler.java
@@ -12,12 +12,11 @@
  */
 package tests;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.communication.crypto.EncryptionHandler;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.HeaderCommand;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.ParadoxIPPacket;
@@ -70,6 +69,6 @@ public class TestEncryptionHandler {
         ParadoxUtil.printByteArray("Expected=", ENCRYPTED_EXPECTED2);
         ParadoxUtil.printByteArray("Packet=  ", packetBytes);
 
-        Assert.assertTrue(Arrays.equals(packetBytes, ENCRYPTED_EXPECTED2));
+        assertTrue(Arrays.equals(packetBytes, ENCRYPTED_EXPECTED2));
     }
 }

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestGetBytes.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestGetBytes.java
@@ -14,8 +14,8 @@ package tests;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.CommandPayload;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.EpromRequestPayload;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.HeaderCommand;
@@ -57,7 +57,7 @@ public class TestGetBytes {
         ParadoxUtil.printByteArray("Expected =", EXPECTED1);
         ParadoxUtil.printByteArray("Packet   =", packetBytes);
 
-        Assert.assertTrue(Arrays.equals(packetBytes, EXPECTED1));
+        assertTrue(Arrays.equals(packetBytes, EXPECTED1));
     }
 
     private static final byte[] EXPECTED_COMMAND_PAYLOAD = { 0x40, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
@@ -71,7 +71,7 @@ public class TestGetBytes {
         ParadoxUtil.printByteArray("Expected =", EXPECTED_COMMAND_PAYLOAD);
         ParadoxUtil.printByteArray("Result   =", packetBytes);
 
-        Assert.assertTrue(Arrays.equals(packetBytes, EXPECTED_COMMAND_PAYLOAD));
+        assertTrue(Arrays.equals(packetBytes, EXPECTED_COMMAND_PAYLOAD));
     }
 
     private static final byte[] EXPECTED_MEMORY_PAYLOAD = { (byte) 0xAA, 0x0A, 0x00, 0x03, 0x08, (byte) 0xF0, 0x00,

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestGetBytes.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestGetBytes.java
@@ -12,9 +12,10 @@
  */
 package tests;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.CommandPayload;
 import org.openhab.binding.paradoxalarm.internal.communication.messages.EpromRequestPayload;

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestParadoxUtil.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestParadoxUtil.java
@@ -12,8 +12,8 @@
  */
 package tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.util.ParadoxUtil;
 
 /**
@@ -31,7 +31,7 @@ public class TestParadoxUtil {
 
         final byte[] EXPECTED_RESULT = { 0x0A, 0x50, 0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x59, (byte) 0xEE, (byte) 0xEE,
                 (byte) 0xEE, (byte) 0xEE, (byte) 0xEE, (byte) 0xEE, (byte) 0xEE };
-        Assert.assertArrayEquals(EXPECTED_RESULT, extendedArray); //
+        assertArrayEquals(EXPECTED_RESULT, extendedArray); //
     }
 
     @Test
@@ -42,6 +42,6 @@ public class TestParadoxUtil {
         byte[] mergedArrays = ParadoxUtil.mergeByteArrays(ARR1, ARR2, ARR3);
 
         final byte[] EXPECTED_RESULT = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
-        Assert.assertArrayEquals(EXPECTED_RESULT, mergedArrays);
+        assertArrayEquals(EXPECTED_RESULT, mergedArrays);
     }
 }

--- a/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestParadoxUtil.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/test/java/tests/TestParadoxUtil.java
@@ -13,6 +13,7 @@
 package tests;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.paradoxalarm.internal.util.ParadoxUtil;
 

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQTemperatureMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBBQTemperatureMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBBQTemperatureMessage.SubType.BBQ1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,16 +32,16 @@ public class RFXComBBQTemperatureMessageTest {
         String hexMessage = "0A4E012B2955001A002179";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComBBQTemperatureMessage msg = (RFXComBBQTemperatureMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", BBQ1, msg.subType);
-        assertEquals("Seq Number", 43, msg.seqNbr);
-        assertEquals("Sensor Id", "10581", msg.getDeviceId());
-        assertEquals("Food Temperature", 26, msg.foodTemperature, 0.1);
-        assertEquals("BBQ Temperature", 33, msg.bbqTemperature, 0.1);
-        assertEquals("Signal Level", 7, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(BBQ1, msg.subType, "SubType");
+        assertEquals(43, msg.seqNbr, "Seq Number");
+        assertEquals("10581", msg.getDeviceId(), "Sensor Id");
+        assertEquals(26, msg.foodTemperature, 0.1, "Food Temperature");
+        assertEquals(33, msg.bbqTemperature, 0.1, "BBQ Temperature");
+        assertEquals(7, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBarometricMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBarometricMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -24,8 +26,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 @NonNullByDefault
 public class RFXComBarometricMessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.BAROMETRIC);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.BAROMETRIC));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1MessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.Commands;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBlinds1Message.SubType;
@@ -32,15 +32,15 @@ public class RFXComBlinds1MessageTest {
             RFXComBlinds1Message.Commands command) throws RFXComException {
         final RFXComBlinds1Message msg = (RFXComBlinds1Message) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Command", command, msg.command);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(command, msg.command, "Command");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCamera1MessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -24,9 +26,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 @NonNullByDefault
 public class RFXComCamera1MessageTest {
-
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.CAMERA1);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.CAMERA1));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComChimeMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComChimeMessage.SubType;
 import org.openhab.core.util.HexUtils;
@@ -34,13 +34,13 @@ public class RFXComChimeMessageTest {
         String hexMessage = "0716020900A1F350";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComChimeMessage msg = (RFXComChimeMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", SubType.SELECTPLUS, msg.subType);
-        assertEquals("Seq Number", 9, msg.seqNbr);
-        assertEquals("Sensor Id", "41459", msg.getDeviceId());
-        assertEquals("Signal Level", 5, msg.signalLevel);
+        assertEquals(SubType.SELECTPLUS, msg.subType, "SubType");
+        assertEquals(9, msg.seqNbr, "Seq Number");
+        assertEquals("41459", msg.getDeviceId(), "Sensor Id");
+        assertEquals(5, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -31,20 +31,20 @@ public class RFXComCurrentEnergyMessageTest {
             int batteryLevel) throws RFXComException {
         final RFXComCurrentEnergyMessage msg = (RFXComCurrentEnergyMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Count", count, msg.count);
-        assertEquals("Channel 1", channel1, msg.channel1Amps, 0.01);
-        assertEquals("Channel 2", channel2, msg.channel2Amps, 0.01);
-        assertEquals("Channel 3", channel3, msg.channel3Amps, 0.01);
-        assertEquals("Total usage", totalUsage, msg.totalUsage, 0.05);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
-        assertEquals("Battery Level", batteryLevel, msg.batteryLevel);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(count, msg.count, "Count");
+        assertEquals(channel1, msg.channel1Amps, 0.01, "Channel 1");
+        assertEquals(channel2, msg.channel2Amps, 0.01, "Channel 2");
+        assertEquals(channel3, msg.channel3Amps, 0.01, "Channel 3");
+        assertEquals(totalUsage, msg.totalUsage, 0.05, "Total usage");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
+        assertEquals(batteryLevel, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComCurrentMessage.SubType;
 import org.openhab.core.util.HexUtils;
@@ -34,18 +34,18 @@ public class RFXComCurrentMessageTest {
 
         final RFXComCurrentMessage msg = (RFXComCurrentMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(message));
-        assertEquals("SubType", SubType.ELEC1, msg.subType);
-        assertEquals("Seq Number", 15, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "34304", msg.getDeviceId());
-        assertEquals("Count", 4, msg.count);
-        assertEquals("Channel 1", 2.9d, msg.channel1Amps, 0.01);
-        assertEquals("Channel 2", 0d, msg.channel2Amps, 0.01);
-        assertEquals("Channel 3", 0d, msg.channel3Amps, 0.01);
-        assertEquals("Signal Level", 4, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(SubType.ELEC1, msg.subType, "SubType");
+        assertEquals(15, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("34304", msg.getDeviceId(), "Sensor Id");
+        assertEquals(4, msg.count, "Count");
+        assertEquals(2.9d, msg.channel1Amps, 0.01, "Channel 1");
+        assertEquals(0d, msg.channel2Amps, 0.01, "Channel 2");
+        assertEquals(0d, msg.channel3Amps, 0.01, "Channel 3");
+        assertEquals(4, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", message, HexUtils.bytesToHex(decoded));
+        assertEquals(message, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurtain1MessageTest.java
@@ -15,7 +15,7 @@ package org.openhab.binding.rfxcom.internal.messages;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.CURTAIN1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 
 /**

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.util.HexUtils;
@@ -33,17 +33,17 @@ public class RFXComDateTimeMessageTest {
         String hexMessage = "0D580117B90003041D030D150A69";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComDateTimeMessage msg = (RFXComDateTimeMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComDateTimeMessage.SubType.RTGR328N, msg.subType);
-        assertEquals("Seq Number", 23, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "47360", msg.getDeviceId());
-        assertEquals("Date time", "2003-04-29T13:21:10", msg.dateTime);
-        assertEquals("Signal Level", 2, RFXComTestHelper.getActualIntValue(msg, CHANNEL_SIGNAL_LEVEL));
+        assertEquals(RFXComDateTimeMessage.SubType.RTGR328N, msg.subType, "SubType");
+        assertEquals(23, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("47360", msg.getDeviceId(), "Sensor Id");
+        assertEquals("2003-04-29T13:21:10", msg.dateTime, "Date time");
+        assertEquals(2, RFXComTestHelper.getActualIntValue(msg, CHANNEL_SIGNAL_LEVEL), "Signal Level");
 
-        assertEquals("Converted value", DateTimeType.valueOf("2003-04-29T13:21:10"),
-                msg.convertToState(CHANNEL_DATE_TIME, new MockDeviceState()));
+        assertEquals(DateTimeType.valueOf("2003-04-29T13:21:10"),
+                msg.convertToState(CHANNEL_DATE_TIME, new MockDeviceState()), "Converted value");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEdisioTest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.EDISIO;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
@@ -25,8 +26,8 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  */
 @NonNullByDefault
 public class RFXComEdisioTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(EDISIO);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class, () -> RFXComMessageFactory.createMessage(EDISIO));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComEnergyMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComEnergyMessage.SubType.ELEC2;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,17 +32,17 @@ public class RFXComEnergyMessageTest {
         String hexMessage = "115A01071A7300000003F600000000350B89";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComEnergyMessage msg = (RFXComEnergyMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", ELEC2, msg.subType);
-        assertEquals("Seq Number", 7, msg.seqNbr);
-        assertEquals("Sensor Id", "6771", msg.getDeviceId());
-        assertEquals("Count", 0, msg.count);
-        assertEquals("Instant usage", 1014d / 230, msg.instantAmp, 0.01);
-        assertEquals("Total usage", 60.7d / 230, msg.totalAmpHour, 0.01);
-        assertEquals("Signal Level", (byte) 8, msg.signalLevel);
-        assertEquals("Battery Level", (byte) 9, msg.batteryLevel);
+        assertEquals(ELEC2, msg.subType, "SubType");
+        assertEquals(7, msg.seqNbr, "Seq Number");
+        assertEquals("6771", msg.getDeviceId(), "Sensor Id");
+        assertEquals(0, msg.count, "Count");
+        assertEquals(1014d / 230, msg.instantAmp, 0.01, "Instant usage");
+        assertEquals(60.7d / 230, msg.totalAmpHour, 0.01, "Total usage");
+        assertEquals((byte) 8, msg.signalLevel, "Signal Level");
+        assertEquals((byte) 9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFS20MessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,8 +27,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComFS20MessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.FS20);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.FS20));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanFalmecMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanFalmecMessageTest.java
@@ -18,7 +18,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComFanMessage.SubT
 import static org.openhab.binding.rfxcom.internal.messages.RFXComFanMessageTest.testCommand;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanLucciAirDc2MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanLucciAirDc2MessageTest.java
@@ -18,7 +18,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComFanMessage.SubT
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanLucciAirDcMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanLucciAirDcMessageTest.java
@@ -18,7 +18,7 @@ import static org.openhab.binding.rfxcom.internal.messages.RFXComFanMessage.SubT
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.FAN;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComFanMessage.SubType.CASAFAN;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -55,9 +55,9 @@ public class RFXComFanMessageTest {
             @Nullable State expectedCommand, State expectedLightCommand, @Nullable State expectedFanSpeed,
             RFXComBaseMessage.PacketType packetType) throws RFXComException {
         final RFXComFanMessage msg = (RFXComFanMessage) RFXComMessageFactory.createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
 
         assertEquals(expectedCommand, msg.convertToState(CHANNEL_COMMAND, DEVICE_STATE));
         assertEquals(expectedLightCommand, msg.convertToState(CHANNEL_FAN_LIGHT, DEVICE_STATE));
@@ -67,7 +67,7 @@ public class RFXComFanMessageTest {
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComGasMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,8 +27,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComGasMessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.GAS);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.GAS));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHomeConfortTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.HOME_CONFORT;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.Commands;
 import org.openhab.binding.rfxcom.internal.messages.RFXComHomeConfortMessage.SubType;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComHumidityMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,16 +32,16 @@ public class RFXComHumidityMessageTest {
         String hexMessage = "085101027700360189";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComHumidityMessage msg = (RFXComHumidityMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComHumidityMessage.SubType.HUM1, msg.subType);
-        assertEquals("Seq Number", 2, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "30464", msg.getDeviceId());
-        assertEquals("Humidity", 54, msg.humidity);
-        assertEquals("Humidity status", RFXComHumidityMessage.HumidityStatus.COMFORT, msg.humidityStatus);
-        assertEquals("Signal Level", (byte) 8, msg.signalLevel);
-        assertEquals("Battery Level", (byte) 9, msg.batteryLevel);
+        assertEquals(RFXComHumidityMessage.SubType.HUM1, msg.subType, "SubType");
+        assertEquals(2, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("30464", msg.getDeviceId(), "Sensor Id");
+        assertEquals(54, msg.humidity, "Humidity");
+        assertEquals(RFXComHumidityMessage.HumidityStatus.COMFORT, msg.humidityStatus, "Humidity status");
+        assertEquals((byte) 8, msg.signalLevel, "Signal Level");
+        assertEquals((byte) 9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComIOLinesMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,8 +27,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComIOLinesMessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.IO_LINES);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.IO_LINES));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceControlMessageTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.TransceiverType._433_92MHZ_TRANSCEIVER;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.config.RFXComBridgeConfiguration;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
@@ -31,7 +31,7 @@ import org.openhab.core.util.HexUtils;
 public class RFXComInterfaceControlMessageTest {
     private RFXComBridgeConfiguration configuration = new RFXComBridgeConfiguration();
 
-    @Before
+    @BeforeEach
     public void resetConfig() {
         configuration.transmitPower = -18;
         configuration.enableUndecoded = false;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInterfaceMessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.Commands.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType.START_RECEIVER;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.TransceiverType._433_92MHZ_TRANSCEIVER;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.Commands;
 import org.openhab.binding.rfxcom.internal.messages.RFXComInterfaceMessage.SubType;
@@ -36,9 +36,9 @@ public class RFXComInterfaceMessageTest {
             throws RFXComException {
         RFXComInterfaceMessage msg = (RFXComInterfaceMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Command", command, msg.command);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(command, msg.command, "Command");
 
         return msg;
     }
@@ -48,7 +48,7 @@ public class RFXComInterfaceMessageTest {
         RFXComInterfaceMessage msg = testMessage("1401070307436F7079726967687420524658434F4D", START_RECEIVER, 3,
                 Commands.START_RECEIVER);
 
-        assertEquals("text", "Copyright RFXCOM", msg.text);
+        assertEquals("Copyright RFXCOM", msg.text, "text");
     }
 
     @Test
@@ -60,9 +60,9 @@ public class RFXComInterfaceMessageTest {
     public void testStatusMessage() throws RFXComException {
         RFXComInterfaceMessage msg = testMessage("1401000102530C0800270001031C04524658434F4D", RESPONSE, 1, GET_STATUS);
 
-        assertEquals("Command", _433_92MHZ_TRANSCEIVER, msg.transceiverType);
+        assertEquals(_433_92MHZ_TRANSCEIVER, msg.transceiverType, "Command");
 
         // TODO this is not correct, improvements for this have been made in the OH1 repo
-        assertEquals("firmwareVersion", 12, msg.firmwareVersion);
+        assertEquals(12, msg.firmwareVersion, "firmwareVersion");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComInvalidMessageTypeTest.java
@@ -12,9 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
-import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 import org.openhab.core.util.HexUtils;
 
@@ -26,9 +27,9 @@ import org.openhab.core.util.HexUtils;
 @NonNullByDefault
 public class RFXComInvalidMessageTypeTest {
 
-    @Test(expected = RFXComUnsupportedValueException.class)
-    public void testMessage() throws RFXComException {
+    @Test
+    public void testMessage() {
         byte[] message = HexUtils.hexToBytes("07CC01271356ECC0");
-        RFXComMessageFactory.createMessage(message);
+        assertThrows(RFXComUnsupportedValueException.class, () -> RFXComMessageFactory.createMessage(message));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1MessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComLighting1Message.Commands;
@@ -38,17 +38,17 @@ public class RFXComLighting1MessageTest {
             byte signalLevel, Commands command, String commandString) throws RFXComException {
         final RFXComLighting1Message msg = (RFXComLighting1Message) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
-        assertEquals("Command", command, msg.command);
-        assertEquals("Command String", commandString,
-                msg.convertToState(CHANNEL_COMMAND_STRING, deviceState).toString());
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
+        assertEquals(command, msg.command, "Command");
+        assertEquals(commandString, msg.convertToState(CHANNEL_COMMAND_STRING, deviceState).toString(),
+                "Command String");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2MessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,14 +32,14 @@ public class RFXComLighting2MessageTest {
         String hexMessage = "0B11000600109B520B000080";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComLighting2Message msg = (RFXComLighting2Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComLighting2Message.SubType.AC, msg.subType);
-        assertEquals("Seq Number", 6, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "1088338.11", msg.getDeviceId());
-        assertEquals("Command", RFXComLighting2Message.Commands.OFF, msg.command);
-        assertEquals("Signal Level", (byte) 8, msg.signalLevel);
+        assertEquals(RFXComLighting2Message.SubType.AC, msg.subType, "SubType");
+        assertEquals(6, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("1088338.11", msg.getDeviceId(), "Sensor Id");
+        assertEquals(RFXComLighting2Message.Commands.OFF, msg.command, "Command");
+        assertEquals((byte) 8, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3MessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,9 +27,10 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComLighting3MessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
+    @Test
+    public void checkNotImplemented() {
         // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(PacketType.LIGHTING3);
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.LIGHTING3));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4MessageTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING4;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting4Message.Commands.*;
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.config.RFXComDeviceConfiguration;
 import org.openhab.binding.rfxcom.internal.config.RFXComDeviceConfigurationBuilder;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
@@ -49,7 +49,7 @@ public class RFXComLighting4MessageTest {
         byte[] binaryMessage = message.decodeMessage();
         RFXComLighting4Message msg = (RFXComLighting4Message) RFXComMessageFactory.createMessage(binaryMessage);
 
-        assertEquals("Sensor Id", "90000", msg.getDeviceId());
+        assertEquals("90000", msg.getDeviceId(), "Sensor Id");
     }
 
     private void testMessage(String hexMsg, RFXComLighting4Message.SubType subType, String deviceId,
@@ -63,16 +63,16 @@ public class RFXComLighting4MessageTest {
             int onCommand) throws RFXComException {
         RFXComLighting4Message msg = (RFXComLighting4Message) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Command", commandByte, RFXComTestHelper.getActualIntValue(msg, CHANNEL_COMMAND_ID));
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(commandByte, RFXComTestHelper.getActualIntValue(msg, CHANNEL_COMMAND_ID), "Command");
         if (seqNbr != null) {
-            assertEquals("Seq Number", seqNbr.shortValue(), (short) (msg.seqNbr & 0xFF));
+            assertEquals(seqNbr.shortValue(), (short) (msg.seqNbr & 0xFF), "Seq Number");
         }
-        assertEquals("Signal Level", signalLevel, RFXComTestHelper.getActualIntValue(msg, CHANNEL_SIGNAL_LEVEL));
+        assertEquals(signalLevel, RFXComTestHelper.getActualIntValue(msg, CHANNEL_SIGNAL_LEVEL), "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
 
         RFXComTestHelper.checkDiscoveryResult(msg, deviceId, pulse, subType.toString(), offCommand, onCommand);
     }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5MessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.LIGHTING5;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.Commands.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComLighting5Message.SubType.IT;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.core.library.types.OnOffType;
@@ -43,11 +43,11 @@ public class RFXComLighting5MessageTest {
         itMessageObject.convertFromState(CHANNEL_COMMAND, OnOffType.ON);
         byte[] message = itMessageObject.decodeMessage();
         String hexMessage = HexUtils.bytesToHex(message);
-        assertEquals("Message is not as expected", "0A140F0000080D01010000", hexMessage);
+        assertEquals("0A140F0000080D01010000", hexMessage, "Message is not as expected");
         RFXComLighting5Message msg = (RFXComLighting5Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", IT, msg.subType);
-        assertEquals("Sensor Id", "2061.1", msg.getDeviceId());
-        assertEquals("Command", ON, msg.command);
+        assertEquals(IT, msg.subType, "SubType");
+        assertEquals("2061.1", msg.getDeviceId(), "Sensor Id");
+        assertEquals(ON, msg.command, "Command");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6MessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,17 +32,17 @@ public class RFXComLighting6MessageTest {
         String hexMessage = "0B150005D950450101011D80";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComLighting6Message msg = (RFXComLighting6Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComLighting6Message.SubType.BLYSS, msg.subType);
-        assertEquals("Seq Number", 5, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "55632.E.1", msg.getDeviceId());
-        assertEquals("Command", RFXComLighting6Message.Commands.OFF, msg.command);
-        assertEquals("Signal Level", (byte) 8, msg.signalLevel);
+        assertEquals(RFXComLighting6Message.SubType.BLYSS, msg.subType, "SubType");
+        assertEquals(5, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("55632.E.1", msg.getDeviceId(), "Sensor Id");
+        assertEquals(RFXComLighting6Message.Commands.OFF, msg.command, "Command");
+        assertEquals((byte) 8, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
         // the openhab plugin is not (yet) using the cmndseqnbr & seqnbr2
         String acceptedHexMessage = "0B150005D950450101000080";
 
-        assertEquals("Message converted back", acceptedHexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(acceptedHexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
@@ -23,9 +25,10 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  */
 @NonNullByDefault
 public class RFXComPowerMessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
+    @Test
+    public void checkNotImplemented() {
         // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(RFXComBaseMessage.PacketType.POWER);
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(RFXComBaseMessage.PacketType.POWER));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXMeterMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,8 +27,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComRFXMeterMessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.RFXMETER);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.RFXMETER));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRFXSensorMessageTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComRFXSensorMessage.SubType.*;
 
@@ -20,7 +20,7 @@ import javax.xml.bind.DatatypeConverter;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.handler.DeviceState;
 import org.openhab.core.library.types.DecimalType;
@@ -41,20 +41,20 @@ public class RFXComRFXSensorMessageTest {
             DeviceState deviceState) throws RFXComException {
         final RFXComRFXSensorMessage msg = (RFXComRFXSensorMessage) RFXComMessageFactory
                 .createMessage(DatatypeConverter.parseHexBinary(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
-        assertEquals("Temperature", temperature, getMessageTemperature(msg, deviceState));
-        assertEquals("Voltage", voltage, getChannelAsDouble(CHANNEL_VOLTAGE, msg, deviceState));
-        assertEquals("Reference Voltage", referenceVoltage,
-                getChannelAsDouble(CHANNEL_REFERENCE_VOLTAGE, msg, deviceState));
-        assertEquals("Humidity", expectedHumidity, getChannelAsDouble(CHANNEL_HUMIDITY, msg, deviceState));
-        assertEquals("Pressure", expectedPressure, getChannelAsDouble(CHANNEL_PRESSURE, msg, deviceState));
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
+        assertEquals(temperature, getMessageTemperature(msg, deviceState), "Temperature");
+        assertEquals(voltage, getChannelAsDouble(CHANNEL_VOLTAGE, msg, deviceState), "Voltage");
+        assertEquals(referenceVoltage, getChannelAsDouble(CHANNEL_REFERENCE_VOLTAGE, msg, deviceState),
+                "Reference Voltage");
+        assertEquals(expectedHumidity, getChannelAsDouble(CHANNEL_HUMIDITY, msg, deviceState), "Humidity");
+        assertEquals(expectedPressure, getChannelAsDouble(CHANNEL_PRESSURE, msg, deviceState), "Pressure");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, DatatypeConverter.printHexBinary(decoded));
+        assertEquals(hexMsg, DatatypeConverter.printHexBinary(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRadiator1MessageTest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.RADIATOR1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
@@ -25,8 +26,8 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  */
 @NonNullByDefault
 public class RFXComRadiator1MessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(RADIATOR1);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class, () -> RFXComMessageFactory.createMessage(RADIATOR1));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComRainMessage.SubType.RAIN2;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -33,16 +33,16 @@ public class RFXComRainMessageTest {
         String hexMessage = "0B550217B6000000004D3C69";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComRainMessage msg = (RFXComRainMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RAIN2, msg.subType);
-        assertEquals("Seq Number", 23, msg.seqNbr);
-        assertEquals("Sensor Id", "46592", msg.getDeviceId());
-        assertEquals("Rain rate", 0.0, msg.rainRate, 0.001);
-        assertEquals("Total rain", 1977.2, msg.rainTotal, 0.001);
-        assertEquals("Signal Level", 6, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(RAIN2, msg.subType, "SubType");
+        assertEquals(23, msg.seqNbr, "Seq Number");
+        assertEquals("46592", msg.getDeviceId(), "Sensor Id");
+        assertEquals(0.0, msg.rainRate, 0.001, "Rain rate");
+        assertEquals(1977.2, msg.rainTotal, 0.001, "Total rain");
+        assertEquals(6, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRemoteControlMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -24,8 +26,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 @NonNullByDefault
 public class RFXComRemoteControlMessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.REMOTE_CONTROL);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.REMOTE_CONTROL));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComRfyMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.RFY;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComRfyMessage.Commands;
 import org.openhab.binding.rfxcom.internal.messages.RFXComRfyMessage.SubType;

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity1MessageTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.SubType.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedValueException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity1Message.Contact;
@@ -38,18 +38,18 @@ public class RFXComSecurity1MessageTest {
             @Nullable Status status, int signalLevel) throws RFXComException {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComSecurity1Message msg = (RFXComSecurity1Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", sequenceNumber, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Battery level", batteryLevel, msg.batteryLevel);
-        assertEquals("Contact", contact, msg.contact);
-        assertEquals("Motion", motion, msg.motion);
-        assertEquals("Status", status, msg.status);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(sequenceNumber, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(batteryLevel, msg.batteryLevel, "Battery level");
+        assertEquals(contact, msg.contact, "Contact");
+        assertEquals(motion, msg.motion, "Motion");
+        assertEquals(status, msg.status, "Status");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test
@@ -66,8 +66,9 @@ public class RFXComSecurity1MessageTest {
                 0);
     }
 
-    @Test(expected = RFXComUnsupportedValueException.class)
-    public void testSomeInvalidSecurityMessage() throws RFXComException {
-        testSomeMessages("08FF0A1F0000000650", null, 0, null, 0, null, null, null, 0);
+    @Test
+    public void testSomeInvalidSecurityMessage() {
+        assertThrows(RFXComUnsupportedValueException.class,
+                () -> testSomeMessages("08FF0A1F0000000650", null, 0, null, 0, null, null, null, 0));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComSecurity2MessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComSecurity2Message.SubType;
 import org.openhab.core.util.HexUtils;
@@ -35,14 +35,14 @@ public class RFXComSecurity2MessageTest {
         byte[] message = HexUtils.hexToBytes(hexMessage);
 
         RFXComSecurity2Message msg = (RFXComSecurity2Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", SubType.RAW_AES_KEELOQ, msg.subType);
-        assertEquals("Seq Number", 0, msg.seqNbr);
-        assertEquals("Sensor Id", "51450387", msg.getDeviceId());
-        assertEquals("Button Status", 12, msg.buttonStatus);
-        assertEquals("Battery Level", 4, msg.batteryLevel);
-        assertEquals("Signal Level", 5, msg.signalLevel);
+        assertEquals(SubType.RAW_AES_KEELOQ, msg.subType, "SubType");
+        assertEquals(0, msg.seqNbr, "Seq Number");
+        assertEquals("51450387", msg.getDeviceId(), "Sensor Id");
+        assertEquals(12, msg.buttonStatus, "Button Status");
+        assertEquals(4, msg.batteryLevel, "Battery Level");
+        assertEquals(5, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessageTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityBarometricMessage.ForecastStatus.RAIN;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityBarometricMessage.HumidityStatus.DRY;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityBarometricMessage.SubType.THB2;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -36,19 +36,19 @@ public class RFXComTemperatureHumidityBarometricMessageTest {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComTemperatureHumidityBarometricMessage msg = (RFXComTemperatureHumidityBarometricMessage) RFXComMessageFactory
                 .createMessage(message);
-        assertEquals("SubType", THB2, msg.subType);
-        assertEquals("Seq Number", 14, msg.seqNbr);
-        assertEquals("Sensor Id", "59648", msg.getDeviceId());
-        assertEquals("Temperature", 20.1, msg.temperature, 0.01);
-        assertEquals("Humidity", 39, msg.humidity);
-        assertEquals("Humidity status", DRY, msg.humidityStatus);
-        assertEquals("Barometer", 999.0, msg.pressure, 0.001);
-        assertEquals("Forecast", RAIN, msg.forecastStatus);
-        assertEquals("Signal Level", 3, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(THB2, msg.subType, "SubType");
+        assertEquals(14, msg.seqNbr, "Seq Number");
+        assertEquals("59648", msg.getDeviceId(), "Sensor Id");
+        assertEquals(20.1, msg.temperature, 0.01, "Temperature");
+        assertEquals(39, msg.humidity, "Humidity");
+        assertEquals(DRY, msg.humidityStatus, "Humidity status");
+        assertEquals(999.0, msg.pressure, 0.001, "Barometer");
+        assertEquals(RAIN, msg.forecastStatus, "Forecast");
+        assertEquals(3, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityMessageTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.SubType.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureHumidityMessage.HumidityStatus;
 import org.openhab.core.util.HexUtils;
@@ -37,18 +37,18 @@ public class RFXComTemperatureHumidityMessageTest {
         byte[] binaryMessage = HexUtils.hexToBytes(hexMsg);
         final RFXComTemperatureHumidityMessage msg = (RFXComTemperatureHumidityMessage) RFXComMessageFactory
                 .createMessage(binaryMessage);
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", sensorId, msg.sensorId);
-        assertEquals("Temperature", temperature, msg.temperature, 0.01);
-        assertEquals("Humidity", humidity, msg.humidity);
-        assertEquals("Humidity Status", humidityStatus, msg.humidityStatus);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
-        assertEquals("Battery Level", batteryLevel, msg.batteryLevel);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(sensorId, msg.sensorId, "Sensor Id");
+        assertEquals(temperature, msg.temperature, 0.01, "Temperature");
+        assertEquals(humidity, msg.humidity, "Humidity");
+        assertEquals(humidityStatus, msg.humidityStatus, "Humidity Status");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
+        assertEquals(batteryLevel, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureMessage.SubType.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -31,16 +31,16 @@ public class RFXComTemperatureMessageTest {
             double temperature, int signalLevel, int bateryLevel) throws RFXComException {
         final RFXComTemperatureMessage msg = (RFXComTemperatureMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", deviceId, msg.getDeviceId());
-        assertEquals("Temperature", temperature, msg.temperature, 0.001);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
-        assertEquals("Battery", bateryLevel, msg.batteryLevel);
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(deviceId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(temperature, msg.temperature, 0.001, "Temperature");
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
+        assertEquals(bateryLevel, msg.batteryLevel, "Battery");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTemperatureRainMessage.SubType.WS1200;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,15 +32,15 @@ public class RFXComTemperatureRainMessageTest {
         String hexMessage = "0A4F01CCF001004F03B759";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComTemperatureRainMessage msg = (RFXComTemperatureRainMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", WS1200, msg.subType);
-        assertEquals("Seq Number", 204, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "61441", msg.getDeviceId());
-        assertEquals("Temperature", 7.9, msg.temperature, 0.001);
-        assertEquals("Rain total", 95.1, msg.rainTotal, 0.001);
-        assertEquals("Signal Level", (byte) 5, msg.signalLevel);
+        assertEquals(WS1200, msg.subType, "SubType");
+        assertEquals(204, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("61441", msg.getDeviceId(), "Sensor Id");
+        assertEquals(7.9, msg.temperature, 0.001, "Temperature");
+        assertEquals(95.1, msg.rainTotal, 0.001, "Rain total");
+        assertEquals((byte) 5, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTestHelper.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -35,8 +35,8 @@ class RFXComTestHelper {
         // This is a place where its easy to make mistakes in coding, and can result in errors, normally
         // array bounds errors
         byte[] binaryMessage = message.decodeMessage();
-        assertEquals("Wrong packet length", binaryMessage[0], binaryMessage.length - 1);
-        assertEquals("Wrong packet type", packetType.toByte(), binaryMessage[1]);
+        assertEquals(binaryMessage[0], binaryMessage.length - 1, "Wrong packet length");
+        assertEquals(packetType.toByte(), binaryMessage[1], "Wrong packet type");
     }
 
     static void checkDiscoveryResult(RFXComDeviceMessage msg, String deviceId, @Nullable Integer pulse, String subType,
@@ -48,13 +48,13 @@ class RFXComTestHelper {
         msg.addDevicePropertiesTo(builder);
 
         Map<String, Object> properties = builder.build().getProperties();
-        assertEquals("Device Id", deviceId, properties.get("deviceId"));
-        assertEquals("Sub type", subType, properties.get("subType"));
+        assertEquals(deviceId, properties.get("deviceId"), "Device Id");
+        assertEquals(subType, properties.get("subType"), "Sub type");
         if (pulse != null) {
-            assertEquals("Pulse", pulse, properties.get("pulse"));
+            assertEquals(pulse, properties.get("pulse"), "Pulse");
         }
-        assertEquals("On command", onCommand, properties.get("onCommandId"));
-        assertEquals("Off command", offCommand, properties.get("offCommandId"));
+        assertEquals(onCommand, properties.get("onCommandId"), "On command");
+        assertEquals(offCommand, properties.get("offCommandId"), "Off command");
     }
 
     static int getActualIntValue(RFXComDeviceMessage msg, String channelId) throws RFXComException {

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat1MessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,17 +32,17 @@ public class RFXComThermostat1MessageTest {
         String hexMessage = "0940001B6B1816150270";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComThermostat1Message msg = (RFXComThermostat1Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", RFXComThermostat1Message.SubType.DIGIMAX, msg.subType);
-        assertEquals("Seq Number", 27, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", "27416", msg.getDeviceId());
-        assertEquals("Temperature", 22, msg.temperature);
-        assertEquals("Set point", 21, msg.set);
-        assertEquals("Mode", RFXComThermostat1Message.Mode.HEATING, msg.mode);
-        assertEquals("Status", RFXComThermostat1Message.Status.NO_DEMAND, msg.status);
-        assertEquals("Signal Level", (byte) 7, msg.signalLevel);
+        assertEquals(RFXComThermostat1Message.SubType.DIGIMAX, msg.subType, "SubType");
+        assertEquals(27, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("27416", msg.getDeviceId(), "Sensor Id");
+        assertEquals(22, msg.temperature, "Temperature");
+        assertEquals(21, msg.set, "Set point");
+        assertEquals(RFXComThermostat1Message.Mode.HEATING, msg.mode, "Mode");
+        assertEquals(RFXComThermostat1Message.Status.NO_DEMAND, msg.status, "Status");
+        assertEquals((byte) 7, msg.signalLevel, "Signal Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2MessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -24,9 +26,10 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 @NonNullByDefault
 public class RFXComThermostat2MessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
+    @Test
+    public void checkNotImplemented() {
         // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(PacketType.THERMOSTAT2);
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.THERMOSTAT2));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3MessageTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.rfxcom.internal.RFXComBindingConstants.*;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT3;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComThermostat3Message.SubType.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComUnsupportedChannelException;
 import org.openhab.core.library.types.OnOffType;
@@ -69,11 +69,11 @@ public class RFXComThermostat3MessageTest {
             throws RFXComException {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComThermostat3Message msg = (RFXComThermostat3Message) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", subtype, msg.subType);
-        assertEquals("Seq Number", sequenceNumber, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Sensor Id", sensorId, msg.getDeviceId());
-        assertEquals(CHANNEL_COMMAND, command, msg.command);
-        assertEquals("Signal Level", signalLevel, msg.signalLevel);
+        assertEquals(subtype, msg.subType, "SubType");
+        assertEquals(sequenceNumber, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals(sensorId, msg.getDeviceId(), "Sensor Id");
+        assertEquals(command, msg.command, CHANNEL_COMMAND);
+        assertEquals(signalLevel, msg.signalLevel, "Signal Level");
 
         assertEquals(commandChannel, msg.convertToState(CHANNEL_COMMAND, deviceState));
         assertEquals(secondCommandChannel, msg.convertToState(CHANNEL_COMMAND_SECOND, deviceState));
@@ -82,7 +82,7 @@ public class RFXComThermostat3MessageTest {
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
     // TODO please add tests for real messages
 

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat4MessageTest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType.THERMOSTAT4;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 
 /**
@@ -25,8 +26,8 @@ import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplemente
  */
 @NonNullByDefault
 public class RFXComThermostat4MessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(THERMOSTAT4);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class, () -> RFXComMessageFactory.createMessage(THERMOSTAT4));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComTransmitterMessageTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.Response.ACK;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.SubType.RESPONSE;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.Response;
 import org.openhab.binding.rfxcom.internal.messages.RFXComTransmitterMessage.SubType;
@@ -33,13 +33,13 @@ public class RFXComTransmitterMessageTest {
     private void testMessage(String hexMsg, Response response, SubType subType, int seqNbr) throws RFXComException {
         final RFXComTransmitterMessage msg = (RFXComTransmitterMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Response", response, msg.response);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(response, msg.response, "Response");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUVMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -34,19 +34,19 @@ public class RFXComUVMessageTest {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComUVMessage msg = (RFXComUVMessage) RFXComMessageFactory.createMessage(message);
 
-        assertEquals("SubType", RFXComUVMessage.SubType.UV3, msg.subType);
-        assertEquals("Seq Number", 18, msg.seqNbr);
-        assertEquals("Sensor Id", "13345", msg.getDeviceId());
+        assertEquals(RFXComUVMessage.SubType.UV3, msg.subType, "SubType");
+        assertEquals(18, msg.seqNbr, "Seq Number");
+        assertEquals("13345", msg.getDeviceId(), "Sensor Id");
 
-        assertEquals("UV", 2.5, msg.uv, 0.001);
-        assertEquals("Temperature", 1822.5, msg.temperature, 0.001);
+        assertEquals(2.5, msg.uv, 0.001, "UV");
+        assertEquals(1822.5, msg.temperature, 0.001, "Temperature");
 
-        assertEquals("Signal Level", 14, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(14, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test
@@ -56,18 +56,18 @@ public class RFXComUVMessageTest {
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComUVMessage msg = (RFXComUVMessage) RFXComMessageFactory.createMessage(message);
 
-        assertEquals("SubType", RFXComUVMessage.SubType.UV3, msg.subType);
-        assertEquals("Seq Number", 18, msg.seqNbr);
-        assertEquals("Sensor Id", "13345", msg.getDeviceId());
+        assertEquals(RFXComUVMessage.SubType.UV3, msg.subType, "SubType");
+        assertEquals(18, msg.seqNbr, "Seq Number");
+        assertEquals("13345", msg.getDeviceId(), "Sensor Id");
 
-        assertEquals("UV", 2.5, msg.uv, 0.001);
-        assertEquals("Temperature", -1822.5, msg.temperature, 0.001);
+        assertEquals(2.5, msg.uv, 0.001, "UV");
+        assertEquals(-1822.5, msg.temperature, 0.001, "Temperature");
 
-        assertEquals("Signal Level", 14, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(14, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessageTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageTooLongException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
@@ -34,14 +34,14 @@ public class RFXComUndecodedRFMessageTest {
             throws RFXComException {
         final RFXComUndecodedRFMessage msg = (RFXComUndecodedRFMessage) RFXComMessageFactory
                 .createMessage(HexUtils.hexToBytes(hexMsg));
-        assertEquals("SubType", subType, msg.subType);
-        assertEquals("Seq Number", seqNbr, (short) (msg.seqNbr & 0xFF));
-        assertEquals("Device Id", "UNDECODED", msg.getDeviceId());
-        assertEquals("Payload", rawPayload, HexUtils.bytesToHex(msg.rawPayload));
+        assertEquals(subType, msg.subType, "SubType");
+        assertEquals(seqNbr, (short) (msg.seqNbr & 0xFF), "Seq Number");
+        assertEquals("UNDECODED", msg.getDeviceId(), "Device Id");
+        assertEquals(rawPayload, HexUtils.bytesToHex(msg.rawPayload), "Payload");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMsg, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMsg, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 
     @Test
@@ -49,13 +49,14 @@ public class RFXComUndecodedRFMessageTest {
         testMessage("070301271356ECC0", RFXComUndecodedRFMessage.SubType.ARC, 0x27, "1356ECC0");
     }
 
-    @Test(expected = RFXComMessageTooLongException.class)
+    @Test
     public void testLongMessage() throws RFXComException {
         RFXComUndecodedRFMessage msg = (RFXComUndecodedRFMessage) RFXComMessageFactory
                 .createMessage(PacketType.UNDECODED_RF_MESSAGE);
         msg.subType = RFXComUndecodedRFMessage.SubType.ARC;
         msg.seqNbr = 1;
         msg.rawPayload = HexUtils.hexToBytes("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021");
-        msg.decodeMessage();
+
+        assertThrows(RFXComMessageTooLongException.class, () -> msg.decodeMessage());
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWaterMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -25,8 +27,9 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
 @NonNullByDefault
 public class RFXComWaterMessageTest {
 
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
-        RFXComMessageFactory.createMessage(PacketType.WATER);
+    @Test
+    public void checkNotImplemented() {
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.WATER));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessageTest.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComMessageNotImplementedException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -24,9 +26,10 @@ import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType
  */
 @NonNullByDefault
 public class RFXComWeightMessageTest {
-    @Test(expected = RFXComMessageNotImplementedException.class)
-    public void checkNotImplemented() throws Exception {
+    @Test
+    public void checkNotImplemented() {
         // TODO Note that this message is supported in the 1.9 binding
-        RFXComMessageFactory.createMessage(PacketType.WEIGHT);
+        assertThrows(RFXComMessageNotImplementedException.class,
+                () -> RFXComMessageFactory.createMessage(PacketType.WEIGHT));
     }
 }

--- a/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
+++ b/bundles/org.openhab.binding.rfxcom/src/test/java/org/openhab/binding/rfxcom/internal/messages/RFXComWindMessageTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.rfxcom.internal.messages.RFXComWindMessage.SubType.WIND1;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.rfxcom.internal.exceptions.RFXComException;
 import org.openhab.core.util.HexUtils;
 
@@ -32,17 +32,17 @@ public class RFXComWindMessageTest {
         String hexMessage = "105601122F000087000000140000000079";
         byte[] message = HexUtils.hexToBytes(hexMessage);
         RFXComWindMessage msg = (RFXComWindMessage) RFXComMessageFactory.createMessage(message);
-        assertEquals("SubType", WIND1, msg.subType);
-        assertEquals("Seq Number", 18, msg.seqNbr);
-        assertEquals("Sensor Id", "12032", msg.getDeviceId());
-        assertEquals("Direction", 135.0, msg.windDirection, 0.001);
-        // assertEquals("Average speed", 0.0, msg.w9j, 0.001);
-        assertEquals("Wind Gust", 2.0, msg.windSpeed, 0.001);
-        assertEquals("Signal Level", 7, msg.signalLevel);
-        assertEquals("Battery Level", 9, msg.batteryLevel);
+        assertEquals(WIND1, msg.subType, "SubType");
+        assertEquals(18, msg.seqNbr, "Seq Number");
+        assertEquals("12032", msg.getDeviceId(), "Sensor Id");
+        assertEquals(135.0, msg.windDirection, 0.001, "Direction");
+        // assertEquals(0.0, msg.w9j, 0.001, "Average speed");
+        assertEquals(2.0, msg.windSpeed, 0.001, "Wind Gust");
+        assertEquals(7, msg.signalLevel, "Signal Level");
+        assertEquals(9, msg.batteryLevel, "Battery Level");
 
         byte[] decoded = msg.decodeMessage();
 
-        assertEquals("Message converted back", hexMessage, HexUtils.bytesToHex(decoded));
+        assertEquals(hexMessage, HexUtils.bytesToHex(decoded), "Message converted back");
     }
 }

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/RobonectClientTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/RobonectClientTest.java
@@ -12,10 +12,8 @@
  */
 package org.openhab.binding.robonect.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
@@ -26,10 +24,11 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpMethod;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.robonect.internal.model.ErrorList;
 import org.openhab.binding.robonect.internal.model.MowerInfo;
 import org.openhab.binding.robonect.internal.model.Name;
@@ -38,25 +37,20 @@ import org.openhab.binding.robonect.internal.model.VersionInfo;
 /**
  * The goal of this class is to test the functionality of the RobonectClient,
  * by mocking the module responses.
- * 
+ *
  * @author Marco Meyer - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class RobonectClientTest {
 
     private RobonectClient subject;
 
-    @Mock
-    private HttpClient httpClientMock;
+    private @Mock HttpClient httpClientMock;
+    private @Mock ContentResponse responseMock;
+    private @Mock Request requestMock;
 
-    @Mock
-    private ContentResponse responseMock;
-
-    @Mock
-    private Request requestMock;
-
-    @Before
+    @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
         RobonectEndpoint dummyEndPoint = new RobonectEndpoint("123.456.789.123", null, null);
         subject = new RobonectClient(httpClientMock, dummyEndPoint);
     }
@@ -179,33 +173,33 @@ public class RobonectClientTest {
         verify(httpClientMock, times(1)).newRequest("http://123.456.789.123/json?cmd=status");
     }
 
-    @Test(expected = RobonectCommunicationException.class)
+    @Test
     public void shouldReceiveErrorAnswerOnInterruptedException()
             throws InterruptedException, ExecutionException, TimeoutException {
         when(httpClientMock.newRequest("http://123.456.789.123/json?cmd=status")).thenReturn(requestMock);
         when(requestMock.method(HttpMethod.GET)).thenReturn(requestMock);
         when(requestMock.timeout(30000L, TimeUnit.MILLISECONDS)).thenReturn(requestMock);
         when(requestMock.send()).thenThrow(new InterruptedException("Mock Interrupted Exception"));
-        MowerInfo answer = subject.getMowerInfo();
+        assertThrows(RobonectCommunicationException.class, () -> subject.getMowerInfo());
     }
 
-    @Test(expected = RobonectCommunicationException.class)
+    @Test
     public void shouldReceiveErrorAnswerOnExecutionException()
             throws InterruptedException, ExecutionException, TimeoutException {
         when(httpClientMock.newRequest("http://123.456.789.123/json?cmd=status")).thenReturn(requestMock);
         when(requestMock.method(HttpMethod.GET)).thenReturn(requestMock);
         when(requestMock.timeout(30000L, TimeUnit.MILLISECONDS)).thenReturn(requestMock);
         when(requestMock.send()).thenThrow(new ExecutionException(new Exception("Mock Exception")));
-        MowerInfo answer = subject.getMowerInfo();
+        assertThrows(RobonectCommunicationException.class, () -> subject.getMowerInfo());
     }
 
-    @Test(expected = RobonectCommunicationException.class)
+    @Test
     public void shouldReceiveErrorAnswerOnTimeoutException()
             throws InterruptedException, ExecutionException, TimeoutException {
         when(httpClientMock.newRequest("http://123.456.789.123/json?cmd=status")).thenReturn(requestMock);
         when(requestMock.method(HttpMethod.GET)).thenReturn(requestMock);
         when(requestMock.timeout(30000L, TimeUnit.MILLISECONDS)).thenReturn(requestMock);
         when(requestMock.send()).thenThrow(new TimeoutException("Mock Timeout Exception"));
-        MowerInfo answer = subject.getMowerInfo();
+        assertThrows(RobonectCommunicationException.class, () -> subject.getMowerInfo());
     }
 }

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/handler/RobonectHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.robonect.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -21,12 +21,15 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jetty.client.HttpClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.robonect.internal.RobonectBindingConstants;
 import org.openhab.binding.robonect.internal.RobonectClient;
 import org.openhab.binding.robonect.internal.model.ErrorEntry;
@@ -57,28 +60,20 @@ import org.openhab.core.types.UnDefType;
  *
  * @author Marco Meyer - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class RobonectHandlerTest {
 
     private RobonectHandler subject;
 
-    @Mock
-    private Thing robonectThingMock;
+    private @Mock Thing robonectThingMock;
+    private @Mock RobonectClient robonectClientMock;
+    private @Mock ThingHandlerCallback callbackMock;
+    private @Mock HttpClient httpClientMock;
+    private @Mock TimeZoneProvider timezoneProvider;
 
-    @Mock
-    private RobonectClient robonectClientMock;
-
-    @Mock
-    private ThingHandlerCallback callbackMock;
-
-    @Mock
-    private HttpClient httpClientMock;
-
-    @Mock
-    private TimeZoneProvider timezoneProvider;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         subject = new RobonectHandler(robonectThingMock, httpClientMock, timezoneProvider);
         subject.setCallback(callbackMock);
         subject.setRobonectClient(robonectClientMock);

--- a/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/model/ModelParserTest.java
+++ b/bundles/org.openhab.binding.robonect/src/test/java/org/openhab/binding/robonect/internal/model/ModelParserTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.robonect.internal.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * The goal of this class is to test the model parser to make sure the structures
@@ -29,7 +29,7 @@ public class ModelParserTest {
 
     private ModelParser subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new ModelParser();
     }

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/WireHelper.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/WireHelper.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.sensibo.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/GetPodDetailsResponseTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/GetPodDetailsResponseTest.java
@@ -12,16 +12,13 @@
  */
 package org.openhab.binding.sensibo.internal.dto;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensibo.internal.dto.poddetails.AcStateDTO;
 import org.openhab.binding.sensibo.internal.dto.poddetails.MeasurementDTO;
 import org.openhab.binding.sensibo.internal.dto.poddetails.ModeCapabilityDTO;

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/GetPodsResponseTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/GetPodsResponseTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.sensibo.internal.dto;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensibo.internal.dto.pods.PodDTO;
 
 import com.google.gson.reflect.TypeToken;

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetAcStatePropertyRequestTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetAcStatePropertyRequestTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.sensibo.internal.dto;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensibo.internal.dto.setacstateproperty.SetAcStatePropertyRequest;
 
 /**

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetAcStatePropertyResponseTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetAcStatePropertyResponseTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.sensibo.internal.dto;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensibo.internal.dto.setacstateproperty.SetAcStatePropertyReponse;
 
 /**

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetTimerRequestTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/dto/SetTimerRequestTest.java
@@ -12,13 +12,11 @@
  */
 package org.openhab.binding.sensibo.internal.dto;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sensibo.internal.dto.poddetails.AcStateDTO;
 import org.openhab.binding.sensibo.internal.dto.settimer.SetTimerRequest;
 

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboAccountHandlerTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboAccountHandlerTest.java
@@ -12,11 +12,8 @@
  */
 package org.openhab.binding.sensibo.internal.handler;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.Assert.assertEquals;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -25,44 +22,49 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.client.HttpClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.sensibo.internal.config.SensiboAccountConfiguration;
 import org.openhab.binding.sensibo.internal.model.SensiboSky;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingUID;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * @author Arne Seime - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class SensiboAccountHandlerTest {
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
-
-    @Mock
-    private Bridge sensiboAccountMock;
+    private WireMockServer wireMockServer;
 
     private HttpClient httpClient;
-    @Mock
-    private Configuration configuration;
 
-    @Before
+    private @Mock Configuration configuration;
+    private @Mock Bridge sensiboAccountMock;
+
+    @BeforeEach
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+
+        int port = wireMockServer.port();
+        WireMock.configureFor("localhost", port);
+
         httpClient = new HttpClient();
         httpClient.start();
-        SensiboAccountHandler.API_ENDPOINT = "http://localhost:" + wireMockRule.port() + "/api"; // https://home.sensibo.com/api/v2
+
+        SensiboAccountHandler.API_ENDPOINT = "http://localhost:" + port + "/api"; // https://home.sensibo.com/api/v2
     }
 
-    @After
+    @AfterEach
     public void shutdown() throws Exception {
         httpClient.stop();
     }

--- a/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandlerTest.java
+++ b/bundles/org.openhab.binding.sensibo/src/test/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandlerTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.sensibo.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;

--- a/bundles/org.openhab.binding.siemensrds/src/test/java/org/openhab/binding/siemensrds/test/RdsTestData.java
+++ b/bundles/org.openhab.binding.siemensrds/src/test/java/org/openhab/binding/siemensrds/test/RdsTestData.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.siemensrds.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.siemensrds.internal.RdsBindingConstants.*;
 
 import java.io.BufferedReader;
@@ -24,7 +24,7 @@ import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.siemensrds.internal.RdsAccessToken;
 import org.openhab.binding.siemensrds.internal.RdsCloudException;
 import org.openhab.binding.siemensrds.internal.RdsDataPoints;

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/LocalTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/LocalTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.sleepiq.api.impl.typeadapters;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link LocalTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class LocalTimeTypeAdapter extends TemporalTypeAdapter<LocalTime> {
 
-  public LocalTimeTypeAdapter() {
-    super(LocalTime::parse);
-  }
+    public LocalTimeTypeAdapter() {
+        super(LocalTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/OffsetDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/OffsetDateTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.sleepiq.api.impl.typeadapters;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link OffsetDateTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class OffsetDateTimeTypeAdapter extends DateTimeTypeAdapter<OffsetDateTime> {
 
-  public OffsetDateTimeTypeAdapter() {
-    super(OffsetDateTime::parse);
-  }
+    public OffsetDateTimeTypeAdapter() {
+        super(OffsetDateTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/OffsetTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/OffsetTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.sleepiq.api.impl.typeadapters;
 
 import java.time.OffsetTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link OffsetTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class OffsetTimeTypeAdapter extends TemporalTypeAdapter<OffsetTime> {
 
-  public OffsetTimeTypeAdapter() {
-    super(OffsetTime::parse);
-  }
+    public OffsetTimeTypeAdapter() {
+        super(OffsetTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/TemporalTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/TemporalTypeAdapter.java
@@ -20,15 +20,14 @@
  */
 package org.openhab.binding.sleepiq.api.impl.typeadapters;
 
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
+
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-
-import java.io.IOException;
-import java.time.temporal.TemporalAccessor;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * Abstract type adapter for jsr310 date-time types.
@@ -37,33 +36,33 @@ import java.util.function.Function;
  */
 abstract class TemporalTypeAdapter<T> extends TypeAdapter<T> {
 
-  Function<String, T> parseFunction;
+    Function<String, T> parseFunction;
 
-  TemporalTypeAdapter(Function<String, T> parseFunction) {
-    Objects.requireNonNull(parseFunction);
-    this.parseFunction = parseFunction;
-  }
-
-  @Override
-  public void write(JsonWriter out, T value) throws IOException {
-    if (value == null) {
-      out.nullValue();
-    } else {
-      out.value(value.toString());
+    TemporalTypeAdapter(Function<String, T> parseFunction) {
+        Objects.requireNonNull(parseFunction);
+        this.parseFunction = parseFunction;
     }
-  }
 
-  @Override
-  public T read(JsonReader in) throws IOException {
-    if (in.peek() == JsonToken.NULL) {
-      in.nextNull();
-      return null;
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+        } else {
+            out.value(value.toString());
+        }
     }
-    String temporalString = preProcess(in.nextString());
-    return parseFunction.apply(temporalString);
-  }
 
-  public String preProcess(String in) {
-    return in;
-  }
+    @Override
+    public T read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+        }
+        String temporalString = preProcess(in.nextString());
+        return parseFunction.apply(temporalString);
+    }
+
+    public String preProcess(String in) {
+        return in;
+    }
 }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/ZonedDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/java/org/openhab/binding/sleepiq/api/impl/typeadapters/ZonedDateTimeTypeAdapter.java
@@ -21,7 +21,6 @@
 package org.openhab.binding.sleepiq.api.impl.typeadapters;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Type adapter for jsr310 {@link ZonedDateTime} class.
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class ZonedDateTimeTypeAdapter extends DateTimeTypeAdapter<ZonedDateTime> {
 
-  public ZonedDateTimeTypeAdapter() {
-    super(ZonedDateTime::parse);
-  }
+    public ZonedDateTimeTypeAdapter() {
+        super(ZonedDateTime::parse);
+    }
 }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedSideStatusTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedSideStatusTest.java
@@ -15,50 +15,36 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.BedSideStatus;
-import org.openhab.binding.sleepiq.api.model.TimeSince;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class BedSideStatusTest extends AbstractTest
-{
+public class BedSideStatusTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        BedSideStatus bedSideStatus = new BedSideStatus().withAlertDetailedMessage("No Alert")
-                                                         .withAlertId(0L)
-                                                         .withInBed(false)
-                                                         .withLastLink(new TimeSince().withDuration(3,
-                                                                                                    5,
-                                                                                                    4,
-                                                                                                    38))
-                                                         .withPressure(573)
-                                                         .withSleepNumber(55);
+    public void testSerializeAllFields() throws Exception {
+        BedSideStatus bedSideStatus = new BedSideStatus().withAlertDetailedMessage("No Alert").withAlertId(0L)
+                .withInBed(false).withLastLink(new TimeSince().withDuration(3, 5, 4, 38)).withPressure(573)
+                .withSleepNumber(55);
         assertEquals(readJson("bed-side-status.json"), gson.toJson(bedSideStatus));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("bed-side-status.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("bed-side-status.json"))) {
             BedSideStatus bedSideStatus = gson.fromJson(reader, BedSideStatus.class);
             assertEquals("No Alert", bedSideStatus.getAlertDetailedMessage());
             assertEquals(Long.valueOf(0L), bedSideStatus.getAlertId());

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedStatusTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedStatusTest.java
@@ -15,47 +15,36 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.BedSideStatus;
-import org.openhab.binding.sleepiq.api.model.BedStatus;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class BedStatusTest extends AbstractTest
-{
+public class BedStatusTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
+    public void testSerializeAllFields() throws Exception {
         BedStatus bedStatus = new BedStatus().withBedId("-9999999999999999999")
-                                             .withLeftSide(new BedSideStatus().withInBed(true))
-                                             .withRightSide(new BedSideStatus().withInBed(false))
-                                             .withStatus(1L);
+                .withLeftSide(new BedSideStatus().withInBed(true)).withRightSide(new BedSideStatus().withInBed(false))
+                .withStatus(1L);
         assertEquals(readJson("bed-status.json"), gson.toJson(bedStatus));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("bed-status.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("bed-status.json"))) {
             BedStatus bedStatus = gson.fromJson(reader, BedStatus.class);
             assertEquals("-9999999999999999999", bedStatus.getBedId());
             assertEquals(Long.valueOf(1L), bedStatus.getStatus());

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedTest.java
@@ -15,76 +15,43 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileReader;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.Bed;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class BedTest extends AbstractTest
-{
+public class BedTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        Bed bed = new Bed().withAccountId("-8888888888888888888")
-                           .withBase("MODULAR")
-                           .withBedId("-9999999999999999999")
-                           .withDualSleep(true)
-                           .withKidsBed(false)
-                           .withMacAddress("AABBCCDDEEFF")
-                           .withModel("P5")
-                           .withName("Bed")
-                           .withPurchaseDate(ZonedDateTime.of(2017,
-                                                              2,
-                                                              2,
-                                                              0,
-                                                              0,
-                                                              1,
-                                                              0,
-                                                              ZoneId.of("Z").normalized()))
-                           .withReference("55555555555-5")
-                           .withRegistrationDate(ZonedDateTime.of(2017,
-                                                                  2,
-                                                                  17,
-                                                                  2,
-                                                                  14,
-                                                                  10,
-                                                                  0,
-                                                                  ZoneId.of("Z").normalized()))
-                           .withReturnRequestStatus(0L)
-                           .withSerial("")
-                           .withSize("QUEEN")
-                           .withSku("QP5")
-                           .withSleeperLeftId("-2222222222222222222")
-                           .withSleeperRightId("-1111111111111111111")
-                           .withStatus(1L)
-                           .withTimezone("US/Pacific")
-                           .withVersion("")
-                           .withZipCode("90210");
+    public void testSerializeAllFields() throws Exception {
+        Bed bed = new Bed().withAccountId("-8888888888888888888").withBase("MODULAR").withBedId("-9999999999999999999")
+                .withDualSleep(true).withKidsBed(false).withMacAddress("AABBCCDDEEFF").withModel("P5").withName("Bed")
+                .withPurchaseDate(ZonedDateTime.of(2017, 2, 2, 0, 0, 1, 0, ZoneId.of("Z").normalized()))
+                .withReference("55555555555-5")
+                .withRegistrationDate(ZonedDateTime.of(2017, 2, 17, 2, 14, 10, 0, ZoneId.of("Z").normalized()))
+                .withReturnRequestStatus(0L).withSerial("").withSize("QUEEN").withSku("QP5")
+                .withSleeperLeftId("-2222222222222222222").withSleeperRightId("-1111111111111111111").withStatus(1L)
+                .withTimezone("US/Pacific").withVersion("").withZipCode("90210");
         assertEquals(readJson("bed.json"), gson.toJson(bed));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("bed.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("bed.json"))) {
             Bed bed = gson.fromJson(reader, Bed.class);
             assertEquals("-8888888888888888888", bed.getAccountId());
             assertEquals("MODULAR", bed.getBase());
@@ -94,11 +61,10 @@ public class BedTest extends AbstractTest
             assertEquals("AABBCCDDEEFF", bed.getMacAddress());
             assertEquals("P5", bed.getModel());
             assertEquals("Bed", bed.getName());
-            assertEquals(ZonedDateTime.of(2017, 2, 2, 0, 0, 1, 0, ZoneId.of("Z").normalized()),
-                         bed.getPurchaseDate());
+            assertEquals(ZonedDateTime.of(2017, 2, 2, 0, 0, 1, 0, ZoneId.of("Z").normalized()), bed.getPurchaseDate());
             assertEquals("55555555555-5", bed.getReference());
             assertEquals(ZonedDateTime.of(2017, 2, 17, 2, 14, 10, 0, ZoneId.of("Z").normalized()),
-                         bed.getRegistrationDate());
+                    bed.getRegistrationDate());
             assertEquals(Long.valueOf(0L), bed.getReturnRequestStatus());
             assertEquals("", bed.getSerial());
             assertEquals("QUEEN", bed.getSize());

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedsResponseTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/BedsResponseTest.java
@@ -15,45 +15,37 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.Bed;
-import org.openhab.binding.sleepiq.api.model.BedsResponse;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class BedsResponseTest extends AbstractTest
-{
+public class BedsResponseTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        BedsResponse bedsResponse = new BedsResponse().withBeds(Arrays.asList(new Bed().withName("Bed1"),
-                                                                              new Bed().withName("Bed2")));
+    public void testSerializeAllFields() throws Exception {
+        BedsResponse bedsResponse = new BedsResponse()
+                .withBeds(Arrays.asList(new Bed().withName("Bed1"), new Bed().withName("Bed2")));
         assertEquals(readJson("beds-response.json"), gson.toJson(bedsResponse));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("beds-response.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("beds-response.json"))) {
             BedsResponse bedsResponse = gson.fromJson(reader, BedsResponse.class);
 
             List<Bed> beds = bedsResponse.getBeds();

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/FamilyStatusTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/FamilyStatusTest.java
@@ -15,44 +15,36 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.BedStatus;
-import org.openhab.binding.sleepiq.api.model.FamilyStatus;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class FamilyStatusTest extends AbstractTest
-{
+public class FamilyStatusTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
+    public void testSerializeAllFields() throws Exception {
         FamilyStatus familyStatus = new FamilyStatus().withBeds(Arrays.asList(new BedStatus().withStatus(1L)));
         assertEquals(readJson("family-status.json"), gson.toJson(familyStatus));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("family-status.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("family-status.json"))) {
             FamilyStatus familyStatus = gson.fromJson(reader, FamilyStatus.class);
 
             List<BedStatus> beds = familyStatus.getBeds();

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/PauseModeTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/PauseModeTest.java
@@ -15,42 +15,35 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.PauseMode;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class PauseModeTest extends AbstractTest
-{
+public class PauseModeTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        PauseMode pauseMode = new PauseMode().withAccountId("-8888888888888888888")
-                                             .withBedId("-9999999999999999999")
-                                             .withPauseMode("off");
+    public void testSerializeAllFields() throws Exception {
+        PauseMode pauseMode = new PauseMode().withAccountId("-8888888888888888888").withBedId("-9999999999999999999")
+                .withPauseMode("off");
         assertEquals(readJson("pause-mode.json"), gson.toJson(pauseMode));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("pause-mode.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("pause-mode.json"))) {
             PauseMode pauseMode = gson.fromJson(reader, PauseMode.class);
             assertEquals("-8888888888888888888", pauseMode.getAccountId());
             assertEquals("-9999999999999999999", pauseMode.getBedId());

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/SleeperTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/SleeperTest.java
@@ -15,69 +15,45 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileReader;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.Sleeper;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class SleeperTest extends AbstractTest
-{
+public class SleeperTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        Sleeper sleeper = new Sleeper().withAccountId("-5555555555555555555")
-                                       .withAccountOwner(true)
-                                       .withActive(true)
-                                       .withAvatar("")
-                                       .withBedId("-9999999999999999999")
-                                       .withBirthMonth(6)
-                                       .withBirthYear("1970")
-                                       .withChild(false)
-                                       .withDuration("")
-                                       .withEmail("alice@domain.com")
-                                       .withEmailValidated(true)
-                                       .withFirstName("Alice")
-                                       .withHeight(64)
-                                       .withLastLogin("2017-02-17 20:19:36 CST")
-                                       .withLicenseVersion(6L)
-                                       .withMale(false)
-                                       .withSide(1)
-                                       .withSleeperId("-1111111111111111111")
-                                       .withSleepGoal(450)
-                                       .withTimezone("US/Pacific")
-                                       .withUsername("alice@domain.com")
-                                       .withWeight(110)
-                                       .withZipCode("90210");
+    public void testSerializeAllFields() throws Exception {
+        Sleeper sleeper = new Sleeper().withAccountId("-5555555555555555555").withAccountOwner(true).withActive(true)
+                .withAvatar("").withBedId("-9999999999999999999").withBirthMonth(6).withBirthYear("1970")
+                .withChild(false).withDuration("").withEmail("alice@domain.com").withEmailValidated(true)
+                .withFirstName("Alice").withHeight(64).withLastLogin("2017-02-17 20:19:36 CST").withLicenseVersion(6L)
+                .withMale(false).withSide(1).withSleeperId("-1111111111111111111").withSleepGoal(450)
+                .withTimezone("US/Pacific").withUsername("alice@domain.com").withWeight(110).withZipCode("90210");
         assertEquals(readJson("sleeper.json"), gson.toJson(sleeper));
     }
 
     @Test
-    public void testSerializeLastLoginNull() throws Exception
-    {
+    public void testSerializeLastLoginNull() throws Exception {
         Sleeper sleeper = new Sleeper().withLastLogin("null");
         assertEquals(readJson("sleeper-lastlogin-null.json"), gson.toJson(sleeper));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("sleeper.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("sleeper.json"))) {
             Sleeper sleeper = gson.fromJson(reader, Sleeper.class);
             assertEquals("-5555555555555555555", sleeper.getAccountId());
             assertEquals(true, sleeper.isAccountOwner());
@@ -106,10 +82,8 @@ public class SleeperTest extends AbstractTest
     }
 
     @Test
-    public void testDeserializeLastLoginNull() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("sleeper-lastlogin-null.json")))
-        {
+    public void testDeserializeLastLoginNull() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("sleeper-lastlogin-null.json"))) {
             Sleeper sleeper = gson.fromJson(reader, Sleeper.class);
             assertEquals("null", sleeper.getLastLogin());
         }

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/SleepersResponseTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/SleepersResponseTest.java
@@ -15,45 +15,37 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileReader;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.sleepiq.api.impl.GsonGenerator;
-import org.openhab.binding.sleepiq.api.model.Sleeper;
-import org.openhab.binding.sleepiq.api.model.SleepersResponse;
 import org.openhab.binding.sleepiq.api.test.AbstractTest;
 
 import com.google.gson.Gson;
 
-public class SleepersResponseTest extends AbstractTest
-{
+public class SleepersResponseTest extends AbstractTest {
     private static Gson gson;
 
-    @BeforeClass
-    public static void setUpBeforeClass()
-    {
+    @BeforeAll
+    public static void setUpBeforeClass() {
         gson = GsonGenerator.create(true);
     }
 
     @Test
-    public void testSerializeAllFields() throws Exception
-    {
-        SleepersResponse sleepersResponse = new SleepersResponse().withSleepers(Arrays.asList(new Sleeper().withFirstName("Alice"),
-                                                                                              new Sleeper().withFirstName("Bob")));
+    public void testSerializeAllFields() throws Exception {
+        SleepersResponse sleepersResponse = new SleepersResponse()
+                .withSleepers(Arrays.asList(new Sleeper().withFirstName("Alice"), new Sleeper().withFirstName("Bob")));
         assertEquals(readJson("sleepers-response.json"), gson.toJson(sleepersResponse));
     }
 
     @Test
-    public void testDeserializeAllFields() throws Exception
-    {
-        try (FileReader reader = new FileReader(getTestDataFile("sleepers-response.json")))
-        {
+    public void testDeserializeAllFields() throws Exception {
+        try (FileReader reader = new FileReader(getTestDataFile("sleepers-response.json"))) {
             SleepersResponse sleepersResponse = gson.fromJson(reader, SleepersResponse.class);
 
             List<Sleeper> sleepers = sleepersResponse.getSleepers();

--- a/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/TimeSinceTest.java
+++ b/bundles/org.openhab.binding.sleepiq/src/3rdparty/test/org/openhab/binding/sleepiq/api/model/TimeSinceTest.java
@@ -15,53 +15,42 @@
  */
 package org.openhab.binding.sleepiq.api.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 
-import org.junit.Test;
-import org.openhab.binding.sleepiq.api.model.TimeSince;
+import org.junit.jupiter.api.Test;
 
-public class TimeSinceTest
-{
+public class TimeSinceTest {
     @Test
-    public void testWithDuration()
-    {
+    public void testWithDuration() {
         assertEquals(new TimeSince().withDuration(0, 0, 0, 0).getDuration(),
-                     new TimeSince().withDuration(Duration.parse("PT00H00M00S")).getDuration());
+                new TimeSince().withDuration(Duration.parse("PT00H00M00S")).getDuration());
         assertEquals(new TimeSince().withDuration(0, 2, 3, 4).getDuration(),
-                     new TimeSince().withDuration(Duration.parse("PT02H03M04S")).getDuration());
+                new TimeSince().withDuration(Duration.parse("PT02H03M04S")).getDuration());
         assertEquals(new TimeSince().withDuration(0, 12, 34, 56).getDuration(),
-                     new TimeSince().withDuration(Duration.parse("PT12H34M56S")).getDuration());
+                new TimeSince().withDuration(Duration.parse("PT12H34M56S")).getDuration());
         assertEquals(new TimeSince().withDuration(1, 2, 3, 4).getDuration(),
-                     new TimeSince().withDuration(Duration.parse("P1DT02H03M04S")).getDuration());
+                new TimeSince().withDuration(Duration.parse("P1DT02H03M04S")).getDuration());
         assertEquals(new TimeSince().withDuration(12, 23, 34, 45).getDuration(),
-                     new TimeSince().withDuration(Duration.parse("P12DT23H34M45S")).getDuration());
+                new TimeSince().withDuration(Duration.parse("P12DT23H34M45S")).getDuration());
     }
 
     @Test
-    public void testToString()
-    {
-        assertEquals("00:00:00",
-                     new TimeSince().withDuration(Duration.parse("PT00H00M00S")).toString());
-        assertEquals("02:03:04",
-                     new TimeSince().withDuration(Duration.parse("PT02H03M04S")).toString());
-        assertEquals("12:34:56",
-                     new TimeSince().withDuration(Duration.parse("PT12H34M56S")).toString());
-        assertEquals("1 d 02:03:04",
-                     new TimeSince().withDuration(Duration.parse("P1DT02H03M04S")).toString());
-        assertEquals("12 d 23:34:45",
-                     new TimeSince().withDuration(Duration.parse("P12DT23H34M45S")).toString());
+    public void testToString() {
+        assertEquals("00:00:00", new TimeSince().withDuration(Duration.parse("PT00H00M00S")).toString());
+        assertEquals("02:03:04", new TimeSince().withDuration(Duration.parse("PT02H03M04S")).toString());
+        assertEquals("12:34:56", new TimeSince().withDuration(Duration.parse("PT12H34M56S")).toString());
+        assertEquals("1 d 02:03:04", new TimeSince().withDuration(Duration.parse("P1DT02H03M04S")).toString());
+        assertEquals("12 d 23:34:45", new TimeSince().withDuration(Duration.parse("P12DT23H34M45S")).toString());
     }
 
     @Test
-    public void testParse()
-    {
+    public void testParse() {
         assertEquals(Duration.parse("PT00H00M00S"), TimeSince.parse("00:00:00").getDuration());
         assertEquals(Duration.parse("PT2H3M4S"), TimeSince.parse("02:03:04").getDuration());
         assertEquals(Duration.parse("PT12H34M56S"), TimeSince.parse("12:34:56").getDuration());
         assertEquals(Duration.parse("P1DT2H3M4S"), TimeSince.parse("1 d 02:03:04").getDuration());
-        assertEquals(Duration.parse("P12DT23H34M45S"),
-                     TimeSince.parse("12 d 23:34:45").getDuration());
+        assertEquals(Duration.parse("P12DT23H34M45S"), TimeSince.parse("12 d 23:34:45").getDuration());
     }
 }

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestMeterReading.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 import javax.measure.Quantity;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.openhab.binding.smartmeter.connectors.ConnectorBase;

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.smartmeter;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.smartmeter.internal.MeterValue;
 import org.openhab.binding.smartmeter.internal.conformity.negate.NegateBitModel;

--- a/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
+++ b/bundles/org.openhab.binding.smartmeter/src/test/java/org/openhab/binding/smartmeter/TestNegateBit.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.binding.smartmeter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.smartmeter.internal.MeterValue;
 import org.openhab.binding.smartmeter.internal.conformity.negate.NegateBitModel;
 import org.openhab.binding.smartmeter.internal.conformity.negate.NegateBitParser;
@@ -30,9 +30,9 @@ public class TestNegateBit {
     public void testNegateBitParsing() {
         String negateProperty = "1-0_1-8-0:5:1";
         NegateBitModel parseNegateProperty = NegateBitParser.parseNegateProperty(negateProperty);
-        Assert.assertEquals("1-0_1-8-0", parseNegateProperty.getNegateChannelId());
-        Assert.assertEquals(5, parseNegateProperty.getNegatePosition());
-        Assert.assertEquals(true, parseNegateProperty.isNegateBit());
+        assertEquals("1-0_1-8-0", parseNegateProperty.getNegateChannelId());
+        assertEquals(5, parseNegateProperty.getNegatePosition());
+        assertEquals(true, parseNegateProperty.isNegateBit());
     }
 
     @Test
@@ -43,7 +43,7 @@ public class TestNegateBit {
             return new MeterValue<>(obis, "65954", null);
         });
 
-        Assert.assertTrue(negateState);
+        assertTrue(negateState);
     }
 
     @Test
@@ -54,6 +54,6 @@ public class TestNegateBit {
             return new MeterValue<>(obis, "0", null, "65922");
         });
 
-        Assert.assertFalse(negateState);
+        assertFalse(negateState);
     }
 }

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/AbstractSnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/AbstractSnmpTargetHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.snmp.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.snmp.internal.SnmpBindingConstants.THING_TYPE_TARGET;

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.snmp.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/StringChannelTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/StringChannelTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.snmp.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.StringType;
 import org.snmp4j.PDU;

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SwitchChannelTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SwitchChannelTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.snmp.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.UnDefType;
 import org.snmp4j.PDU;

--- a/bundles/org.openhab.binding.teleinfo/src/test/java/org/openhab/binding/teleinfo/internal/reader/io/TeleinfoInputStreamTest.java
+++ b/bundles/org.openhab.binding.teleinfo/src/test/java/org/openhab/binding/teleinfo/internal/reader/io/TeleinfoInputStreamTest.java
@@ -15,8 +15,8 @@ package org.openhab.binding.teleinfo.internal.reader.io;
 import java.io.FileInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.teleinfo.internal.dto.Frame;
 import org.openhab.binding.teleinfo.internal.dto.cbemm.evoicc.FrameCbemmEvolutionIccBaseOption;
 import org.openhab.binding.teleinfo.internal.dto.cbemm.evoicc.FrameCbemmEvolutionIccHcOption;
@@ -42,22 +42,22 @@ public class TeleinfoInputStreamTest {
                 new FileInputStream(TestUtils.getTestFile("cbetm-base-option-1.raw")))) {
             Frame frame = in.readNextFrame();
 
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbetmLongBaseOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbetmLongBaseOption.class, frame.getClass());
             FrameCbetmLongBaseOption frameCbetmLongBaseOption = (FrameCbetmLongBaseOption) frame;
-            Assert.assertEquals("XXXXXXXXXXXX", frameCbetmLongBaseOption.getAdco());
-            Assert.assertEquals(20, frameCbetmLongBaseOption.getIsousc());
-            Assert.assertEquals(1181243, frameCbetmLongBaseOption.getBase());
-            Assert.assertEquals(Ptec.TH, frameCbetmLongBaseOption.getPtec());
-            Assert.assertEquals(0, frameCbetmLongBaseOption.getIinst1());
-            Assert.assertEquals(2, frameCbetmLongBaseOption.getIinst2());
-            Assert.assertEquals(0, frameCbetmLongBaseOption.getIinst3());
-            Assert.assertEquals(26, frameCbetmLongBaseOption.getImax1().intValue());
-            Assert.assertEquals(18, frameCbetmLongBaseOption.getImax2().intValue());
-            Assert.assertEquals(27, frameCbetmLongBaseOption.getImax3().intValue());
-            Assert.assertEquals(7990, frameCbetmLongBaseOption.getPmax());
-            Assert.assertEquals(540, frameCbetmLongBaseOption.getPapp());
-            Assert.assertEquals("00", frameCbetmLongBaseOption.getPpot());
+            assertEquals("XXXXXXXXXXXX", frameCbetmLongBaseOption.getAdco());
+            assertEquals(20, frameCbetmLongBaseOption.getIsousc());
+            assertEquals(1181243, frameCbetmLongBaseOption.getBase());
+            assertEquals(Ptec.TH, frameCbetmLongBaseOption.getPtec());
+            assertEquals(0, frameCbetmLongBaseOption.getIinst1());
+            assertEquals(2, frameCbetmLongBaseOption.getIinst2());
+            assertEquals(0, frameCbetmLongBaseOption.getIinst3());
+            assertEquals(26, frameCbetmLongBaseOption.getImax1().intValue());
+            assertEquals(18, frameCbetmLongBaseOption.getImax2().intValue());
+            assertEquals(27, frameCbetmLongBaseOption.getImax3().intValue());
+            assertEquals(7990, frameCbetmLongBaseOption.getPmax());
+            assertEquals(540, frameCbetmLongBaseOption.getPapp());
+            assertEquals("00", frameCbetmLongBaseOption.getPpot());
         }
     }
 
@@ -67,19 +67,19 @@ public class TeleinfoInputStreamTest {
                 new FileInputStream(TestUtils.getTestFile("cbemm-evo-icc-hc-option-1.raw")))) {
             Frame frame = in.readNextFrame();
 
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbemmEvolutionIccHcOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbemmEvolutionIccHcOption.class, frame.getClass());
             FrameCbemmEvolutionIccHcOption frameCbemmEvolutionIccHcOption = (FrameCbemmEvolutionIccHcOption) frame;
-            Assert.assertEquals("XXXXXXXXXXXX", frameCbemmEvolutionIccHcOption.getAdco());
-            Assert.assertEquals(30, frameCbemmEvolutionIccHcOption.getIsousc());
-            Assert.assertEquals(6906827, frameCbemmEvolutionIccHcOption.getHchc());
-            Assert.assertEquals(7617931, frameCbemmEvolutionIccHcOption.getHchp());
-            Assert.assertEquals(Ptec.HP, frameCbemmEvolutionIccHcOption.getPtec());
-            Assert.assertEquals(3, frameCbemmEvolutionIccHcOption.getIinst());
-            Assert.assertEquals(44, frameCbemmEvolutionIccHcOption.getImax().intValue());
-            Assert.assertEquals(680, frameCbemmEvolutionIccHcOption.getPapp());
-            Assert.assertNull(frameCbemmEvolutionIccHcOption.getAdps());
-            Assert.assertEquals(Hhphc.A, frameCbemmEvolutionIccHcOption.getHhphc());
+            assertEquals("XXXXXXXXXXXX", frameCbemmEvolutionIccHcOption.getAdco());
+            assertEquals(30, frameCbemmEvolutionIccHcOption.getIsousc());
+            assertEquals(6906827, frameCbemmEvolutionIccHcOption.getHchc());
+            assertEquals(7617931, frameCbemmEvolutionIccHcOption.getHchp());
+            assertEquals(Ptec.HP, frameCbemmEvolutionIccHcOption.getPtec());
+            assertEquals(3, frameCbemmEvolutionIccHcOption.getIinst());
+            assertEquals(44, frameCbemmEvolutionIccHcOption.getImax().intValue());
+            assertEquals(680, frameCbemmEvolutionIccHcOption.getPapp());
+            assertNull(frameCbemmEvolutionIccHcOption.getAdps());
+            assertEquals(Hhphc.A, frameCbemmEvolutionIccHcOption.getHhphc());
         }
     }
 
@@ -89,24 +89,24 @@ public class TeleinfoInputStreamTest {
                 new FileInputStream(TestUtils.getTestFile("cbetm-ejp-option-1.raw")))) {
             Frame frame = in.readNextFrame();
 
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbetmLongEjpOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbetmLongEjpOption.class, frame.getClass());
             FrameCbetmLongEjpOption frameCbetmLongEjpOption = (FrameCbetmLongEjpOption) frame;
-            Assert.assertEquals("XXXXXXXXXX", frameCbetmLongEjpOption.getAdco());
-            Assert.assertEquals(30, frameCbetmLongEjpOption.getIsousc());
-            Assert.assertEquals(1111111, frameCbetmLongEjpOption.getEjphn());
-            Assert.assertEquals(2222222, frameCbetmLongEjpOption.getEjphpm());
-            Assert.assertNull(frameCbetmLongEjpOption.getPejp());
-            Assert.assertEquals(Ptec.HN, frameCbetmLongEjpOption.getPtec());
-            Assert.assertEquals(10, frameCbetmLongEjpOption.getIinst1());
-            Assert.assertEquals(5, frameCbetmLongEjpOption.getIinst2());
-            Assert.assertEquals(8, frameCbetmLongEjpOption.getIinst3());
-            Assert.assertEquals(38, frameCbetmLongEjpOption.getImax1().intValue());
-            Assert.assertEquals(42, frameCbetmLongEjpOption.getImax2().intValue());
-            Assert.assertEquals(44, frameCbetmLongEjpOption.getImax3().intValue());
-            Assert.assertEquals(17480, frameCbetmLongEjpOption.getPmax());
-            Assert.assertEquals(5800, frameCbetmLongEjpOption.getPapp());
-            Assert.assertEquals("00", frameCbetmLongEjpOption.getPpot());
+            assertEquals("XXXXXXXXXX", frameCbetmLongEjpOption.getAdco());
+            assertEquals(30, frameCbetmLongEjpOption.getIsousc());
+            assertEquals(1111111, frameCbetmLongEjpOption.getEjphn());
+            assertEquals(2222222, frameCbetmLongEjpOption.getEjphpm());
+            assertNull(frameCbetmLongEjpOption.getPejp());
+            assertEquals(Ptec.HN, frameCbetmLongEjpOption.getPtec());
+            assertEquals(10, frameCbetmLongEjpOption.getIinst1());
+            assertEquals(5, frameCbetmLongEjpOption.getIinst2());
+            assertEquals(8, frameCbetmLongEjpOption.getIinst3());
+            assertEquals(38, frameCbetmLongEjpOption.getImax1().intValue());
+            assertEquals(42, frameCbetmLongEjpOption.getImax2().intValue());
+            assertEquals(44, frameCbetmLongEjpOption.getImax3().intValue());
+            assertEquals(17480, frameCbetmLongEjpOption.getPmax());
+            assertEquals(5800, frameCbetmLongEjpOption.getPapp());
+            assertEquals("00", frameCbetmLongEjpOption.getPpot());
         }
     }
 
@@ -116,26 +116,26 @@ public class TeleinfoInputStreamTest {
                 new FileInputStream(TestUtils.getTestFile("cbemm-evo-icc-tempo-option-1.raw")))) {
             Frame frame = in.readNextFrame();
 
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbemmEvolutionIccTempoOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbemmEvolutionIccTempoOption.class, frame.getClass());
             FrameCbemmEvolutionIccTempoOption frameCbemmEvolutionIccTempoOption = (FrameCbemmEvolutionIccTempoOption) frame;
-            Assert.assertEquals("XXXXXXXXXXXX", frameCbemmEvolutionIccTempoOption.getAdco());
-            Assert.assertEquals(45, frameCbemmEvolutionIccTempoOption.getIsousc());
-            Assert.assertEquals(2697099, frameCbemmEvolutionIccTempoOption.getBbrhcjb());
-            Assert.assertEquals(3494559, frameCbemmEvolutionIccTempoOption.getBbrhpjb());
-            Assert.assertEquals(41241, frameCbemmEvolutionIccTempoOption.getBbrhcjw());
-            Assert.assertEquals(194168, frameCbemmEvolutionIccTempoOption.getBbrhpjw());
-            Assert.assertEquals(0, frameCbemmEvolutionIccTempoOption.getBbrhcjr());
-            Assert.assertEquals(89736, frameCbemmEvolutionIccTempoOption.getBbrhpjr());
-            Assert.assertEquals(Ptec.HPJR, frameCbemmEvolutionIccTempoOption.getPtec());
-            Assert.assertNull(frameCbemmEvolutionIccTempoOption.getDemain());
-            Assert.assertEquals(3, frameCbemmEvolutionIccTempoOption.getIinst());
-            Assert.assertEquals(37, frameCbemmEvolutionIccTempoOption.getImax().intValue());
-            Assert.assertEquals(620, frameCbemmEvolutionIccTempoOption.getPapp());
-            Assert.assertNull(frameCbemmEvolutionIccTempoOption.getAdps());
-            Assert.assertEquals(Hhphc.Y, frameCbemmEvolutionIccTempoOption.getHhphc());
-            Assert.assertEquals(ProgrammeCircuit1.B, frameCbemmEvolutionIccTempoOption.getProgrammeCircuit1());
-            Assert.assertEquals(ProgrammeCircuit2.P2, frameCbemmEvolutionIccTempoOption.getProgrammeCircuit2());
+            assertEquals("XXXXXXXXXXXX", frameCbemmEvolutionIccTempoOption.getAdco());
+            assertEquals(45, frameCbemmEvolutionIccTempoOption.getIsousc());
+            assertEquals(2697099, frameCbemmEvolutionIccTempoOption.getBbrhcjb());
+            assertEquals(3494559, frameCbemmEvolutionIccTempoOption.getBbrhpjb());
+            assertEquals(41241, frameCbemmEvolutionIccTempoOption.getBbrhcjw());
+            assertEquals(194168, frameCbemmEvolutionIccTempoOption.getBbrhpjw());
+            assertEquals(0, frameCbemmEvolutionIccTempoOption.getBbrhcjr());
+            assertEquals(89736, frameCbemmEvolutionIccTempoOption.getBbrhpjr());
+            assertEquals(Ptec.HPJR, frameCbemmEvolutionIccTempoOption.getPtec());
+            assertNull(frameCbemmEvolutionIccTempoOption.getDemain());
+            assertEquals(3, frameCbemmEvolutionIccTempoOption.getIinst());
+            assertEquals(37, frameCbemmEvolutionIccTempoOption.getImax().intValue());
+            assertEquals(620, frameCbemmEvolutionIccTempoOption.getPapp());
+            assertNull(frameCbemmEvolutionIccTempoOption.getAdps());
+            assertEquals(Hhphc.Y, frameCbemmEvolutionIccTempoOption.getHhphc());
+            assertEquals(ProgrammeCircuit1.B, frameCbemmEvolutionIccTempoOption.getProgrammeCircuit1());
+            assertEquals(ProgrammeCircuit2.P2, frameCbemmEvolutionIccTempoOption.getProgrammeCircuit2());
         }
     }
 
@@ -144,17 +144,17 @@ public class TeleinfoInputStreamTest {
         try (TeleinfoInputStream in = new TeleinfoInputStream(
                 new FileInputStream(TestUtils.getTestFile("cbemm-evo-icc-base-option-1.raw")))) {
             Frame frame = in.readNextFrame();
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbemmEvolutionIccBaseOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbemmEvolutionIccBaseOption.class, frame.getClass());
             FrameCbemmEvolutionIccBaseOption frameCbemmEvolutionIccBaseOption = (FrameCbemmEvolutionIccBaseOption) frame;
-            Assert.assertEquals("031762120162", frameCbemmEvolutionIccBaseOption.getAdco());
-            Assert.assertEquals(30, frameCbemmEvolutionIccBaseOption.getIsousc());
-            Assert.assertEquals(190575, frameCbemmEvolutionIccBaseOption.getBase());
-            Assert.assertEquals(Ptec.TH, frameCbemmEvolutionIccBaseOption.getPtec());
-            Assert.assertEquals(1, frameCbemmEvolutionIccBaseOption.getIinst());
-            Assert.assertEquals(90, frameCbemmEvolutionIccBaseOption.getImax().intValue());
-            Assert.assertEquals(270, frameCbemmEvolutionIccBaseOption.getPapp());
-            Assert.assertNull(frameCbemmEvolutionIccBaseOption.getAdps());
+            assertEquals("031762120162", frameCbemmEvolutionIccBaseOption.getAdco());
+            assertEquals(30, frameCbemmEvolutionIccBaseOption.getIsousc());
+            assertEquals(190575, frameCbemmEvolutionIccBaseOption.getBase());
+            assertEquals(Ptec.TH, frameCbemmEvolutionIccBaseOption.getPtec());
+            assertEquals(1, frameCbemmEvolutionIccBaseOption.getIinst());
+            assertEquals(90, frameCbemmEvolutionIccBaseOption.getImax().intValue());
+            assertEquals(270, frameCbemmEvolutionIccBaseOption.getPapp());
+            assertNull(frameCbemmEvolutionIccBaseOption.getAdps());
         }
     }
 
@@ -164,10 +164,10 @@ public class TeleinfoInputStreamTest {
                 new FileInputStream(TestUtils.getTestFile("invalid-adps-groupline.raw")), true)) {
             Frame frame = in.readNextFrame();
 
-            Assert.assertNotNull(frame);
-            Assert.assertEquals(FrameCbemmEvolutionIccBaseOption.class, frame.getClass());
+            assertNotNull(frame);
+            assertEquals(FrameCbemmEvolutionIccBaseOption.class, frame.getClass());
             FrameCbemmEvolutionIccBaseOption frameCbemmEvolutionIccBaseOption = (FrameCbemmEvolutionIccBaseOption) frame;
-            Assert.assertEquals(37, frameCbemmEvolutionIccBaseOption.getAdps().intValue());
+            assertEquals(37, frameCbemmEvolutionIccBaseOption.getAdps().intValue());
         }
     }
 }

--- a/bundles/org.openhab.binding.teleinfo/src/test/java/org/openhab/binding/teleinfo/internal/reader/io/TeleinfoInputStreamTest.java
+++ b/bundles/org.openhab.binding.teleinfo/src/test/java/org/openhab/binding/teleinfo/internal/reader/io/TeleinfoInputStreamTest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.teleinfo.internal.reader.io;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.io.FileInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.teleinfo.internal.dto.Frame;
 import org.openhab.binding.teleinfo.internal.dto.cbemm.evoicc.FrameCbemmEvolutionIccBaseOption;

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/CryptUtilTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/CryptUtilTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.tplinksmarthome.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link CryptUtil} class.

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/CryptUtilTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/CryptUtilTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tplinksmarthome.internal;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,13 +30,13 @@ public class CryptUtilTest {
 
     /**
      * Test round trip of encrypt and decrypt that should return the same value.
-     * 
+     *
      * @throws IOException exception in case device not reachable
      */
     @Test
     public void testCrypt() throws IOException {
-        assertEquals("Crypting should result in same string", TEST_STRING,
-                CryptUtil.decrypt(CryptUtil.encrypt(TEST_STRING), TEST_STRING.length()));
+        assertEquals(TEST_STRING, CryptUtil.decrypt(CryptUtil.encrypt(TEST_STRING), TEST_STRING.length()),
+                "Crypting should result in same string");
     }
 
     /**
@@ -47,7 +47,7 @@ public class CryptUtilTest {
     @Test
     public void testCryptWithLength() throws IOException {
         try (final ByteArrayInputStream is = new ByteArrayInputStream(CryptUtil.encryptWithLength(TEST_STRING))) {
-            assertEquals("Crypting should result in same string", TEST_STRING, CryptUtil.decryptWithLength(is));
+            assertEquals(TEST_STRING, CryptUtil.decryptWithLength(is), "Crypting should result in same string");
         }
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollectorTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/PropertiesCollectorTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.tplinksmarthome.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.model.GetSysinfo;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 
@@ -65,8 +65,8 @@ public class PropertiesCollectorTest {
         final Map<String, Object> props = PropertiesCollector.collectProperties(thingType, "localhost",
                 ModelTestUtil.jsonFromFile(responseFile, GetSysinfo.class).getSysinfo());
 
-        assertEquals("Number of properties not as expected for properties: " + props, expectedSize, props.size());
+        assertEquals(expectedSize, props.size(), "Number of properties not as expected for properties: " + props);
         props.entrySet().stream().forEach(
-                entry -> assertNotNull("Property '" + entry.getKey() + "' should not be null", entry.getValue()));
+                entry -> assertNotNull(entry.getValue(), "Property '" + entry.getKey() + "' should not be null"));
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactoryTest.java
@@ -12,20 +12,18 @@
  */
 package org.openhab.binding.tplinksmarthome.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.binding.tplinksmarthome.internal.device.BulbDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.DimmerDevice;
 import org.openhab.binding.tplinksmarthome.internal.device.EnergySwitchDevice;
@@ -41,7 +39,7 @@ import org.openhab.core.thing.ThingTypeUID;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
-@RunWith(value = Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class TPLinkSmartHomeHandlerFactoryTest {
 
     private static final String SMART_HOME_DEVICE_FIELD = "smartHomeDevice";
@@ -67,42 +65,28 @@ public class TPLinkSmartHomeHandlerFactoryTest {
     });
     // @formatter:on
 
-    @Mock
-    Thing thing;
+    private @Mock Thing thing;
 
-    private final String name;
-    private final Class<?> clazz;
-
-    public TPLinkSmartHomeHandlerFactoryTest(String name, Class<?> clazz) {
-        this.name = name;
-        this.clazz = clazz;
-    }
-
-    @Parameters(name = "{0} - {1}")
     public static List<Object[]> data() {
         return TESTS;
     }
 
-    @Before
-    public void setUp() {
-        initMocks(this);
-    }
-
-    @Test
-    public void testCorrectClass()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCorrectClass(String name, Class<?> clazz)
             throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
         when(thing.getThingTypeUID()).thenReturn(new ThingTypeUID(TPLinkSmartHomeBindingConstants.BINDING_ID, name));
         SmartHomeHandler handler = (SmartHomeHandler) factory.createHandler(thing);
 
         if (clazz == null) {
-            assertNull(name + " should not return any handler but null", handler);
+            assertNull(handler, name + " should not return any handler but null");
         } else {
-            assertNotNull(name + " should no return null handler", handler);
+            assertNotNull(handler, name + " should no return null handler");
             Field smartHomeDeviceField = SmartHomeHandler.class.getDeclaredField(SMART_HOME_DEVICE_FIELD);
 
             smartHomeDeviceField.setAccessible(true);
-            assertSame(name + " should return expected device class", clazz,
-                    smartHomeDeviceField.get(handler).getClass());
+            assertSame(clazz, smartHomeDeviceField.get(handler).getClass(),
+                    name + " should return expected device class");
         }
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
@@ -20,6 +20,7 @@ import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeThingT
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.core.library.types.DecimalType;
@@ -34,6 +35,7 @@ import org.openhab.core.types.UnDefType;
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @NonNullByDefault
+@Disabled("Needs to be updated for OH3")
 public class BulbDeviceTest extends DeviceTestBase<BulbDevice> {
 
     private static final String DEVICE_OFF = "bulb_get_sysinfo_response_off";

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
@@ -20,7 +20,7 @@ import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeThingT
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.core.library.types.DecimalType;
@@ -35,7 +35,6 @@ import org.openhab.core.types.UnDefType;
  * @author Hilbrand Bouwkamp - Initial contribution
  */
 @NonNullByDefault
-@Disabled("Needs to be updated for OH3")
 public class BulbDeviceTest extends DeviceTestBase<BulbDevice> {
 
     private static final String DEVICE_OFF = "bulb_get_sysinfo_response_off";
@@ -45,6 +44,7 @@ public class BulbDeviceTest extends DeviceTestBase<BulbDevice> {
                 "bulb_get_sysinfo_response_on");
     }
 
+    @BeforeEach
     @Override
     public void setUp() throws IOException {
         super.setUp();

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/BulbDeviceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.*;
 import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeBindingConstants.*;
 import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeThingType.LB130;
@@ -20,7 +20,7 @@ import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeThingT
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -52,120 +52,120 @@ public class BulbDeviceTest extends DeviceTestBase<BulbDevice> {
     @Test
     public void testHandleCommandBrightness() throws IOException {
         assertInput("bulb_transition_light_state_brightness");
-        assertTrue("Brightness channel should be handled",
-                device.handleCommand(CHANNEL_UID_BRIGHTNESS, new PercentType(33)));
+        assertTrue(device.handleCommand(CHANNEL_UID_BRIGHTNESS, new PercentType(33)),
+                "Brightness channel should be handled");
     }
 
     @Test
     public void testHandleCommandBrightnessOnOff() throws IOException {
         assertInput("bulb_transition_light_state_on");
-        assertTrue("Brightness channel with OnOff state should be handled",
-                device.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.ON),
+                "Brightness channel with OnOff state should be handled");
     }
 
     @Test
     public void testHandleCommandColor() throws IOException {
         assertInput("bulb_transition_light_state_color");
-        assertTrue("Color channel should be handled", device.handleCommand(CHANNEL_UID_COLOR, new HSBType("55,44,33")));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR, new HSBType("55,44,33")), "Color channel should be handled");
     }
 
     public void testHandleCommandColorBrightness() throws IOException {
         assertInput("bulb_transition_light_state_brightness");
-        assertTrue("Color channel with Percentage state (=brightness) should be handled",
-                device.handleCommand(CHANNEL_UID_COLOR, new PercentType(33)));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR, new PercentType(33)),
+                "Color channel with Percentage state (=brightness) should be handled");
     }
 
     public void testHandleCommandColorOnOff() throws IOException {
         assertInput("bulb_transition_light_state_on");
-        assertTrue("Color channel with OnOff state should be handled",
-                device.handleCommand(CHANNEL_UID_COLOR, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR, OnOffType.ON),
+                "Color channel with OnOff state should be handled");
     }
 
     @Test
     public void testHandleCommandColorTemperature() throws IOException {
         assertInput("bulb_transition_light_state_color_temp");
-        assertTrue("Color temperature channel should be handled",
-                device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE, new PercentType(40)));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE, new PercentType(40)),
+                "Color temperature channel should be handled");
     }
 
     @Test
     public void testHandleCommandColorTemperatureAbs() throws IOException {
         assertInput("bulb_transition_light_state_color_temp");
-        assertTrue("Color temperature channel should be handled",
-                device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE_ABS, new DecimalType(5100)));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE_ABS, new DecimalType(5100)),
+                "Color temperature channel should be handled");
     }
 
     @Test
     public void testHandleCommandColorTemperatureOnOff() throws IOException {
         assertInput("bulb_transition_light_state_on");
-        assertTrue("Color temperature channel with OnOff state should be handled",
-                device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_COLOR_TEMPERATURE, OnOffType.ON),
+                "Color temperature channel with OnOff state should be handled");
     }
 
     @Test
     public void testHandleCommandSwitch() throws IOException {
         assertInput("bulb_transition_light_state_on");
-        assertTrue("Switch channel should be handled", device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON), "Switch channel should be handled");
     }
 
     @Test
     public void testUpdateChannelBrightnessOn() {
-        assertEquals("Brightness should be on", new PercentType(92),
-                device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState));
+        assertEquals(new PercentType(92), device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState),
+                "Brightness should be on");
     }
 
     @Test
     public void testUpdateChannelBrightnessOff() throws IOException {
         deviceState = new DeviceState(ModelTestUtil.readJson(DEVICE_OFF));
-        assertEquals("Brightness should be off", PercentType.ZERO,
-                device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState));
+        assertEquals(PercentType.ZERO, device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState),
+                "Brightness should be off");
     }
 
     @Test
     public void testUpdateChannelColorOn() {
-        assertEquals("Color should be on", new HSBType("7,44,92"),
-                device.updateChannel(CHANNEL_UID_COLOR, deviceState));
+        assertEquals(new HSBType("7,44,92"), device.updateChannel(CHANNEL_UID_COLOR, deviceState),
+                "Color should be on");
     }
 
     @Test
     public void testUpdateChannelColorOff() throws IOException {
         deviceState = new DeviceState(ModelTestUtil.readJson(DEVICE_OFF));
-        assertEquals("Color should be off", new HSBType("7,44,0"),
-                device.updateChannel(CHANNEL_UID_COLOR, deviceState));
+        assertEquals(new HSBType("7,44,0"), device.updateChannel(CHANNEL_UID_COLOR, deviceState),
+                "Color should be off");
     }
 
     @Test
     public void testUpdateChannelSwitchOn() {
-        assertSame("Switch should be on", OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState), "Switch should be on");
     }
 
     @Test
     public void testUpdateChannelSwitchOff() throws IOException {
         deviceState = new DeviceState(ModelTestUtil.readJson(DEVICE_OFF));
-        assertSame("Switch should be off", OnOffType.OFF, device.updateChannel(CHANNEL_UID_SWITCH, deviceState));
+        assertSame(OnOffType.OFF, device.updateChannel(CHANNEL_UID_SWITCH, deviceState), "Switch should be off");
     }
 
     @Test
     public void testUpdateChannelColorTemperature() {
-        assertEquals("Color temperature should be set", new PercentType(2),
-                device.updateChannel(CHANNEL_UID_COLOR_TEMPERATURE, deviceState));
+        assertEquals(new PercentType(2), device.updateChannel(CHANNEL_UID_COLOR_TEMPERATURE, deviceState),
+                "Color temperature should be set");
     }
 
     @Test
     public void testUpdateChannelColorTemperatureAbs() {
-        assertEquals("Color temperature should be set", new DecimalType(2630),
-                device.updateChannel(CHANNEL_UID_COLOR_TEMPERATURE_ABS, deviceState));
+        assertEquals(new DecimalType(2630), device.updateChannel(CHANNEL_UID_COLOR_TEMPERATURE_ABS, deviceState),
+                "Color temperature should be set");
     }
 
     @Test
     public void testUpdateChannelOther() {
-        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF,
-                device.updateChannel(CHANNEL_UID_OTHER, deviceState));
+        assertSame(UnDefType.UNDEF, device.updateChannel(CHANNEL_UID_OTHER, deviceState),
+                "Unknown channel should return UNDEF");
     }
 
     @Test
     public void testUpdateChannelPower() {
-        assertEquals("Power values should be set", new DecimalType(10.8),
-                device.updateChannel(CHANNEL_UID_ENERGY_POWER, deviceState));
+        assertEquals(new DecimalType(10.8), device.updateChannel(CHANNEL_UID_ENERGY_POWER, deviceState),
+                "Power values should be set");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DeviceTestBase.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DeviceTestBase.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,8 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.tplinksmarthome.internal.Connection;
 import org.openhab.binding.tplinksmarthome.internal.CryptUtil;
 import org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeConfiguration;
@@ -37,6 +40,8 @@ import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public class DeviceTestBase<T extends SmartHomeDevice> {
 
@@ -47,10 +52,8 @@ public class DeviceTestBase<T extends SmartHomeDevice> {
 
     private final String deviceStateFilename;
 
-    @Mock
-    private @NonNullByDefault({}) Socket socket;
-    @Mock
-    private @NonNullByDefault({}) OutputStream outputStream;
+    private @Mock @NonNullByDefault({}) Socket socket;
+    private @Mock @NonNullByDefault({}) OutputStream outputStream;
 
     /**
      * Constructor.
@@ -75,9 +78,8 @@ public class DeviceTestBase<T extends SmartHomeDevice> {
         device.initialize(connection, configuration);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
-        initMocks(this);
         when(socket.getOutputStream()).thenReturn(outputStream);
         deviceState = new DeviceState(ModelTestUtil.readJson(deviceStateFilename));
     }
@@ -121,7 +123,7 @@ public class DeviceTestBase<T extends SmartHomeDevice> {
             byte[] input = (byte[]) arg.getArguments()[0];
             try (ByteArrayInputStream inputStream = new ByteArrayInputStream(input)) {
                 String expectedString = expectedProcessor.apply(CryptUtil.decryptWithLength(inputStream));
-                assertEquals(filenames[index.get()], json, expectedString);
+                assertEquals(json, expectedString, filenames[index.get()]);
             }
             index.incrementAndGet();
             return null;

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/DimmerDeviceTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.*;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -42,43 +42,44 @@ public class DimmerDeviceTest extends DeviceTestBase<DimmerDevice> {
     public void testHandleCommandBrightnessOnOff() throws IOException {
         assertInput("dimmer_set_switch_state_on");
         setSocketReturnAssert("dimmer_set_switch_state_on");
-        assertTrue("Brightness channel as OnOffType type should be handled",
-                device.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.ON),
+                "Brightness channel as OnOffType type should be handled");
     }
 
     @Test
     public void testHandleCommandBrightnessZero() throws IOException {
         assertInput("dimmer_set_switch_state_off");
         setSocketReturnAssert("dimmer_set_switch_state_response");
-        assertTrue("Brightness channel with percentage 0 should be handled",
-                device.handleCommand(CHANNEL_UID_BRIGHTNESS, PercentType.ZERO));
+        assertTrue(device.handleCommand(CHANNEL_UID_BRIGHTNESS, PercentType.ZERO),
+                "Brightness channel with percentage 0 should be handled");
     }
 
     @Test
     public void testHandleCommandBrightness() throws IOException {
         assertInput("dimmer_set_brightness", "dimmer_set_switch_state_on");
         setSocketReturnAssert("dimmer_set_brightness_response", "dimmer_set_switch_state_on");
-        assertTrue("Brightness channel should be handled",
-                device.handleCommand(CHANNEL_UID_BRIGHTNESS, new PercentType(17)));
+        assertTrue(device.handleCommand(CHANNEL_UID_BRIGHTNESS, new PercentType(17)),
+                "Brightness channel should be handled");
     }
 
     @Test
     public void testUpdateChannelSwitch() throws IOException {
         deviceState = new DeviceState(ModelTestUtil.readJson("hs220_get_sysinfo_response_off"));
 
-        assertSame("Dimmer device should be off", OnOffType.OFF,
-                ((PercentType) device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState)).as(OnOffType.class));
+        assertSame(OnOffType.OFF,
+                ((PercentType) device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState)).as(OnOffType.class),
+                "Dimmer device should be off");
     }
 
     @Test
     public void testUpdateChannelBrightness() {
-        assertEquals("Dimmer brightness should be set", BRIGHTNESS_VALUE,
-                device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState));
+        assertEquals(BRIGHTNESS_VALUE, device.updateChannel(CHANNEL_UID_BRIGHTNESS, deviceState),
+                "Dimmer brightness should be set");
     }
 
     @Test
     public void testUpdateChannelOther() {
-        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF,
-                device.updateChannel(CHANNEL_UID_OTHER, deviceState));
+        assertSame(UnDefType.UNDEF, device.updateChannel(CHANNEL_UID_OTHER, deviceState),
+                "Unknown channel should return UNDEF");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EncodingTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EncodingTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class to test if text read from the device is correctly decoded to handle special characters.

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EnergySwitchDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/EnergySwitchDeviceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.*;
 
 import java.io.IOException;
@@ -20,10 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.types.State;
@@ -34,7 +32,6 @@ import org.openhab.core.types.UnDefType;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
-@RunWith(value = Parameterized.class)
 @NonNullByDefault
 public class EnergySwitchDeviceTest {
 
@@ -42,45 +39,49 @@ public class EnergySwitchDeviceTest {
             .asList(new Object[][] { { "plug_get_realtime_response", }, { "plug_get_realtime_response_v2", } });
 
     private final EnergySwitchDevice device = new EnergySwitchDevice();
-    private final DeviceState deviceState;
 
-    public EnergySwitchDeviceTest(String name) throws IOException {
-        deviceState = new DeviceState(ModelTestUtil.readJson(name));
-    }
-
-    @Parameters(name = "{0}")
     public static List<Object[]> data() {
         return TESTS;
     }
 
-    @Test
-    public void testUpdateChannelEnergyCurrent() {
-        assertEquals("Energy current should have valid state value", new QuantityType<>(1 + " A"),
-                device.updateChannel(CHANNEL_UID_ENERGY_CURRENT, deviceState));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdateChannelEnergyCurrent(String name) throws IOException {
+        DeviceState deviceState = new DeviceState(ModelTestUtil.readJson(name));
+        assertEquals(new QuantityType<>(1 + " A"), device.updateChannel(CHANNEL_UID_ENERGY_CURRENT, deviceState),
+                "Energy current should have valid state value");
     }
 
-    @Test
-    public void testUpdateChannelEnergyTotal() {
-        assertEquals("Energy total should have valid state value", new QuantityType<>(10 + " kWh"),
-                device.updateChannel(CHANNEL_UID_ENERGY_TOTAL, deviceState));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdateChannelEnergyTotal(String name) throws IOException {
+        DeviceState deviceState = new DeviceState(ModelTestUtil.readJson(name));
+        assertEquals(new QuantityType<>(10 + " kWh"), device.updateChannel(CHANNEL_UID_ENERGY_TOTAL, deviceState),
+                "Energy total should have valid state value");
     }
 
-    @Test
-    public void testUpdateChannelEnergyVoltage() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdateChannelEnergyVoltage(String name) throws IOException {
+        DeviceState deviceState = new DeviceState(ModelTestUtil.readJson(name));
         State state = device.updateChannel(CHANNEL_UID_ENERGY_VOLTAGE, deviceState);
-        assertEquals("Energy voltage should have valid state value", 230, ((QuantityType<?>) state).intValue());
-        assertEquals("Channel patten to format voltage correctly", "230 V", state.format("%.0f %unit%"));
+        assertEquals(230, ((QuantityType<?>) state).intValue(), "Energy voltage should have valid state value");
+        assertEquals("230 V", state.format("%.0f %unit%"), "Channel patten to format voltage correctly");
     }
 
-    @Test
-    public void testUpdateChanneEnergyPower() {
-        assertEquals("Energy power should have valid state value", new QuantityType<>(20 + " W"),
-                device.updateChannel(CHANNEL_UID_ENERGY_POWER, deviceState));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdateChanneEnergyPower(String name) throws IOException {
+        DeviceState deviceState = new DeviceState(ModelTestUtil.readJson(name));
+        assertEquals(new QuantityType<>(20 + " W"), device.updateChannel(CHANNEL_UID_ENERGY_POWER, deviceState),
+                "Energy power should have valid state value");
     }
 
-    @Test
-    public void testUpdateChannelOther() {
-        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF,
-                device.updateChannel(CHANNEL_UID_OTHER, deviceState));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdateChannelOther(String name) throws IOException {
+        DeviceState deviceState = new DeviceState(ModelTestUtil.readJson(name));
+        assertSame(UnDefType.UNDEF, device.updateChannel(CHANNEL_UID_OTHER, deviceState),
+                "Unknown channel should return UNDEF");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/PowerStripDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/PowerStripDeviceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeBindingConstants.*;
 import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeThingType.HS300;
 
@@ -23,8 +23,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants;
 import org.openhab.binding.tplinksmarthome.internal.model.ModelTestUtil;
 import org.openhab.binding.tplinksmarthome.internal.model.SetRelayState;
@@ -56,7 +56,7 @@ public class PowerStripDeviceTest extends DeviceTestBase<PowerStripDevice> {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         super.setUp();
         final AtomicInteger inputCounter = new AtomicInteger(0);
@@ -73,22 +73,23 @@ public class PowerStripDeviceTest extends DeviceTestBase<PowerStripDevice> {
                 .toJson(ModelTestUtil.GSON.fromJson(s, SetRelayState.class));
         assertInput(normalize, normalize, "hs300_set_relay_state");
         setSocketReturnAssert("hs300_set_relay_state_response");
-        assertTrue("Outlet channel 2 should be handled", device.handleCommand(CHANNEL_OUTLET_2, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_OUTLET_2, OnOffType.ON), "Outlet channel 2 should be handled");
     }
 
     @Test
     public void testUpdateChannelOutlet1() {
-        assertSame("Outlet 1 should be on", OnOffType.ON, device.updateChannel(CHANNEL_OUTLET_1, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_OUTLET_1, deviceState), "Outlet 1 should be on");
     }
 
     @Test
     public void testUpdateChannelOutlet2() {
-        assertSame("Outlet 2 should be off", OnOffType.OFF, device.updateChannel(CHANNEL_OUTLET_2, deviceState));
+        assertSame(OnOffType.OFF, device.updateChannel(CHANNEL_OUTLET_2, deviceState), "Outlet 2 should be off");
     }
 
     @Test
     public void testUpdateChannelEnergyCurrent() {
-        assertEquals("Energy current should have valid state value", 1,
-                ((QuantityType<?>) device.updateChannel(CHANNEL_ENERGY_CURRENT_OUTLET_2, deviceState)).intValue());
+        assertEquals(1,
+                ((QuantityType<?>) device.updateChannel(CHANNEL_ENERGY_CURRENT_OUTLET_2, deviceState)).intValue(),
+                "Energy current should have valid state value");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/RangeExtenderDeviceTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.*;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.UnDefType;
 
@@ -36,23 +36,23 @@ public class RangeExtenderDeviceTest extends DeviceTestBase<RangeExtenderDevice>
 
     @Test
     public void testHandleCommandSwitch() throws IOException {
-        assertFalse("Switch channel not yet supported so should not be handled",
-                device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON));
+        assertFalse(device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON),
+                "Switch channel not yet supported so should not be handled");
     }
 
     @Test
     public void testUpdateChannelSwitch() {
-        assertSame("Switch should be on", OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState), "Switch should be on");
     }
 
     @Test
     public void testUpdateChannelLed() {
-        assertSame("Led should be on", OnOffType.ON, device.updateChannel(CHANNEL_UID_LED, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_UID_LED, deviceState), "Led should be on");
     }
 
     @Test
     public void testUpdateChannelOther() {
-        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF,
-                device.updateChannel(CHANNEL_UID_OTHER, deviceState));
+        assertSame(UnDefType.UNDEF, device.updateChannel(CHANNEL_UID_OTHER, deviceState),
+                "Unknown channel should return UNDEF");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDeviceTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/device/SwitchDeviceTest.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.device;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.*;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.UnDefType;
 
@@ -38,29 +38,29 @@ public class SwitchDeviceTest extends DeviceTestBase<SwitchDevice> {
     public void testHandleCommandSwitch() throws IOException {
         assertInput("plug_set_relay_state_on");
         setSocketReturnAssert("plug_set_relay_state_on");
-        assertTrue("Switch channel should be handled", device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_SWITCH, OnOffType.ON), "Switch channel should be handled");
     }
 
     @Test
     public void testHandleCommandLed() throws IOException {
         assertInput("plug_set_led_on");
         setSocketReturnAssert("plug_set_led_on");
-        assertTrue("Led channel should be handled", device.handleCommand(CHANNEL_UID_LED, OnOffType.ON));
+        assertTrue(device.handleCommand(CHANNEL_UID_LED, OnOffType.ON), "Led channel should be handled");
     }
 
     @Test
     public void testUpdateChannelSwitch() {
-        assertSame("Switch should be on", OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_UID_SWITCH, deviceState), "Switch should be on");
     }
 
     @Test
     public void testUpdateChannelLed() {
-        assertSame("Led should be on", OnOffType.ON, device.updateChannel(CHANNEL_UID_LED, deviceState));
+        assertSame(OnOffType.ON, device.updateChannel(CHANNEL_UID_LED, deviceState), "Led should be on");
     }
 
     @Test
     public void testUpdateChannelOther() {
-        assertSame("Unknown channel should return UNDEF", UnDefType.UNDEF,
-                device.updateChannel(CHANNEL_UID_OTHER, deviceState));
+        assertSame(UnDefType.UNDEF, device.updateChannel(CHANNEL_UID_OTHER, deviceState),
+                "Unknown channel should return UNDEF");
     }
 }

--- a/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/handler/SmartHomeHandlerTest.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/test/java/org/openhab/binding/tplinksmarthome/internal/handler/SmartHomeHandlerTest.java
@@ -12,22 +12,25 @@
  */
 package org.openhab.binding.tplinksmarthome.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants.CHANNEL_UID_SWITCH;
 import static org.openhab.binding.tplinksmarthome.internal.TPLinkSmartHomeBindingConstants.*;
 
 import java.io.IOException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.tplinksmarthome.internal.ChannelUIDConstants;
 import org.openhab.binding.tplinksmarthome.internal.Commands;
 import org.openhab.binding.tplinksmarthome.internal.Connection;
@@ -52,27 +55,23 @@ import org.openhab.core.types.State;
  *
  * @author Hilbrand Bouwkamp - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public class SmartHomeHandlerTest {
 
     private @NonNullByDefault({}) SmartHomeHandler handler;
 
-    @Mock
-    private @NonNullByDefault({}) Connection connection;
-    @Mock
-    private @NonNullByDefault({}) ThingHandlerCallback callback;
-    @Mock
-    private @NonNullByDefault({}) Thing thing;
-    @Mock
-    private @NonNullByDefault({}) SmartHomeDevice smartHomeDevice;
-    @Mock
-    private @NonNullByDefault({}) TPLinkSmartHomeDiscoveryService discoveryService;
+    private @Mock @NonNullByDefault({}) Connection connection;
+    private @Mock @NonNullByDefault({}) ThingHandlerCallback callback;
+    private @Mock @NonNullByDefault({}) Thing thing;
+    private @Mock @NonNullByDefault({}) SmartHomeDevice smartHomeDevice;
+    private @Mock @NonNullByDefault({}) TPLinkSmartHomeDiscoveryService discoveryService;
 
     private final Configuration configuration = new Configuration();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
-        initMocks(this);
         configuration.put(CONFIG_IP, "localhost");
         configuration.put(CONFIG_REFRESH, 1);
         when(thing.getConfiguration()).thenReturn(configuration);
@@ -90,7 +89,7 @@ public class SmartHomeHandlerTest {
         handler.setCallback(callback);
     }
 
-    @After
+    @AfterEach
     public void after() {
         handler.dispose();
     }
@@ -102,7 +101,7 @@ public class SmartHomeHandlerTest {
 
         verify(callback).statusUpdated(eq(thing), statusInfoCaptor.capture());
         ThingStatusInfo thingStatusInfo = statusInfoCaptor.getValue();
-        assertEquals("Device should be unknown", ThingStatus.UNKNOWN, thingStatusInfo.getStatus());
+        assertEquals(ThingStatus.UNKNOWN, thingStatusInfo.getStatus(), "Device should be unknown");
     }
 
     @Test
@@ -125,8 +124,8 @@ public class SmartHomeHandlerTest {
         handler.handleCommand(channelUID, RefreshType.REFRESH);
         ArgumentCaptor<State> stateCaptor = ArgumentCaptor.forClass(State.class);
         verify(callback).stateUpdated(eq(channelUID), stateCaptor.capture());
-        assertEquals("State of RSSI channel should be set", new QuantityType<>(expectedRssi + " dBm"),
-                stateCaptor.getValue());
+        assertEquals(new QuantityType<>(expectedRssi + " dBm"), stateCaptor.getValue(),
+                "State of RSSI channel should be set");
     }
 
     @Test
@@ -137,7 +136,7 @@ public class SmartHomeHandlerTest {
         handler.handleCommand(channelUID, RefreshType.REFRESH);
         ArgumentCaptor<State> stateCaptor = ArgumentCaptor.forClass(State.class);
         verify(callback).stateUpdated(eq(channelUID), stateCaptor.capture());
-        assertSame("State of channel switch should be set", OnOffType.ON, stateCaptor.getValue());
+        assertSame(OnOffType.ON, stateCaptor.getValue(), "State of channel switch should be set");
     }
 
     @Test

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/TradfriColorTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/TradfriColorTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.tradfri.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.PercentType;
 

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryServiceTest.java
@@ -13,18 +13,22 @@
 package org.openhab.binding.tradfri.internal.discovery;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 import static org.openhab.binding.tradfri.internal.config.TradfriDeviceConfig.CONFIG_ID;
 
 import java.util.Collection;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.binding.tradfri.internal.handler.TradfriGatewayHandler;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -43,12 +47,13 @@ import com.google.gson.JsonParser;
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added support for remote controller and motion sensor devices (read-only battery level)
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class TradfriDiscoveryServiceTest {
 
     private static final ThingUID GATEWAY_THING_UID = new ThingUID("tradfri:gateway:1");
 
-    @Mock
-    private TradfriGatewayHandler handler;
+    private @Mock TradfriGatewayHandler handler;
 
     private final DiscoveryListener listener = new DiscoveryListener() {
         @Override
@@ -71,10 +76,8 @@ public class TradfriDiscoveryServiceTest {
 
     private TradfriDiscoveryService discovery;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
-
         when(handler.getThing()).thenReturn(BridgeBuilder.create(GATEWAY_TYPE_UID, "1").build());
 
         discovery = new TradfriDiscoveryService();
@@ -82,7 +85,7 @@ public class TradfriDiscoveryServiceTest {
         discovery.addDiscoveryListener(listener);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         discoveryResult = null;
     }

--- a/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/model/TradfriVersionTest.java
+++ b/bundles/org.openhab.binding.tradfri/src/test/java/org/openhab/binding/tradfri/internal/model/TradfriVersionTest.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.tradfri.internal.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link TradfriVersion}.
@@ -34,9 +34,9 @@ public class TradfriVersionTest {
     private static final String VERSION_STRING = "1.2.42";
     private static final TradfriVersion VERSION = new TradfriVersion(VERSION_STRING);
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIllegalArgumentException() throws IllegalArgumentException {
-        new TradfriVersion("FAILURE");
+        assertThrows(IllegalArgumentException.class, () -> new TradfriVersion("FAILURE"));
     }
 
     @Test

--- a/bundles/org.openhab.binding.upb/src/test/java/org/openhab/binding/upb/internal/message/MessageBuilderTest.java
+++ b/bundles/org.openhab.binding.upb/src/test/java/org/openhab/binding/upb/internal/message/MessageBuilderTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.upb.internal.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Marcus Better - Initial contribution

--- a/bundles/org.openhab.binding.wifiled/src/test/java/org/openhab/binding/wifiled/internal/handler/LEDStateDTOTest.java
+++ b/bundles/org.openhab.binding.wifiled/src/test/java/org/openhab/binding/wifiled/internal/handler/LEDStateDTOTest.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.wifiled.internal.handler;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for LEDStateDTO

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/YamahaReceiverHandlerTest.java
@@ -13,16 +13,15 @@
 package org.openhab.binding.yamahareceiver.internal;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openhab.binding.yamahareceiver.internal.config.YamahaBridgeConfig;
@@ -48,32 +47,17 @@ public class YamahaReceiverHandlerTest extends AbstractXMLProtocolTest {
 
     private YamahaBridgeHandler subject;
 
-    @Mock
-    private YamahaBridgeConfig bridgeConfig;
-
-    @Mock
-    private Configuration configuration;
-
-    @Mock
-    private ProtocolFactory protocolFactory;
-
-    @Mock
-    private DeviceInformation deviceInformation;
-
-    @Mock
-    private SystemControl systemControl;
-
-    @Mock
-    private ThingHandlerCallback callback;
-
-    @Mock
-    private Bridge bridge;
+    private @Mock YamahaBridgeConfig bridgeConfig;
+    private @Mock Configuration configuration;
+    private @Mock ProtocolFactory protocolFactory;
+    private @Mock DeviceInformation deviceInformation;
+    private @Mock SystemControl systemControl;
+    private @Mock ThingHandlerCallback callback;
+    private @Mock Bridge bridge;
 
     @Override
     protected void onSetUp() throws Exception {
         super.onSetUp();
-
-        initMocks(this);
 
         ctx.prepareForModel(TestModels.RX_S601D);
         ctx.respondWith("<Main_Zone><Input><Input_Sel_Item>GetParam</Input_Sel_Item></Input></Main_Zone>",

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/XMLProtocolFactoryTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/XMLProtocolFactoryTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone.Zone_2;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.openhab.binding.yamahareceiver.internal.config.YamahaZoneConfig;
 import org.openhab.binding.yamahareceiver.internal.protocol.xml.AbstractXMLProtocolTest;
@@ -37,11 +37,8 @@ import org.openhab.binding.yamahareceiver.internal.state.ZoneControlStateListene
  */
 public class XMLProtocolFactoryTest extends AbstractXMLProtocolTest {
 
-    @Mock
-    private YamahaZoneConfig zoneConfig;
-
-    @Mock
-    private ZoneControlStateListener zoneControlStateListener;
+    private @Mock YamahaZoneConfig zoneConfig;
+    private @Mock ZoneControlStateListener zoneControlStateListener;
 
     private DeviceInformationState state = new DeviceInformationState();
 
@@ -70,7 +67,7 @@ public class XMLProtocolFactoryTest extends AbstractXMLProtocolTest {
         ZoneControl zoneControl = subject.ZoneControl(con, zoneConfig, zoneControlStateListener, () -> null, state);
 
         // assert
-        assertTrue("Created ZoneB control", zoneControl instanceof ZoneBControlXML);
+        assertTrue(zoneControl instanceof ZoneBControlXML, "Created ZoneB control");
     }
 
     @Test
@@ -86,6 +83,6 @@ public class XMLProtocolFactoryTest extends AbstractXMLProtocolTest {
         ZoneControl zoneControl = subject.ZoneControl(con, zoneConfig, zoneControlStateListener, () -> null, state);
 
         // assert
-        assertTrue("Created Zone control", zoneControl instanceof ZoneControlXML);
+        assertTrue(zoneControl instanceof ZoneControlXML, "Created Zone control");
     }
 }

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/AbstractXMLProtocolTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/AbstractXMLProtocolTest.java
@@ -12,26 +12,28 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * Baseline for tests for the XML protocol implementation.
  *
  * @author Tomasz Maruszak - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public abstract class AbstractXMLProtocolTest {
 
-    @Mock
-    protected XMLConnection con;
+    protected @Mock XMLConnection con;
 
     protected ModelContext ctx;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
         ctx = new ModelContext(con);
 
         onSetUp();

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/AbstractZoneControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/AbstractZoneControlXMLTest.java
@@ -28,16 +28,11 @@ import org.openhab.binding.yamahareceiver.internal.state.ZoneControlStateListene
  */
 public abstract class AbstractZoneControlXMLTest extends AbstractXMLProtocolTest {
 
-    @Mock
-    protected YamahaZoneConfig zoneConfig;
-
-    @Mock
-    protected ZoneControlStateListener zoneControlStateListener;
-
     protected DeviceInformationState deviceInformationState;
 
-    @Mock
-    protected InputConverter inputConverter;
+    protected @Mock InputConverter inputConverter;
+    protected @Mock ZoneControlStateListener zoneControlStateListener;
+    protected @Mock YamahaZoneConfig zoneConfig;
 
     @Override
     protected void onSetUp() throws Exception {

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/DeviceDescriptorXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/DeviceDescriptorXMLTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Feature.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone.*;
 
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants;
 
 /**
@@ -87,15 +87,15 @@ public class DeviceDescriptorXMLTest extends AbstractXMLProtocolTest {
         assertCommands(subject.system, systemCommandsSpec);
 
         assertNotNull(subject.features);
-        assertTrue("Desired features present", subject.features.keySet().containsAll(features));
+        assertTrue(subject.features.keySet().containsAll(features), "Desired features present");
 
         assertNotNull(subject.zones);
-        assertEquals("Number of zones match", zones.size(), subject.zones.size());
+        assertEquals(zones.size(), subject.zones.size(), "Number of zones match");
 
         for (int i = 0; i < zones.size(); i++) {
             YamahaReceiverBindingConstants.Zone zone = zones.get(i);
 
-            assertTrue("Desired zone is present", subject.zones.containsKey(zone));
+            assertTrue(subject.zones.containsKey(zone), "Desired zone is present");
 
             DeviceDescriptorXML.ZoneDescriptor zoneDesc = subject.zones.get(zone);
             CommandsSpec zoneSpec = zonesCommandsSpec[i];
@@ -104,9 +104,9 @@ public class DeviceDescriptorXMLTest extends AbstractXMLProtocolTest {
     }
 
     private void assertCommands(DeviceDescriptorXML.HasCommands descWithCommands, CommandsSpec spec) {
-        assertNotNull("Descriptor commands are present", descWithCommands);
-        assertEquals("Expected number of commands", spec.expectedNumber, descWithCommands.commands.size());
-        assertTrue("Expected commands are present", descWithCommands.commands.containsAll(spec.expected));
+        assertNotNull(descWithCommands, "Descriptor commands are present");
+        assertEquals(spec.expectedNumber, descWithCommands.commands.size(), "Expected number of commands");
+        assertTrue(descWithCommands.commands.containsAll(spec.expected), "Expected commands are present");
     }
 
     private static class CommandsSpec {

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/DeviceInformationXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/DeviceInformationXMLTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Feature.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone.*;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.yamahareceiver.internal.protocol.ReceivedMessageParseException;
 import org.openhab.binding.yamahareceiver.internal.state.DeviceInformationState;
 
@@ -50,8 +50,8 @@ public class DeviceInformationXMLTest extends AbstractXMLProtocolTest {
         subject.update();
 
         // assert
-        assertTrue("ZONE_B detected", state.features.contains(ZONE_B));
-        assertTrue("Zone_2 added", state.zones.contains(Zone_2));
+        assertTrue(state.features.contains(ZONE_B), "ZONE_B detected");
+        assertTrue(state.zones.contains(Zone_2), "Zone_2 added");
     }
 
     @Test
@@ -64,7 +64,7 @@ public class DeviceInformationXMLTest extends AbstractXMLProtocolTest {
         subject.update();
 
         // assert
-        assertTrue("Zones detected", state.zones.containsAll(Arrays.asList(Main_Zone, Zone_2, Zone_3)));
-        assertTrue("Features detected", state.features.containsAll(Arrays.asList(TUNER, BLUETOOTH)));
+        assertTrue(state.zones.containsAll(Arrays.asList(Main_Zone, Zone_2, Zone_3)), "Zones detected");
+        assertTrue(state.features.containsAll(Arrays.asList(TUNER, BLUETOOTH)), "Features detected");
     }
 }

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputConverterXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputConverterXMLTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Inputs.*;
 import static org.openhab.binding.yamahareceiver.internal.protocol.xml.XMLConstants.Commands.ZONE_INPUT_QUERY;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link InputConverterXML}.

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithPlayControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithPlayControlXMLTest.java
@@ -12,16 +12,15 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.openhab.binding.yamahareceiver.internal.TestModels.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Inputs.*;
 
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -31,21 +30,16 @@ import org.openhab.binding.yamahareceiver.internal.state.PlayInfoStateListener;
 
 /**
  * Unit test for {@link InputWithPlayControlXML}.
- * 
+ *
  * @author Tomasz Maruszak - Initial contribution
  */
 public class InputWithPlayControlXMLTest extends AbstractZoneControlXMLTest {
 
     private InputWithPlayControlXML subject;
 
-    @Mock
-    private PlayInfoStateListener playInfoStateListener;
-
-    @Captor
-    private ArgumentCaptor<PlayInfoState> playInfoStateArg;
-
-    @Mock
-    private YamahaBridgeConfig bridgeConfig;
+    private @Mock PlayInfoStateListener playInfoStateListener;
+    private @Captor ArgumentCaptor<PlayInfoState> playInfoStateArg;
+    private @Mock YamahaBridgeConfig bridgeConfig;
 
     private String albumUrl;
 

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithPresetControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/InputWithPresetControlXMLTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.openhab.binding.yamahareceiver.internal.TestModels.*;
@@ -20,7 +20,7 @@ import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingC
 
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -36,11 +36,8 @@ public class InputWithPresetControlXMLTest extends AbstractZoneControlXMLTest {
 
     private InputWithPresetControlXML subject;
 
-    @Mock
-    private PresetInfoStateListener presetInfoStateListener;
-
-    @Captor
-    private ArgumentCaptor<PresetInfoState> presetInfoStateArg;
+    private @Mock PresetInfoStateListener presetInfoStateListener;
+    private @Captor ArgumentCaptor<PresetInfoState> presetInfoStateArg;
 
     private void given(String model, String input, Consumer<ModelContext> setup) throws Exception {
         ctx.prepareForModel(model);

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/SystemControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/SystemControlXMLTest.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openhab.binding.yamahareceiver.internal.TestModels;
@@ -35,8 +35,7 @@ public class SystemControlXMLTest extends AbstractXMLProtocolTest {
 
     private DeviceInformationState deviceInformationState;
 
-    @Mock
-    private SystemControlStateListener systemControlStateListener;
+    private @Mock SystemControlStateListener systemControlStateListener;
 
     protected void setupFor(String model) throws Exception {
         ctx.prepareForModel(model);

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneBControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneBControlXMLTest.java
@@ -12,14 +12,12 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.openhab.binding.yamahareceiver.internal.TestModels.HTR_4069;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.binding.yamahareceiver.internal.state.ZoneControlState;
 

--- a/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXMLTest.java
+++ b/bundles/org.openhab.binding.yamahareceiver/src/test/java/org/openhab/binding/yamahareceiver/internal/protocol/xml/ZoneControlXMLTest.java
@@ -12,14 +12,13 @@
  */
 package org.openhab.binding.yamahareceiver.internal.protocol.xml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.openhab.binding.yamahareceiver.internal.TestModels.*;
 import static org.openhab.binding.yamahareceiver.internal.YamahaReceiverBindingConstants.Zone.Main_Zone;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.binding.yamahareceiver.internal.state.ZoneControlState;
 

--- a/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactoryTest.java
+++ b/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/YeelightHandlerFactoryTest.java
@@ -12,23 +12,27 @@
  */
 package org.openhab.binding.yeelight.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openhab.binding.yeelight.internal.YeelightBindingConstants.PARAMETER_DEVICE_ID;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.openhab.binding.yeelight.internal.handler.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.yeelight.internal.handler.YeelightCeilingHandler;
+import org.openhab.binding.yeelight.internal.handler.YeelightCeilingWithAmbientHandler;
+import org.openhab.binding.yeelight.internal.handler.YeelightCeilingWithNightHandler;
+import org.openhab.binding.yeelight.internal.handler.YeelightColorHandler;
+import org.openhab.binding.yeelight.internal.handler.YeelightStripeHandler;
+import org.openhab.binding.yeelight.internal.handler.YeelightWhiteHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -40,7 +44,8 @@ import org.openhab.core.thing.binding.ThingHandler;
  * @author Viktor Koop - Initial contribution
  * @author Nikita Pogudalov - Added YeelightCeilingWithNightHandler for Ceiling 1
  */
-@RunWith(value = Parameterized.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class YeelightHandlerFactoryTest {
 
     private static final List<Object[]> TESTS = Arrays.asList(
@@ -52,41 +57,31 @@ public class YeelightHandlerFactoryTest {
 
     private final YeelightHandlerFactory factory = new YeelightHandlerFactory();
 
-    @Mock
-    private Thing thing;
+    private @Mock Thing thing;
 
-    private final String name;
-    private final Class<?> clazz;
-
-    public YeelightHandlerFactoryTest(String name, Class<?> clazz) {
-        this.name = name;
-        this.clazz = clazz;
-    }
-
-    @Parameters(name = "{0} - {1}")
     public static List<Object[]> data() {
         return TESTS;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
         Configuration configuration = new Configuration();
         configuration.put(PARAMETER_DEVICE_ID, "");
 
         when(thing.getConfiguration()).thenReturn(configuration);
     }
 
-    @Test
-    public void testCorrectClass() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCorrectClass(String name, Class<?> clazz) {
         when(thing.getThingTypeUID()).thenReturn(new ThingTypeUID(YeelightBindingConstants.BINDING_ID, name));
         ThingHandler handler = factory.createHandler(thing);
 
         if (null == clazz) {
-            assertNull(name + " should not return any handler but null", handler);
+            assertNull(handler, name + " should not return any handler but null");
         } else {
-            assertNotNull(name + " should no return null handler", handler);
-            assertEquals(" should be correct matcher", clazz, handler.getClass());
+            assertNotNull(handler, name + " should no return null handler");
+            assertEquals(clazz, handler.getClass(), " should be correct matcher");
 
             assertEquals(thing, handler.getThing());
         }

--- a/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/lib/device/DeviceBaseTest.java
+++ b/bundles/org.openhab.binding.yeelight/src/test/java/org/openhab/binding/yeelight/internal/lib/device/DeviceBaseTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.yeelight.internal.lib.device;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.yeelight.internal.lib.enums.ActiveMode;
 
 /**
@@ -27,7 +27,7 @@ public class DeviceBaseTest {
 
     private DeviceBase deviceBase;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         deviceBase = new DeviceBase("myid") {
         };

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/automation/RuleConditionHandlerTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/automation/RuleConditionHandlerTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.automation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -22,6 +23,11 @@ import java.util.Random;
 import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.util.ConditionBuilder;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.library.items.ContactItem;
@@ -30,11 +36,6 @@ import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.util.ConditionBuilder;
 import org.openhab.io.hueemulation.internal.DeviceType;
 import org.openhab.io.hueemulation.internal.RuleUtils;
 import org.openhab.io.hueemulation.internal.dto.HueDataStore;
@@ -64,7 +65,7 @@ public class RuleConditionHandlerTests {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ds = new HueDataStore();
 
@@ -76,12 +77,12 @@ public class RuleConditionHandlerTests {
                 new HueGroupEntry("name", new GroupItem("white", new NumberItem("number")), DeviceType.SwitchType));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         RuleUtils.random = new Random();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void itemNotExisting() {
         Configuration configuration = new Configuration();
         configuration.put("address", "/groups/9/action");
@@ -89,7 +90,7 @@ public class RuleConditionHandlerTests {
         configuration.put("value", "");
         Condition c = ConditionBuilder.create().withId("a").withTypeUID(HueRuleConditionHandler.MODULE_TYPE_ID)
                 .withConfiguration(configuration).build();
-        new HueRuleConditionHandler(c, ds);
+        assertThrows(IllegalStateException.class, () -> new HueRuleConditionHandler(c, ds));
     }
 
     @Test

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/CommonSetup.java
@@ -29,19 +29,22 @@ import java.util.logging.Logger;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
-import org.openhab.core.events.EventPublisher;
-import org.openhab.core.items.MetadataRegistry;
-import org.openhab.core.net.NetworkAddressService;
-import org.openhab.core.storage.Storage;
-import org.openhab.core.storage.StorageService;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.logging.LoggingFeature.Verbosity;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.net.NetworkAddressService;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.storage.StorageService;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.rest.mocks.ConfigStoreWithoutMetadata;
 import org.openhab.io.hueemulation.internal.rest.mocks.DummyMetadataRegistry;
@@ -58,12 +61,13 @@ import org.osgi.service.cm.ConfigurationAdmin;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class CommonSetup {
 
     public UserManagement userManagement;
 
-    @Mock
-    public EventPublisher eventPublisher;
+    public @Mock EventPublisher eventPublisher;
 
     public ConfigStore cs;
 
@@ -102,7 +106,6 @@ public class CommonSetup {
     public String basePath;
 
     public CommonSetup(boolean withMetadata) throws IOException {
-        MockitoAnnotations.initMocks(this);
         when(configAdmin.getConfiguration(anyString())).thenReturn(configAdminConfig);
         when(configAdmin.getConfiguration(anyString(), any())).thenReturn(configAdminConfig);
         Dictionary<String, Object> mockProperties = new Hashtable<>();

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
@@ -13,7 +13,7 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -21,15 +21,15 @@ import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
 import org.openhab.core.library.items.SwitchItem;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.dto.HueLightEntry;
 import org.openhab.io.hueemulation.internal.dto.HueStatePlug;
@@ -47,7 +47,7 @@ public class ItemUIDtoHueIDMappingTests {
 
     LightsAndGroups lightsAndGroups = new LightsAndGroups();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(true);
         commonSetup.start(new ResourceConfig());
@@ -61,7 +61,7 @@ public class ItemUIDtoHueIDMappingTests {
         lightsAndGroups.activate();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         commonSetup.dispose();
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
@@ -23,6 +24,10 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.events.Event;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.ItemRegistry;
@@ -31,10 +36,6 @@ import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.DeviceType;
 import org.openhab.io.hueemulation.internal.dto.HueGroupEntry;
@@ -56,7 +57,7 @@ public class LightsAndGroupsTests {
 
     LightsAndGroups subject = new LightsAndGroups();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
         itemRegistry = new DummyItemRegistry();
@@ -81,7 +82,7 @@ public class LightsAndGroupsTests {
         commonSetup.start(new ResourceConfig().registerInstances(subject));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         commonSetup.dispose();
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/RulesTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/RulesTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -25,6 +26,15 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.Rule;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.ColorItem;
@@ -32,15 +42,6 @@ import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.State;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.Rule;
-import org.openhab.core.automation.RuleRegistry;
-import org.openhab.core.automation.Trigger;
-import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.RuleUtils;
 import org.openhab.io.hueemulation.internal.dto.HueRuleEntry;
@@ -75,7 +76,7 @@ public class RulesTests {
         itemRegistry.add(item);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
         this.cs = commonSetup.cs;
@@ -104,7 +105,7 @@ public class RulesTests {
         commonSetup.start(new ResourceConfig().registerInstances(subject));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         RuleUtils.random = new Random();
         commonSetup.dispose();

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SceneTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SceneTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -24,6 +25,14 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Rule;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.ItemRegistry;
@@ -36,14 +45,6 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.core.automation.Rule;
-import org.openhab.core.automation.RuleRegistry;
-import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.dto.HueSceneEntry;
 import org.openhab.io.hueemulation.internal.rest.mocks.DummyItemRegistry;
@@ -72,7 +73,7 @@ public class SceneTests {
         itemRegistry.add(item);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
         this.cs = commonSetup.cs;
@@ -97,7 +98,7 @@ public class SceneTests {
         commonSetup.start(new ResourceConfig().registerInstances(subject));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         commonSetup.dispose();
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ScheduleTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ScheduleTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -28,19 +29,19 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.config.core.Configuration;
-import org.openhab.core.library.items.ColorItem;
-import org.openhab.core.library.items.SwitchItem;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.RuleManager;
 import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.automation.util.TriggerBuilder;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.items.ColorItem;
+import org.openhab.core.library.items.SwitchItem;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.DeviceType;
 import org.openhab.io.hueemulation.internal.RuleUtils;
@@ -66,7 +67,7 @@ public class ScheduleTests {
 
     Schedules subject = new Schedules();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
         this.cs = commonSetup.cs;
@@ -97,7 +98,7 @@ public class ScheduleTests {
         RuleUtils.random = random;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         RuleUtils.random = new Random();
         commonSetup.dispose();

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/SensorTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -21,6 +22,10 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.ColorItem;
@@ -35,10 +40,6 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.types.State;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.rest.mocks.DummyItemRegistry;
 
@@ -61,7 +62,7 @@ public class SensorTests {
         itemRegistry.add(item);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
         itemRegistry = new DummyItemRegistry();
@@ -84,7 +85,7 @@ public class SensorTests {
         commonSetup.start(new ResourceConfig().registerInstances(subject));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         commonSetup.dispose();
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/UsersAndConfigTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/UsersAndConfigTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.rest;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -23,9 +24,9 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.io.hueemulation.internal.ConfigStore;
 import org.openhab.io.hueemulation.internal.HueEmulationConfig;
@@ -49,7 +50,7 @@ public class UsersAndConfigTests {
 
     CommonSetup commonSetup;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         commonSetup = new CommonSetup(false);
 
@@ -60,7 +61,7 @@ public class UsersAndConfigTests {
         commonSetup.start(new ResourceConfig().registerInstances(configurationAccess));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         commonSetup.dispose();
     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
@@ -13,7 +13,8 @@
 package org.openhab.io.hueemulation.internal.upnp;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -31,11 +32,11 @@ import org.glassfish.grizzly.osgi.httpservice.OSGiMainHandler;
 import org.glassfish.grizzly.osgi.httpservice.util.Logger;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.openhab.io.hueemulation.internal.rest.CommonSetup;
@@ -57,7 +58,7 @@ public class UpnpTests {
 
     LightsAndGroups lightsAndGroups = new LightsAndGroups();
 
-    @BeforeClass
+    @BeforeAll
     public static void setupHttpParts() throws IOException {
         commonSetup = new CommonSetup(true);
         commonSetup.start(new ResourceConfig());
@@ -72,7 +73,7 @@ public class UpnpTests {
         httpServiceImpl = new HttpServiceImpl(mock(Bundle.class), logger);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         Executor executor = mock(Executor.class);
         Mockito.doAnswer(a -> {
@@ -87,12 +88,12 @@ public class UpnpTests {
         subject.overwriteReadyToFalse = false;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         subject.deactivate();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownHttp() {
         mainHttpHandler.unregisterAll();
         commonSetup.dispose();

--- a/bundles/org.openhab.io.mqttembeddedbroker/src/test/java/org/openhab/io/mqttembeddedbroker/internal/MqttEmbeddedBrokerServiceTest.java
+++ b/bundles/org.openhab.io.mqttembeddedbroker/src/test/java/org/openhab/io/mqttembeddedbroker/internal/MqttEmbeddedBrokerServiceTest.java
@@ -13,7 +13,8 @@
 package org.openhab.io.mqttembeddedbroker.internal;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 
@@ -33,11 +34,12 @@ import javax.naming.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.config.core.ConfigConstants;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection.Protocol;
@@ -56,16 +58,15 @@ import io.moquette.broker.subscriptions.Topic;
  *
  * @author David Graeff - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
 public class MqttEmbeddedBrokerServiceTest extends JavaTest {
 
     private EmbeddedBrokerService subject;
     private Map<String, Object> config = new HashMap<>();
     private @Mock MqttService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws ConfigurationException, MqttException, GeneralSecurityException, IOException {
-        MockitoAnnotations.initMocks(this);
-
         config.put("username", "username");
         config.put("password", "password");
         config.put("port", 12345);
@@ -75,7 +76,7 @@ public class MqttEmbeddedBrokerServiceTest extends JavaTest {
         subject = new EmbeddedBrokerService(service, config);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         subject.deactivate();
     }

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BasicBitArrayTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BasicBitArrayTest.java
@@ -13,9 +13,10 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.io.transport.modbus.BitArray;
 
 /**
@@ -60,27 +61,27 @@ public class BasicBitArrayTest {
         assertThat(data1.getBit(2), is(equalTo(false)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testOutOfBounds() {
         BitArray data1 = new BitArray(true, false, true);
-        data1.getBit(3);
+        assertThrows(IndexOutOfBoundsException.class, () -> data1.getBit(3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testOutOfBounds2() {
         BitArray data1 = new BitArray(true, false, true);
-        data1.getBit(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> data1.getBit(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testOutOfBounds3() {
         BitArray data1 = new BitArray(3);
-        data1.getBit(3);
+        assertThrows(IndexOutOfBoundsException.class, () -> data1.getBit(3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testOutOfBounds4() {
         BitArray data1 = new BitArray(3);
-        data1.getBit(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> data1.getBit(-1));
     }
 }

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesExtractStringFromRegistersTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesExtractStringFromRegistersTest.java
@@ -13,7 +13,8 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -24,40 +25,19 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.core.library.types.StringType;
 import org.openhab.io.transport.modbus.ModbusBitUtilities;
 import org.openhab.io.transport.modbus.ModbusRegister;
 import org.openhab.io.transport.modbus.ModbusRegisterArray;
 
+import io.swagger.v3.oas.annotations.Parameters;
+
 /**
  * @author Sami Salonen - Initial contribution
  */
-@RunWith(Parameterized.class)
 public class BitUtilitiesExtractStringFromRegistersTest {
-
-    final ModbusRegisterArray registers;
-    final int index;
-    final int length;
-    final Object expectedResult;
-    final Charset charset;
-
-    @Rule
-    public final ExpectedException shouldThrow = ExpectedException.none();
-
-    public BitUtilitiesExtractStringFromRegistersTest(Object expectedResult, ModbusRegisterArray registers, int index,
-            int length, Charset charset) {
-        this.registers = registers;
-        this.index = index;
-        this.length = length;
-        this.charset = charset;
-        this.expectedResult = expectedResult;
-    }
 
     private static ModbusRegisterArray shortArrayToRegisterArray(int... arr) {
         ModbusRegister[] tmp = new ModbusRegister[0];
@@ -99,14 +79,17 @@ public class BitUtilitiesExtractStringFromRegistersTest {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Test
-    public void testExtractStringFromRegisters() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testExtractStringFromRegisters(Object expectedResult, ModbusRegisterArray registers, int index,
+            int length, Charset charset) {
         if (expectedResult instanceof Class && Exception.class.isAssignableFrom((Class) expectedResult)) {
-            shouldThrow.expect((Class) expectedResult);
+            assertThrows((Class) expectedResult,
+                    () -> ModbusBitUtilities.extractStringFromRegisters(registers, index, length, charset));
+            return;
         }
 
-        StringType actualState = ModbusBitUtilities.extractStringFromRegisters(this.registers, this.index, this.length,
-                this.charset);
+        StringType actualState = ModbusBitUtilities.extractStringFromRegisters(registers, index, length, charset);
         assertThat(String.format("registers=%s, index=%d, length=%d", registers, index, length), actualState,
                 is(equalTo(expectedResult)));
     }

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesTranslateCommand2BooleanTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/BitUtilitiesTranslateCommand2BooleanTest.java
@@ -13,11 +13,11 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/IntegrationTestSupport.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/IntegrationTestSupport.java
@@ -13,7 +13,8 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -27,11 +28,13 @@ import java.util.HashMap;
 import java.util.function.LongSupplier;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.mockito.MockitoAnnotations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
 import org.openhab.io.transport.modbus.endpoint.ModbusTCPSlaveEndpoint;
@@ -62,6 +65,8 @@ import net.wimpi.modbus.util.SerialParameters;
 /**
  * @author Sami Salonen - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class IntegrationTestSupport extends JavaTest {
 
     public enum ServerType {
@@ -113,14 +118,9 @@ public class IntegrationTestSupport extends JavaTest {
 
     private static AtomicCounter udpServerIndex = new AtomicCounter(0);
 
-    @Spy
-    protected TCPSlaveConnectionFactory tcpConnectionFactory = new TCPSlaveConnectionFactoryImpl();
-
-    @Spy
-    protected UDPSlaveTerminalFactory udpTerminalFactory = new UDPSlaveTerminalFactoryImpl();
-
-    @Spy
-    protected SerialConnectionFactory serialConnectionFactory = new SerialConnectionFactoryImpl();
+    protected @Spy TCPSlaveConnectionFactory tcpConnectionFactory = new TCPSlaveConnectionFactoryImpl();
+    protected @Spy UDPSlaveTerminalFactory udpTerminalFactory = new UDPSlaveTerminalFactoryImpl();
+    protected @Spy SerialConnectionFactory serialConnectionFactory = new SerialConnectionFactoryImpl();
 
     protected ResultCaptor<ModbusRequest> modbustRequestCaptor;
 
@@ -146,7 +146,7 @@ public class IntegrationTestSupport extends JavaTest {
         return InetAddress.getByName("127.0.0.1");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         modbustRequestCaptor = new ResultCaptor<>(new LongSupplier() {
 
@@ -155,12 +155,11 @@ public class IntegrationTestSupport extends JavaTest {
                 return artificialServerWait;
             }
         });
-        MockitoAnnotations.initMocks(this);
         modbusManager = new NonOSGIModbusManager();
         startServer();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         stopServer();
         modbusManager.close();
@@ -238,8 +237,8 @@ public class IntegrationTestSupport extends JavaTest {
 
         udpListener.start();
         waitForUDPServerStartup();
-        Assert.assertNotSame(-1, udpModbusPort);
-        Assert.assertNotSame(0, udpModbusPort);
+        assertNotSame(-1, udpModbusPort);
+        assertNotSame(0, udpModbusPort);
     }
 
     private void waitForUDPServerStartup() throws InterruptedException {
@@ -256,8 +255,8 @@ public class IntegrationTestSupport extends JavaTest {
         tcpListener.start();
         // Query server port. It seems to take time (probably due to thread starting)
         waitForTCPServerStartup();
-        Assert.assertNotSame(-1, tcpModbusPort);
-        Assert.assertNotSame(0, tcpModbusPort);
+        assertNotSame(-1, tcpModbusPort);
+        assertNotSame(0, tcpModbusPort);
     }
 
     private void waitForTCPServerStartup() throws InterruptedException {

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.io.transport.modbus.test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.openhab.io.transport.modbus.endpoint.ModbusSerialSlaveEndpoint;
 import org.openhab.io.transport.modbus.endpoint.ModbusTCPSlaveEndpoint;
 import org.openhab.io.transport.modbus.endpoint.ModbusUDPSlaveEndpoint;
@@ -30,7 +30,7 @@ public class ModbusSlaveEndpointTestCase {
     public void testEqualsSameTcp() {
         ModbusTCPSlaveEndpoint e1 = new ModbusTCPSlaveEndpoint("127.0.0.1", 500);
         ModbusTCPSlaveEndpoint e2 = new ModbusTCPSlaveEndpoint("127.0.0.1", 500);
-        Assert.assertEquals(e1, e2);
+        assertEquals(e1, e2);
     }
 
     @Test
@@ -41,7 +41,7 @@ public class ModbusSlaveEndpointTestCase {
         ModbusSerialSlaveEndpoint e2 = new ModbusSerialSlaveEndpoint("port1", 9600, SerialPort.FLOWCONTROL_NONE,
                 SerialPort.FLOWCONTROL_NONE, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE,
                 Modbus.DEFAULT_SERIAL_ENCODING, true, 500);
-        Assert.assertEquals(e1, e2);
+        assertEquals(e1, e2);
     }
 
     /**
@@ -55,8 +55,8 @@ public class ModbusSlaveEndpointTestCase {
         ModbusSerialSlaveEndpoint e2 = new ModbusSerialSlaveEndpoint("port1", 9600, SerialPort.FLOWCONTROL_NONE,
                 SerialPort.FLOWCONTROL_NONE, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE,
                 Modbus.DEFAULT_SERIAL_ENCODING, false, 500);
-        Assert.assertEquals(e1, e2);
-        Assert.assertEquals(e1.hashCode(), e2.hashCode());
+        assertEquals(e1, e2);
+        assertEquals(e1.hashCode(), e2.hashCode());
     }
 
     @Test
@@ -67,32 +67,32 @@ public class ModbusSlaveEndpointTestCase {
         ModbusSerialSlaveEndpoint e2 = new ModbusSerialSlaveEndpoint("port2", 9600, SerialPort.FLOWCONTROL_NONE,
                 SerialPort.FLOWCONTROL_NONE, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE,
                 Modbus.DEFAULT_SERIAL_ENCODING, true, 500);
-        Assert.assertNotEquals(e1, e2);
-        Assert.assertNotEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1, e2);
+        assertNotEquals(e1.hashCode(), e2.hashCode());
     }
 
     @Test
     public void testEqualsDifferentTCPPort() {
         ModbusTCPSlaveEndpoint e1 = new ModbusTCPSlaveEndpoint("127.0.0.1", 500);
         ModbusTCPSlaveEndpoint e2 = new ModbusTCPSlaveEndpoint("127.0.0.1", 501);
-        Assert.assertNotEquals(e1, e2);
-        Assert.assertNotEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1, e2);
+        assertNotEquals(e1.hashCode(), e2.hashCode());
     }
 
     @Test
     public void testEqualsDifferentTCPHost() {
         ModbusTCPSlaveEndpoint e1 = new ModbusTCPSlaveEndpoint("127.0.0.1", 500);
         ModbusTCPSlaveEndpoint e2 = new ModbusTCPSlaveEndpoint("127.0.0.2", 501);
-        Assert.assertNotEquals(e1, e2);
-        Assert.assertNotEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1, e2);
+        assertNotEquals(e1.hashCode(), e2.hashCode());
     }
 
     @Test
     public void testEqualsDifferentProtocol() {
         ModbusTCPSlaveEndpoint e1 = new ModbusTCPSlaveEndpoint("127.0.0.1", 500);
         ModbusUDPSlaveEndpoint e2 = new ModbusUDPSlaveEndpoint("127.0.0.1", 500);
-        Assert.assertNotEquals(e1, e2);
-        Assert.assertNotEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1, e2);
+        assertNotEquals(e1.hashCode(), e2.hashCode());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class ModbusSlaveEndpointTestCase {
         ModbusSerialSlaveEndpoint e2 = new ModbusSerialSlaveEndpoint("port2", 9600, SerialPort.FLOWCONTROL_NONE,
                 SerialPort.FLOWCONTROL_NONE, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE,
                 Modbus.DEFAULT_SERIAL_ENCODING, true, 500);
-        Assert.assertNotEquals(e1, e2);
-        Assert.assertNotEquals(e1.hashCode(), e2.hashCode());
+        assertNotEquals(e1, e2);
+        assertNotEquals(e1.hashCode(), e2.hashCode());
     }
 }

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
@@ -13,6 +13,7 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.openhab.io.transport.modbus.endpoint.ModbusSerialSlaveEndpoint;
 import org.openhab.io.transport.modbus.endpoint.ModbusTCPSlaveEndpoint;

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
@@ -13,8 +13,9 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -35,8 +36,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.io.transport.modbus.BitArray;
 import org.openhab.io.transport.modbus.ModbusCommunicationInterface;
 import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
@@ -132,7 +133,7 @@ public class SmokeTest extends IntegrationTestSupport {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUpSocketSpy() throws IOException {
         socketSpy.sockets.clear();
     }
@@ -164,7 +165,7 @@ public class SmokeTest extends IntegrationTestSupport {
 
             assertThat(okCount.get(), is(equalTo(0)));
             assertThat(errorCount.get(), is(equalTo(1)));
-            assertTrue(lastError.toString(), lastError.get() instanceof ModbusSlaveErrorResponseException);
+            assertTrue(lastError.get() instanceof ModbusSlaveErrorResponseException, lastError.toString());
         }
     }
 
@@ -201,7 +202,7 @@ public class SmokeTest extends IntegrationTestSupport {
 
             assertThat(okCount.get(), is(equalTo(0)));
             assertThat(errorCount.get(), is(equalTo(1)));
-            assertTrue(lastError.toString(), lastError.get() instanceof ModbusConnectionException);
+            assertTrue(lastError.get() instanceof ModbusConnectionException, lastError.toString());
         }
     }
 
@@ -234,7 +235,7 @@ public class SmokeTest extends IntegrationTestSupport {
             assertTrue(callbackCalled.await(15, TimeUnit.SECONDS));
             assertThat(okCount.get(), is(equalTo(0)));
             assertThat(lastError.toString(), errorCount.get(), is(equalTo(1)));
-            assertTrue(lastError.toString(), lastError.get() instanceof ModbusSlaveIOException);
+            assertTrue(lastError.get() instanceof ModbusSlaveIOException, lastError.toString());
         }
     }
 
@@ -473,7 +474,7 @@ public class SmokeTest extends IntegrationTestSupport {
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
 
             assertThat(unexpectedCount.get(), is(equalTo(0)));
-            assertTrue(lastError.toString(), lastError.get() instanceof ModbusSlaveErrorResponseException);
+            assertTrue(lastError.get() instanceof ModbusSlaveErrorResponseException, lastError.toString());
 
             assertThat(modbustRequestCaptor.getAllReturnValues().size(), is(equalTo(1)));
             ModbusRequest request = modbustRequestCaptor.getAllReturnValues().get(0);
@@ -550,7 +551,7 @@ public class SmokeTest extends IntegrationTestSupport {
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
 
             assertThat(unexpectedCount.get(), is(equalTo(0)));
-            assertTrue(lastError.toString(), lastError.get() instanceof ModbusSlaveErrorResponseException);
+            assertTrue(lastError.get() instanceof ModbusSlaveErrorResponseException, lastError.toString());
 
             assertThat(modbustRequestCaptor.getAllReturnValues().size(), is(equalTo(1)));
             ModbusRequest request = modbustRequestCaptor.getAllReturnValues().get(0);
@@ -705,13 +706,13 @@ public class SmokeTest extends IntegrationTestSupport {
         assertTrue(responses > 1);
 
         // Rest of the (timing-sensitive) assertions are not run in CI
-        assumeFalse("Running in CI! Will not test timing-sensitive details", isRunningInCI());
+        assumeFalse(isRunningInCI(), "Running in CI! Will not test timing-sensitive details");
         float averagePollPeriodMillis = ((float) (pollEndMillis - pollStartMillis)) / (responses - 1);
-        assertTrue(String.format(
-                "Measured avarage poll period %f ms (%d responses in %d ms) is not withing expected limits [%d, %d]",
-                averagePollPeriodMillis, responses, pollEndMillis - pollStartMillis, expectedPollAverageMin,
-                expectedPollAverageMax),
-                averagePollPeriodMillis > expectedPollAverageMin && averagePollPeriodMillis < expectedPollAverageMax);
+        assertTrue(averagePollPeriodMillis > expectedPollAverageMin && averagePollPeriodMillis < expectedPollAverageMax,
+                String.format(
+                        "Measured avarage poll period %f ms (%d responses in %d ms) is not withing expected limits [%d, %d]",
+                        averagePollPeriodMillis, responses, pollEndMillis - pollStartMillis, expectedPollAverageMin,
+                        expectedPollAverageMax));
     }
 
     @Test
@@ -828,10 +829,10 @@ public class SmokeTest extends IntegrationTestSupport {
 
     @Test
     public void testConnectionCloseAfterLastCommunicationInterfaceClosed() throws IllegalArgumentException, Exception {
-        assumeFalse("Running in CI! Will not test timing-sensitive details", isRunningInCI());
+        assumeFalse(isRunningInCI(), "Running in CI! Will not test timing-sensitive details");
         ModbusSlaveEndpoint endpoint = getEndpoint();
-        assumeTrue("Connection closing test supported only with TCP slaves",
-                endpoint instanceof ModbusTCPSlaveEndpoint);
+        assumeTrue(endpoint instanceof ModbusTCPSlaveEndpoint,
+                "Connection closing test supported only with TCP slaves");
 
         // Generate server data
         generateData();
@@ -893,10 +894,10 @@ public class SmokeTest extends IntegrationTestSupport {
 
     @Test
     public void testConnectionCloseAfterOneOffPoll() throws IllegalArgumentException, Exception {
-        assumeFalse("Running in CI! Will not test timing-sensitive details", isRunningInCI());
+        assumeFalse(isRunningInCI(), "Running in CI! Will not test timing-sensitive details");
         ModbusSlaveEndpoint endpoint = getEndpoint();
-        assumeTrue("Connection closing test supported only with TCP slaves",
-                endpoint instanceof ModbusTCPSlaveEndpoint);
+        assumeTrue(endpoint instanceof ModbusTCPSlaveEndpoint,
+                "Connection closing test supported only with TCP slaves");
 
         // Generate server data
         generateData();

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/WriteRequestJsonUtilitiesTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/WriteRequestJsonUtilitiesTest.java
@@ -13,8 +13,9 @@
 package org.openhab.io.transport.modbus.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.ArrayMatching.arrayContaining;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openhab.io.transport.modbus.ModbusConstants.*;
 
 import java.util.Collection;
@@ -24,7 +25,7 @@ import java.util.stream.IntStream;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.io.transport.modbus.ModbusWriteFunctionCode;
 import org.openhab.io.transport.modbus.ModbusWriteRequestBlueprint;
 import org.openhab.io.transport.modbus.json.WriteRequestJsonUtilities;
@@ -49,13 +50,13 @@ public class WriteRequestJsonUtilitiesTest {
         assertThat(WriteRequestJsonUtilities.fromJson(3, "[]").size(), is(equalTo(0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC6NoRegister() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 6,"//
                 + "\"address\": 5412,"//
                 + "\"value\": []"//
-                + "}]");
+                + "}]"));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -83,22 +84,22 @@ public class WriteRequestJsonUtilitiesTest {
                         (Matcher) new RegisterMatcher(55, 5412, 99, ModbusWriteFunctionCode.WRITE_SINGLE_REGISTER, 3)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC6MultipleRegisters() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 6,"//
                 + "\"address\": 5412,"//
                 + "\"value\": [3, 4]"//
-                + "}]");
+                + "}]"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC16NoRegister() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 16,"//
                 + "\"address\": 5412,"//
                 + "\"value\": []"//
-                + "}]");
+                + "}]"));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -135,13 +136,13 @@ public class WriteRequestJsonUtilitiesTest {
         assertThat(writes.size(), is(equalTo(1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC16MultipleRegistersTooManyRegisters() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 16,"//
                 + "\"address\": 5412,"//
                 + "\"value\": [" + String.join(",", OVER_MAX_REGISTERS) + "]"//
-                + "}]");
+                + "}]"));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -156,13 +157,13 @@ public class WriteRequestJsonUtilitiesTest {
                         ModbusWriteFunctionCode.WRITE_COIL, true)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC5MultipleCoils() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 5,"//
                 + "\"address\": 5412,"//
                 + "\"value\": [3, 4]"//
-                + "}]");
+                + "}]"));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -199,25 +200,25 @@ public class WriteRequestJsonUtilitiesTest {
         assertThat(writes.size(), is(equalTo(1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFC15MultipleCoilsTooManyCoils() {
-        WriteRequestJsonUtilities.fromJson(55, "[{"//
+        assertThrows(IllegalArgumentException.class, () -> WriteRequestJsonUtilities.fromJson(55, "[{"//
                 + "\"functionCode\": 15,"//
                 + "\"address\": 5412,"//
                 + "\"value\": [" + String.join(",", OVER_MAX_COILS) + "]"//
-                + "}]");
+                + "}]"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testEmptyObject() {
         // we are expecting list, not object -> error
-        WriteRequestJsonUtilities.fromJson(3, "{}");
+        assertThrows(IllegalStateException.class, () -> WriteRequestJsonUtilities.fromJson(3, "{}"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testNumber() {
         // we are expecting list, not primitive (number) -> error
-        WriteRequestJsonUtilities.fromJson(3, "3");
+        assertThrows(IllegalStateException.class, () -> WriteRequestJsonUtilities.fromJson(3, "3"));
     }
 
     @Test

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractTwoItemIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractTwoItemIntegrationTest.java
@@ -33,7 +33,7 @@ import org.openhab.core.types.State;
  * against actual dynamo db database.
  *
  *
- * Inheritor of this base class needs to store two states of one item in a static method annotated with @BeforeClass.
+ * Inheritor of this base class needs to store two states of one item in a static method annotated with @BeforeAll.
  * This
  * static
  * class should update the private static fields

--- a/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
@@ -13,6 +13,7 @@
 package org.openhab.transform.jinja.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;

--- a/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.jinja/src/test/java/org/openhab/transform/jinja/internal/JinjaTransformationServiceTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.transform.jinja.internal;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
 
 /**
@@ -24,7 +24,7 @@ public class JinjaTransformationServiceTest {
 
     private JinjaTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new JinjaTransformationService();
     }
@@ -36,7 +36,7 @@ public class JinjaTransformationServiceTest {
         String transformedResponse = processor.transform("{{value_json['AM2301'].Temperature}}", json);
 
         // Asserts
-        Assert.assertEquals("4.7", transformedResponse);
+        assertEquals("4.7", transformedResponse);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class JinjaTransformationServiceTest {
         String transformedResponse = processor.transform("Hello {{ value }}!", value);
 
         // Asserts
-        Assert.assertEquals("Hello world!", transformedResponse);
+        assertEquals("Hello world!", transformedResponse);
     }
 
     @Test
@@ -56,6 +56,6 @@ public class JinjaTransformationServiceTest {
         String transformedResponse = processor.transform("Hello {{ value_json }}!", value);
 
         // Asserts
-        Assert.assertEquals("Hello world!", transformedResponse);
+        assertEquals("Hello world!", transformedResponse);
     }
 }

--- a/bundles/org.openhab.transform.jsonpath/src/test/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.jsonpath/src/test/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -12,11 +12,10 @@
  */
 package org.openhab.transform.jsonpath.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
 
 /**
@@ -26,7 +25,7 @@ public class JSonPathTransformationServiceTest {
 
     private JSonPathTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new JSonPathTransformationService();
     }
@@ -38,7 +37,7 @@ public class JSonPathTransformationServiceTest {
         String transformedResponse = processor.transform("$.store.book[0].author", json);
 
         // Asserts
-        Assert.assertEquals("Nigel Rees", transformedResponse);
+        assertEquals("Nigel Rees", transformedResponse);
     }
 
     private static final String jsonArray = "[" + //
@@ -58,19 +57,19 @@ public class JSonPathTransformationServiceTest {
         assertEquals("2", transformedResponse);
     }
 
-    @Test(expected = TransformationException.class)
-    public void testInvalidPathThrowsException() throws TransformationException {
-        processor.transform("$$", jsonArray);
+    @Test
+    public void testInvalidPathThrowsException() {
+        assertThrows(TransformationException.class, () -> processor.transform("$$", jsonArray));
     }
 
-    @Test(expected = TransformationException.class)
-    public void testPathMismatchReturnNull() throws TransformationException {
-        processor.transform("$[5].id", jsonArray);
+    @Test
+    public void testPathMismatchReturnNull() {
+        assertThrows(TransformationException.class, () -> processor.transform("$[5].id", jsonArray));
     }
 
-    @Test(expected = TransformationException.class)
+    @Test
     public void testInvalidJsonReturnNull() throws TransformationException {
-        processor.transform("$", "{id:");
+        assertThrows(TransformationException.class, () -> processor.transform("$", "{id:"));
     }
 
     @Test

--- a/bundles/org.openhab.transform.map/src/test/java/org/openhab/transform/map/internal/MapTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.map/src/test/java/org/openhab/transform/map/internal/MapTransformationServiceTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.transform.map.internal;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.FileReader;
@@ -23,17 +23,21 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.osgi.framework.BundleContext;
 
 /**
  * @author Gaël L'hopital - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class MapTransformationServiceTest {
 
     private static final String SOURCE_CLOSED = "CLOSED";
@@ -47,8 +51,7 @@ public class MapTransformationServiceTest {
     private static final String CONFIG_FOLDER = BASE_FOLDER + File.separator + SRC_FOLDER;
     private static final String USED_FILENAME = CONFIG_FOLDER + File.separator + "transform/" + EXISTING_FILENAME_DE;
 
-    @Mock
-    private BundleContext bundleContext;
+    private @Mock BundleContext bundleContext;
 
     private TestableMapTransformationService processor;
 
@@ -74,16 +77,14 @@ public class MapTransformationServiceTest {
         }
     };
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
-
         processor = new TestableMapTransformationService();
         processor.activate(bundleContext);
         FileUtils.copyDirectory(new File(SRC_FOLDER), new File(CONFIG_FOLDER));
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
         processor.deactivate();
         FileUtils.deleteDirectory(new File(CONFIG_FOLDER));
@@ -93,7 +94,7 @@ public class MapTransformationServiceTest {
     public void testTransformByMap() throws Exception {
         // Test that we find a translation in an existing file
         String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
-        Assert.assertEquals("zu", transformedResponse);
+        assertEquals("zu", transformedResponse);
 
         Properties properties = new Properties();
         try (FileReader reader = new FileReader(USED_FILENAME); FileWriter writer = new FileWriter(USED_FILENAME)) {
@@ -107,7 +108,7 @@ public class MapTransformationServiceTest {
                 @Override
                 public Void call() throws Exception {
                     final String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
-                    Assert.assertEquals("changevalue", transformedResponse);
+                    assertEquals("changevalue", transformedResponse);
                     return null;
                 }
             }, 10000, 100);
@@ -119,7 +120,7 @@ public class MapTransformationServiceTest {
                 @Override
                 public Void call() throws Exception {
                     final String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
-                    Assert.assertEquals("zu", transformedResponse);
+                    assertEquals("zu", transformedResponse);
                     return null;
                 }
             }, 10000, 100);
@@ -130,7 +131,7 @@ public class MapTransformationServiceTest {
         // Checks that an unknown input in an existing file give the expected
         // transformed response that shall be empty string (Issue #1107) if not found in the file
         transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_UNKNOWN);
-        Assert.assertEquals("", transformedResponse);
+        assertEquals("", transformedResponse);
 
         // Test that an inexisting file raises correct exception as expected
         try {
@@ -144,19 +145,19 @@ public class MapTransformationServiceTest {
         transformedResponse = processor.transform(SHOULD_BE_LOCALIZED_FILENAME, SOURCE_CLOSED);
         // as we don't know the real locale at the moment the
         // test is run, we test that the string has actually been transformed
-        Assert.assertNotEquals(SOURCE_CLOSED, transformedResponse);
+        assertNotEquals(SOURCE_CLOSED, transformedResponse);
         transformedResponse = processor.transform(SHOULD_BE_LOCALIZED_FILENAME, SOURCE_CLOSED);
-        Assert.assertNotEquals(SOURCE_CLOSED, transformedResponse);
+        assertNotEquals(SOURCE_CLOSED, transformedResponse);
     }
 
     @Test
     public void testTransformByMapWithDefault() throws Exception {
         // Standard behaviour with no default value
         String transformedResponse = processor.transform(SHOULD_BE_LOCALIZED_FILENAME, "toBeDefaulted");
-        Assert.assertEquals("", transformedResponse);
+        assertEquals("", transformedResponse);
         // Modified behaviour with a file containing default value definition
         transformedResponse = processor.transform(DEFAULTED_FILENAME, "toBeDefaulted");
-        Assert.assertEquals("Default Value", transformedResponse);
+        assertEquals("Default Value", transformedResponse);
     }
 
     protected void waitForAssert(Callable<Void> assertion, int timeout, int sleepTime) throws Exception {

--- a/bundles/org.openhab.transform.map/src/test/java/org/openhab/transform/map/internal/MapTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.map/src/test/java/org/openhab/transform/map/internal/MapTransformationServiceTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -38,6 +39,7 @@ import org.osgi.framework.BundleContext;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
+@Disabled("Needs to be updated for OH3")
 public class MapTransformationServiceTest {
 
     private static final String SOURCE_CLOSED = "CLOSED";

--- a/bundles/org.openhab.transform.regex/src/test/java/org/openhab/transform/regex/internal/RegExTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.regex/src/test/java/org/openhab/transform/regex/internal/RegExTransformationServiceTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.transform.regex.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
 
 /**
@@ -25,7 +25,7 @@ public class RegExTransformationServiceTest extends AbstractTransformationServic
 
     private RegExTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new RegExTransformationService();
     }

--- a/bundles/org.openhab.transform.scale/src/test/java/org/openhab/transform/scale/internal/ScaleTransformServiceTest.java
+++ b/bundles/org.openhab.transform.scale/src/test/java/org/openhab/transform/scale/internal/ScaleTransformServiceTest.java
@@ -12,15 +12,14 @@
  */
 package org.openhab.transform.scale.internal;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Locale;
 
 import javax.measure.quantity.Dimensionless;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.transform.TransformationException;
 
@@ -30,7 +29,7 @@ import org.openhab.core.transform.TransformationException;
 public class ScaleTransformServiceTest {
     private ScaleTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new ScaleTransformationService() {
             @Override
@@ -46,12 +45,12 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/humidex_de.scale";
         String source = "10";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("nicht wesentlich", transformedResponse);
+        assertEquals("nicht wesentlich", transformedResponse);
 
         existingscale = "scale/limits.scale";
         source = "10";
         transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("middle", transformedResponse);
+        assertEquals("middle", transformedResponse);
     }
 
     @Test
@@ -61,18 +60,18 @@ public class ScaleTransformServiceTest {
         // Testing upper bound opened range
         String source = "500";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("extreme", transformedResponse);
+        assertEquals("extreme", transformedResponse);
 
         // Testing lower bound opened range
         source = "-10";
         transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("low", transformedResponse);
+        assertEquals("low", transformedResponse);
 
         // Testing unfinite up and down range
         existingscale = "scale/catchall.scale";
         source = "-10";
         transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("catchall", transformedResponse);
+        assertEquals("catchall", transformedResponse);
     }
 
     @Test
@@ -82,7 +81,7 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/humidex_fr.scale";
         String source = "-";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("", transformedResponse);
+        assertEquals("", transformedResponse);
     }
 
     @Test
@@ -106,7 +105,7 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/evaluationorder.scale";
         String source = "azerty";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("", transformedResponse);
+        assertEquals("", transformedResponse);
     }
 
     @Test
@@ -117,7 +116,7 @@ public class ScaleTransformServiceTest {
         String source = "12";
 
         String transformedResponse = processor.transform(evaluationOrder, source);
-        Assert.assertEquals("first", transformedResponse);
+        assertEquals("first", transformedResponse);
     }
 
     @Test
@@ -127,7 +126,7 @@ public class ScaleTransformServiceTest {
         String expected = "Correcte (992 ppm) !";
 
         String transformedResponse = processor.transform(aqScaleFile, airQuality.toString());
-        Assert.assertEquals(expected, transformedResponse);
+        assertEquals(expected, transformedResponse);
     }
 
     @Test
@@ -136,7 +135,7 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/catchnonnumeric.scale";
         String source = "azerty";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("Non Numeric", transformedResponse);
+        assertEquals("Non Numeric", transformedResponse);
     }
 
     @Test
@@ -144,7 +143,7 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/netatmo_aq.scale";
         String source = "992";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("Correcte (992) !", transformedResponse);
+        assertEquals("Correcte (992) !", transformedResponse);
     }
 
     @Test
@@ -152,6 +151,6 @@ public class ScaleTransformServiceTest {
         String existingscale = "scale/humidex.scale";
         String source = "200";
         String transformedResponse = processor.transform(existingscale, source);
-        Assert.assertEquals("", transformedResponse);
+        assertEquals("", transformedResponse);
     }
 }

--- a/bundles/org.openhab.transform.xpath/src/test/java/org/openhab/transform/xpath/internal/XPathTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.xpath/src/test/java/org/openhab/transform/xpath/internal/XPathTransformationServiceTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.transform.xpath.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
 
 /**
@@ -25,7 +25,7 @@ public class XPathTransformationServiceTest extends AbstractTransformationServic
 
     private XPathTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new XPathTransformationService();
     }

--- a/bundles/org.openhab.transform.xslt/src/test/java/org/openhab/transform/xslt/internal/XsltTransformationServiceTest.java
+++ b/bundles/org.openhab.transform.xslt/src/test/java/org/openhab/transform/xslt/internal/XsltTransformationServiceTest.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.transform.xslt.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.transform.TransformationException;
 
 /**
@@ -25,7 +25,7 @@ public class XsltTransformationServiceTest extends AbstractTransformationService
 
     private XsltTransformationService processor;
 
-    @Before
+    @BeforeEach
     public void init() {
         processor = new XsltTransformationService();
     }

--- a/bundles/org.openhab.voice.mactts/src/test/java/org/openhab/voice/mactts/internal/MacTTSVoiceTest.java
+++ b/bundles/org.openhab.voice.mactts/src/test/java/org/openhab/voice/mactts/internal/MacTTSVoiceTest.java
@@ -12,14 +12,15 @@
  */
 package org.openhab.voice.mactts.internal;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +37,8 @@ public class MacTTSVoiceTest {
      * Test MacTTSVoice(String) constructor
      */
     @Test
-    public void testConstructor() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+    public void testConstructor() throws IOException {
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
         BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
@@ -46,9 +47,7 @@ public class MacTTSVoiceTest {
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
-            Assert.assertNotNull("The MacTTSVoice(String) constructor failed", voiceMacOS);
-        } catch (IOException e) {
-            Assert.fail("testConstructor() failed with IOException: " + e.getMessage());
+            assertNotNull(voiceMacOS, "The MacTTSVoice(String) constructor failed");
         } finally {
             IOUtils.closeQuietly(bufferedReader);
         }
@@ -58,8 +57,8 @@ public class MacTTSVoiceTest {
      * Test VoiceMacOS.getUID()
      */
     @Test
-    public void getUIDTest() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+    public void getUIDTest() throws IOException {
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
         BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
@@ -68,10 +67,7 @@ public class MacTTSVoiceTest {
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice macTTSVoice = new MacTTSVoice(nextLine);
-            Assert.assertTrue("The VoiceMacOS UID has an incorrect format",
-                    (0 == macTTSVoice.getUID().indexOf("mactts:")));
-        } catch (IOException e) {
-            Assert.fail("getUIDTest() failed with IOException: " + e.getMessage());
+            assertTrue(0 == macTTSVoice.getUID().indexOf("mactts:"), "The VoiceMacOS UID has an incorrect format");
         } finally {
             IOUtils.closeQuietly(bufferedReader);
         }
@@ -81,8 +77,8 @@ public class MacTTSVoiceTest {
      * Test MacTTSVoice.getLabel()
      */
     @Test
-    public void getLabelTest() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+    public void getLabelTest() throws IOException {
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
         BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
@@ -91,9 +87,7 @@ public class MacTTSVoiceTest {
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
-            Assert.assertNotNull("The MacTTSVoice label has an incorrect format", voiceMacOS.getLabel());
-        } catch (IOException e) {
-            Assert.fail("getLabelTest() failed with IOException: " + e.getMessage());
+            assertNotNull(voiceMacOS.getLabel(), "The MacTTSVoice label has an incorrect format");
         } finally {
             IOUtils.closeQuietly(bufferedReader);
         }
@@ -103,8 +97,8 @@ public class MacTTSVoiceTest {
      * Test MacTTSVoice.getLocale()
      */
     @Test
-    public void getLocaleTest() {
-        Assume.assumeTrue("Mac OS X" == System.getProperty("os.name"));
+    public void getLocaleTest() throws IOException {
+        assumeTrue("Mac OS X" == System.getProperty("os.name"));
         BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
@@ -113,9 +107,7 @@ public class MacTTSVoiceTest {
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
-            Assert.assertNotNull("The MacTTSVoice locale has an incorrect format", voiceMacOS.getLocale());
-        } catch (IOException e) {
-            Assert.fail("getLocaleTest() failed with IOException: " + e.getMessage());
+            assertNotNull(voiceMacOS.getLocale(), "The MacTTSVoice locale has an incorrect format");
         } finally {
             IOUtils.closeQuietly(bufferedReader);
         }

--- a/bundles/org.openhab.voice.mactts/src/test/java/org/openhab/voice/mactts/internal/TTSServiceMacOSTest.java
+++ b/bundles/org.openhab.voice.mactts/src/test/java/org/openhab/voice/mactts/internal/TTSServiceMacOSTest.java
@@ -12,12 +12,13 @@
  */
 package org.openhab.voice.mactts.internal;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.IOException;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.voice.TTSException;
@@ -35,10 +36,10 @@ public class TTSServiceMacOSTest {
      */
     @Test
     public void getAvailableVoicesTest() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
 
         MacTTSService ttsServiceMacOS = new MacTTSService();
-        Assert.assertFalse("The getAvailableVoicesTest() failed", ttsServiceMacOS.getAvailableVoices().isEmpty());
+        assertFalse(ttsServiceMacOS.getAvailableVoices().isEmpty());
     }
 
     /**
@@ -46,34 +47,28 @@ public class TTSServiceMacOSTest {
      */
     @Test
     public void getSupportedFormatsTest() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
 
         MacTTSService ttsServiceMacOS = new MacTTSService();
-        Assert.assertFalse("The getSupportedFormatsTest() failed", ttsServiceMacOS.getSupportedFormats().isEmpty());
+        assertFalse(ttsServiceMacOS.getSupportedFormats().isEmpty());
     }
 
     /**
      * Test TTSServiceMacOS.synthesize(String,Voice,AudioFormat)
      */
     @Test
-    public void synthesizeTest() {
-        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+    public void synthesizeTest() throws IOException, TTSException {
+        assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
 
         MacTTSService ttsServiceMacOS = new MacTTSService();
         Set<Voice> voices = ttsServiceMacOS.getAvailableVoices();
         Set<AudioFormat> audioFormats = ttsServiceMacOS.getSupportedFormats();
         try (AudioStream audioStream = ttsServiceMacOS.synthesize("Hello", voices.iterator().next(),
                 audioFormats.iterator().next())) {
-            Assert.assertNotNull("The test synthesizeTest() created null AudioSource", audioStream);
-            Assert.assertNotNull("The test synthesizeTest() created an AudioSource w/o AudioFormat",
-                    audioStream.getFormat());
-            Assert.assertNotNull("The test synthesizeTest() created an AudioSource w/o InputStream", audioStream);
-            Assert.assertTrue("The test synthesizeTest() returned an AudioSource with no data",
-                    (-1 != audioStream.read(new byte[2])));
-        } catch (TTSException e) {
-            Assert.fail("synthesizeTest() failed with TTSException: " + e.getMessage());
-        } catch (IOException e) {
-            Assert.fail("synthesizeTest() failed with IOException: " + e.getMessage());
+            assertNotNull(audioStream, "created null AudioSource");
+            assertNotNull(audioStream.getFormat(), "created an AudioSource w/o AudioFormat");
+            assertNotNull(audioStream, "created an AudioSource w/o InputStream");
+            assertTrue(-1 != audioStream.read(new byte[2]), "returned an AudioSource with no data");
         }
     }
 }

--- a/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroCommandTest.java
+++ b/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroCommandTest.java
@@ -30,7 +30,7 @@ import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.astro.internal.handler.AstroThingHandler;
 import org.openhab.binding.astro.internal.handler.SunHandler;
 import org.openhab.binding.astro.internal.model.Sun;

--- a/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroValidConfigurationTest.java
+++ b/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/handler/test/AstroValidConfigurationTest.java
@@ -28,7 +28,7 @@ import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.astro.internal.handler.AstroThingHandler;
 import org.openhab.binding.astro.internal.handler.SunHandler;
 

--- a/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/test/AstroStateTest.java
+++ b/itests/org.openhab.binding.astro.tests/src/main/java/org/openhab/binding/astro/test/AstroStateTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.astro.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openhab.binding.astro.internal.AstroBindingConstants.*;
 import static org.openhab.binding.astro.test.cases.AstroBindingTestsData.*;
 import static org.openhab.binding.astro.test.cases.AstroParametrizedTestCases.*;
@@ -24,19 +24,17 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.types.State;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.binding.astro.internal.calc.MoonCalc;
 import org.openhab.binding.astro.internal.calc.SunCalc;
 import org.openhab.binding.astro.internal.config.AstroChannelConfig;
 import org.openhab.binding.astro.internal.model.Planet;
 import org.openhab.binding.astro.internal.util.PropertyUtils;
 import org.openhab.binding.astro.test.cases.AstroParametrizedTestCases;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.types.State;
 
 /**
  * Tests for the Astro Channels state
@@ -47,30 +45,19 @@ import org.openhab.binding.astro.test.cases.AstroParametrizedTestCases;
  * @author Erdoan Hadzhiyusein - Adapted the class to work with the new DateTimeType
  * @author Christoph Weitkamp - Migrated tests to pure Java
  */
-@RunWith(Parameterized.class)
 public class AstroStateTest {
-
-    private String thingID;
-    private String channelId;
-    private State expectedState;
 
     // These test result timestamps are adapted for the +03:00 time zone
     private static final ZoneId ZONE_ID = ZoneId.of("+03:00");
 
-    public AstroStateTest(String thingID, String channelId, State expectedState) {
-        this.thingID = thingID;
-        this.channelId = channelId;
-        this.expectedState = expectedState;
-    }
-
-    @Parameters
     public static List<Object[]> data() {
         AstroParametrizedTestCases cases = new AstroParametrizedTestCases();
         return cases.getCases();
     }
 
-    @Test
-    public void testParametrized() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testParametrized(String thingID, String channelId, State expectedState) {
         try {
             assertStateUpdate(thingID, channelId, expectedState);
         } catch (Exception e) {

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/discovery/AVMFritzDiscoveryServiceOSGiTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.avmfritz.internal.discovery;
 
 import static org.openhab.core.thing.Thing.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 
 import java.io.StringReader;
@@ -31,9 +31,9 @@ import org.openhab.core.config.discovery.DiscoveryResultFlag;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.avmfritz.internal.dto.AVMFritzBaseModel;
 import org.openhab.binding.avmfritz.internal.dto.DeviceListModel;
 import org.openhab.binding.avmfritz.internal.handler.AVMFritzThingHandlerOSGiTest;
@@ -71,7 +71,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
     };
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
         discovery = new AVMFritzDiscoveryService();
@@ -79,7 +79,7 @@ public class AVMFritzDiscoveryServiceOSGiTest extends AVMFritzThingHandlerOSGiTe
         discovery.addDiscoveryListener(listener);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         discoveryResult = null;
     }

--- a/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzThingHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.avmfritz.tests/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzThingHandlerOSGiTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.avmfritz.internal.handler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.*;
 
@@ -21,19 +21,19 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.openhab.binding.avmfritz.internal.AVMFritzDynamicCommandDescriptionProvider;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.ThingProvider;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.openhab.binding.avmfritz.internal.AVMFritzDynamicCommandDescriptionProvider;
 
 /**
  * Tests for {@link AVMFritzThingHandlerOSGiTest}.
@@ -51,17 +51,17 @@ public abstract class AVMFritzThingHandlerOSGiTest extends JavaOSGiTest {
     protected @NonNullByDefault({}) Bridge bridge;
     protected @NonNullByDefault({}) BoxHandler bridgeHandler;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception {
         httpClient.start();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerService(volatileStorageService);
 
         managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
-        assertNotNull("Could not get ManagedThingProvider", managedThingProvider);
+        assertNotNull(managedThingProvider, "Could not get ManagedThingProvider");
 
         bridge = buildBridge();
         assertNotNull(bridge.getConfiguration());
@@ -82,7 +82,7 @@ public abstract class AVMFritzThingHandlerOSGiTest extends JavaOSGiTest {
         bridgeHandler.initialize();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (bridge != null) {
             managedThingProvider.remove(bridge.getUID());
@@ -91,7 +91,7 @@ public abstract class AVMFritzThingHandlerOSGiTest extends JavaOSGiTest {
         unregisterService(volatileStorageService);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         httpClient.stop();
     }

--- a/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
+++ b/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.feed.test;
 
 import static java.lang.Thread.sleep;
-import static org.openhab.core.thing.ThingStatus.*;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.openhab.core.thing.ThingStatus.*;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -27,12 +27,19 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.feed.internal.FeedBindingConstants;
+import org.openhab.binding.feed.internal.handler.FeedHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.StateChangeListener;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ManagedThingProvider;
@@ -47,14 +54,6 @@ import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.openhab.binding.feed.internal.FeedBindingConstants;
-import org.openhab.binding.feed.internal.handler.FeedHandler;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
@@ -143,7 +142,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         volatileStorageService = new VolatileStorageService();
         registerService(volatileStorageService);
@@ -157,7 +156,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
         registerFeedTestServlet();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         currentItemState = null;
         if (feedThing != null) {
@@ -315,7 +314,6 @@ public class FeedHandlerTest extends JavaOSGiTest {
     }
 
     @Test
-    @Category(SlowTests.class)
     public void assertThatItemsStateIsNotUpdatedOnAutoRefreshIfContentIsNotChanged()
             throws IOException, InterruptedException {
         boolean commandReceived = false;
@@ -324,7 +322,6 @@ public class FeedHandlerTest extends JavaOSGiTest {
     }
 
     @Test
-    @Category(SlowTests.class)
     public void assertThatItemsStateIsUpdatedOnAutoRefreshIfContentChanged() throws IOException, InterruptedException {
         boolean commandReceived = false;
         boolean contentChanged = true;

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/AbstractHueOSGiTestParent.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/AbstractHueOSGiTestParent.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.hue.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.binding.ThingHandler;

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.hue.internal;
 
-import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
+import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -23,6 +24,11 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.hue.internal.discovery.HueLightDiscoveryService;
+import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
@@ -36,12 +42,6 @@ import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.binding.hue.internal.discovery.HueLightDiscoveryService;
-import org.openhab.binding.hue.internal.handler.HueBridgeHandler;
 
 /**
  * Tests for {@link HueLightDiscoveryService}.
@@ -64,7 +64,7 @@ public class HueLightDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent 
     protected final ThingTypeUID BRIDGE_THING_TYPE_UID = new ThingTypeUID("hue", "bridge");
     protected final ThingUID BRIDGE_THING_UID = new ThingUID(BRIDGE_THING_TYPE_UID, "testBridge");
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerVolatileStorageService();
 
@@ -89,7 +89,7 @@ public class HueLightDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent 
         assertThat(discoveryService, is(notNullValue()));
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         thingRegistry.remove(BRIDGE_THING_UID);
         waitForAssert(() -> {
@@ -217,7 +217,7 @@ public class HueLightDiscoveryServiceOSGiTest extends AbstractHueOSGiTestParent 
                 usernameField.setAccessible(true);
                 usernameField.set(hueBridgeValue, hueBridgeHandler.getThing().getConfiguration().get(USER_NAME));
             } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException ex) {
-                Assert.fail("Reflection usage error");
+                fail("Reflection usage error");
             }
         });
         hueBridgeHandler.initialize();

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipantOSGITest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipantOSGITest.java
@@ -12,23 +12,18 @@
  */
 package org.openhab.binding.hue.internal.discovery;
 
-import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
+import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.openhab.core.config.discovery.DiscoveryResult;
-import org.openhab.core.config.discovery.DiscoveryResultFlag;
-import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ManufacturerDetails;
@@ -38,6 +33,11 @@ import org.jupnp.model.meta.RemoteDeviceIdentity;
 import org.jupnp.model.meta.RemoteService;
 import org.jupnp.model.types.DeviceType;
 import org.jupnp.model.types.UDN;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultFlag;
+import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.ThingUID;
 
 /**
  * Tests for {@link org.openhab.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant}.
@@ -53,7 +53,7 @@ public class HueBridgeDiscoveryParticipantOSGITest extends JavaOSGiTest {
     RemoteDevice hueDevice;
     RemoteDevice otherDevice;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         discoveryParticipant = getService(UpnpDiscoveryParticipant.class, HueBridgeDiscoveryParticipant.class);
         assertThat(discoveryParticipant, is(notNullValue()));
@@ -74,11 +74,11 @@ public class HueBridgeDiscoveryParticipantOSGITest extends JavaOSGiTest {
                             new ManufacturerDetails("Taiwan"), new ModelDetails("$%&/"), "serial567", "upc"),
                     remoteService);
         } catch (final ValidationException | MalformedURLException ex) {
-            Assert.fail("Internal test error.");
+            fail("Internal test error.");
         }
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
     }
 

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscoveryOSGITest.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.binding.hue.internal.discovery;
 
-import static org.openhab.core.config.discovery.inbox.InboxPredicates.forThingTypeUID;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openhab.binding.hue.internal.HueBindingConstants.THING_TYPE_BRIDGE;
+import static org.openhab.core.config.discovery.inbox.InboxPredicates.forThingTypeUID;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -24,16 +25,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.discovery.DiscoveryListener;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.config.discovery.inbox.Inbox;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.ThingUID;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.Before;
-import org.junit.Test;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 
 /**
  *
@@ -139,7 +140,7 @@ public class HueBridgeNupnpDiscoveryOSGITest extends JavaOSGiTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerService(volatileStorageService);
 

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
@@ -12,33 +12,34 @@
  */
 package org.openhab.binding.hue.internal.handler;
 
-import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 import static org.openhab.binding.hue.internal.config.HueBridgeConfig.HTTP;
+import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.openhab.core.config.core.Configuration;
-import org.openhab.core.config.core.status.ConfigStatusMessage;
-import org.openhab.core.common.ThreadPoolManager;
-import org.openhab.core.thing.Bridge;
-import org.openhab.core.thing.ThingRegistry;
-import org.openhab.core.thing.ThingStatus;
-import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.ThingUID;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.binding.hue.internal.AbstractHueOSGiTestParent;
 import org.openhab.binding.hue.internal.HueBridge;
 import org.openhab.binding.hue.internal.HueConfigStatusMessage;
 import org.openhab.binding.hue.internal.exceptions.ApiException;
 import org.openhab.binding.hue.internal.exceptions.LinkButtonException;
 import org.openhab.binding.hue.internal.exceptions.UnauthorizedException;
+import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.config.core.status.ConfigStatusMessage;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 
 /**
  * Tests for {@link HueBridgeHandler}.
@@ -57,7 +58,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
 
     private ScheduledExecutorService scheduler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerVolatileStorageService();
         thingRegistry = getService(ThingRegistry.class, ThingRegistry.class);

--- a/itests/org.openhab.binding.max.tests/src/main/java/org/openhab/binding/max/test/MaxCubeBridgeHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.max.tests/src/main/java/org/openhab/binding/max/test/MaxCubeBridgeHandlerOSGiTest.java
@@ -13,10 +13,17 @@
 package org.openhab.binding.max.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openhab.binding.max.internal.MaxBindingConstants.*;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.max.internal.MaxBindingConstants;
+import org.openhab.binding.max.internal.handler.MaxCubeBridgeHandler;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
@@ -24,13 +31,6 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.binding.max.internal.MaxBindingConstants;
-import org.openhab.binding.max.internal.handler.MaxCubeBridgeHandler;
 
 /**
  * Tests for {@link MaxCubeBridgeHandler}.
@@ -47,7 +47,7 @@ public class MaxCubeBridgeHandlerOSGiTest extends JavaOSGiTest {
 
     private Bridge maxBridge;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerService(volatileStorageService);
 
@@ -55,7 +55,7 @@ public class MaxCubeBridgeHandlerOSGiTest extends JavaOSGiTest {
         assertThat(thingRegistry, is(notNullValue()));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (maxBridge != null) {
             thingRegistry.remove(maxBridge.getUID());

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
@@ -13,9 +13,10 @@
 package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -32,6 +33,15 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.binding.modbus.internal.ModbusHandlerFactory;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventSubscriber;
@@ -41,6 +51,7 @@ import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ManagedItemProvider;
 import org.openhab.core.items.events.ItemStateEvent;
 import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
@@ -52,12 +63,6 @@ import org.openhab.core.thing.link.ItemChannelLinkProvider;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
 import org.openhab.core.transform.TransformationService;
 import org.openhab.core.types.State;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.junit.After;
-import org.junit.Before;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.openhab.binding.modbus.internal.ModbusHandlerFactory;
 import org.openhab.io.transport.modbus.ModbusCommunicationInterface;
 import org.openhab.io.transport.modbus.ModbusManager;
 import org.slf4j.Logger;
@@ -66,6 +71,8 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Sami Salonen - Initial contribution
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 @NonNullByDefault
 public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
 
@@ -99,8 +106,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractModbusOSGiTest.class);
 
-    @Mock
-    protected @NonNullByDefault({}) ModbusManager mockedModbusManager;
+    protected @Mock @NonNullByDefault({}) ModbusManager mockedModbusManager;
     protected @NonNullByDefault({}) ManagedThingProvider thingProvider;
     protected @NonNullByDefault({}) ManagedItemProvider itemProvider;
     protected @NonNullByDefault({}) ManagedItemChannelLinkProvider itemChannelLinkProvider;
@@ -113,8 +119,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
     private Set<ItemChannelLink> addedLinks = new HashSet<>();
     private StateSubscriber stateSubscriber = new StateSubscriber();
 
-    @Mock
-    protected @NonNullByDefault({}) ModbusCommunicationInterface comms;
+    protected @Mock @NonNullByDefault({}) ModbusCommunicationInterface comms;
 
     public AbstractModbusOSGiTest() {
         super();
@@ -123,7 +128,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
     /**
      * Before each test, configure mocked services
      */
-    @Before
+    @BeforeEach
     public void setUpAbstractModbusOSGiTest() {
         logger.debug("setUpAbstractModbusOSGiTest BEGIN");
         registerVolatileStorageService();
@@ -150,7 +155,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
         logger.debug("setUpAbstractModbusOSGiTest END");
     }
 
-    @After
+    @AfterEach
     public void tearDownAbstractModbusOSGiTest() {
         logger.debug("tearDownAbstractModbusOSGiTest BEGIN");
         swapModbusManagerToReal();

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -30,6 +31,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.lang.StringUtils;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.handler.ModbusPollerThingHandler;
+import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
+import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.Item;
@@ -55,16 +64,6 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-import org.hamcrest.Matcher;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
-import org.openhab.binding.modbus.handler.ModbusPollerThingHandler;
-import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
-import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
 import org.openhab.io.transport.modbus.AsyncModbusFailure;
 import org.openhab.io.transport.modbus.AsyncModbusReadResult;
 import org.openhab.io.transport.modbus.AsyncModbusWriteResult;
@@ -89,7 +88,6 @@ import org.osgi.framework.InvalidSyntaxException;
 /**
  * @author Sami Salonen - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
 
     private final class MultiplyTransformation implements TransformationService {
@@ -115,7 +113,7 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
     }
     private List<ModbusWriteRequestBlueprint> writeRequests = new ArrayList<>();
 
-    @After
+    @AfterEach
     public void tearDown() {
         writeRequests.clear();
     }

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
@@ -13,8 +13,9 @@
 package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -22,6 +23,17 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openhab.binding.modbus.handler.ModbusPollerThingHandler;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
+import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
@@ -31,19 +43,6 @@ import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.handler.ModbusPollerThingHandler;
-import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
-import org.openhab.binding.modbus.internal.handler.ModbusDataThingHandler;
 import org.openhab.io.transport.modbus.AsyncModbusFailure;
 import org.openhab.io.transport.modbus.AsyncModbusReadResult;
 import org.openhab.io.transport.modbus.BitArray;
@@ -62,7 +61,6 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Sami Salonen - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
 
     private static final String HOST = "thisishost";
@@ -73,8 +71,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
     private Bridge endpoint;
     private Bridge poller;
 
-    @Mock
-    private ThingHandlerCallback thingCallback;
+    private @Mock ThingHandlerCallback thingCallback;
 
     public static BridgeBuilder createTcpThingBuilder(String id) {
         return BridgeBuilder
@@ -114,7 +111,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
     /**
      * Before each test, setup TCP endpoint thing, configure mocked item registry
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         mockCommsToModbusManager();
         Configuration tcpConfig = new Configuration();
@@ -127,7 +124,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         assertThat(endpoint.getStatus(), is(equalTo(ThingStatus.ONLINE)));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (endpoint != null) {
             thingProvider.remove(endpoint.getUID());

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
@@ -13,24 +13,23 @@
 package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Objects;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
+import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
+import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
-import org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal;
-import org.openhab.binding.modbus.internal.handler.ModbusTcpThingHandler;
 import org.openhab.io.transport.modbus.endpoint.EndpointPoolConfiguration;
 import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
 import org.openhab.io.transport.modbus.endpoint.ModbusTCPSlaveEndpoint;
@@ -38,7 +37,6 @@ import org.openhab.io.transport.modbus.endpoint.ModbusTCPSlaveEndpoint;
 /**
  * @author Sami Salonen - Initial contribution
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ModbusTcpThingHandlerTest extends AbstractModbusOSGiTest {
 
     private static BridgeBuilder createTcpThingBuilder(String id) {

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.9-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homeassistant.tests</artifactId>

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
@@ -14,7 +14,7 @@ package org.openhab.binding.mqtt;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -26,10 +26,9 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.openhab.binding.mqtt.generic.AvailabilityTracker;
 import org.openhab.binding.mqtt.generic.ChannelStateUpdateListener;
@@ -39,6 +38,8 @@ import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents;
 import org.openhab.binding.mqtt.homeassistant.internal.DiscoverComponents.ComponentDiscovered;
 import org.openhab.binding.mqtt.homeassistant.internal.HaID;
 import org.openhab.binding.mqtt.homeassistant.internal.HandlerConfiguration;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.core.test.java.JavaOSGiTest;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -49,24 +50,19 @@ import com.google.gson.GsonBuilder;
  * @author David Graeff - Initial contribution
  */
 public class DiscoverComponentsTest extends JavaOSGiTest {
-    @Mock
-    MqttBrokerConnection connection;
 
-    @Mock
-    ComponentDiscovered discovered;
+    private AutoCloseable mocksCloseable;
 
-    @Mock
-    TransformationServiceProvider transformationServiceProvider;
+    private @Mock MqttBrokerConnection connection;
+    private @Mock ComponentDiscovered discovered;
+    private @Mock TransformationServiceProvider transformationServiceProvider;
+    private @Mock ChannelStateUpdateListener channelStateUpdateListener;
+    private @Mock AvailabilityTracker availabilityTracker;
 
-    @Mock
-    ChannelStateUpdateListener channelStateUpdateListener;
+    @BeforeEach
+    public void beforeEach() {
+        mocksCloseable = openMocks(this);
 
-    @Mock
-    AvailabilityTracker availabilityTracker;
-
-    @Before
-    public void setUp() {
-        initMocks(this);
         CompletableFuture<Void> voidFutureComplete = new CompletableFuture<>();
         voidFutureComplete.complete(null);
         doReturn(voidFutureComplete).when(connection).unsubscribeAll();
@@ -76,6 +72,11 @@ public class DiscoverComponentsTest extends JavaOSGiTest {
         doReturn(CompletableFuture.completedFuture(true)).when(connection).publish(any(), any(), anyInt(),
                 anyBoolean());
         doReturn(null).when(transformationServiceProvider).getTransformationService(any());
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        mocksCloseable.close();
     }
 
     @Test

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.mqtt;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +63,7 @@ public class EmbeddedBrokerTools {
 
             };
             mqttService.addBrokersListener(observer);
-            assertTrue("Wait for embedded connection client failed", semaphore.tryAcquire(1000, TimeUnit.MILLISECONDS));
+            assertTrue(semaphore.tryAcquire(1000, TimeUnit.MILLISECONDS), "Wait for embedded connection client failed");
         }
         MqttBrokerConnection embeddedConnection = this.embeddedConnection;
         if (embeddedConnection == null) {
@@ -81,8 +81,8 @@ public class EmbeddedBrokerTools {
         if (embeddedConnection.connectionState() == MqttConnectionState.CONNECTED) {
             semaphore.release();
         }
-        assertTrue("Connection " + embeddedConnection.getClientId() + " failed. State: "
-                + embeddedConnection.connectionState(), semaphore.tryAcquire(500, TimeUnit.MILLISECONDS));
+        assertTrue(semaphore.tryAcquire(500, TimeUnit.MILLISECONDS), "Connection " + embeddedConnection.getClientId()
+                + " failed. State: " + embeddedConnection.connectionState());
         return embeddedConnection;
     }
 

--- a/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homie.tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.9-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.homie.tests</artifactId>

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.mqtt;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +65,7 @@ public class EmbeddedBrokerTools {
                 }
             };
             mqttService.addBrokersListener(observer);
-            assertTrue("Wait for embedded connection client failed", semaphore.tryAcquire(700, TimeUnit.MILLISECONDS));
+            assertTrue(semaphore.tryAcquire(700, TimeUnit.MILLISECONDS), "Wait for embedded connection client failed");
         }
         MqttBrokerConnection embeddedConnection = this.embeddedConnection;
         if (embeddedConnection == null) {
@@ -84,8 +84,8 @@ public class EmbeddedBrokerTools {
         if (embeddedConnection.connectionState() == MqttConnectionState.CONNECTED) {
             semaphore.release();
         }
-        assertTrue("Connection " + embeddedConnection.getClientId() + " failed. State: "
-                + embeddedConnection.connectionState(), semaphore.tryAcquire(500, TimeUnit.MILLISECONDS));
+        assertTrue(semaphore.tryAcquire(500, TimeUnit.MILLISECONDS), "Connection " + embeddedConnection.getClientId()
+                + " failed. State: " + embeddedConnection.connectionState());
         return embeddedConnection;
     }
 }

--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.ntp.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -26,6 +27,16 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.openhab.binding.ntp.internal.NtpBindingConstants;
+import org.openhab.binding.ntp.internal.handler.NtpHandler;
+import org.openhab.binding.ntp.server.SimpleNTPServer;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventSubscriber;
@@ -39,6 +50,8 @@ import org.openhab.core.library.items.DateTimeItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ManagedThingProvider;
@@ -57,18 +70,6 @@ import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.State;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.openhab.binding.ntp.internal.NtpBindingConstants;
-import org.openhab.binding.ntp.internal.handler.NtpHandler;
-import org.openhab.binding.ntp.server.SimpleNTPServer;
 
 /**
  * OSGi tests for the {@link NtpHandler}
@@ -122,7 +123,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         // Initializing a new local server on this port
         timeServer = new SimpleNTPServer(TEST_PORT);
@@ -144,7 +145,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         Locale.setDefault(Locale.US);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         VolatileStorageService volatileStorageService = new VolatileStorageService();
         registerService(volatileStorageService);
@@ -165,7 +166,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         registerService(channelTypeProvider);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (ntpThing != null) {
             Thing removedThing = thingRegistry.forceRemove(ntpThing.getUID());
@@ -177,7 +178,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         // Stopping the local time server
         timeServer.stopServer();
@@ -274,7 +275,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    @Ignore("https://github.com/eclipse/smarthome/issues/5224")
+    @Disabled("https://github.com/eclipse/smarthome/issues/5224")
     public void testDateTimeChannelCalendarDefaultTimeZoneUpdate() {
         Configuration configuration = new Configuration();
         // Initialize with configuration with no time zone property set.

--- a/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
+++ b/itests/org.openhab.binding.systeminfo.tests/src/main/java/org/openhab/binding/systeminfo/test/SysteminfoOSGiTest.java
@@ -15,7 +15,8 @@ package org.openhab.binding.systeminfo.test;
 import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
@@ -23,6 +24,16 @@ import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants;
+import org.openhab.binding.systeminfo.internal.SysteminfoHandlerFactory;
+import org.openhab.binding.systeminfo.internal.discovery.SysteminfoDiscoveryService;
+import org.openhab.binding.systeminfo.internal.handler.SysteminfoHandler;
+import org.openhab.binding.systeminfo.internal.model.DeviceNotFoundException;
+import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -35,6 +46,8 @@ import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ManagedThingProvider;
@@ -55,18 +68,6 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.openhab.binding.systeminfo.internal.SysteminfoBindingConstants;
-import org.openhab.binding.systeminfo.internal.SysteminfoHandlerFactory;
-import org.openhab.binding.systeminfo.internal.discovery.SysteminfoDiscoveryService;
-import org.openhab.binding.systeminfo.internal.handler.SysteminfoHandler;
-import org.openhab.binding.systeminfo.internal.model.DeviceNotFoundException;
-import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
 
 /**
  * OSGi tests for the {@link SysteminfoHandler}
@@ -105,7 +106,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
     private ItemRegistry itemRegistry;
     private SysteminfoHandlerFactory systeminfoHandlerFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         VolatileStorageService volatileStorageService = new VolatileStorageService();
         registerService(volatileStorageService);
@@ -138,7 +139,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         assertThat(itemRegistry, is(notNullValue()));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (systemInfoThing != null) {
             // Remove the systeminfo thing. The handler will be also disposed automatically
@@ -658,7 +659,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
                 mockedDriveSerialNumber);
     }
 
-    @Ignore
+    @Disabled
     // There is a bug opened for this issue - https://github.com/dblock/oshi/issues/185
     @Test
     public void assertChannelSensorsCpuTempIsUpdated() {
@@ -927,7 +928,7 @@ public class SysteminfoOSGiTest extends JavaOSGiTest {
         waitForAssert(() -> {
             List<DiscoveryResult> results = inbox.stream().filter(InboxPredicates.forThingUID(computerUID))
                     .collect(toList());
-            assertFalse("No Thing with UID " + computerUID.getAsString() + " in inbox", results.isEmpty());
+            assertFalse(results.isEmpty(), "No Thing with UID " + computerUID.getAsString() + " in inbox");
         });
 
         inbox.approve(computerUID, SysteminfoDiscoveryService.DEFAULT_THING_LABEL);

--- a/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryParticipantOSGITest.java
+++ b/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/discovery/TradfriDiscoveryParticipantOSGITest.java
@@ -13,22 +13,24 @@
 package org.openhab.binding.tradfri.internal.discovery;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 
 import javax.jmdns.ServiceInfo;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
 import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
 
 /**
  * Tests for {@link TradfriDiscoveryParticipant}.
@@ -39,15 +41,15 @@ public class TradfriDiscoveryParticipantOSGITest extends JavaOSGiTest {
 
     private MDNSDiscoveryParticipant discoveryParticipant;
 
-    @Mock
-    private ServiceInfo tradfriGateway;
+    private AutoCloseable mocksCloseable;
 
-    @Mock
-    private ServiceInfo otherDevice;
+    private @Mock ServiceInfo tradfriGateway;
+    private @Mock ServiceInfo otherDevice;
 
-    @Before
-    public void setUp() {
-        initMocks(this);
+    @BeforeEach
+    public void beforeEach() {
+        mocksCloseable = openMocks(this);
+
         discoveryParticipant = getService(MDNSDiscoveryParticipant.class, TradfriDiscoveryParticipant.class);
 
         when(tradfriGateway.getType()).thenReturn("_coap._udp.local.");
@@ -61,6 +63,11 @@ public class TradfriDiscoveryParticipantOSGITest extends JavaOSGiTest {
         when(otherDevice.getHostAddresses()).thenReturn(new String[] { "192.168.0.5" });
         when(otherDevice.getPort()).thenReturn(1234);
         when(otherDevice.getPropertyString("version")).thenReturn("1.1");
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        mocksCloseable.close();
     }
 
     @Test

--- a/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.tradfri.tests/src/main/java/org/openhab/binding/tradfri/internal/handler/TradfriHandlerOSGiTest.java
@@ -13,26 +13,26 @@
 package org.openhab.binding.tradfri.internal.handler;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.openhab.binding.tradfri.internal.TradfriBindingConstants.*;
 import static org.openhab.binding.tradfri.internal.config.TradfriDeviceConfig.CONFIG_ID;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingProvider;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests cases for {@link TradfriGatewayHandler}.
@@ -46,7 +46,7 @@ public class TradfriHandlerOSGiTest extends JavaOSGiTest {
     private Bridge bridge;
     private Thing thing;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         registerService(volatileStorageService);
         managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
@@ -64,7 +64,7 @@ public class TradfriHandlerOSGiTest extends JavaOSGiTest {
                 .withConfiguration(new Configuration(properties)).build();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         managedThingProvider.remove(thing.getUID());
         managedThingProvider.remove(bridge.getUID());

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoDiscoveryOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoDiscoveryOSGiTest.java
@@ -12,9 +12,10 @@
  */
 package org.openhab.binding.wemo.internal.discovery.test;
 
-import static org.openhab.core.config.discovery.inbox.InboxPredicates.forThingUID;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openhab.core.config.discovery.inbox.InboxPredicates.forThingUID;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -23,19 +24,19 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.config.discovery.DiscoveryResult;
-import org.openhab.core.config.discovery.inbox.Inbox;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.ThingUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.jupnp.model.meta.Device;
 import org.openhab.binding.wemo.internal.WemoBindingConstants;
 import org.openhab.binding.wemo.internal.discovery.WemoDiscoveryService;
 import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.inbox.Inbox;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 
 /**
  * Tests for {@link WemoDiscoveryService}.
@@ -52,7 +53,7 @@ public class WemoDiscoveryOSGiTest extends GenericWemoOSGiTest {
 
     private @NonNullByDefault({}) Inbox inbox;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpServices();
 
@@ -60,7 +61,7 @@ public class WemoDiscoveryOSGiTest extends GenericWemoOSGiTest {
         assertThat(inbox, is(notNullValue()));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         List<DiscoveryResult> results = inbox.getAll();
         assertThat(results.size(), is(0));

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoDiscoveryParticipantTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoDiscoveryParticipantTest.java
@@ -13,18 +13,15 @@
 package org.openhab.binding.wemo.internal.discovery.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.openhab.core.config.discovery.DiscoveryResult;
-import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.ThingUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ManufacturerDetails;
@@ -37,6 +34,10 @@ import org.jupnp.model.types.UDN;
 import org.openhab.binding.wemo.internal.WemoBindingConstants;
 import org.openhab.binding.wemo.internal.discovery.WemoDiscoveryParticipant;
 import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
 
 /**
  * Tests for {@link WemoDiscoveryParticipant}.

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoLinkDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/discovery/test/WemoLinkDiscoveryServiceOSGiTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.wemo.internal.discovery.test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -23,8 +23,8 @@ import java.util.List;
 
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -43,7 +43,7 @@ import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
  */
 public class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTestParent {
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpServices();
     }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerOSGiTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.wemo.internal.handler.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -22,16 +23,9 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import org.openhab.core.library.types.OnOffType;
-import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingStatus;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.RefreshType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jupnp.model.ValidationException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -39,6 +33,13 @@ import org.openhab.binding.wemo.internal.WemoBindingConstants;
 import org.openhab.binding.wemo.internal.handler.WemoHandler;
 import org.openhab.binding.wemo.internal.http.WemoHttpCall;
 import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 
 /**
  * Tests for {@link WemoHandler}.
@@ -58,12 +59,12 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
     private final String SERVICE_ID = "basicevent";
     private final String SERVICE_NUMBER = "1";
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpServices();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         removeThing();
     }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoHandlerTest.java
@@ -13,10 +13,16 @@
 package org.openhab.binding.wemo.internal.handler.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.wemo.internal.WemoBindingConstants.*;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.wemo.internal.WemoBindingConstants;
+import org.openhab.binding.wemo.internal.handler.WemoHandler;
+import org.openhab.binding.wemo.internal.http.WemoHttpCall;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Thing;
@@ -25,12 +31,6 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.types.State;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openhab.binding.wemo.internal.WemoBindingConstants;
-import org.openhab.binding.wemo.internal.handler.WemoHandler;
-import org.openhab.binding.wemo.internal.http.WemoHttpCall;
 
 /**
  * Tests for {@link WemoHandler}.
@@ -60,7 +60,7 @@ public class WemoHandlerTest {
 
     private final Thing thing = mock(Thing.class);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         insightParams = new WemoInsightParams();
         when(thing.getUID()).thenReturn(new ThingUID(THING_TYPE, THING_ID));
@@ -68,7 +68,7 @@ public class WemoHandlerTest {
         when(thing.getStatus()).thenReturn(ThingStatus.ONLINE);
     }
 
-    @After
+    @AfterEach
     public void clear() {
         handler.channelState = null;
         handler.channelToWatch = null;

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoLightHandlerOSGiTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.wemo.internal.handler.test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -22,6 +23,16 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jupnp.model.ValidationException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.openhab.binding.wemo.internal.WemoBindingConstants;
+import org.openhab.binding.wemo.internal.handler.WemoLightHandler;
+import org.openhab.binding.wemo.internal.http.WemoHttpCall;
+import org.openhab.binding.wemo.internal.test.GenericWemoLightOSGiTestParent;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -32,16 +43,6 @@ import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.jupnp.model.ValidationException;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.openhab.binding.wemo.internal.WemoBindingConstants;
-import org.openhab.binding.wemo.internal.handler.WemoLightHandler;
-import org.openhab.binding.wemo.internal.http.WemoHttpCall;
-import org.openhab.binding.wemo.internal.test.GenericWemoLightOSGiTestParent;
 
 /**
  * Tests for {@link WemoLightHandler}.
@@ -54,12 +55,12 @@ public class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTestParent {
     private static final String GET_ACTION = "GetDeviceStatus";
     private static final String SET_ACTION = "SetDeviceStatus";
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpServices();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         removeThing();
     }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/handler/test/WemoMakerHandlerOSGiTest.java
@@ -13,7 +13,8 @@
 package org.openhab.binding.wemo.internal.handler.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -22,6 +23,16 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jupnp.model.ValidationException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.openhab.binding.wemo.internal.WemoBindingConstants;
+import org.openhab.binding.wemo.internal.handler.WemoMakerHandler;
+import org.openhab.binding.wemo.internal.http.WemoHttpCall;
+import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -30,16 +41,6 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.jupnp.model.ValidationException;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.openhab.binding.wemo.internal.WemoBindingConstants;
-import org.openhab.binding.wemo.internal.handler.WemoMakerHandler;
-import org.openhab.binding.wemo.internal.http.WemoHttpCall;
-import org.openhab.binding.wemo.internal.test.GenericWemoOSGiTest;
 
 /**
  * Tests for {@link WemoMakerHandler}.
@@ -59,12 +60,12 @@ public class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
     private final String BASIC_EVENT_SERVICE_ID = "basicevent";
     private final String SERVICE_NUMBER = "1";
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setUpServices();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         removeThing();
     }

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoLightOSGiTestParent.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoLightOSGiTestParent.java
@@ -13,8 +13,11 @@
 package org.openhab.binding.wemo.internal.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.openhab.binding.wemo.internal.WemoBindingConstants;
+import org.openhab.binding.wemo.internal.handler.AbstractWemoHandler;
+import org.openhab.binding.wemo.internal.http.WemoHttpCall;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -28,9 +31,6 @@ import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.type.ChannelKind;
-import org.openhab.binding.wemo.internal.WemoBindingConstants;
-import org.openhab.binding.wemo.internal.handler.AbstractWemoHandler;
-import org.openhab.binding.wemo.internal.http.WemoHttpCall;
 
 /**
  * Generic test class for all WemoLight related tests that contains methods and constants used across the different test

--- a/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoOSGiTest.java
+++ b/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoOSGiTest.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.wemo.internal.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -24,25 +24,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
-import org.openhab.core.config.core.Configuration;
-import org.openhab.core.library.CoreItemFactory;
-import org.openhab.core.thing.Channel;
-import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.ManagedThingProvider;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingRegistry;
-import org.openhab.core.thing.ThingTypeUID;
-import org.openhab.core.thing.ThingUID;
-import org.openhab.core.thing.binding.ThingHandler;
-import org.openhab.core.thing.binding.builder.ChannelBuilder;
-import org.openhab.core.thing.binding.builder.ThingBuilder;
-import org.openhab.core.thing.type.ChannelKind;
-import org.openhab.core.thing.type.ChannelTypeBuilder;
-import org.openhab.core.thing.type.ChannelTypeProvider;
-import org.openhab.core.thing.type.ChannelTypeUID;
-import org.openhab.core.io.transport.upnp.UpnpIOService;
-import org.openhab.core.test.java.JavaOSGiTest;
-import org.openhab.core.test.storage.VolatileStorageService;
 import org.jupnp.UpnpService;
 import org.jupnp.mock.MockUpnpService;
 import org.jupnp.model.ValidationException;
@@ -59,6 +40,25 @@ import org.jupnp.model.types.UDN;
 import org.openhab.binding.wemo.internal.WemoBindingConstants;
 import org.openhab.binding.wemo.internal.handler.AbstractWemoHandler;
 import org.openhab.binding.wemo.internal.http.WemoHttpCall;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.io.transport.upnp.UpnpIOService;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ManagedThingProvider;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * Generic test class for all Wemo related tests that contains methods and constants used across the different test

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.addons.itests</groupId>
     <artifactId>org.openhab.addons.reactor.itests</artifactId>
-    <version>2.5.9-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.io.mqttembeddedbroker.tests</artifactId>

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.io.mqttembeddedbroker;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +25,6 @@ import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
 import org.openhab.core.io.transport.mqtt.MqttConnectionState;
 import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.io.transport.mqtt.MqttServiceObserver;
-import org.openhab.io.mqttembeddedbroker.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +65,7 @@ public class EmbeddedBrokerTools {
 
             };
             mqttService.addBrokersListener(observer);
-            assertTrue("Wait for embedded connection client failed", semaphore.tryAcquire(700, TimeUnit.MILLISECONDS));
+            assertTrue(semaphore.tryAcquire(700, TimeUnit.MILLISECONDS), "Wait for embedded connection client failed");
         }
         MqttBrokerConnection embeddedConnection = this.embeddedConnection;
         if (embeddedConnection == null) {
@@ -85,8 +84,8 @@ public class EmbeddedBrokerTools {
         if (embeddedConnection.connectionState() == MqttConnectionState.CONNECTED) {
             semaphore.release();
         }
-        assertTrue("Connection " + embeddedConnection.getClientId() + " failed. State: "
-                + embeddedConnection.connectionState(), semaphore.tryAcquire(500, TimeUnit.MILLISECONDS));
+        assertTrue(semaphore.tryAcquire(500, TimeUnit.MILLISECONDS), "Connection " + embeddedConnection.getClientId()
+                + " failed. State: " + embeddedConnection.connectionState());
         return embeddedConnection;
     }
 

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
@@ -13,8 +13,9 @@
 package org.openhab.io.mqttembeddedbroker;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -25,14 +26,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
 import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
 import org.openhab.core.io.transport.mqtt.MqttConnectionState;
 import org.openhab.core.io.transport.mqtt.MqttService;
 import org.openhab.core.test.java.JavaOSGiTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Moquette test
@@ -41,6 +42,8 @@ import org.junit.Test;
  */
 public class MoquetteTest extends JavaOSGiTest {
     private static final String TEST_TOPIC = "testtopic";
+
+    private AutoCloseable mocksCloseable;
 
     private MqttService mqttService;
     private MqttBrokerConnection embeddedConnection;
@@ -53,10 +56,10 @@ public class MoquetteTest extends JavaOSGiTest {
     private MqttConnectionObserver failIfChange = (state, error) -> assertThat(state,
             is(MqttConnectionState.CONNECTED));
 
-    @Before
-    public void setUp() throws InterruptedException, ExecutionException, TimeoutException {
+    @BeforeEach
+    public void beforeEach() throws Exception {
         registerVolatileStorageService();
-        initMocks(this);
+        mocksCloseable = openMocks(this);
         mqttService = getService(MqttService.class);
 
         // Wait for the EmbeddedBrokerService internal connection to be connected
@@ -72,12 +75,13 @@ public class MoquetteTest extends JavaOSGiTest {
         clientConnection.addConnectionObserver(failIfChange);
     }
 
-    @After
-    public void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
+    @AfterEach
+    public void afterEach() throws Exception {
         if (clientConnection != null) {
             clientConnection.removeConnectionObserver(failIfChange);
             clientConnection.stop().get(500, TimeUnit.MILLISECONDS);
         }
+        mocksCloseable.close();
     }
 
     @Test
@@ -101,8 +105,10 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1, true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1, true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
+                true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
+                true));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
@@ -120,8 +126,10 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1, true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1, true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
+                true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
+                true));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
@@ -138,8 +146,10 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1, true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1, true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
+                true));
+        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
+                true));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
Mosts tests already work though a few still fail also because of changes in the core.

For instance the tests of the following bundles fail:

* org.openhab.binding.bluetooth: BluetoothDiscoveryServiceTest
* org.openhab.transform.map: MapTransformationServiceTest

I think it's best to merge this PR and then proceed with other changes and fixing the tests.
