### PR TITLE
[velbus] Fixed 3 bugs

### DIFF
--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBridgeHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusBridgeHandler.java
@@ -253,8 +253,9 @@ public abstract class VelbusBridgeHandler extends BaseBridgeHandler {
             int reconnectionInterval = bridgeConfig.reconnectionInterval;
             if (reconnectionInterval > 0) {
                 this.reconnectionHandler = scheduler.scheduleWithFixedDelay(() -> {
-                    if (connect() && reconnectionHandler != null) {
-                        reconnectionHandler.cancel(false);
+                    final ScheduledFuture<?> currentReconnectionHandler = this.reconnectionHandler;
+                    if (connect() && currentReconnectionHandler != null) {
+                        currentReconnectionHandler.cancel(false);
                     }
                 }, reconnectionInterval, reconnectionInterval, TimeUnit.SECONDS);
             }

--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusNetworkBridgeHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusNetworkBridgeHandler.java
@@ -63,18 +63,19 @@ public class VelbusNetworkBridgeHandler extends VelbusBridgeHandler {
             updateStatus(ThingStatus.ONLINE);
             logger.debug("Bridge online on network address {}:{}", networkBridgeConfig.address,
                     networkBridgeConfig.port);
+
+            // Start Velbus packet listener. This listener will act on all packets coming from
+            // IP-interface.
+            Thread thread = new Thread(this::readPackets, "OH-binding-" + this.thing.getUID());
+            thread.setDaemon(true);
+            thread.start();
+
             return true;
         } catch (IOException ex) {
             onConnectionLost();
             logger.debug("Failed to connect to network address {}:{}", networkBridgeConfig.address,
                     networkBridgeConfig.port);
         }
-
-        // Start Velbus packet listener. This listener will act on all packets coming from
-        // IP-interface.
-        Thread thread = new Thread(this::readPackets, "OH-binding-" + this.thing.getUID());
-        thread.setDaemon(true);
-        thread.start();
 
         return false;
     }

--- a/bundles/org.openhab.binding.velbus/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.velbus/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1338,7 +1338,7 @@
 				<label>Clock Alarm 1 Wakeup Hour</label>
 			</channel>
 			<channel id="clockAlarm1WakeupMinute" typeId="minute">
-				<label>Clock Alarm 1 Minute</label>
+				<label>Clock Alarm 1 Wakeup Minute</label>
 			</channel>
 			<channel id="clockAlarm1BedtimeHour" typeId="hour">
 				<label>Clock Alarm 1 Bedtime Hour</label>


### PR DESCRIPTION
This PR fixes 2 bugs:
1.) The network bridge wasn't correctly listening on the bus, because the listening thread was never started
2.) The reconnection handler kept trying to reconnect, even after a successful reconnection, because it had a wrong (always null) reference to the scheduled action and wasn't able to cancel itself.
3.) Minor typo in alarm 1 wakeup time channels