### PR TITLE
Configure XStream security and resolve itest bundles

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -64,6 +64,8 @@ public class CcuGateway extends AbstractHomematicGateway {
             HttpClient httpClient) {
         super(id, config, gatewayAdapter, httpClient);
 
+        XStream.setupDefaultSecurity(xStream);
+        xStream.allowTypesByWildcard(new String[] { HmDevice.class.getPackageName() + ".**" });
         xStream.setClassLoader(CcuGateway.class.getClassLoader());
         xStream.autodetectAnnotations(true);
         xStream.alias("scripts", TclScriptList.class);

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryService.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryService.java
@@ -148,6 +148,8 @@ public class LcnPchkDiscoveryService extends AbstractDiscoveryService {
 
     ServicesResponse xmlToServiceResponse(String response) {
         XStream xstream = new XStream(new StaxDriver());
+        XStream.setupDefaultSecurity(xstream);
+        xstream.allowTypesByWildcard(new String[] { ServicesResponse.class.getPackageName() + ".**" });
         xstream.setClassLoader(getClass().getClassLoader());
         xstream.autodetectAnnotations(true);
         xstream.alias("ServicesResponse", ServicesResponse.class);

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
@@ -49,15 +49,21 @@ public class DbXmlInfoReader {
 
         xstream = new XStream(driver);
 
+        configureSecurity(xstream);
         setClassLoader(Project.class.getClassLoader());
-        registerAliases(this.xstream);
+        registerAliases(xstream);
     }
 
-    public void setClassLoader(ClassLoader classLoader) {
+    private void configureSecurity(XStream xstream) {
+        XStream.setupDefaultSecurity(xstream);
+        xstream.allowTypesByWildcard(new String[] { Project.class.getPackageName() + ".**" });
+    }
+
+    private void setClassLoader(ClassLoader classLoader) {
         xstream.setClassLoader(classLoader);
     }
 
-    public void registerAliases(XStream xstream) {
+    private void registerAliases(XStream xstream) {
         xstream.alias("Project", Project.class);
         xstream.aliasField("AppVer", Project.class, "appVersion");
         xstream.aliasField("XMLVer", Project.class, "xmlVersion");

--- a/itests/org.openhab.binding.feed.tests/itest.bndrun
+++ b/itests/org.openhab.binding.feed.tests/itest.bndrun
@@ -23,7 +23,6 @@ Fragment-Host: org.openhab.binding.feed
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -71,4 +70,5 @@ Fragment-Host: org.openhab.binding.feed
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.hue.tests/itest.bndrun
+++ b/itests/org.openhab.binding.hue.tests/itest.bndrun
@@ -26,7 +26,6 @@ Fragment-Host: org.openhab.binding.hue
 	org.jupnp;version='[2.5.2,2.5.3)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
@@ -72,4 +71,5 @@ Fragment-Host: org.openhab.binding.hue
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.max.tests/itest.bndrun
+++ b/itests/org.openhab.binding.max.tests/itest.bndrun
@@ -27,7 +27,6 @@ Fragment-Host: org.openhab.binding.max
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -58,4 +57,5 @@ Fragment-Host: org.openhab.binding.max
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -45,7 +45,6 @@ Fragment-Host: org.openhab.binding.modbus
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	org.apache.commons.commons-pool2;version='[2.8.1,2.8.2)',\
@@ -77,4 +76,5 @@ Fragment-Host: org.openhab.binding.modbus
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.nest.tests/itest.bndrun
+++ b/itests/org.openhab.binding.nest.tests/itest.bndrun
@@ -26,7 +26,6 @@ Fragment-Host: org.openhab.binding.nest
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
@@ -86,4 +85,5 @@ Fragment-Host: org.openhab.binding.nest
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.ntp.tests/itest.bndrun
+++ b/itests/org.openhab.binding.ntp.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.binding.ntp
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -63,4 +62,5 @@ Fragment-Host: org.openhab.binding.ntp
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.systeminfo.tests/itest.bndrun
@@ -25,7 +25,6 @@ Fragment-Host: org.openhab.binding.systeminfo
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -66,4 +65,5 @@ Fragment-Host: org.openhab.binding.systeminfo
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -27,7 +27,6 @@ Fragment-Host: org.openhab.binding.tradfri
 	javax.jmdns;version='[3.5.5,3.5.6)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.binding.tradfri
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.binding.wemo.tests/itest.bndrun
+++ b/itests/org.openhab.binding.wemo.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.binding.wemo
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
@@ -77,4 +76,5 @@ Fragment-Host: org.openhab.binding.wemo
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
+	xstream;version='[1.4.13,1.4.14)'


### PR DESCRIPTION
* Configures XStream security to prevent "Security framework of XStream not initialized, XStream is probably vulnerable" warnings.
* Resolves the itest bundles for the upgrade to XStream 1.4.13

Depends on openhab/openhab-core#1688