### PR TITLE
Remove deprecated handleUpdate from ThingHandler

### DIFF
--- a/bundles/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/handler/Cm11aBridgeHandler.java
+++ b/bundles/org.openhab.binding.cm11a/src/main/java/org/openhab/binding/cm11a/internal/handler/Cm11aBridgeHandler.java
@@ -202,35 +202,25 @@ public class Cm11aBridgeHandler extends BaseBridgeHandler implements ReceivedDat
         // Perform appropriate update based on X10Command received
         // Handle ON/OFF commands
         if (cmd == X10ReceivedData.X10COMMAND.ON) {
-            handleUpdate(channelUid, OnOffType.ON);
+            updateState(channelUid, OnOffType.ON);
             handler.setCurrentState(OnOffType.ON);
         } else if (cmd == X10ReceivedData.X10COMMAND.OFF) {
-            handleUpdate(channelUid, OnOffType.OFF);
+            updateState(channelUid, OnOffType.OFF);
             handler.setCurrentState(OnOffType.OFF);
             // Handle DIM/Bright commands
         } else if (cmd == X10ReceivedData.X10COMMAND.DIM) {
             State newState = handler.addDimsToCurrentState(dims);
-            handleUpdate(channelUid, newState);
+            updateState(channelUid, newState);
             handler.setCurrentState(newState);
             logger.debug("Current state set to: {}", handler.getCurrentState().toFullString());
         } else if (cmd == X10ReceivedData.X10COMMAND.BRIGHT) {
             State newState = handler.addBrightsToCurrentState(dims);
-            handleUpdate(channelUid, newState);
+            updateState(channelUid, newState);
             handler.setCurrentState(newState);
             logger.debug("Current state set to: {}", handler.getCurrentState().toFullString());
         } else {
             logger.warn("Received unknown command from cm11a: {}", cmd);
         }
