### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -231,7 +231,6 @@
 /bundles/org.openhab.binding.sonyprojector/ @lolodomo
 /bundles/org.openhab.binding.spotify/ @Hilbrand
 /bundles/org.openhab.binding.squeezebox/ @digitaldan @mhilbush
-/bundles/org.openhab.binding.mpd/ @stefanroellin
 /bundles/org.openhab.binding.synopanalyzer/ @clinique
 /bundles/org.openhab.binding.systeminfo/ @svilenvul
 /bundles/org.openhab.binding.tacmi/ @twendt @Wolfgang1966 @marvkis

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@
 /bundles/org.openhab.binding.bticinosmarther/ @MrRonfo
 /bundles/org.openhab.binding.buienradar/ @gedejong
 /bundles/org.openhab.binding.caddx/ @jossuar
+/bundles/org.openhab.binding.cbus/ @jpharvey
 /bundles/org.openhab.binding.chromecast/ @kaikreuzer
 /bundles/org.openhab.binding.cm11a/ @BobRak
 /bundles/org.openhab.binding.comfoair/ @boehan
@@ -52,9 +53,9 @@
 /bundles/org.openhab.binding.draytonwiser/ @andrew-schofield
 /bundles/org.openhab.binding.dscalarm/ @RSStephens
 /bundles/org.openhab.binding.dsmr/ @Hilbrand
-/bundles/org.openhab.binding.ecobee/ @mhilbush
 /bundles/org.openhab.binding.dwdpollenflug/ @DerOetzi
 /bundles/org.openhab.binding.dwdunwetter/ @limdul79
+/bundles/org.openhab.binding.ecobee/ @mhilbush
 /bundles/org.openhab.binding.elerotransmitterstick/ @vbier
 /bundles/org.openhab.binding.energenie/ @hmerk
 /bundles/org.openhab.binding.enigma2/ @gdolfen
@@ -75,6 +76,7 @@
 /bundles/org.openhab.binding.gardena/ @gerrieg
 /bundles/org.openhab.binding.gce/ @clinique
 /bundles/org.openhab.binding.globalcache/ @mhilbush
+/bundles/org.openhab.binding.goecharger/ @SamuelBrucksch
 /bundles/org.openhab.binding.gpstracker/ @gbicskei
 /bundles/org.openhab.binding.gree/ @markus7017
 /bundles/org.openhab.binding.groheondus/ @FlorianSW
@@ -89,14 +91,15 @@
 /bundles/org.openhab.binding.hue/ @cweitkamp
 /bundles/org.openhab.binding.hydrawise/ @digitaldan
 /bundles/org.openhab.binding.hyperion/ @tavalin
+/bundles/org.openhab.binding.iammeter/ @lewei50
 /bundles/org.openhab.binding.iaqualink/ @digitaldan
 /bundles/org.openhab.binding.icalendar/ @daMihe
 /bundles/org.openhab.binding.icloud/ @pgfeller
 /bundles/org.openhab.binding.ihc/ @paulianttila
 /bundles/org.openhab.binding.innogysmarthome/ @ollie-dev
 /bundles/org.openhab.binding.insteon/ @robnielsen
-/bundles/org.openhab.binding.ipcamera/ @Skinah
 /bundles/org.openhab.binding.intesis/ @hmerk
+/bundles/org.openhab.binding.ipcamera/ @Skinah
 /bundles/org.openhab.binding.ipp/ @peuter
 /bundles/org.openhab.binding.irtrans/ @kgoderis
 /bundles/org.openhab.binding.ism8/ @hans-reiner
@@ -109,6 +112,7 @@
 /bundles/org.openhab.binding.kodi/ @pail23 @cweitkamp
 /bundles/org.openhab.binding.konnected/ @volfan6415
 /bundles/org.openhab.binding.kostalinverter/ @cschneider
+/bundles/org.openhab.binding.kvv/ @ne0h
 /bundles/org.openhab.binding.lametrictime/ @syphr42
 /bundles/org.openhab.binding.lcn/ @fwolter
 /bundles/org.openhab.binding.leapmotion/ @kaikreuzer
@@ -134,16 +138,17 @@
 /bundles/org.openhab.binding.miele/ @kgoderis
 /bundles/org.openhab.binding.mihome/ @pboos
 /bundles/org.openhab.binding.miio/ @marcelrv
-/bundles/org.openhab.binding.millheat/ @seime
 /bundles/org.openhab.binding.milight/ @davidgraeff
+/bundles/org.openhab.binding.millheat/ @seime
 /bundles/org.openhab.binding.minecraft/ @ibaton
 /bundles/org.openhab.binding.modbus/ @ssalonen
 /bundles/org.openhab.binding.modbus.e3dc/ @weymann
+/bundles/org.openhab.binding.modbus.helioseasycontrols/ @bern77
+/bundles/org.openhab.binding.modbus.stiebeleltron/ @pail23
 /bundles/org.openhab.binding.modbus.studer/ @giovannimirulla
 /bundles/org.openhab.binding.modbus.sunspec/ @mrbig
