### PR TITLE
Fix disabled integration tests

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/test/java/org/openhab/binding/mqtt/homie/internal/handler/HomieThingHandlerTests.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.mqtt.homie.internal.handler;
 
+import static org.eclipse.jdt.annotation.Checks.requireNonNull;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -249,7 +250,7 @@ public class HomieThingHandlerTests {
         node.properties.put(property.propertyID, property);
         thingHandler.device.nodes.put(node.nodeID, node);
 
-        ChannelState channelState = property.getChannelState();
+        ChannelState channelState = requireNonNull(property.getChannelState());
         assertNotNull(channelState);
         ChannelStateHelper.setConnection(channelState, connection);// Pretend we called start()
         ThingHandlerHelper.setConnection(thingHandler, connection);

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/itest.bndrun
@@ -9,6 +9,10 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	bnd.identity;id='org.openhab.core.thing.xml',\
 	bnd.identity;id='org.openhab.io.mqttembeddedbroker'
 
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
+
 #
 # done
 #
@@ -83,6 +87,7 @@ Fragment-Host: org.openhab.binding.mqtt.homeassistant
 	org.openhab.core.transform;version='[3.0.0,3.0.1)',\
 	org.openhab.io.mqttembeddedbroker;version='[3.0.0,3.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)'
+	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)',\
+	moquette-broker;version='[0.13.0,0.13.1)'
 
 -runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/pom.xml
@@ -82,7 +82,6 @@
       <groupId>com.h2database</groupId>
       <artifactId>h2-mvstore</artifactId>
       <version>1.4.199</version>
-
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -99,7 +98,6 @@
       <artifactId>netty-handler</artifactId>
       <version>${netty.version}</version>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/DiscoverComponentsTest.java
