### PR TITLE
Remove deprecated ConfigOptionProvider.getParameterOptions method

### DIFF
--- a/bundles/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/config/AmazonDashButtonConfigOptionProvider.java
+++ b/bundles/org.openhab.binding.amazondashbutton/src/main/java/org/openhab/binding/amazondashbutton/internal/config/AmazonDashButtonConfigOptionProvider.java
@@ -46,11 +46,6 @@ import org.pcap4j.core.PcapAddress;
 public class AmazonDashButtonConfigOptionProvider implements ConfigOptionProvider {
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-        return getParameterOptions(uri, param, null, locale);
-    }
-
-    @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
         if ("thing-type".equals(uri.getScheme())) {

--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/GPSTrackerHandlerFactory.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/GPSTrackerHandlerFactory.java
@@ -207,11 +207,6 @@ public class GPSTrackerHandlerFactory extends BaseThingHandlerFactory implements
     }
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-        return getParameterOptions(uri, param, null, locale);
-    }
-
-    @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
         if (URI_STR.equals(uri.toString()) && ConfigHelper.CONFIG_REGION_NAME.equals(param)) {

--- a/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/SmartMeterConfigProvider.java
+++ b/bundles/org.openhab.binding.smartmeter/src/main/java/org/openhab/binding/smartmeter/internal/SmartMeterConfigProvider.java
@@ -39,11 +39,6 @@ import org.osgi.service.component.annotations.Component;
 public class SmartMeterConfigProvider implements ConfigOptionProvider {
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-        return getParameterOptions(uri, param, null, locale);
-    }
-
-    @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
         if (!SmartMeterBindingConstants.THING_TYPE_SMLREADER.getAsString().equals(uri.getSchemeSpecificPart())) {


### PR DESCRIPTION
Related to openhab/openhab-core#1667