### PR TITLE
[hue] Improve HueBridgeHandlerOSGiTest stability

### DIFF
--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -67,4 +67,5 @@ Fragment-Host: org.openhab.binding.hue
 	org.openhab.core.test;version='[3.0.0,3.0.1)',\
 	org.openhab.core.thing;version='[3.0.0,3.0.1)',\
 	org.openhab.core.thing.xml;version='[3.0.0,3.0.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)'

--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.hue.internal.handler;
 
+import static org.eclipse.jdt.annotation.Checks.requireNonNull;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,7 +51,7 @@ import org.openhab.core.thing.ThingUID;
  */
 public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
 
-    private final ThingTypeUID BRIDGE_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "bridge");
+    private static final ThingTypeUID BRIDGE_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "bridge");
     private static final String TEST_USER_NAME = "eshTestUser";
     private static final String DUMMY_HOST = "1.2.3.4";
 
@@ -132,7 +133,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
         hueBridgeHandler.onNotAuthenticated();
 
         assertEquals("notAuthenticatedUser", bridge.getConfiguration().get(USER_NAME));
-        assertEquals(ThingStatus.OFFLINE, bridge.getStatus());
+        waitForAssert(() -> assertEquals(ThingStatus.OFFLINE, bridge.getStatus()));
         assertEquals(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, bridge.getStatusInfo().getStatusDetail());
     }
 
@@ -156,7 +157,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
         hueBridgeHandler.onNotAuthenticated();
 
         assertNull(bridge.getConfiguration().get(USER_NAME));
-        assertEquals(ThingStatus.OFFLINE, bridge.getStatus());
+        waitForAssert(() -> assertEquals(ThingStatus.OFFLINE, bridge.getStatus()));
         assertEquals(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, bridge.getStatusInfo().getStatusDetail());
     }
 
@@ -180,7 +181,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
         hueBridgeHandler.onNotAuthenticated();
 
         assertNull(bridge.getConfiguration().get(USER_NAME));
-        assertEquals(ThingStatus.OFFLINE, bridge.getStatus());
+        waitForAssert(() -> assertEquals(ThingStatus.OFFLINE, bridge.getStatus()));
         assertEquals(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, bridge.getStatusInfo().getStatusDetail());
     }
 
@@ -196,7 +197,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
 
         hueBridgeHandler.onConnectionLost();
 
-        assertEquals(ThingStatus.OFFLINE, bridge.getStatus());
+        waitForAssert(() -> assertEquals(ThingStatus.OFFLINE, bridge.getStatus()));
         assertNotEquals(ThingStatusDetail.BRIDGE_OFFLINE, bridge.getStatusInfo().getStatusDetail());
     }
 
@@ -236,7 +237,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
         Bridge bridge = (Bridge) thingRegistry.createThingOfType(BRIDGE_THING_TYPE_UID,
                 new ThingUID(BRIDGE_THING_TYPE_UID, "testBridge"), null, "Bridge", configuration);
 
-        assertNotNull(bridge);
+        bridge = requireNonNull(bridge, "Bridge is null");
         thingRegistry.add(bridge);
         return bridge;
     }


### PR DESCRIPTION
The ThingStatus is updated asynchronously so the test is unstable when the status is not updated immediately.

See also https://ci.openhab.org/job/openHAB-Addons/69/ :

```
TEST org.openhab.binding.hue.internal.handler.HueBridgeHandlerOSGiTest#verifyStatusIfLinkButtonIsNotPressed() <<< ERROR: expected: <CONFIGURATION_ERROR> but was: <NONE>
org.opentest4j.AssertionFailedError: expected: <CONFIGURATION_ERROR> but was: <NONE>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
        at org.openhab.binding.hue.internal.handler.HueBridgeHandlerOSGiTest.verifyStatusIfLinkButtonIsNotPressed(HueBridgeHandlerOSGiTest.java:160)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
        at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
        at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
        at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
        at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
```