### PR TITLE
[feed] Reenable itest

### DIFF
--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -10,6 +10,10 @@ Fragment-Host: org.openhab.binding.feed
 	bnd.identity;id='org.apache.felix.configadmin',\
 	osgi.identity;filter:='(&(osgi.identity=org.ops4j.pax.web.pax-web-runtime)(version>=7.2.3))'
 
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
+
 -runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
 
 #
@@ -49,8 +53,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.11,7.2.12)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	junit-jupiter-api;version='[5.6.2,5.6.3)',\
 	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
@@ -68,4 +70,6 @@ Fragment-Host: org.openhab.binding.feed
 	org.openhab.core.test;version='[3.0.0,3.0.1)',\
 	org.openhab.core.thing;version='[3.0.0,3.0.1)',\
 	org.openhab.core.thing.xml;version='[3.0.0,3.0.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)'

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -18,6 +18,7 @@
 
   <modules>
     <module>org.openhab.binding.astro.tests</module>
+    <module>org.openhab.binding.feed.tests</module>
     <module>org.openhab.binding.hue.tests</module>
     <module>org.openhab.binding.max.tests</module>
     <module>org.openhab.binding.modbus.tests</module>


### PR DESCRIPTION
With these changes and working channelLink events (openhab/openhab-core#1634) the feed itest works again.

Related to #8537