### PR TITLE
remove embedded broker

### DIFF
--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1368,11 +1368,6 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
-      <artifactId>org.openhab.io.mqttembeddedbroker</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.transform.bin2json</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/features/openhab-addons/pom.xml
+++ b/features/openhab-addons/pom.xml
@@ -49,6 +49,7 @@
                     <exclude name="**/org.openhab.binding.bluetooth*/**/feature.xml"/>
                     <exclude name="**/org.openhab.binding.modbus*/**/feature.xml"/>
                     <exclude name="**/org.openhab.binding.mqtt*/**/feature.xml"/>
+                    <exclude name="**/org.openhab.io.mqttembeddedbroker/**/feature.xml"/>
                   </fileset>
                   <filterchain>
                     <linecontainsRegExp>


### PR DESCRIPTION
As discussed before the embedded broker will be removed for OH3 as the underlying moquette library has issues and is not maintained anymore.

This leaves the code in place for the itests but removes the feature and the bundle from the addons-bom.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>

