### PR TITLE
Adds exceptions for KarafAddonFeatureCheck

### DIFF
--- a/bundles/org.openhab.binding.remoteopenhab/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.remoteopenhab/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 
 	<feature name="openhab-binding-remoteopenhab" description="Remote openHAB Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.remoteopenhab/${project.version}
-		</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.remoteopenhab/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.velux/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.velux/src/main/feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="org.openhab.binding.netatmo-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="org.openhab.binding.velux-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-velux" description="Velux Binding" version="${project.version}">

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -3,3 +3,5 @@ checkstyle.headerCheck.values=2010,2021
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time,tec.uom.se
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.requiredFilesCheck.files=pom.xml
+checkstyle.karafAddonFeatureCheck.featureNamePatterns=-transform-:-transformation-,-io-transport-modbus:-transport-modbus,-io-:-misc-,mqttembeddedbroker:mqttbroker
+checkstyle.karafAddonFeatureCheck.excludeFeatureNames=openhab-persistence-jdbc

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -3,5 +3,5 @@ checkstyle.headerCheck.values=2010,2021
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time,tec.uom.se
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.requiredFilesCheck.files=pom.xml
-checkstyle.karafAddonFeatureCheck.featureNamePatterns=-transform-:-transformation-,-io-transport-modbus:-transport-modbus,-io-:-misc-,mqttembeddedbroker:mqttbroker
-checkstyle.karafAddonFeatureCheck.excludeFeatureNames=openhab-persistence-jdbc
+checkstyle.karafAddonFeatureCheck.featureNameMappings=-transform-:-transformation-,-io-:-misc-
+checkstyle.karafAddonFeatureCheck.excludeAddonPatterns=org.openhab.persistence.jdbc.*,org.openhab.binding.modbus.*


### PR DESCRIPTION
This adds the configuration to get things working when the new sat check for the feature.xml would be merged, released and activated here. See https://github.com/openhab/static-code-analysis/pull/395

Depending on review comments on the sat pr there might be changes to this pr required. So it should not be merged before the sat pr is merged.