### PR TITLE
[ntp] Reenable itest

### DIFF
--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -69,6 +69,7 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 
 /**
@@ -489,7 +490,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         registerService(eventSubscriberMock);
 
         if (updateEventType.equals(UpdateEventType.HANDLE_COMMAND)) {
-            ntpHandler.handleCommand(new ChannelUID("ntp:test:chan:1"), new StringType("test"));
+            ntpHandler.handleCommand(new ChannelUID("ntp:test:chan:1"), RefreshType.REFRESH);
         } else if (updateEventType.equals(UpdateEventType.CHANNEL_LINKED)) {
             ntpHandler.channelLinked(new ChannelUID("ntp:test:chan:1"));
         }

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -22,6 +22,7 @@
     <module>org.openhab.binding.max.tests</module>
     <module>org.openhab.binding.modbus.tests</module>
     <module>org.openhab.binding.nest.tests</module>
+    <module>org.openhab.binding.ntp.tests</module>
     <module>org.openhab.binding.systeminfo.tests</module>
     <module>org.openhab.binding.tradfri.tests</module>
     <module>org.openhab.binding.wemo.tests</module>


### PR DESCRIPTION
With these changes and working channelLink events (openhab/openhab-core#1634) the ntp itest works again.
In #7834 the command handling was changed to only refresh when REFRESH commands are received instead of every command.

Related to #8537