### PR TITLE
[modbus] Fixes #8538 (modbus extensions missing)

### DIFF
--- a/bundles/org.openhab.binding.modbus.e3dc/README.md
+++ b/bundles/org.openhab.binding.modbus.e3dc/README.md
@@ -1,4 +1,4 @@
-# E3DC Binding
+# E3DC
 
 <img align="right" src="./doc/E3DC_logo.png"/>
 

--- a/bundles/org.openhab.binding.modbus.helioseasycontrols/README.md
+++ b/bundles/org.openhab.binding.modbus.helioseasycontrols/README.md
@@ -1,4 +1,4 @@
-# Helios easyControls Binding
+# Helios easyControls
 
 Helios Heat-Recovery Ventilation devices use a Modbus protocol to communicate with different sensors, switches, etc. Some devices come with an integrated web interface (easyControls) as well as a Modbus TCP/IP Gateway.
 See https://www.easycontrols.net/de/service/downloads/send/4-software/16-modbus-dokumentation-f%C3%BCr-kwl-easycontrols-ger%C3%A4te for the corresponding specification.

--- a/bundles/org.openhab.binding.modbus.stiebeleltron/README.md
+++ b/bundles/org.openhab.binding.modbus.stiebeleltron/README.md
@@ -1,4 +1,4 @@
-# Stiebel Eltron ISG Binding
+# Stiebel Eltron ISG
 
 This extension adds support for the Stiebel Eltron modbus protocol.
 

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -24,6 +24,10 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-modbus</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.e3dc/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.helioseasycontrols/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.stiebeleltron/${project.version}</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.studer/${project.version}</bundle>		
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.modbus.sunspec/${project.version}</bundle>
 	</feature>
 


### PR DESCRIPTION
Applied #8549 against main. Fixes #8538 (modbus extensions missing)