### PR TITLE
[velux] eliminate dependency on org.apache.commons.lang.StringUtils

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBinding.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/VeluxBinding.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.binding.velux.internal;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
-
 import java.lang.reflect.Field;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -65,11 +63,11 @@ public class VeluxBinding extends VeluxBridgeConfiguration {
             logger.debug("No configuration found, using default values.");
         } else {
             logger.trace("VeluxBinding(): checking {}.", VeluxBridgeConfiguration.BRIDGE_PROTOCOL);
-            if (isNotBlank(uncheckedConfiguration.protocol)) {
+            if (!uncheckedConfiguration.protocol.isBlank()) {
                 this.protocol = uncheckedConfiguration.protocol;
             }
             logger.trace("VeluxBinding(): checking {}.", VeluxBridgeConfiguration.BRIDGE_IPADDRESS);
-            if (isNotBlank(uncheckedConfiguration.ipAddress)) {
+            if (!uncheckedConfiguration.ipAddress.isBlank()) {
                 this.ipAddress = uncheckedConfiguration.ipAddress;
             }
             logger.trace("VeluxBinding(): checking {}.", VeluxBridgeConfiguration.BRIDGE_TCPPORT);
@@ -77,7 +75,7 @@ public class VeluxBinding extends VeluxBridgeConfiguration {
                 this.tcpPort = uncheckedConfiguration.tcpPort;
             }
             logger.trace("VeluxBinding(): checking {}.", VeluxBridgeConfiguration.BRIDGE_PASSWORD);
-            if (isNotBlank(uncheckedConfiguration.password)) {
+            if (!uncheckedConfiguration.password.isBlank()) {
                 this.password = uncheckedConfiguration.password;
             }
             logger.trace("VeluxBinding(): checking {}.", VeluxBridgeConfiguration.BRIDGE_TIMEOUT_MSECS);


### PR DESCRIPTION
Removed one further dependency on `org.apache.commons.lang.StringUtils` that had been overlooked before