-/bundles/org.openhab.binding.modbus.stiebeleltron/ @pail23
-/bundles/org.openhab.binding.modbus.helioseasycontrols/ @bern77
 /bundles/org.openhab.binding.monopriceaudio/ @mlobstein
+/bundles/org.openhab.binding.mpd/ @stefanroellin
 /bundles/org.openhab.binding.mqtt/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.generic/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.homeassistant/ @davidgraeff
@@ -170,8 +175,8 @@
 /bundles/org.openhab.binding.ojelectronics/ @EvilPingu
 /bundles/org.openhab.binding.omnikinverter/ @hansbogert
 /bundles/org.openhab.binding.onebusaway/ @sdwilsh
-/bundles/org.openhab.binding.onewiregpio/ @aogorek
 /bundles/org.openhab.binding.onewire/ @J-N-K
+/bundles/org.openhab.binding.onewiregpio/ @aogorek
 /bundles/org.openhab.binding.onkyo/ @pail23 @paulianttila
 /bundles/org.openhab.binding.opengarage/ @psmedley
 /bundles/org.openhab.binding.opensprinkler/ @CrackerStealth @FlorianSW
@@ -198,7 +203,6 @@
 /bundles/org.openhab.binding.rme/ @kgoderis
 /bundles/org.openhab.binding.robonect/ @reyem
 /bundles/org.openhab.binding.rotel/ @lolodomo
-/bundles/org.openhab.binding.rotelra1x/ @fa2k
 /bundles/org.openhab.binding.russound/ @tmrobert8
 /bundles/org.openhab.binding.sagercaster/ @clinique
 /bundles/org.openhab.binding.samsungtv/ @paulianttila
@@ -215,8 +219,8 @@
 /bundles/org.openhab.binding.sleepiq/ @syphr42
 /bundles/org.openhab.binding.smaenergymeter/ @monnimeter
 /bundles/org.openhab.binding.smartmeter/ @msteigenberger
-/bundles/org.openhab.binding.smhi/ @pacive
 /bundles/org.openhab.binding.smartthings/ @BobRak
+/bundles/org.openhab.binding.smhi/ @pacive
 /bundles/org.openhab.binding.snmp/ @J-N-K
 /bundles/org.openhab.binding.solaredge/ @alexf2015
 /bundles/org.openhab.binding.solarlog/ @johannrichard
@@ -241,8 +245,8 @@
 /bundles/org.openhab.binding.tplinksmarthome/ @Hilbrand
 /bundles/org.openhab.binding.tradfri/ @cweitkamp @kaikreuzer
 /bundles/org.openhab.binding.unifi/ @mgbowman
-/bundles/org.openhab.binding.upnpcontrol/ @mherwege
 /bundles/org.openhab.binding.upb/ @marcusb
+/bundles/org.openhab.binding.upnpcontrol/ @mherwege
 /bundles/org.openhab.binding.urtsi/ @OLibutzki
 /bundles/org.openhab.binding.valloxmv/ @bjoernbrings
 /bundles/org.openhab.binding.vektiva/ @octa22
@@ -273,7 +277,14 @@
 /bundles/org.openhab.io.neeo/ @tmrobert8
 /bundles/org.openhab.io.openhabcloud/ @kaikreuzer
 /bundles/org.openhab.io.transport.modbus/ @ssalonen
+/bundles/org.openhab.persistence.dynamodb/ @ssalonen
+/bundles/org.openhab.persistence.influxdb/ @lujop
+/bundles/org.openhab.persistence.jdbc/ @openhab/add-ons-maintainers
+/bundles/org.openhab.persistence.jpa/ @openhab/add-ons-maintainers
 /bundles/org.openhab.persistence.mapdb/ @mkhl
+/bundles/org.openhab.persistence.mongodb/ @openhab/add-ons-maintainers
+/bundles/org.openhab.persistence.rrd4j/ @openhab/add-ons-maintainers
+/bundles/org.openhab.transform.bin2json/ @paulianttila
 /bundles/org.openhab.transform.exec/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.javascript/ @openhab/add-ons-maintainers
 /bundles/org.openhab.transform.jinja/ @jochen314
@@ -302,7 +313,6 @@
 /itests/org.openhab.binding.systeminfo.tests/ @svilenvul
 /itests/org.openhab.binding.tradfri.tests/ @cweitkamp @kaikreuzer
 /itests/org.openhab.binding.wemo.tests/ @hmerk
-/itests/org.openhab.io.hueemulation.tests/ @davidgraeff @digitaldan
 /itests/org.openhab.io.mqttembeddedbroker.tests/ @J-N-K
 /itests/org.openhab.persistence.mapdb.tests/ @mkhl
 


### PR DESCRIPTION
* Add missing bundles/itests dirs
* Remove bundles/itests dirs that no longer exist
* Sort list

Perhaps @kaikreuzer can invite any missing contributors to the [contributors team](https://github.com/orgs/openhab/teams/contributors/members)?

I think @ssalonen has a stake in the DynamoDB persistence add-on so I added him as code owner but if you don't want that please comment. :wink: 

Maybe @lewie also wants to review or be notified of PRs for persistence add-ons?

