### PR TITLE
[miio] avoid IndexOutOfBoundsException exception

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -426,6 +426,7 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         if (res.size() != para.size()) {
             logger.debug("Unexpected size different. Request size {},  response size {}. (Req: {}, Resp:{})",
                     para.size(), res.size(), para, res);
+            return;
         }
         for (int i = 0; i < para.size(); i++) {
             // This is a miot parameter


### PR DESCRIPTION
In case of the parameters & response are not equal avoid the
java.lang.IndexOutOfBoundsException:

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>