### PR TITLE
Fix build errors

### DIFF
--- a/bundles/org.openhab.binding.lametrictime/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lametrictime/src/main/feature/feature.xml
@@ -5,6 +5,7 @@
 	<feature name="openhab-binding-lametrictime" description="LaMetric Time Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-upnp</feature>
+		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.2.1/1.2.1_2</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.lametrictime/${project.version}</bundle>
 	</feature>
 </features>

--- a/itests/org.openhab.binding.astro.tests/itest.bndrun
+++ b/itests/org.openhab.binding.astro.tests/itest.bndrun
@@ -19,7 +19,6 @@ Fragment-Host: org.openhab.binding.astro
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
@@ -44,4 +43,5 @@ Fragment-Host: org.openhab.binding.astro
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
-	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)'
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'


### PR DESCRIPTION
This fixed the build errors I was seeing for the lameterictime addon.

After fixing that I also encountered another error regarding extra tabs getting included in the generate `features/openhab-addons/src/main/feature/feature.xml`. I have no idea what caused it but I haven't been able to reproduce it.

The changes to the astro bnd file is just a sideeffect of building I guess, since I never modified that file manually.

Hopefully this PR will be enough to get the jenkins build working again.

Signed-off-by: Connor Petty <mistercpp2000+gitsignoff@gmail.com>