-    }
-
-    /**
-     * The default implementation of this method doesn't do anything. We need it to update the ui as done by the
-     * updateState function.
-     * And, update state can not be called directly because it is protected
-     */
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        updateState(channelUID, newState);
     }
 
     /**

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/KNXBridgeBaseThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/KNXBridgeBaseThingHandler.java
@@ -27,7 +27,6 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 
 import tuwien.auto.calimero.IndividualAddress;
 import tuwien.auto.calimero.mgmt.Destination;
@@ -50,11 +49,6 @@ public abstract class KNXBridgeBaseThingHandler extends BaseBridgeHandler implem
     }
 
     protected abstract KNXClient getClient();
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        // Nothing to do here
-    }
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/handler/DimmerHandler.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/radiora/handler/DimmerHandler.java
@@ -27,7 +27,6 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 
 /**
  * Handler for RadioRA dimmers
@@ -73,14 +72,6 @@ public class DimmerHandler extends LutronHandler {
                 updateInternalState(onOffCmd);
 
             }
-        }
-    }
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        if (LutronBindingConstants.CHANNEL_LIGHTLEVEL.equals(channelUID.getId())) {
-            PercentType percent = (PercentType) newState.as(PercentType.class);
-            updateInternalState(percent.intValue());
         }
     }
 

--- a/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiActorGatewayHandler.java
+++ b/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiActorGatewayHandler.java
@@ -22,7 +22,6 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,28 +124,6 @@ public class XiaomiActorGatewayHandler extends XiaomiActorBaseHandler {
     private void updateLastVolume(DecimalType newVolume) {
         lastVolume = newVolume.intValue();
         logger.debug("Changed volume to {}", lastVolume);
-    }
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        logger.debug("Update {} for channel {} received", newState, channelUID);
-        switch (channelUID.getId()) {
-            case CHANNEL_BRIGHTNESS:
-                if (newState instanceof PercentType) {
-                    lastBrigthness = ((PercentType) newState).intValue();
-                }
-                break;
-            case CHANNEL_COLOR:
-                if (newState instanceof HSBType) {
-                    lastColor = ((HSBType) newState).getRGB();
-                }
-                break;
-            case CHANNEL_GATEWAY_VOLUME:
-                if (newState instanceof DecimalType) {
-                    updateLastVolume((DecimalType) newState);
-                }
-                break;
-        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorBaseHandlerWithTimer.java
+++ b/bundles/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/internal/handler/XiaomiSensorBaseHandlerWithTimer.java
@@ -16,9 +16,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
-import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,16 +83,6 @@ public abstract class XiaomiSensorBaseHandlerWithTimer extends XiaomiSensorBaseH
         } catch (NumberFormatException e) {
             logger.debug("Cannot parse the value {} to an Integer", value);
             timerSetpoint = defaultTimer;
-        }
-    }
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        if (setpointChannel.equals(channelUID.getId())) {
-            if (newState instanceof DecimalType) {
-                logger.debug("Received update for timer setpoint channel: {}", newState);
-                timerSetpoint = ((DecimalType) newState).intValue();
-            }
         }
     }
 }

--- a/bundles/org.openhab.binding.phc/src/main/java/org/openhab/binding/phc/internal/handler/PHCHandler.java
+++ b/bundles/org.openhab.binding.phc/src/main/java/org/openhab/binding/phc/internal/handler/PHCHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.openhab.core.config.core.Configuration;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StopMoveType;
@@ -122,14 +121,6 @@ public class PHCHandler extends BaseThingHandler {
             logger.debug("send command: {}, {}", channelUID, command);
         } else {
             logger.info("The Thing {} is offline.", getThing().getUID());
-        }
-    }
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        if (CHANNELS_JRM_TIME.equals(channelUID.getGroupId())) {
-            times[Integer
-                    .parseInt(channelUID.getIdWithoutGroup())] = (short) (((DecimalType) newState).floatValue() * 10);
         }
     }
 

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/live/TelldusLiveBridgeHandler.java
@@ -36,7 +36,6 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
-import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tellstick.device.TellstickDeviceEvent;
@@ -245,11 +244,6 @@ public class TelldusLiveBridgeHandler extends BaseBridgeHandler implements Telld
     @Override
     public void handleRemoval() {
         super.handleRemoval();
-    }
-
-    @Override
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        super.handleUpdate(channelUID, newState);
     }
 
     @Override

--- a/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/profiles/ExecTransformationProfile.java
+++ b/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/profiles/ExecTransformationProfile.java
@@ -82,7 +82,6 @@ public class ExecTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/profiles/JavascriptTransformationProfile.java
+++ b/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/profiles/JavascriptTransformationProfile.java
@@ -84,7 +84,6 @@ public class JavascriptTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/profiles/JinjaTransformationProfile.java
+++ b/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/profiles/JinjaTransformationProfile.java
@@ -83,7 +83,6 @@ public class JinjaTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
@@ -84,7 +84,6 @@ public class JSonPathTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/profiles/MapTransformationProfile.java
+++ b/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/profiles/MapTransformationProfile.java
@@ -83,7 +83,6 @@ public class MapTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/profiles/RegexTransformationProfile.java
+++ b/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/profiles/RegexTransformationProfile.java
@@ -83,7 +83,6 @@ public class RegexTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/profiles/ScaleTransformationProfile.java
+++ b/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/profiles/ScaleTransformationProfile.java
@@ -83,7 +83,6 @@ public class ScaleTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/profiles/XPathTransformationProfile.java
+++ b/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/profiles/XPathTransformationProfile.java
@@ -83,7 +83,6 @@ public class XPathTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override

--- a/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/profiles/XSLTTransformationProfile.java
+++ b/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/profiles/XSLTTransformationProfile.java
@@ -83,7 +83,6 @@ public class XSLTTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 
     @Override


### PR DESCRIPTION
The handleUpdate method was deprecated when profiles were introduced (see eclipse-archived/smarthome#4108).
Instead the [follow profile](https://www.openhab.org/docs/developer/transformations/#followprofile) can be used which forwards item updates as commands to handlers.
This profile works with any binding instead of only those that implement the handleUpdate method.

Related to openhab/openhab-core#1669