@@ -26,6 +26,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,26 +51,26 @@ import com.google.gson.GsonBuilder;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class DiscoverComponentsTest extends JavaOSGiTest {
 
-    private AutoCloseable mocksCloseable;
+    private @NonNullByDefault({}) AutoCloseable mocksCloseable;
 
-    private @Mock MqttBrokerConnection connection;
-    private @Mock ComponentDiscovered discovered;
-    private @Mock TransformationServiceProvider transformationServiceProvider;
-    private @Mock ChannelStateUpdateListener channelStateUpdateListener;
-    private @Mock AvailabilityTracker availabilityTracker;
+    private @Mock @NonNullByDefault({}) MqttBrokerConnection connection;
+    private @Mock @NonNullByDefault({}) ComponentDiscovered discovered;
+    private @Mock @NonNullByDefault({}) TransformationServiceProvider transformationServiceProvider;
+    private @Mock @NonNullByDefault({}) ChannelStateUpdateListener channelStateUpdateListener;
+    private @Mock @NonNullByDefault({}) AvailabilityTracker availabilityTracker;
 
     @BeforeEach
     public void beforeEach() {
         mocksCloseable = openMocks(this);
 
-        CompletableFuture<Void> voidFutureComplete = new CompletableFuture<>();
+        CompletableFuture<@Nullable Void> voidFutureComplete = new CompletableFuture<>();
         voidFutureComplete.complete(null);
         doReturn(voidFutureComplete).when(connection).unsubscribeAll();
         doReturn(CompletableFuture.completedFuture(true)).when(connection).subscribe(any(), any());
         doReturn(CompletableFuture.completedFuture(true)).when(connection).unsubscribe(any(), any());
-        doReturn(CompletableFuture.completedFuture(true)).when(connection).publish(any(), any());
         doReturn(CompletableFuture.completedFuture(true)).when(connection).publish(any(), any(), anyInt(),
                 anyBoolean());
         doReturn(null).when(transformationServiceProvider).getTransformationService(any());

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -50,7 +49,7 @@ public class EmbeddedBrokerTools {
             MqttServiceObserver observer = new MqttServiceObserver() {
 
                 @Override
-                public void brokerAdded(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerAdded(String brokerID, MqttBrokerConnection broker) {
                     if (brokerID.equals(Constants.CLIENTID)) {
                         embeddedConnection = broker;
                         semaphore.release();
@@ -58,7 +57,7 @@ public class EmbeddedBrokerTools {
                 }
 
                 @Override
-                public void brokerRemoved(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerRemoved(String brokerID, MqttBrokerConnection broker) {
                 }
             };
             mqttService.addBrokersListener(observer);

--- a/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
+++ b/itests/org.openhab.binding.mqtt.homeassistant.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt;
 
 import static org.openhab.binding.mqtt.homeassistant.generic.internal.MqttBindingConstants.HOMEASSISTANT_MQTT_THING;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingUID;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.thing.ThingUID;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class ThingChannelConstants {
     // Common ThingUID and ChannelUIDs
     public static final ThingUID testHomeAssistantThing = new ThingUID(HOMEASSISTANT_MQTT_THING, "device234");

--- a/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
+++ b/itests/org.openhab.binding.mqtt.homie.tests/itest.bndrun
@@ -9,6 +9,10 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	bnd.identity;id='org.openhab.core.thing.xml',\
 	bnd.identity;id='org.openhab.io.mqttembeddedbroker'
 
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
+
 #
 # done
 #
@@ -83,5 +87,6 @@ Fragment-Host: org.openhab.binding.mqtt.homie
 	org.openhab.core.transform;version='[3.0.0,3.0.1)',\
 	org.openhab.io.mqttembeddedbroker;version='[3.0.0,3.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)'
+	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)',\
+	moquette-broker;version='[0.13.0,0.13.1)'
 -runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/EmbeddedBrokerTools.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -53,7 +52,7 @@ public class EmbeddedBrokerTools {
             MqttServiceObserver observer = new MqttServiceObserver() {
 
                 @Override
-                public void brokerAdded(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerAdded(String brokerID, MqttBrokerConnection broker) {
                     if (brokerID.equals(Constants.CLIENTID)) {
                         embeddedConnection = broker;
                         semaphore.release();
@@ -61,7 +60,7 @@ public class EmbeddedBrokerTools {
                 }
 
                 @Override
-                public void brokerRemoved(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerRemoved(String brokerID, MqttBrokerConnection broker) {
                 }
             };
             mqttService.addBrokersListener(observer);

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +31,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,25 +65,26 @@ import org.openhab.core.types.UnDefType;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class HomieImplementationTest extends JavaOSGiTest {
     private static final String BASE_TOPIC = "homie";
     private static final String DEVICE_ID = ThingChannelConstants.testHomieThing.getId();
     private static final String DEVICE_TOPIC = BASE_TOPIC + "/" + DEVICE_ID;
 
-    private MqttService mqttService;
-    private MqttBrokerConnection embeddedConnection;
-    private MqttBrokerConnection connection;
+    private @NonNullByDefault({}) MqttService mqttService;
+    private @NonNullByDefault({}) MqttBrokerConnection embeddedConnection;
+    private @NonNullByDefault({}) MqttBrokerConnection connection;
     private int registeredTopics = 100;
 
-    private AutoCloseable mocksCloseable;
+    private @NonNullByDefault({}) AutoCloseable mocksCloseable;
 
     // The handler is not tested here, so just mock the callback
-    private @Mock DeviceCallback callback;
+    private @Mock @NonNullByDefault({}) DeviceCallback callback;
 
     // A handler mock is required to verify that channel value changes have been received
-    private @Mock HomieThingHandler handler;
+    private @Mock @NonNullByDefault({}) HomieThingHandler handler;
 
-    private ScheduledExecutorService scheduler;
+    private ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(6);
 
     /**
      * Create an observer that fails the test as soon as the broker client connection changes its connection state
@@ -92,7 +93,7 @@ public class HomieImplementationTest extends JavaOSGiTest {
     private MqttConnectionObserver failIfChange = (state, error) -> assertThat(state,
             is(MqttConnectionState.CONNECTED));
 
-    private String propertyTestTopic;
+    private String propertyTestTopic = "";
 
     @BeforeEach
     public void beforeEach() throws Exception {
@@ -102,55 +103,56 @@ public class HomieImplementationTest extends JavaOSGiTest {
 
         embeddedConnection = new EmbeddedBrokerTools().waitForConnection(mqttService);
         embeddedConnection.setQos(1);
-        embeddedConnection.setRetain(true);
 
         connection = new MqttBrokerConnection(embeddedConnection.getHost(), embeddedConnection.getPort(),
                 embeddedConnection.isSecure(), "homie");
         connection.setQos(1);
-        connection.setPersistencePath(Paths.get("subconn"));
         connection.start().get(500, TimeUnit.MILLISECONDS);
         assertThat(connection.connectionState(), is(MqttConnectionState.CONNECTED));
         // If the connection state changes in between -> fail
         connection.addConnectionObserver(failIfChange);
 
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$homie", "3.0".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$name", "Name".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$state", "ready".getBytes()));
-        futures.add(embeddedConnection.publish(DEVICE_TOPIC + "/$nodes", "testnode".getBytes()));
+        futures.add(publish(DEVICE_TOPIC + "/$homie", "3.0"));
+        futures.add(publish(DEVICE_TOPIC + "/$name", "Name"));
+        futures.add(publish(DEVICE_TOPIC + "/$state", "ready"));
+        futures.add(publish(DEVICE_TOPIC + "/$nodes", "testnode"));
 
         // Add homie node topics
         final String testNode = DEVICE_TOPIC + "/testnode";
-        futures.add(embeddedConnection.publish(testNode + "/$name", "Testnode".getBytes()));
-        futures.add(embeddedConnection.publish(testNode + "/$type", "Type".getBytes()));
-        futures.add(
-                embeddedConnection.publish(testNode + "/$properties", "temperature,doorbell,testRetain".getBytes()));
+        futures.add(publish(testNode + "/$name", "Testnode"));
+        futures.add(publish(testNode + "/$type", "Type"));
+        futures.add(publish(testNode + "/$properties", "temperature,doorbell,testRetain"));
 
         // Add homie property topics
         final String property = testNode + "/temperature";
-        futures.add(embeddedConnection.publish(property, "10".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$name", "Testprop".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$settable", "true".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$unit", "°C".getBytes(StandardCharsets.UTF_8)));
-        futures.add(embeddedConnection.publish(property + "/$datatype", "float".getBytes()));
-        futures.add(embeddedConnection.publish(property + "/$format", "-100:100".getBytes()));
+        futures.add(publish(property, "10"));
+        futures.add(publish(property + "/$name", "Testprop"));
+        futures.add(publish(property + "/$settable", "true"));
+        futures.add(publish(property + "/$unit", "°C"));
+        futures.add(publish(property + "/$datatype", "float"));
+        futures.add(publish(property + "/$format", "-100:100"));
 
         final String propertyBellTopic = testNode + "/doorbell";
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$name", "Doorbell".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$settable", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyBellTopic + "/$datatype", "boolean".getBytes()));
+        futures.add(publish(propertyBellTopic + "/$name", "Doorbell"));
+        futures.add(publish(propertyBellTopic + "/$settable", "false"));
+        futures.add(publish(propertyBellTopic + "/$retained", "false"));
+        futures.add(publish(propertyBellTopic + "/$datatype", "boolean"));
 
         this.propertyTestTopic = testNode + "/testRetain";
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$name", "Test".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$settable", "true".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$retained", "false".getBytes()));
-        futures.add(embeddedConnection.publish(propertyTestTopic + "/$datatype", "boolean".getBytes()));
+        futures.add(publish(propertyTestTopic + "/$name", "Test"));
+        futures.add(publish(propertyTestTopic + "/$settable", "true"));
+        futures.add(publish(propertyTestTopic + "/$retained", "false"));
+        futures.add(publish(propertyTestTopic + "/$datatype", "boolean"));
 
         registeredTopics = futures.size();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
         scheduler = new ScheduledThreadPoolExecutor(6);
+    }
+
+    private CompletableFuture<Boolean> publish(String topic, String message) {
+        return embeddedConnection.publish(topic, message.getBytes(StandardCharsets.UTF_8), 0, true);
     }
 
     @AfterEach

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/HomieImplementationTest.java
@@ -84,7 +84,7 @@ public class HomieImplementationTest extends JavaOSGiTest {
     // A handler mock is required to verify that channel value changes have been received
     private @Mock @NonNullByDefault({}) HomieThingHandler handler;
 
-    private ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(6);
+    private @NonNullByDefault({}) ScheduledExecutorService scheduler;
 
     /**
      * Create an observer that fails the test as soon as the broker client connection changes its connection state

--- a/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
+++ b/itests/org.openhab.binding.mqtt.homie.tests/src/main/java/org/openhab/binding/mqtt/ThingChannelConstants.java
@@ -14,6 +14,7 @@ package org.openhab.binding.mqtt;
 
 import static org.openhab.binding.mqtt.homie.generic.internal.MqttBindingConstants.HOMIE300_MQTT_THING;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingUID;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.thing.ThingUID;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class ThingChannelConstants {
     // Common ThingUID and ChannelUIDs
     public final static ThingUID testHomieThing = new ThingUID(HOMIE300_MQTT_THING, "device123");

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/itest.bndrun
@@ -4,7 +4,11 @@ Bundle-SymbolicName: ${project.artifactId}
 Fragment-Host: org.openhab.io.mqttembeddedbroker
 
 -runrequires: \
-  bnd.identity;id='org.openhab.io.mqttembeddedbroker.tests'
+	bnd.identity;id='org.openhab.io.mqttembeddedbroker.tests'
+
+# We would like to use the "volatile" storage only
+-runblacklist: \
+	bnd.identity;id='org.openhab.core.storage.json'
 
 #
 # done
@@ -67,5 +71,6 @@ Fragment-Host: org.openhab.io.mqttembeddedbroker
 	org.openhab.io.mqttembeddedbroker;version='[3.0.0,3.0.1)',\
 	org.openhab.io.mqttembeddedbroker.tests;version='[3.0.0,3.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)'
+	org.reactivestreams.reactive-streams;version='[1.0.2,1.0.3)',\
+	moquette-broker;version='[0.13.0,0.13.1)'
 -runvm: -Dio.netty.noUnsafe=true

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/EmbeddedBrokerTools.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
@@ -52,7 +51,7 @@ public class EmbeddedBrokerTools {
             MqttServiceObserver observer = new MqttServiceObserver() {
 
                 @Override
-                public void brokerAdded(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerAdded(String brokerID, MqttBrokerConnection broker) {
                     if (brokerID.equals(Constants.CLIENTID)) {
                         embeddedConnection = broker;
                         semaphore.release();
@@ -60,7 +59,7 @@ public class EmbeddedBrokerTools {
                 }
 
                 @Override
-                public void brokerRemoved(@NonNull String brokerID, @NonNull MqttBrokerConnection broker) {
+                public void brokerRemoved(String brokerID, MqttBrokerConnection broker) {
                 }
             };
             mqttService.addBrokersListener(observer);

--- a/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
+++ b/itests/org.openhab.io.mqttembeddedbroker.tests/src/main/java/org/openhab/io/mqttembeddedbroker/MoquetteTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,14 +41,15 @@ import org.openhab.core.test.java.JavaOSGiTest;
  *
  * @author Jan N. Klug - Initial contribution
  */
+@NonNullByDefault
 public class MoquetteTest extends JavaOSGiTest {
     private static final String TEST_TOPIC = "testtopic";
 
-    private AutoCloseable mocksCloseable;
+    private @NonNullByDefault({}) AutoCloseable mocksCloseable;
 
-    private MqttService mqttService;
-    private MqttBrokerConnection embeddedConnection;
-    private MqttBrokerConnection clientConnection;
+    private @NonNullByDefault({}) MqttService mqttService;
+    private @NonNullByDefault({}) MqttBrokerConnection embeddedConnection;
+    private @NonNullByDefault({}) MqttBrokerConnection clientConnection;
 
     /**
      * Create an observer that fails the test as soon as the broker client connection changes its connection state
@@ -84,11 +86,15 @@ public class MoquetteTest extends JavaOSGiTest {
         mocksCloseable.close();
     }
 
+    private CompletableFuture<Boolean> publish(String topic, String message) {
+        return embeddedConnection.publish(topic, message.getBytes(StandardCharsets.UTF_8), 0, true);
+    }
+
     @Test
     public void singleTopic() throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC, "testPayload".getBytes(StandardCharsets.UTF_8), 1, true));
+        futures.add(publish(TEST_TOPIC, "testPayload"));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
@@ -105,10 +111,8 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
-                true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
-                true));
+        futures.add(publish(TEST_TOPIC + "/1", "testPayload1"));
+        futures.add(publish(TEST_TOPIC + "/2", "testPayload2"));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
@@ -126,10 +130,8 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
-                true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
-                true));
+        futures.add(publish(TEST_TOPIC + "/1", "testPayload1"));
+        futures.add(publish(TEST_TOPIC + "/2", "testPayload2"));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 
@@ -146,10 +148,8 @@ public class MoquetteTest extends JavaOSGiTest {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
 
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/1", "testPayload1".getBytes(StandardCharsets.UTF_8), 1,
-                true));
-        futures.add(embeddedConnection.publish(TEST_TOPIC + "/2", "testPayload2".getBytes(StandardCharsets.UTF_8), 1,
-                true));
+        futures.add(publish(TEST_TOPIC + "/1", "testPayload1"));
+        futures.add(publish(TEST_TOPIC + "/2", "testPayload2"));
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(1000, TimeUnit.MILLISECONDS);
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -23,11 +23,14 @@
     <module>org.openhab.binding.hue.tests</module>
     <module>org.openhab.binding.max.tests</module>
     <module>org.openhab.binding.modbus.tests</module>
+    <module>org.openhab.binding.mqtt.homeassistant.tests</module>
+    <module>org.openhab.binding.mqtt.homie.tests</module>
     <module>org.openhab.binding.nest.tests</module>
     <module>org.openhab.binding.ntp.tests</module>
     <module>org.openhab.binding.systeminfo.tests</module>
     <module>org.openhab.binding.tradfri.tests</module>
     <module>org.openhab.binding.wemo.tests</module>
+    <module>org.openhab.io.mqttembeddedbroker.tests</module>
     <module>org.openhab.persistence.mapdb.tests</module>
   </modules>
 


### PR DESCRIPTION
Fixes and enables:

* org.openhab.binding.mqtt.homeassistant.tests
* org.openhab.binding.mqtt.homie.tests
* org.openhab.io.mqttembeddedbroker.tests

Fixes #8537