### PR TITLE
[velux] eliminate mvn compiler warnings

### DIFF
--- a/bundles/org.openhab.binding.velux/README.md
+++ b/bundles/org.openhab.binding.velux/README.md
@@ -197,7 +197,7 @@ The bridge Thing provides the following properties.
 | products          | List of all recognized products                                 |
 | scenes            | List of all defined scenes                                      |
 | subnetMask        | IP subnetmask of the Bridge                                     |
-| vendor            | Vendow name                                                     |
+| vendor            | Vendor name                                                     |
 | WLANSSID          | Name of the wireless network (not suported any more)            |
 | WLANPassword      | WLAN Authentication Password (not suported any more)            |
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBinding.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBinding.java
@@ -16,7 +16,6 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 import java.lang.reflect.Field;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.velux.internal.config.VeluxBridgeConfiguration;
@@ -56,8 +55,9 @@ public class VeluxBinding extends VeluxBridgeConfiguration {
         logger.trace("VeluxBinding(constructor) called.");
         if (logger.isTraceEnabled()) {
             for (Field field : VeluxBridgeConfiguration.class.getFields()) {
-                if (!StringUtils.capitalize(field.getName()).contentEquals(field.getName())) {
-                    logger.trace("VeluxBinding(): FYI: a potential configuration string is '{}'.", field.getName());
+                String fName = field.getName();
+                if ((fName.length() > 0) && Character.isUpperCase(fName.charAt(0))) {
+                    logger.trace("VeluxBinding(): FYI: a potential configuration string is '{}'.", fName);
                 }
             }
         }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeActuators.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeActuators.java
@@ -64,7 +64,6 @@ public class VeluxBridgeActuators {
      * <li>existingProducts ({@link VeluxExistingProducts}).
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public VeluxExistingProducts existingProducts = new VeluxExistingProducts();
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeDeviceStatus.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeDeviceStatus.java
@@ -48,7 +48,6 @@ public class VeluxBridgeDeviceStatus {
      * <li>{@link #gwStateDescription} containing the verbose gateway state.
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public boolean isRetrieved = false;
         public StringType gwState = new StringType(VeluxBindingConstants.UNKNOWN);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeGetFirmware.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeGetFirmware.java
@@ -46,7 +46,6 @@ public class VeluxBridgeGetFirmware {
      * <li>firmwareVersion (human readable String).
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public boolean isRetrieved = false;
         public StringType firmwareVersion = new StringType(VeluxBindingConstants.UNKNOWN);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeLANConfig.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeLANConfig.java
@@ -50,7 +50,6 @@ public class VeluxBridgeLANConfig {
      * <li>enabledDHCP.
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public boolean isRetrieved = false;
         public StringType openHABipAddress = new StringType(VeluxBindingConstants.UNKNOWN);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeScenes.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeScenes.java
@@ -49,7 +49,6 @@ public class VeluxBridgeScenes {
      * <li>existingScenes ({@link VeluxExistingScenes}).
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public VeluxExistingScenes existingScenes = new VeluxExistingScenes();
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeWLANConfig.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridgeWLANConfig.java
@@ -48,7 +48,6 @@ public class VeluxBridgeWLANConfig {
      * <li>wlanPassword.
      * </ul>
      */
-    @NonNullByDefault
     public class Channel {
         public boolean isRetrieved = false;
         public StringType openHABwlanSSID = new StringType(VeluxBindingConstants.UNKNOWN);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetDeviceStatus.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetDeviceStatus.java
@@ -62,7 +62,6 @@ class JCgetDeviceStatus extends GetDeviceStatus implements JsonBridgeCommunicati
      * NOTE: the gateway software is extremely sensitive to this exact JSON structure.
      * Any modifications (like omitting empty params) will lead to an gateway error.
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -93,7 +92,6 @@ class JCgetDeviceStatus extends GetDeviceStatus implements JsonBridgeCommunicati
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetFirmware.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetFirmware.java
@@ -56,7 +56,6 @@ class JCgetFirmware extends GetFirmware implements JsonBridgeCommunicationProtoc
      * {"action":"getFirmware","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -76,7 +75,6 @@ class JCgetFirmware extends GetFirmware implements JsonBridgeCommunicationProtoc
      * <P>
      * Used within structure {@link JCgetFirmware} to describe the software of the Bridge.
      */
-    @NonNullByDefault
     private static class BCfirmwareVersion {
         /*
          * "version": "0.1.1.0.41.0"
@@ -100,7 +98,6 @@ class JCgetFirmware extends GetFirmware implements JsonBridgeCommunicationProtoc
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetLANConfig.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetLANConfig.java
@@ -57,7 +57,6 @@ class JCgetLANConfig extends GetLANConfig implements BridgeCommunicationProtocol
      * {"action":"get","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -81,7 +80,6 @@ class JCgetLANConfig extends GetLANConfig implements BridgeCommunicationProtocol
      * {"ipAddress":"192.168.45.9","subnetMask":"255.255.255.0","defaultGateway":"192.168.45.129","dhcp":false}
      * </pre>
      */
-    @NonNullByDefault
     private static class BCLANConfig {
         private String ipAddress = VeluxBindingConstants.UNKNOWN;
         private String subnetMask = VeluxBindingConstants.UNKNOWN;
@@ -111,7 +109,6 @@ class JCgetLANConfig extends GetLANConfig implements BridgeCommunicationProtocol
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetProducts.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetProducts.java
@@ -61,7 +61,6 @@ class JCgetProducts extends GetProducts implements JsonBridgeCommunicationProtoc
      * ]
      * </PRE>
      */
-    @NonNullByDefault
     private class BCproduct {
         private String name = VeluxBindingConstants.UNKNOWN;
         @SuppressWarnings("unused")
@@ -84,7 +83,6 @@ class JCgetProducts extends GetProducts implements JsonBridgeCommunicationProtoc
      * {"action":"get","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -126,7 +124,6 @@ class JCgetProducts extends GetProducts implements JsonBridgeCommunicationProtoc
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetScenes.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetScenes.java
@@ -59,7 +59,6 @@ class JCgetScenes extends GetScenes implements JsonBridgeCommunicationProtocol {
      * "status": 0
      * </PRE>
      */
-    @NonNullByDefault
     private static class BCproductState {
         private int typeId;
         private String name = VeluxBindingConstants.UNKNOWN;
@@ -91,7 +90,6 @@ class JCgetScenes extends GetScenes implements JsonBridgeCommunicationProtocol {
      * },
      * </PRE>
      */
-    @NonNullByDefault
     private static class BCscene {
         private String name = VeluxBindingConstants.UNKNOWN;
         private int id;
@@ -110,7 +108,6 @@ class JCgetScenes extends GetScenes implements JsonBridgeCommunicationProtocol {
      * {"action":"get","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -150,7 +147,6 @@ class JCgetScenes extends GetScenes implements JsonBridgeCommunicationProtocol {
      * }
      * </PRE>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetWLANConfig.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCgetWLANConfig.java
@@ -57,7 +57,6 @@ class JCgetWLANConfig extends GetWLANConfig implements JsonBridgeCommunicationPr
      * {"action":"wifi","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -81,7 +80,6 @@ class JCgetWLANConfig extends GetWLANConfig implements JsonBridgeCommunicationPr
      * {"password":"Esf56mxqFY","name":"VELUX_KLF_847C"}
      * </PRE>
      */
-    @NonNullByDefault
     private static class BCWLANConfig {
 
         private String password = VeluxBindingConstants.UNKNOWN;
@@ -110,7 +108,6 @@ class JCgetWLANConfig extends GetWLANConfig implements JsonBridgeCommunicationPr
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JClogin.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JClogin.java
@@ -45,7 +45,6 @@ class JClogin extends Login implements JsonBridgeCommunicationProtocol {
     /*
      * Message Objects
      */
-    @NonNullByDefault
     private static class ParamsLogin {
         @SuppressWarnings("unused")
         private String password = VeluxBindingConstants.UNKNOWN;
@@ -61,7 +60,6 @@ class JClogin extends Login implements JsonBridgeCommunicationProtocol {
      * {"action":"login","params":{"password":"PASSWORD"}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -83,7 +81,6 @@ class JClogin extends Login implements JsonBridgeCommunicationProtocol {
      * '{"token": "PHPnfLda71xfGlxoYEOTGQ==", "result": true, "deviceStatus": "IDLE", "data": {}, "errors": [] }'
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         private String token = VeluxBindingConstants.UNKNOWN;
         private boolean result;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JClogout.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JClogout.java
@@ -51,7 +51,6 @@ class JClogout extends Logout implements JsonBridgeCommunicationProtocol {
      * {"action":"logout","params":{}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -75,7 +74,6 @@ class JClogout extends Logout implements JsonBridgeCommunicationProtocol {
      * '{"token": "PHPnfLda71xfGlxoYEOTGQ==", "result": true, "deviceStatus": "IDLE", "data": {}, "errors": [] }'
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductDiscovery.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductDiscovery.java
@@ -58,7 +58,6 @@ class JCrunProductDiscovery extends RunProductDiscovery implements JsonBridgeCom
      * NOTE: the gateway software is extremely sensitive to this exact JSON structure.
      * Any modifications (like omitting empty params) will lead to an gateway error.
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -89,7 +88,6 @@ class JCrunProductDiscovery extends RunProductDiscovery implements JsonBridgeCom
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductIdentification.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductIdentification.java
@@ -46,7 +46,6 @@ class JCrunProductIdentification extends RunProductIdentification implements Jso
     /*
      * Message Objects
      */
-    @NonNullByDefault
     private static class ParamsIdentifyProduct {
         @SuppressWarnings("unused")
         private int id;
@@ -68,7 +67,6 @@ class JCrunProductIdentification extends RunProductIdentification implements Jso
      * {"action":"identify","params":{"id":23,"time":254}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
         @SuppressWarnings("unused")
         private String action;
@@ -98,7 +96,6 @@ class JCrunProductIdentification extends RunProductIdentification implements Jso
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductSearch.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunProductSearch.java
@@ -60,7 +60,6 @@ class JCrunProductSearch extends RunProductSearch implements JsonBridgeCommunica
      * NOTE: the gateway software is extremely sensitive to this exact JSON structure.
      * Any modifications (like omitting empty params) will lead to an gateway error.
      */
-    @NonNullByDefault
     private static class Request {
 
         @SuppressWarnings("unused")
@@ -91,7 +90,6 @@ class JCrunProductSearch extends RunProductSearch implements JsonBridgeCommunica
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunScene.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCrunScene.java
@@ -42,7 +42,6 @@ class JCrunScene extends RunScene implements JsonBridgeCommunicationProtocol {
     /*
      * Message Objects
      */
-    @NonNullByDefault
     private static class ParamsRunScene {
         @SuppressWarnings("unused")
         private int id;
@@ -58,7 +57,6 @@ class JCrunScene extends RunScene implements JsonBridgeCommunicationProtocol {
      * {"action":"run","params":{"id":9}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
         @SuppressWarnings("unused")
         private String action;
@@ -86,7 +84,6 @@ class JCrunScene extends RunScene implements JsonBridgeCommunicationProtocol {
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCsetSceneVelocity.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JCsetSceneVelocity.java
@@ -45,7 +45,6 @@ class JCsetSceneVelocity extends SetSceneVelocity implements JsonBridgeCommunica
     /*
      * Message Objects
      */
-    @NonNullByDefault
     private static class ParamsRunScene {
         @SuppressWarnings("unused")
         private int id;
@@ -68,7 +67,6 @@ class JCsetSceneVelocity extends SetSceneVelocity implements JsonBridgeCommunica
      * {"action":"setSilentMode","params":{"id":9,"silent":false}}}
      * </pre>
      */
-    @NonNullByDefault
     private static class Request {
         @SuppressWarnings("unused")
         private String action;
@@ -97,7 +95,6 @@ class JCsetSceneVelocity extends SetSceneVelocity implements JsonBridgeCommunica
      * }
      * </pre>
      */
-    @NonNullByDefault
     private static class Response {
         @SuppressWarnings("unused")
         private String token = VeluxBindingConstants.UNKNOWN;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JsonVeluxBridge.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JsonVeluxBridge.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.binding.velux.internal.bridge.json;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.TreeSet;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.velux.internal.bridge.VeluxBridge;
 import org.openhab.binding.velux.internal.bridge.VeluxBridgeInstance;
@@ -236,7 +236,7 @@ public class JsonVeluxBridge extends VeluxBridge {
                 if (authentication.length() > 0) {
                     headerItems.setProperty("Authorization", String.format("Bearer %s", authentication));
                 }
-                InputStream content = IOUtils.toInputStream(jsonRequest, StandardCharsets.UTF_8.name());
+                InputStream content = new ByteArrayInputStream(jsonRequest.getBytes(StandardCharsets.UTF_8));
 
                 String jsonResponse = HttpUtil.executeUrl("PUT", url, headerItems, content, "application/json",
                         this.bridgeInstance.veluxBridgeConfiguration().timeoutMsecs);
@@ -256,7 +256,6 @@ public class JsonVeluxBridge extends VeluxBridge {
                 T response = gson.fromJson(jsonResponse, classOfResponse);
                 lastCommunicationInMSecs = lastSuccessfulCommunicationInMSecs = System.currentTimeMillis();
                 return response;
-
             } catch (IOException ioe) {
                 logger.trace("io(): Exception occurred during I/O: {}.", ioe.getMessage());
                 // Error Retries with Exponential Backoff
@@ -272,7 +271,6 @@ public class JsonVeluxBridge extends VeluxBridge {
                 logger.info("io(): Exception occurred on deserialization: {}, aborting.", jse.getMessage());
                 throw jse;
             }
-
         } while (retryCount++ < this.bridgeInstance.veluxBridgeConfiguration().retries);
         throw new IOException(String.format("io(): socket I/O failed (%d times).",
                 this.bridgeInstance.veluxBridgeConfiguration().retries));

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JsonVeluxBridge.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/json/JsonVeluxBridge.java
@@ -185,6 +185,9 @@ public class JsonVeluxBridge extends VeluxBridge {
             } else {
                 response = ioUnauthenticated(sapURL, getRequest, classOfResponse);
             }
+            if (response == null) {
+                throw new IOException("Failed to create 'response' object");
+            }
             communication.setResponse(response);
             logger.trace("bridgeCommunicate(): communication result is {}, returning details.",
                     communication.isCommunicationSuccessful());

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/utils/SlipEncoding.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/utils/SlipEncoding.java
@@ -58,7 +58,7 @@ public class SlipEncoding {
      */
     public SlipEncoding(short command, byte[] data) {
         logger.trace("SlipEncoding(constructor) for command 0x{} with data size {} called.",
-                Integer.toHexString(new Short(command).intValue()), data.length);
+                Integer.toHexString(Short.valueOf(command).intValue()), data.length);
         if (data.length > 250) {
             logger.warn("SlipEncoding(constructor) called with data size {}: too big, aborting.", data.length);
             encodingValid = false;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -68,9 +68,11 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
 
     private void registerDeviceDiscoveryService(VeluxBridgeHandler bridgeHandler) {
         logger.trace("registerDeviceDiscoveryService({}) called.", bridgeHandler);
-        boolean createNew = (discoveryService == null);
-        if (createNew) {
+        boolean createNew = false;
+        VeluxDiscoveryService discoveryService = this.discoveryService;
+        if (discoveryService == null) {
             discoveryService = new VeluxDiscoveryService(localization);
+            createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);
         if (createNew) {
@@ -81,10 +83,14 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
 
     private synchronized void unregisterDeviceDiscoveryService(VeluxBridgeHandler bridgeHandler) {
         logger.trace("unregisterDeviceDiscoveryService({}) called.", bridgeHandler);
+        VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService != null) {
             discoveryService.removeBridge(bridgeHandler);
             if (discoveryService.isEmpty()) {
-                discoveryServiceRegistration.unregister();
+                ServiceRegistration<?> discoveryServiceRegistration = this.discoveryServiceRegistration;
+                if (discoveryServiceRegistration != null) {
+                    discoveryServiceRegistration.unregister();
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -156,7 +156,6 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
      * <LI>{@link #wlanConfig} - Information about the gateway configuration.</LI>
      * </UL>
      */
-    @NonNullByDefault
     public class BridgeParameters {
         /** Information retrieved by {@link VeluxBridgeActuators#getProducts} */
         public VeluxBridgeActuators actuators = new VeluxBridgeActuators();

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxKLFAPI.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxKLFAPI.java
@@ -66,7 +66,6 @@ public class VeluxKLFAPI {
      * <LI>Method {@link toString} to return a String.</LI>
      * </UL>
      */
-    @NonNullByDefault
     public static class CommandName {
         private String name;
 
@@ -90,7 +89,6 @@ public class VeluxKLFAPI {
      * <LI>Method {@link toString} to return a well-formatted String.</LI>
      * </UL>
      */
-    @NonNullByDefault
     public static class CommandNumber {
         private short commandNumber;
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxKLFAPI.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxKLFAPI.java
@@ -102,7 +102,7 @@ public class VeluxKLFAPI {
 
         @Override
         public String toString() {
-            return "0x" + Integer.toHexString(new Short(commandNumber).intValue());
+            return "0x" + Integer.toHexString(Short.valueOf(commandNumber).intValue());
         }
     }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProduct.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProduct.java
@@ -33,7 +33,6 @@ public class VeluxProduct {
 
     // Type definitions
 
-    @NonNullByDefault
     public static class ProductBridgeIndex {
 
         // Public definition

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProductState.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxProductState.java
@@ -37,7 +37,6 @@ public class VeluxProductState {
 
     // Type definitions
 
-    @NonNullByDefault
     private class ProductState {
 
         private int state;

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxScene.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/things/VeluxScene.java
@@ -45,7 +45,6 @@ public class VeluxScene {
 
     // Type definitions
 
-    @NonNullByDefault
     public static class SceneName {
 
         private static final SceneName UNKNOWN = new SceneName(VeluxBindingConstants.UNKNOWN);
@@ -66,7 +65,6 @@ public class VeluxScene {
         }
     }
 
-    @NonNullByDefault
     public static class SceneBridgeIndex {
 
         private static final SceneBridgeIndex UNKNOWN = new SceneBridgeIndex(0);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/utils/Localization.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/utils/Localization.java
@@ -53,7 +53,6 @@ public class Localization {
     /**
      * Class, which is needed to maintain a @NonNullByDefault for class {@link Localization}.
      */
-    @NonNullByDefault
     private class UnknownLocale implements LocaleProvider {
         @Override
         public Locale getLocale() {


### PR DESCRIPTION
In PR #8520 maven would produce about fifty non fatal compiler warnings (below), and this PR eliminates them..

- redundant NonNullByDefault code style warnings
- spurious potential null check warnings
- deprecated Java 11 method call warnings
- dependency on forbidden package warnings
