### PR TITLE
[insteon] remove optional from the description of network parameters

### DIFF
--- a/bundles/org.openhab.binding.insteon/README.md
+++ b/bundles/org.openhab.binding.insteon/README.md
@@ -44,8 +44,8 @@ The Insteon PLM or hub is configured with the following parameters:
 |----------|---------:|--------:|-------------|
 | port   |         |   Yes    | **Examples:**<br>- PLM on  Linux: `/dev/ttyS0` or `/dev/ttyUSB0`<br>- Smartenit ZBPLM on Linux: `/dev/ttyUSB0,baudRate=115200`<br>- PLM on Windows: `COM1`<br>- Current  hub (2245-222) at 192.168.1.100 on port 25105, with a poll interval of 1000 ms (1 second): `/hub2/my_user_name:my_password@192.168.1.100:25105,poll_time=1000`<br>- Legacy hub (2242-222) at 192.168.1.100 on port 9761:`/hub/192.168.1.100:9761`<br>- Networked PLM using ser2net at 192.168.1.100 on port 9761:`/tcp/192.168.1.100:9761` |
 | devicePollIntervalSeconds | 300 |  No  | Poll interval of devices in seconds. Poll too often and you will overload the insteon network, leading to sluggish or no response when trying to send messages to devices. The default poll interval of 300 seconds has been tested and found to be a good compromise in a configuration of about 110 switches/dimmers. |
-| additionalDevices | |       No     | Optional file with additional device types. The syntax of the file is identical to the `device_types.xml` file in the source tree. Please remember to post successfully added device types to the openhab group so the developers can include them into the `device_types.xml` file! |
-| additionalFeatures | |      No     | Optional file with additional feature templates, like in the `device_features.xml` file in the source tree. |
+| additionalDevices | |       No     | File with additional device types. The syntax of the file is identical to the `device_types.xml` file in the source tree. Please remember to post successfully added device types to the openhab group so the developers can include them into the `device_types.xml` file! |
+| additionalFeatures | |      No     | File with additional feature templates, like in the `device_features.xml` file in the source tree. |
 
 >NOTE: For users upgrading from InsteonPLM, The parameter port_1 is now port.
 

--- a/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.insteon/src/main/resources/OH-INF/thing/thing-types.xml
@@ -21,12 +21,12 @@
 
 			<parameter name="additionalDevices" type="text">
 				<label>Additional Devices</label>
-				<description>Optional file with additional device types.</description>
+				<description>File with additional device types.</description>
 			</parameter>
 
 			<parameter name="additionalFeatures" type="text">
 				<label>Additional Features</label>
-				<description>Optional file with additional feature templates.</description>
+				<description>File with additional feature templates.</description>
 			</parameter>
 		</config-description>
 	</bridge-type>


### PR DESCRIPTION
Fixed documentation to match functionality.