### PR TITLE
[WLed]  Initial contribution - Binding for LED strings with a large range of built in FX.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -262,6 +262,7 @@
 /bundles/org.openhab.binding.wifiled/ @rvt @xylo
 /bundles/org.openhab.binding.windcentrale/ @marcelrv
 /bundles/org.openhab.binding.wlanthermo/ @CSchlipp
+/bundles/org.openhab.binding.wled/ @Skinah
 /bundles/org.openhab.binding.xmltv/ @clinique
 /bundles/org.openhab.binding.xmppclient/ @pavel-gololobov
 /bundles/org.openhab.binding.yamahareceiver/ @davidgraeff @zarusz

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1302,6 +1302,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+	<dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.wled</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.xmltv</artifactId>
       <version>${project.version}</version>

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1302,7 +1302,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-	<dependency>
       <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.wled</artifactId>
       <version>${project.version}</version>

--- a/bundles/org.openhab.binding.wled/NOTICE
+++ b/bundles/org.openhab.binding.wled/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -15,8 +15,8 @@ The auto discovery will find your WLED if your network supports mDNS and the UDP
 Before discovering any WLED devices, you may wish to name them by providing a 'Server description' in the WLED web page, CONFIG>User Interface> setup page.
 openHAB will then discover and auto name your WLED to the name provided as the 'Server description'.
 If it fails to find your WLED, you can still manually add a `wled` thing by using the UI or textual methods.
-For multiple segments, the binding will only auto find the first segment which has an index of 0.
-For any additional segments, you can add them manually and set the `segmentIndex` config to the correct number shown in the WLED control web page.
+For multiple segments, the binding will only auto find the first segment.
+For additional segments, you can add them manually and set the `segmentIndex` config to the correct number shown in the WLED control web page.
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -1,0 +1,96 @@
+# WLED Binding
+
+This openHAB binding allows you to auto discover and use LED strings based on the WLED project:
+<https://github.com/Aircoookie/WLED>
+
+## Fault Finding
+
+To watch what the binding does you can enter this in to the openHAB console, `log:set TRACE org.openhab.binding.wled` which will allow you to test the same commands in a web browser to determine if it is a bug in the binding, or in the firmware for WLED.
+Firmware 0.10.2 is working very well with this binding after extensive testing, so if an issue is found please report what firmware version you are using.
+
+## Supported Things
+
+| Thing Type ID | Description |
+|-|-|
+| `wled` | Use this for RGB and RGBW strings. |
+
+## Discovery
+
+The auto discovery will work with this binding if your network supports mDNS.
+If it fails to find your WLED, you can manually add a `wled` thing by using the UI or textual methods.
+The full example section below gives everything needed to quickly setup using textual config.
+
+## Thing Configuration
+
+| Parameter | Description |
+|-|-|
+| `address`| The full URL to your WLED device. Example is `http://192.168.0.2:80` |
+| `pollTime`| How often you want the states of the LED fetched in case you make changes with a non openHAB app, web browser, or the light is auto changing FX or presets. |
+| `saturationThreshold` | Allows you to use a colorpicker control linked to the `masterControls` channel to trigger only using the pure white LEDs when your using RGBW strings instead of creating fake white light from the RGB channels. Try setting the value to 12 or for RGB strings, leave this on 0. |
+
+## Channels
+
+| Channel | Type | Description |
+|-|-|-|
+| `masterControls` | Color | Gives you control over the WLED like it is any normal light. Tag this control for Alexa or Google/Nest to change the lights instantly to any colour, brightness or on/off state that you ask for regardless of what mode the light is in. |
+| `primaryColor` | Color | The primary colour used in FX. |
+| `primaryWhite` | Dimmer | The amount of white light used in the primary colour if you have RGBW LEDs. |
+| `secondaryColor` | Color | The secondary colour used in FX. |
+| `secondaryWhite` | Dimmer | The amount of white light used in the secondary colour if you have RGBW LEDs. |
+| `palettes` | String | A list of colour palettes you can select from that are used in the FX. |
+| `fx` | String |  A list of Effects you can select from. |
+| `speed` | Dimmer | Changes the speed of the loaded effect. |
+| `intensity` | Dimmer | Changes the intensity of the loaded effect. |
+| `presets` | String |  A list of presets that you can select from.  |
+| `presetCycle` | Switch | Turns ON/OFF the automatic changing from one preset to the next. |
+| `presetDuration` | Dimmer | How long it will display a preset for, before it begins to change from one preset to the next with `presetCycle` turned ON. |
+| `transformTime` | Dimmer | How long it takes to transform/morph from one look to the next. |
+| `sleep` | Switch | Turns on the sleep timer. |
+
+## Full Example
+
+*.things
+
+```
+Thing wled:wled:ChristmasTree "My Christmas Tree" @ "Lights" [address="http://192.168.0.4:80"]
+```
+
+*.items
+
+```
+Color XmasTree_MasterControls "Christmas Tree" ["Lighting"] {channel="wled:wled:ChristmasTree:masterControls"}
+Color XmasTree_Primary "Primary Color"    {channel="wled:wled:ChristmasTree:primaryColor"}
+Color XmasTree_Secondary   "Secondary Color"  {channel="wled:wled:ChristmasTree:secondaryColor"}
+String XmasTree_FX       "FX"        <text>{channel="wled:wled:ChristmasTree:fx"}
+String XmasTree_Palette  "Palette"   <colorwheel>    {channel="wled:wled:ChristmasTree:palettes"}
+String XmasTree_Presets  "Preset"    <text> {channel="wled:wled:ChristmasTree:presets"}
+Dimmer XmasTree_Speed    "FX Speed"  <time>  {channel="wled:wled:ChristmasTree:speed"}
+Dimmer XmasTree_Intensity "FX Intensity" {channel="wled:wled:ChristmasTree:intensity"}
+Switch XmasTree_PresetCycle "presetCycle" <time> {channel="wled:wled:ChristmasTree:presetCycle"}
+Dimmer XmasTree_PresetDuration "presetDuration" <time> {channel="wled:wled:ChristmasTree:presetDuration"}
+Dimmer XmasTree_TransformTime "presetTransformTime" <time> {channel="wled:wled:ChristmasTree:transformTime"}
+Switch XmasTree_Sleep    "Sleep"     <moon> {channel="wled:wled:ChristmasTree:sleep"}
+
+```
+
+*.sitemap
+
+```
+        Text label="XmasLights" icon="rgb"{
+            Switch item=XmasTree_MasterControls
+            Slider item=XmasTree_MasterControls
+            Colorpicker item=XmasTree_MasterControls
+            Switch item=XmasTree_Sleep
+            Colorpicker item=XmasTree_Primary
+            Colorpicker item=XmasTree_Secondary            
+            Selection item=XmasTree_FX
+            Selection item=XmasTree_Palette
+            Selection item=XmasTree_Presets
+            Default item=XmasTree_Speed  
+            Default item=XmasTree_Intensity            
+            Default item=XmasTree_PresetCycle  
+            Default item=XmasTree_PresetDuration 
+            Default item=XmasTree_TransformTime
+        }
+        
+```

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -37,9 +37,9 @@ If it fails to find your WLED, you can manually add a `wled` thing by using the 
 | `intensity` | Dimmer | Changes the intensity of the loaded effect. |
 | `presets` | String |  A list of presets that you can select from.  |
 | `presetCycle` | Switch | Turns ON/OFF the automatic changing from one preset to the next. |
-| `presetDuration` | Dimmer | How long it will display a preset for, before it begins to change from one preset to the next with `presetCycle` turned ON. |
-| `transformTime` | Dimmer | How long it takes to transform/morph from one look to the next. |
-| `sleep` | Switch | Turns on the sleep timer. |
+| `presetDuration` | Number:Time | How long in seconds it will display a preset for, before it begins to change from one preset to the next with `presetCycle` turned ON. |
+| `transformTime` | Number:Time | How long in seconds it takes to transform/morph from one look to the next. |
+| `sleep` | Switch | Turns on the sleep or 'night light' timer which can be configured to work in many different ways. Refer to WLED documentation for how this can be setup. The default action is the light will fade to OFF over the next 60 minutes. |
 
 ## Rule Actions
 
@@ -59,7 +59,7 @@ If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the
 *.sitemap
 
 ```
-Text label="XmasLights" icon="rgb"{
+        Text label="XmasLights" icon="rgb"{
             Switch item=XmasTree_MasterControls
             Slider item=XmasTree_MasterControls
             Colorpicker item=XmasTree_MasterControls
@@ -72,8 +72,8 @@ Text label="XmasLights" icon="rgb"{
             Default item=XmasTree_FXSpeed
             Default item=XmasTree_FXIntensity
             Default item=XmasTree_PresetCycle
-            Default item=XmasTree_PresetDuration
-            Default item=XmasTree_TransformTime
+            Selection item=XmasTree_PresetDuration mappings=[2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='1 minute']
+            Selection item=XmasTree_TransformTime mappings=[0='0 seconds', 2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='1 minute']
         }
         
 ```

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -45,6 +45,8 @@ For any additional segments, you can add them manually and set the `segmentIndex
 | `presetDuration` | Number:Time | How long in seconds it will display a preset for, before it begins to change from one preset to the next with `presetCycle` turned ON. |
 | `transformTime` | Number:Time | How long in seconds it takes to transform/morph from one look to the next. |
 | `sleep` | Switch | Turns on the sleep or 'night light' timer which can be configured to work in many different ways. Refer to WLED documentation for how this can be setup. The default action is the light will fade to OFF over the next 60 minutes. |
+| `syncSend` | Switch | Sends UDP packets that tell other WLED lights to follow this one. |
+| `syncReceive` | Switch | Allows UDP packets from other WLED lights to control this one. |
 
 ## Rule Actions
 

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -41,6 +41,17 @@ If it fails to find your WLED, you can manually add a `wled` thing by using the 
 | `transformTime` | Dimmer | How long it takes to transform/morph from one look to the next. |
 | `sleep` | Switch | Turns on the sleep timer. |
 
+## Rule Actions
+
+This binding has a rule Action `savePreset(int presetNumber)` which can save the current state of the WLED string into a preset slot that you can specify.
+Currently 1 to 16 are valid preset slots.
+
+In Xtend rules, you can use the Actions like this.
+
+```
+getActions("wled", "wled:wled:XmasTree").savePreset(5)
+```
+
 ## Sitemap Example
 
 If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the below and just change the name before the underscore to match what you named the `wled` thing when it was added.

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -52,20 +52,20 @@ The full example section below gives everything needed to quickly setup using te
 *.things
 
 ```
-Thing wled:wled:ChristmasTree "My Christmas Tree" @ "Lights" [address="http://192.168.0.4:80"]
+Thing wled:wled:XmasTree "My Christmas Tree" @ "Lights" [address="http://192.168.0.4:80"]
 ```
 
 *.items
 
 ```
 Color XmasTree_MasterControls "Christmas Tree" ["Lighting"] {channel="wled:wled:ChristmasTree:masterControls"}
-Color XmasTree_Primary "Primary Color"    {channel="wled:wled:ChristmasTree:primaryColor"}
-Color XmasTree_Secondary   "Secondary Color"  {channel="wled:wled:ChristmasTree:secondaryColor"}
-String XmasTree_FX       "FX"        <text>{channel="wled:wled:ChristmasTree:fx"}
-String XmasTree_Palette  "Palette"   <colorwheel>    {channel="wled:wled:ChristmasTree:palettes"}
+Color XmasTree_PrimaryColor "Primary Color"    {channel="wled:wled:ChristmasTree:primaryColor"}
+Color XmasTree_SecondaryColor   "Secondary Color"  {channel="wled:wled:ChristmasTree:secondaryColor"}
+String XmasTree_Effect      "FX"        <text>{channel="wled:wled:ChristmasTree:fx"}
+String XmasTree_Palettes  "Palette"   <colorwheel>    {channel="wled:wled:ChristmasTree:palettes"}
 String XmasTree_Presets  "Preset"    <text> {channel="wled:wled:ChristmasTree:presets"}
-Dimmer XmasTree_Speed    "FX Speed"  <time>  {channel="wled:wled:ChristmasTree:speed"}
-Dimmer XmasTree_Intensity "FX Intensity" {channel="wled:wled:ChristmasTree:intensity"}
+Dimmer XmasTree_FXSpeed    "FX Speed"  <time>  {channel="wled:wled:ChristmasTree:speed"}
+Dimmer XmasTree_FXIntensity "FX Intensity" {channel="wled:wled:ChristmasTree:intensity"}
 Switch XmasTree_PresetCycle "presetCycle" <time> {channel="wled:wled:ChristmasTree:presetCycle"}
 Dimmer XmasTree_PresetDuration "presetDuration" <time> {channel="wled:wled:ChristmasTree:presetDuration"}
 Dimmer XmasTree_TransformTime "presetTransformTime" <time> {channel="wled:wled:ChristmasTree:transformTime"}
@@ -76,20 +76,20 @@ Switch XmasTree_Sleep    "Sleep"     <moon> {channel="wled:wled:ChristmasTree:sl
 *.sitemap
 
 ```
-        Text label="XmasLights" icon="rgb"{
+Text label="XmasLights" icon="rgb"{
             Switch item=XmasTree_MasterControls
             Slider item=XmasTree_MasterControls
             Colorpicker item=XmasTree_MasterControls
             Switch item=XmasTree_Sleep
-            Colorpicker item=XmasTree_Primary
-            Colorpicker item=XmasTree_Secondary            
-            Selection item=XmasTree_FX
-            Selection item=XmasTree_Palette
+            Colorpicker item=XmasTree_PrimaryColor
+            Colorpicker item=XmasTree_SecondaryColor
+            Selection item=XmasTree_Effect
+            Selection item=XmasTree_Palettes
             Selection item=XmasTree_Presets
-            Default item=XmasTree_Speed  
-            Default item=XmasTree_Intensity            
-            Default item=XmasTree_PresetCycle  
-            Default item=XmasTree_PresetDuration 
+            Default item=XmasTree_FXSpeed
+            Default item=XmasTree_FXIntensity
+            Default item=XmasTree_PresetCycle
+            Default item=XmasTree_PresetDuration
             Default item=XmasTree_TransformTime
         }
         

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -24,7 +24,7 @@ For any additional segments, you can add them manually and set the `segmentIndex
 |-|-|-|-|
 | `address`| The full URL to your WLED device. Example is `http://192.168.0.2:80` | Y | |
 | `pollTime`| How often in seconds you want the states of the LED fetched in case you make changes with a non openHAB app, web browser, or the light is auto changing FX or presets. | Y | 10 |
-| `segmentIndex` | The index number to the LED segment you wish these channels to control. Leave on 0 if you do not know what a segment is. | Y | 0 |
+| `segmentIndex` | The index number to the LED segment you wish these channels to control. Leave on -1 if you do not know what a segment is. | Y | -1 |
 | `saturationThreshold` | Allows you to use a colorpicker control linked to the `masterControls` channel to trigger only using the pure white LEDs instead of creating fake white light from the RGB channels. Try setting the value to 12 or leave this on 0 for RGB strings. | Y | 0 |
 
 ## Channels

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -68,7 +68,7 @@ If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the
             Switch item=XmasTree_MasterControls
             Slider item=XmasTree_MasterControls
             Colorpicker item=XmasTree_MasterControls
-            Switch item=XmasTree_Sleep
+            Switch item=XmasTree_SleepTimer
             Colorpicker item=XmasTree_PrimaryColor
             Colorpicker item=XmasTree_SecondaryColor
             Selection item=XmasTree_Effect
@@ -77,8 +77,8 @@ If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the
             Default item=XmasTree_FXSpeed
             Default item=XmasTree_FXIntensity
             Default item=XmasTree_PresetCycle
-            Selection item=XmasTree_PresetDuration mappings=[2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='1 minute']
-            Selection item=XmasTree_TransformTime mappings=[0='0 seconds', 2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='1 minute']
+            Selection item=XmasTree_PresetDuration mappings=[2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='60 seconds']
+            Selection item=XmasTree_TransformTime mappings=[0='0 seconds', 2 ='2 seconds', 10='10 seconds', 30='30 seconds', 60='60 seconds']
         }
         
 ```

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -11,8 +11,12 @@ This binding allows you to auto discover and use LED strings based on the WLED p
 
 ## Discovery
 
-The auto discovery will work with this binding if your network supports mDNS.
-If it fails to find your WLED, you can manually add a `wled` thing by using the UI or textual methods.
+The auto discovery will find your WLED if your network supports mDNS and the UDP port 5353 is not blocked by a fire wall.
+Before discovering any WLED devices, you may wish to name them by providing a 'Server description' in the WLED web page, CONFIG>User Interface> setup page.
+openHAB will then discover and auto name your WLED to the name provided as the 'Server description'.
+If it fails to find your WLED, you can still manually add a `wled` thing by using the UI or textual methods.
+For multiple segments, the binding will only auto find the first segment which has an index of 0.
+For any additional segments, you can add them manually and set the `segmentIndex` config to the correct number shown in the WLED control web page.
 
 ## Thing Configuration
 
@@ -20,6 +24,7 @@ If it fails to find your WLED, you can manually add a `wled` thing by using the 
 |-|-|-|-|
 | `address`| The full URL to your WLED device. Example is `http://192.168.0.2:80` | Y | |
 | `pollTime`| How often in seconds you want the states of the LED fetched in case you make changes with a non openHAB app, web browser, or the light is auto changing FX or presets. | Y | 10 |
+| `segmentIndex` | The index number to the LED segment you wish these channels to control. Leave on 0 if you do not know what a segment is. | Y | 0 |
 | `saturationThreshold` | Allows you to use a colorpicker control linked to the `masterControls` channel to trigger only using the pure white LEDs instead of creating fake white light from the RGB channels. Try setting the value to 12 or leave this on 0 for RGB strings. | Y | 0 |
 
 ## Channels
@@ -54,7 +59,7 @@ getActions("wled", "wled:wled:XmasTree").savePreset(5)
 
 ## Sitemap Example
 
-If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the below and just change the name before the underscore to match what you named the `wled` thing when it was added.
+If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the below and just change the name before the underscore to match what you named the `wled` thing when it was added via the Inbox.
 
 *.sitemap
 

--- a/bundles/org.openhab.binding.wled/README.md
+++ b/bundles/org.openhab.binding.wled/README.md
@@ -1,12 +1,7 @@
 # WLED Binding
 
-This openHAB binding allows you to auto discover and use LED strings based on the WLED project:
+This binding allows you to auto discover and use LED strings based on the WLED project:
 <https://github.com/Aircoookie/WLED>
-
-## Fault Finding
-
-To watch what the binding does you can enter this in to the openHAB console, `log:set TRACE org.openhab.binding.wled` which will allow you to test the same commands in a web browser to determine if it is a bug in the binding, or in the firmware for WLED.
-Firmware 0.10.2 is working very well with this binding after extensive testing, so if an issue is found please report what firmware version you are using.
 
 ## Supported Things
 
@@ -18,15 +13,14 @@ Firmware 0.10.2 is working very well with this binding after extensive testing, 
 
 The auto discovery will work with this binding if your network supports mDNS.
 If it fails to find your WLED, you can manually add a `wled` thing by using the UI or textual methods.
-The full example section below gives everything needed to quickly setup using textual config.
 
 ## Thing Configuration
 
-| Parameter | Description |
-|-|-|
-| `address`| The full URL to your WLED device. Example is `http://192.168.0.2:80` |
-| `pollTime`| How often you want the states of the LED fetched in case you make changes with a non openHAB app, web browser, or the light is auto changing FX or presets. |
-| `saturationThreshold` | Allows you to use a colorpicker control linked to the `masterControls` channel to trigger only using the pure white LEDs when your using RGBW strings instead of creating fake white light from the RGB channels. Try setting the value to 12 or for RGB strings, leave this on 0. |
+| Parameter | Description | Required | Default |
+|-|-|-|-|
+| `address`| The full URL to your WLED device. Example is `http://192.168.0.2:80` | Y | |
+| `pollTime`| How often in seconds you want the states of the LED fetched in case you make changes with a non openHAB app, web browser, or the light is auto changing FX or presets. | Y | 10 |
+| `saturationThreshold` | Allows you to use a colorpicker control linked to the `masterControls` channel to trigger only using the pure white LEDs instead of creating fake white light from the RGB channels. Try setting the value to 12 or leave this on 0 for RGB strings. | Y | 0 |
 
 ## Channels
 
@@ -47,31 +41,9 @@ The full example section below gives everything needed to quickly setup using te
 | `transformTime` | Dimmer | How long it takes to transform/morph from one look to the next. |
 | `sleep` | Switch | Turns on the sleep timer. |
 
-## Full Example
+## Sitemap Example
 
-*.things
-
-```
-Thing wled:wled:XmasTree "My Christmas Tree" @ "Lights" [address="http://192.168.0.4:80"]
-```
-
-*.items
-
-```
-Color XmasTree_MasterControls "Christmas Tree" ["Lighting"] {channel="wled:wled:ChristmasTree:masterControls"}
-Color XmasTree_PrimaryColor "Primary Color"    {channel="wled:wled:ChristmasTree:primaryColor"}
-Color XmasTree_SecondaryColor   "Secondary Color"  {channel="wled:wled:ChristmasTree:secondaryColor"}
-String XmasTree_Effect      "FX"        <text>{channel="wled:wled:ChristmasTree:fx"}
-String XmasTree_Palettes  "Palette"   <colorwheel>    {channel="wled:wled:ChristmasTree:palettes"}
-String XmasTree_Presets  "Preset"    <text> {channel="wled:wled:ChristmasTree:presets"}
-Dimmer XmasTree_FXSpeed    "FX Speed"  <time>  {channel="wled:wled:ChristmasTree:speed"}
-Dimmer XmasTree_FXIntensity "FX Intensity" {channel="wled:wled:ChristmasTree:intensity"}
-Switch XmasTree_PresetCycle "presetCycle" <time> {channel="wled:wled:ChristmasTree:presetCycle"}
-Dimmer XmasTree_PresetDuration "presetDuration" <time> {channel="wled:wled:ChristmasTree:presetDuration"}
-Dimmer XmasTree_TransformTime "presetTransformTime" <time> {channel="wled:wled:ChristmasTree:transformTime"}
-Switch XmasTree_Sleep    "Sleep"     <moon> {channel="wled:wled:ChristmasTree:sleep"}
-
-```
+If you use the ADMIN>MODEL>`Create equipment from thing` feature you can use the below and just change the name before the underscore to match what you named the `wled` thing when it was added.
 
 *.sitemap
 

--- a/bundles/org.openhab.binding.wled/pom.xml
+++ b/bundles/org.openhab.binding.wled/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.wled</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: WLed Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features name="org.openhab.binding.wled-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 	<feature name="openhab-binding-wled" description="WLED Binding" version="${project.version}">
-		<feature>openhab-runtime-base</feature>		
+		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.wled/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.wled-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
-
 	<feature name="openhab-binding-wled" description="WLED Binding" version="${project.version}">
-		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.2</bundle>
+		<feature>openhab-runtime-base</feature>		
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.wled/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features name="org.openhab.binding.wled-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
 
-	<feature name="openhab-binding-wled" description="WLed Binding" version="${project.version}">
+	<feature name="openhab-binding-wled" description="WLED Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.2</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.wled/${project.version}</bundle>

--- a/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wled/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.wled-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+
+	<feature name="openhab-binding-wled" description="WLed Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.2</bundle>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.wled/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
@@ -14,11 +14,11 @@ package org.openhab.binding.wled.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingActionsScope;
 import org.openhab.core.thing.binding.ThingHandler;
-import org.openhab.core.automation.annotation.ActionInput;
-import org.openhab.core.automation.annotation.RuleAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
@@ -44,9 +44,9 @@ public class WLedActions implements ThingActions {
         return handler;
     }
 
-    @RuleAction(label = "Save Preset", description = "Save a WLED state to a preset location")
+    @RuleAction(label = "save state to preset", description = "Save a WLED state to a preset slot")
     public void savePreset(
-            @ActionInput(name = "presetNumber", label = "Save Preset Number", description = "Enter the number of the preset you wish to save") int presetNumber) {
+            @ActionInput(name = "presetNumber", label = "Save State to Preset Slot", description = "Enter the number for the preset slot you wish to use") int presetNumber) {
         if (presetNumber > 0 && handler != null) {
             handler.savePreset(presetNumber);
         }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
@@ -46,7 +46,7 @@ public class WLedActions implements ThingActions {
 
     @RuleAction(label = "save state to preset", description = "Save a WLED state to a preset slot")
     public void savePreset(
-            @ActionInput(name = "presetNumber", label = "Save State to Preset Slot", description = "Enter the number for the preset slot you wish to use") int presetNumber) {
+            @ActionInput(name = "presetNumber", label = "Preset Slot", description = "Number for the preset slot you wish to use") int presetNumber) {
         if (presetNumber > 0 && handler != null) {
             handler.savePreset(presetNumber);
         }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
@@ -47,8 +47,9 @@ public class WLedActions implements ThingActions {
     @RuleAction(label = "save state to preset", description = "Save a WLED state to a preset slot")
     public void savePreset(
             @ActionInput(name = "presetNumber", label = "Preset Slot", description = "Number for the preset slot you wish to use") int presetNumber) {
-        if (presetNumber > 0 && handler != null) {
-            handler.savePreset(presetNumber);
+        WLedHandler localHandler = handler;
+        if (presetNumber > 0 && localHandler != null) {
+            localHandler.savePreset(presetNumber);
         }
     }
 

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedActions.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wled.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WLedActions} is responsible for Actions.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+
+@ThingActionsScope(name = "wled")
+@NonNullByDefault
+public class WLedActions implements ThingActions {
+    public final Logger logger = LoggerFactory.getLogger(getClass());
+    private @Nullable WLedHandler handler;
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        this.handler = (WLedHandler) handler;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "Save Preset", description = "Save a WLED state to a preset location")
+    public void savePreset(
+            @ActionInput(name = "presetNumber", label = "Save Preset Number", description = "Enter the number of the preset you wish to save") int presetNumber) {
+        if (presetNumber > 0 && handler != null) {
+            handler.savePreset(presetNumber);
+        }
+    }
+
+    public static void savePreset(@Nullable ThingActions actions, int presetNumber) {
+        if (actions instanceof WLedActions) {
+            ((WLedActions) actions).savePreset(presetNumber);
+        } else {
+            throw new IllegalArgumentException("Instance is not a WLED class.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.wled.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link WLedBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class WLedBindingConstants {
+
+    public static final String BINDING_ID = "wled";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_WLED = new ThingTypeUID(BINDING_ID, "wled");
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>(
+            Arrays.asList(THING_TYPE_WLED));
+
+    // Configs
+    public static final String CONFIG_ADDRESS = "address";
+    public static final String CONFIG_POLL_TIME = "pollTime";
+    public static final String CONFIG_SAT_THRESHOLD = "saturationThreshold";
+
+    // Channels
+    public static final String CHANNEL_MASTER_CONTROLS = "masterControls";
+    public static final String CHANNEL_PRIMARY_COLOR = "primaryColor";
+    public static final String CHANNEL_SECONDARY_COLOR = "secondaryColor";
+    public static final String CHANNEL_PRIMARY_WHITE = "primaryWhite";
+    public static final String CHANNEL_SECONDARY_WHITE = "secondaryWhite";
+    public static final String CHANNEL_PALETTES = "palettes";
+    public static final String CHANNEL_PRESETS = "presets";
+    public static final String CHANNEL_PRESET_DURATION = "presetDuration";
+    public static final String CHANNEL_TRANS_TIME = "transformTime";
+    public static final String CHANNEL_PRESET_CYCLE = "presetCycle";
+    public static final String CHANNEL_FX = "fx";
+    public static final String CHANNEL_SPEED = "speed";
+    public static final String CHANNEL_INTENSITY = "intensity";
+    public static final String CHANNEL_SLEEP = "sleep";
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -39,6 +39,7 @@ public class WLedBindingConstants {
     // Configs
     public static final String CONFIG_ADDRESS = "address";
     public static final String CONFIG_POLL_TIME = "pollTime";
+    public static final String CONFIG_SEGMENT_INDEX = "segmentIndex";
     public static final String CONFIG_SAT_THRESHOLD = "saturationThreshold";
 
     // Channels

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -56,4 +56,6 @@ public class WLedBindingConstants {
     public static final String CHANNEL_SPEED = "speed";
     public static final String CHANNEL_INTENSITY = "intensity";
     public static final String CHANNEL_SLEEP = "sleep";
+    public static final String CHANNEL_SYNC_SEND = "syncSend";
+    public static final String CHANNEL_SYNC_RECEIVE = "syncReceive";
 }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -33,8 +33,7 @@ public class WLedBindingConstants {
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_WLED = new ThingTypeUID(BINDING_ID, "wled");
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>(
-            Arrays.asList(THING_TYPE_WLED));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_WLED);
 
     // Configs
     public static final String CONFIG_ADDRESS = "address";

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -13,8 +13,6 @@
 
 package org.openhab.binding.wled.internal;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedBindingConstants.java
@@ -13,6 +13,7 @@
 
 package org.openhab.binding.wled.internal;
 
+import java.math.BigDecimal;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -28,6 +29,7 @@ import org.openhab.core.thing.ThingTypeUID;
 public class WLedBindingConstants {
 
     public static final String BINDING_ID = "wled";
+    public static final BigDecimal BIG_DECIMAL_2_55 = new BigDecimal(2.55);
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_WLED = new ThingTypeUID(BINDING_ID, "wled");

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
@@ -23,5 +23,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class WLedConfiguration {
     public String address = "";
     public int pollTime;
+    public int segmentIndex;
     public int saturationThreshold;
 }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedConfiguration.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wled.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link WLedConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class WLedConfiguration {
+    public String address = "";
+    public int pollTime;
+    public int saturationThreshold;
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -84,32 +84,31 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
     @Override
     public @Nullable DiscoveryResult createResult(ServiceInfo service) {
         String name = service.getName().toLowerCase();
-        if (!name.equals("wled")) {
+        if (!name.contains("wled")) {
             return null;
         }
         String address[] = service.getURLs();
         if ((address == null) || address.length < 1) {
             logger.debug("WLED discovered with empty IP address-{}", service);
             return null;
-        } else {
-            String response = sendGetRequest(address[0], "/json");
-            // LinkedList<String> segmentIndexList = WLedHelper.listOfResults(response, "{\"id\":", ",");
-            // How to create multiple things from the returned list of segments?
-            String label = WLedHelper.getValue(response, "\"name\":\"", "\"");
-            if (label.isEmpty()) {
-                label = "WLED @ " + address[0];
-            }
-            String macAddress = WLedHelper.getValue(response, "\"mac\":\"", "\"");
-            String firmware = WLedHelper.getValue(response, "\"ver\":\"", "\"");
-            ThingTypeUID thingtypeuid = new ThingTypeUID("wled", "wled");
-            ThingUID thingUID = new ThingUID(thingtypeuid, macAddress);
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(Thing.PROPERTY_MAC_ADDRESS, macAddress);
-            properties.put(Thing.PROPERTY_FIRMWARE_VERSION, firmware);
-            return DiscoveryResultBuilder.create(thingUID).withProperty(CONFIG_ADDRESS, address[0])
-                    .withProperty(CONFIG_SEGMENT_INDEX, 0).withLabel(label).withProperties(properties)
-                    .withRepresentationProperty(Thing.PROPERTY_MAC_ADDRESS).build();
         }
+        String response = sendGetRequest(address[0], "/json");
+        // LinkedList<String> segmentIndexList = WLedHelper.listOfResults(response, "{\"id\":", ",");
+        // How to create multiple things from the returned list of segments?
+        String label = WLedHelper.getValue(response, "\"name\":\"", "\"");
+        if (label.isEmpty()) {
+            label = "WLED @ " + address[0];
+        }
+        String macAddress = WLedHelper.getValue(response, "\"mac\":\"", "\"");
+        String firmware = WLedHelper.getValue(response, "\"ver\":\"", "\"");
+        ThingTypeUID thingtypeuid = new ThingTypeUID("wled", "wled");
+        ThingUID thingUID = new ThingUID(thingtypeuid, macAddress);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Thing.PROPERTY_MAC_ADDRESS, macAddress);
+        properties.put(Thing.PROPERTY_FIRMWARE_VERSION, firmware);
+        return DiscoveryResultBuilder.create(thingUID).withProperty(CONFIG_ADDRESS, address[0])
+                .withProperty(CONFIG_SEGMENT_INDEX, -1).withLabel(label).withProperties(properties)
+                .withRepresentationProperty(Thing.PROPERTY_MAC_ADDRESS).build();
     }
 
     @Override

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.wled.internal;
+
+import static org.openhab.binding.wled.internal.WLedBindingConstants.*;
+
+import java.util.Set;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.mdns.MDNSDiscoveryParticipant;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WLedDiscoveryService} Discovers and adds any Wled devices found.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = MDNSDiscoveryParticipant.class, immediate = true)
+public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
+    private final Logger logger = LoggerFactory.getLogger(WLedDiscoveryService.class);
+
+    @Override
+    public @Nullable DiscoveryResult createResult(ServiceInfo service) {
+        String name = service.getName().toLowerCase();
+        if (!name.equals("wled")) {
+            return null;
+        }
+        String address[] = service.getURLs();
+        if ((address == null) || address.length < 1) {
+            logger.debug("WLED discovered with empty IP address-{}", service);
+            return null;
+        }
+        logger.info("WLED discovered at {}", address[0]);
+        ThingTypeUID thingtypeuid = new ThingTypeUID("wled", "wled");
+        ThingUID thingUID = new ThingUID(thingtypeuid,
+                address[0].substring(7, address[0].length() - 3).replace(".", "-"));
+        return DiscoveryResultBuilder.create(thingUID).withProperty(CONFIG_ADDRESS, address[0])
+                .withLabel("WLED @" + address[0]).build();
+    }
+
+    @Override
+    public @Nullable ThingUID getThingUID(ServiceInfo service) {
+        return null;
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return SUPPORTED_THING_TYPES;
+    }
+
+    @Override
+    public String getServiceType() {
+        return "_http._tcp.local.";
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Matthew Skinner - Initial contribution
  */
 @NonNullByDefault
-@Component(service = MDNSDiscoveryParticipant.class, immediate = true)
+@Component(service = MDNSDiscoveryParticipant.class)
 public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
     private final Logger logger = LoggerFactory.getLogger(WLedDiscoveryService.class);
 

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -15,6 +15,8 @@ package org.openhab.binding.wled.internal;
 
 import static org.openhab.binding.wled.internal.WLedBindingConstants.*;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.jmdns.ServiceInfo;
@@ -54,8 +56,13 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
         ThingTypeUID thingtypeuid = new ThingTypeUID("wled", "wled");
         ThingUID thingUID = new ThingUID(thingtypeuid,
                 address[0].substring(7, address[0].length() - 3).replace(".", "-"));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("address", address[0]);
+
         return DiscoveryResultBuilder.create(thingUID).withProperty(CONFIG_ADDRESS, address[0])
-                .withLabel("WLED @" + address[0]).build();
+                .withLabel("WLED @" + address[0]).withProperties(properties).withRepresentationProperty("address")
+                .build();
     }
 
     @Override

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -76,7 +76,7 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
         } catch (TimeoutException | ExecutionException e) {
             logger.debug(
                     "WLED discovery hit a TimeoutException | ExecutionException which may have blocked a device from getting discovered:{}",
-                    e.getCause());
+                    e.getMessage());
         }
         return "";
     }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -93,9 +93,11 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
             return null;
         } else {
             String response = sendGetRequest(address[0], "/json");
+            // LinkedList<String> segmentIndexList = WLedHelper.listOfResults(response, "{\"id\":", ",");
+            // How to create multiple things from the returned list of segments?
             String label = WLedHelper.getValue(response, "\"name\":\"", "\"");
             if (label.isEmpty()) {
-                label = "WLED Segment 0 @ " + address[0];
+                label = "WLED @ " + address[0];
             }
             String macAddress = WLedHelper.getValue(response, "\"mac\":\"", "\"");
             String firmware = WLedHelper.getValue(response, "\"ver\":\"", "\"");

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -74,6 +74,9 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (TimeoutException | ExecutionException e) {
+            logger.debug(
+                    "WLED discovery hit a TimeoutException | ExecutionException which may have blocked a device from getting discovered:{}",
+                    e.getCause());
         }
         return "";
     }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedDiscoveryService.java
@@ -51,7 +51,6 @@ public class WLedDiscoveryService implements MDNSDiscoveryParticipant {
             logger.debug("WLED discovered with empty IP address-{}", service);
             return null;
         }
-        logger.info("WLED discovered at {}", address[0]);
         ThingTypeUID thingtypeuid = new ThingTypeUID("wled", "wled");
         ThingUID thingUID = new ThingUID(thingtypeuid,
                 address[0].substring(7, address[0].length() - 3).replace(".", "-"));

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -1,0 +1,450 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wled.internal;
+
+import static org.openhab.binding.wled.internal.WLedBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.StateOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WLedHandler} is responsible for handling commands and states, which are
+ * sent to one of the channels or http replies back.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+
+@NonNullByDefault
+public class WLedHandler extends BaseThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final HttpClient httpClient;
+    private final WledDynamicStateDescriptionProvider stateDescriptionProvider;
+    private @Nullable ScheduledFuture<?> pollingFuture = null;
+    private ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(1);
+    private BigDecimal masterBrightness = new BigDecimal(0);
+    private HSBType primaryColor = new HSBType();
+    private BigDecimal primaryWhite = new BigDecimal(0);
+    private HSBType secondaryColor = new HSBType();
+    private BigDecimal secondaryWhite = new BigDecimal(0);
+    private boolean hasWhite = false;
+    private WLedConfiguration config;
+
+    public WLedHandler(Thing thing, HttpClient httpClient,
+            WledDynamicStateDescriptionProvider stateDescriptionProvider) {
+        super(thing);
+        this.httpClient = httpClient;
+        this.stateDescriptionProvider = stateDescriptionProvider;
+        config = getConfigAs(WLedConfiguration.class);
+    }
+
+    void sendGetRequest(String url) {
+        Request request = httpClient.newRequest(config.address + url);
+        request.timeout(3, TimeUnit.SECONDS);
+        request.method(HttpMethod.GET);
+        request.header(HttpHeader.ACCEPT_ENCODING, "gzip");
+        logger.debug("Sending WLED GET:{}", url);
+        String errorReason = "";
+        try {
+            ContentResponse contentResponse = request.send();
+            if (contentResponse.getStatus() == 200) {
+                processState(contentResponse.getContentAsString());
+                return;
+            } else {
+                errorReason = String.format("WLED request failed with %d: %s", contentResponse.getStatus(),
+                        contentResponse.getReason());
+            }
+        } catch (TimeoutException e) {
+            errorReason = "TimeoutException: WLED was not reachable on your network";
+        } catch (ExecutionException e) {
+            errorReason = String.format("ExecutionException: %s", e.getMessage());
+        } catch (InterruptedException e) {
+            errorReason = String.format("InterruptedException: %s", e.getMessage());
+        }
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorReason);
+    }
+
+    private HSBType parseToHSBType(String message, String element) {
+        int startIndex = message.indexOf(element);
+        if (startIndex == -1) {
+            return new HSBType();
+        }
+        int endIndex = message.indexOf("<", startIndex + element.length());
+        int r = 0, g = 0, b = 0;
+        try {
+            r = Integer.parseInt(message.substring(startIndex + element.length(), endIndex));
+            // look for second element
+            startIndex = message.indexOf(element, endIndex);
+            if (startIndex == -1) {
+                return new HSBType();
+            }
+            endIndex = message.indexOf("<", startIndex + element.length());
+            g = Integer.parseInt(message.substring(startIndex + element.length(), endIndex));
+            // look for third element called <cl>
+            startIndex = message.indexOf(element, endIndex);
+            if (startIndex == -1) {
+                return new HSBType();
+            }
+            endIndex = message.indexOf("<", startIndex + element.length());
+            b = Integer.parseInt(message.substring(startIndex + element.length(), endIndex));
+        } catch (NumberFormatException e) {
+            logger.warn("NumberFormatException when parsing the WLED color fields.");
+        }
+        return HSBType.fromRGB(r, g, b);
+    }
+
+    private void parseColours(String message) {
+        primaryColor = parseToHSBType(message, "<cl>");
+        updateState(CHANNEL_PRIMARY_COLOR, primaryColor);
+        secondaryColor = parseToHSBType(message, "<cs>");
+        updateState(CHANNEL_SECONDARY_COLOR, secondaryColor);
+        try {
+            primaryWhite = new BigDecimal(getValue(message, "<wv>", "<"));
+            if (primaryWhite.intValue() > -1) {
+                hasWhite = true;
+                updateState(CHANNEL_PRIMARY_WHITE,
+                        new PercentType(primaryWhite.divide(new BigDecimal(2.55), RoundingMode.HALF_UP)));
+                secondaryWhite = new BigDecimal(getValue(message, "<ws>", "<"));
+                updateState(CHANNEL_SECONDARY_WHITE,
+                        new PercentType(secondaryWhite.divide(new BigDecimal(2.55), RoundingMode.HALF_UP)));
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("NumberFormatException when parsing the WLED colour and white fields.");
+        }
+    }
+
+    private void scrapeChannelOptions(String message) {
+        List<StateOption> fxOptions = new ArrayList<>();
+        List<StateOption> palleteOptions = new ArrayList<>();
+        int counter = 0;
+        for (String value : (getValue(message, "\"effects\":[", "]").replace("\"", "")).split(",")) {
+            fxOptions.add(new StateOption("" + counter++, value));
+        }
+        stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_FX), fxOptions);
+        counter = 0;
+        for (String value : (getValue(message, "\"palettes\":[", "]").replace("\"", "")).split(",")) {
+            palleteOptions.add(new StateOption("" + counter++, value));
+        }
+        stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_PALETTES), palleteOptions);
+    }
+
+    private void processState(String message) {
+        logger.trace("WLED states are:{}", message);
+        if (thing.getStatus() != ThingStatus.ONLINE) {
+            updateStatus(ThingStatus.ONLINE);
+            sendGetRequest("/json"); // fetch FX and Pallete names
+        }
+        if (message.contains("\"effects\":[")) {// JSON API reply
+            scrapeChannelOptions(message);
+            return;
+        }
+        if (message.contains("<ac>0</ac>")) {
+            updateState(CHANNEL_MASTER_CONTROLS, OnOffType.OFF);
+        } else {
+            masterBrightness = new BigDecimal(getValue(message, "<ac>", "<"));
+            updateState(CHANNEL_MASTER_CONTROLS,
+                    new PercentType(masterBrightness.divide(new BigDecimal(2.55), RoundingMode.HALF_UP)));
+        }
+        if (message.contains("<ix>0</ix>")) {
+            updateState(CHANNEL_INTENSITY, OnOffType.OFF);
+        } else {
+            BigDecimal bigTemp = new BigDecimal(getValue(message, "<ix>", "<")).divide(new BigDecimal(2.55),
+                    RoundingMode.HALF_UP);
+            updateState(CHANNEL_INTENSITY, new PercentType(bigTemp));
+        }
+        if (message.contains("<cy>1</cy>")) {
+            updateState(CHANNEL_PRESET_CYCLE, OnOffType.ON);
+        } else {
+            updateState(CHANNEL_PRESET_CYCLE, OnOffType.OFF);
+        }
+        if (message.contains("<nl>1</nl>")) {
+            updateState(CHANNEL_SLEEP, OnOffType.ON);
+        } else {
+            updateState(CHANNEL_SLEEP, OnOffType.OFF);
+        }
+        if (message.contains("<fx>")) {
+            updateState(CHANNEL_FX, new StringType(getValue(message, "<fx>", "<")));
+        }
+        if (message.contains("<sx>")) {
+            BigDecimal bigTemp = new BigDecimal(getValue(message, "<sx>", "<")).divide(new BigDecimal(2.55),
+                    RoundingMode.HALF_UP);
+            updateState(CHANNEL_SPEED, new PercentType(bigTemp));
+        }
+        if (message.contains("<fp>")) {
+            updateState(CHANNEL_PALETTES, new StringType(getValue(message, "<fp>", "<")));
+        }
+        parseColours(message);
+    }
+
+    void sendWhite() {
+        if (hasWhite) {
+            sendGetRequest("/win&TT=1000&FX=0&CY=0&CL=hFF000000" + "&A=" + masterBrightness);
+        } else {
+            sendGetRequest("/win&TT=1000&FX=0&CY=0&CL=hFFFFFF" + "&A=" + masterBrightness);
+        }
+    }
+
+    /**
+     *
+     * @param hsb
+     * @return WLED needs the letter h followed by 2 digit HEX code for RRGGBB
+     */
+    private String createColorHex(HSBType hsb) {
+        String hex = Integer.toHexString(hsb.getRGB() & 0xffffff);
+        while (hex.length() < 6) {
+            hex = "0" + hex;
+        }
+        return "h" + hex;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            switch (channelUID.getId()) {
+                case CHANNEL_MASTER_CONTROLS:
+                    sendGetRequest("/win");
+            }
+            return;// no need to check for refresh below
+        }
+        logger.debug("command {} sent to {}", command, channelUID.getId());
+        switch (channelUID.getId()) {
+            case CHANNEL_PRIMARY_WHITE:
+                if (command instanceof PercentType) {
+                    sendGetRequest("/win&W=" + new BigDecimal(command.toString()).multiply(new BigDecimal(2.55)));
+                }
+                break;
+            case CHANNEL_SECONDARY_WHITE:
+                if (command instanceof PercentType) {
+                    sendGetRequest("/win&W2=" + new BigDecimal(command.toString()).multiply(new BigDecimal(2.55)));
+                }
+                break;
+            case CHANNEL_MASTER_CONTROLS:
+                if (command instanceof OnOffType) {
+                    if (OnOffType.OFF.equals(command)) {
+                        sendGetRequest("/win&TT=500&T=0");
+                    } else {
+                        sendGetRequest("/win&TT=2000&T=1");
+                    }
+                } else if (command instanceof IncreaseDecreaseType) {
+                    if (IncreaseDecreaseType.INCREASE.equals(command)) {
+                        if (masterBrightness.intValue() < 240) {
+                            sendGetRequest("/win&TT=2000&A=~15"); // 255 divided by 15 = 17 levels
+                        } else {
+                            sendGetRequest("/win&TT=2000&A=255");
+                        }
+                    } else {
+                        if (masterBrightness.intValue() > 15) {
+                            sendGetRequest("/win&TT=2000&A=~-15");
+                        } else {
+                            sendGetRequest("/win&TT=2000&A=0");
+                        }
+                    }
+                } else if (command instanceof HSBType) {
+                    if ((((HSBType) command).getBrightness()) == PercentType.ZERO) {
+                        sendGetRequest("/win&TT=500&T=0");
+                    }
+                    masterBrightness = new BigDecimal((((HSBType) command).getBrightness()).toString())
+                            .multiply(new BigDecimal(2.55));
+                    primaryColor = new HSBType(command.toString());
+                    if (primaryColor.getSaturation().intValue() < config.saturationThreshold && hasWhite) {
+                        sendGetRequest("/win&TT=1000&FX=0&CY=0&CL=h000000&W=255" + "&A=" + masterBrightness);
+                    } else if (primaryColor.getSaturation().intValue() == 32 && primaryColor.getHue().intValue() == 36
+                            && hasWhite) {
+                        // Google sends this when it wants white
+                        sendGetRequest("/win&TT=1000&FX=0&CY=0&CL=h000000&W=255" + "&A=" + masterBrightness);
+                    } else {
+                        sendGetRequest(
+                                "/win&TT=1000&FX=0&CY=0&CL=" + createColorHex(primaryColor) + "&A=" + masterBrightness);
+                    }
+                } else {// should only be PercentType left
+                    masterBrightness = new BigDecimal(command.toString()).multiply(new BigDecimal(2.55));
+                    sendGetRequest("/win&TT=2000&A=" + masterBrightness);
+                }
+                return;
+            case CHANNEL_PRIMARY_COLOR:
+                if (command instanceof OnOffType) {
+                    logger.info("OnOffType commands should use masterControls channel");
+                } else if (command instanceof HSBType) {
+                    primaryColor = new HSBType(command.toString());
+                    sendGetRequest("/win&CL=" + createColorHex(primaryColor));
+                } else if (command instanceof IncreaseDecreaseType) {
+                    logger.info("IncreaseDecrease commands should use masterControls channel");
+                } else {// Percentype
+                    primaryColor = new HSBType(primaryColor.getHue().toString() + ","
+                            + primaryColor.getSaturation().toString() + ",command");
+                    sendGetRequest("/win&CL=" + createColorHex(primaryColor));
+                }
+                return;
+            case CHANNEL_SECONDARY_COLOR:
+                if (command instanceof OnOffType) {
+                    logger.info("OnOffType commands should use masterControls channel");
+                } else if (command instanceof HSBType) {
+                    secondaryColor = new HSBType(command.toString());
+                    sendGetRequest("/win&C2=" + createColorHex(secondaryColor));
+                } else if (command instanceof IncreaseDecreaseType) {
+                    logger.info("IncreaseDecrease commands should use masterControls channel");
+                } else {// Percentype
+                    secondaryColor = new HSBType(secondaryColor.getHue().toString() + ","
+                            + secondaryColor.getSaturation().toString() + ",command");
+                    sendGetRequest("/win&C2=" + createColorHex(secondaryColor));
+                }
+                return;
+            case CHANNEL_PALETTES:
+                sendGetRequest("/win&FP=" + command);
+                break;
+            case CHANNEL_FX:
+                sendGetRequest("/win&FX=" + command);
+                break;
+            case CHANNEL_SPEED:
+                BigDecimal bigTemp = new BigDecimal(command.toString());
+                if (OnOffType.OFF.equals(command)) {
+                    bigTemp = new BigDecimal(0);
+                } else if (OnOffType.ON.equals(command)) {
+                    bigTemp = new BigDecimal(255);
+                } else {
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(2.55));
+                }
+                sendGetRequest("/win&SX=" + bigTemp);
+                break;
+            case CHANNEL_INTENSITY:
+                if (OnOffType.OFF.equals(command)) {
+                    bigTemp = new BigDecimal(0);
+                } else if (OnOffType.ON.equals(command)) {
+                    bigTemp = new BigDecimal(255);
+                } else {
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(2.55));
+                }
+                sendGetRequest("/win&IX=" + bigTemp);
+                break;
+            case CHANNEL_SLEEP:
+                if (OnOffType.ON.equals(command)) {
+                    sendGetRequest("/win&ND");
+                } else {
+                    sendGetRequest("/win&NL=0");
+                }
+                break;
+            case CHANNEL_PRESETS:
+                sendGetRequest("/win&PL=" + command);
+                break;
+            case CHANNEL_PRESET_DURATION:
+                if (OnOffType.OFF.equals(command)) {
+                    bigTemp = new BigDecimal(0);
+                } else if (OnOffType.ON.equals(command)) {
+                    bigTemp = new BigDecimal(255);
+                } else {
+                    // scale from 0.5 seconds to 1 minute
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(600)).add(new BigDecimal(500));
+                }
+                sendGetRequest("/win&PT=" + bigTemp);
+                break;
+            case CHANNEL_TRANS_TIME:
+                if (OnOffType.OFF.equals(command)) {
+                    bigTemp = new BigDecimal(0);
+                } else if (OnOffType.ON.equals(command)) {
+                    bigTemp = new BigDecimal(255);
+                } else {
+                    // scale from 0.5 seconds to 1 minute
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(600)).add(new BigDecimal(500));
+                }
+                sendGetRequest("/win&TT=" + bigTemp);
+                break;
+            case CHANNEL_PRESET_CYCLE:
+                if (OnOffType.ON.equals(command)) {
+                    sendGetRequest("/win&CY=1");
+                } else {
+                    sendGetRequest("/win&CY=0");
+                }
+                break;
+        }
+    }
+
+    public void savePreset(int presetIndex) {
+        if (presetIndex > 16) {
+            logger.warn("Presets above 16 do not exist, and the action sent {}", presetIndex);
+            return;
+        }
+        sendGetRequest("/win&PS=" + presetIndex);
+    }
+
+    void pollLED() {
+        sendGetRequest("/win");
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(WLedConfiguration.class);
+        pollingFuture = threadPool.scheduleWithFixedDelay(this::pollLED, 1, config.pollTime, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void dispose() {
+        if (pollingFuture != null) {
+            pollingFuture.cancel(true);
+        }
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(WLedActions.class);
+    }
+
+    /**
+     * @return A string that starts after finding the element and terminates when it finds the first occurence of the
+     *         end char after the element.
+     */
+    static private String getValue(String message, String element, String end) {
+        int startIndex = message.indexOf(element);
+        if (startIndex != -1) // It was found, as -1 means "not found"
+        {
+            int endIndex = message.indexOf(end, startIndex + element.length());
+            if (endIndex != -1)// , not found so make second check
+            {
+                return message.substring(startIndex + element.length(), endIndex);
+            }
+        }
+        return "";
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -430,8 +430,9 @@ public class WLedHandler extends BaseThingHandler {
 
     @Override
     public void dispose() {
-        if (pollingFuture != null) {
-            pollingFuture.cancel(true);
+        Future<?> future = pollingFuture;
+        if (future != null) {
+            future.cancel(true);
         }
     }
 

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -166,7 +166,7 @@ public class WLedHandler extends BaseThingHandler {
         List<StateOption> palleteOptions = new ArrayList<>();
         int counter = 0;
         for (String value : getValue(message, "\"effects\":[", "]").replace("\"", "").split(",")) {
-            fxOptions.add(new StateOption("" + counter++, value));
+            fxOptions.add(new StateOption(Integer.toString(counter++), value));
         }
         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_FX), fxOptions);
         counter = 0;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -71,14 +71,13 @@ public class WLedHandler extends BaseThingHandler {
     private HSBType secondaryColor = new HSBType();
     private BigDecimal secondaryWhite = BigDecimal.ZERO;
     private boolean hasWhite = false;
-    private WLedConfiguration config;
+    private WLedConfiguration config = new WLedConfiguration();
 
     public WLedHandler(Thing thing, HttpClient httpClient,
             WledDynamicStateDescriptionProvider stateDescriptionProvider) {
         super(thing);
         this.httpClient = httpClient;
         this.stateDescriptionProvider = stateDescriptionProvider;
-        config = getConfigAs(WLedConfiguration.class);
     }
 
     private void sendGetRequest(String url) {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -276,7 +276,7 @@ public class WLedHandler extends BaseThingHandler {
                 } else if (command instanceof IncreaseDecreaseType) {
                     if (IncreaseDecreaseType.INCREASE.equals(command)) {
                         if (masterBrightness.intValue() < 240) {
-                            sendGetRequest("/win&TT=2000&A=~15"); // 255 divided by 15 = 17 levels
+                            sendGetRequest("/win&TT=2000&A=~15"); // 255 divided by 15 = 17 different levels
                         } else {
                             sendGetRequest("/win&TT=2000&A=255");
                         }
@@ -444,11 +444,10 @@ public class WLedHandler extends BaseThingHandler {
      */
     static String getValue(String message, String element, String end) {
         int startIndex = message.indexOf(element);
-        if (startIndex != -1) // It was found, as -1 means "not found"
+        if (startIndex != -1) // -1 means "not found"
         {
             int endIndex = message.indexOf(end, startIndex + element.length());
-            if (endIndex != -1)// , not found so make second check
-            {
+            if (endIndex != -1) {
                 return message.substring(startIndex + element.length(), endIndex);
             }
         }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -82,7 +82,7 @@ public class WLedHandler extends BaseThingHandler {
 
     private void sendGetRequest(String url) {
         Request request;
-        if (url.contains("json")) {
+        if (url.contains("json") || config.segmentIndex == -1) {
             request = httpClient.newRequest(config.address + url);
         } else {
             request = httpClient.newRequest(config.address + url + "&SM=" + config.segmentIndex);

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -62,11 +62,11 @@ public class WLedHandler extends BaseThingHandler {
     private final HttpClient httpClient;
     private final WledDynamicStateDescriptionProvider stateDescriptionProvider;
     private @Nullable ScheduledFuture<?> pollingFuture = null;
-    private BigDecimal masterBrightness = new BigDecimal(0);
+    private BigDecimal masterBrightness = BigDecimal.ZERO;
     private HSBType primaryColor = new HSBType();
-    private BigDecimal primaryWhite = new BigDecimal(0);
+    private BigDecimal primaryWhite = BigDecimal.ZERO;
     private HSBType secondaryColor = new HSBType();
-    private BigDecimal secondaryWhite = new BigDecimal(0);
+    private BigDecimal secondaryWhite = BigDecimal.ZERO;
     private boolean hasWhite = false;
     private WLedConfiguration config;
 
@@ -353,7 +353,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_INTENSITY:
                 if (OnOffType.OFF.equals(command)) {
-                    bigTemp = new BigDecimal(0);
+                    bigTemp = BigDecimal.ZERO;
                 } else if (OnOffType.ON.equals(command)) {
                     bigTemp = new BigDecimal(255);
                 } else {
@@ -373,7 +373,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_PRESET_DURATION:
                 if (OnOffType.OFF.equals(command)) {
-                    bigTemp = new BigDecimal(0);
+                    bigTemp = BigDecimal.ZERO;
                 } else if (OnOffType.ON.equals(command)) {
                     bigTemp = new BigDecimal(255);
                 } else {
@@ -383,7 +383,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_TRANS_TIME:
                 if (OnOffType.OFF.equals(command)) {
-                    bigTemp = new BigDecimal(0);
+                    bigTemp = BigDecimal.ZERO;
                 } else if (OnOffType.ON.equals(command)) {
                     bigTemp = new BigDecimal(255);
                 } else {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -367,7 +367,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_SLEEP:
                 if (OnOffType.ON.equals(command)) {
-                    sendGetRequest("/win&NL=1");// was &ND
+                    sendGetRequest("/win&NL=1");
                 } else {
                     sendGetRequest("/win&NL=0");
                 }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -165,7 +165,7 @@ public class WLedHandler extends BaseThingHandler {
         List<StateOption> fxOptions = new ArrayList<>();
         List<StateOption> palleteOptions = new ArrayList<>();
         int counter = 0;
-        for (String value : (getValue(message, "\"effects\":[", "]").replace("\"", "")).split(",")) {
+        for (String value : getValue(message, "\"effects\":[", "]").replace("\"", "").split(",")) {
             fxOptions.add(new StateOption("" + counter++, value));
         }
         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_FX), fxOptions);

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -327,7 +327,7 @@ public class WLedHandler extends BaseThingHandler {
                 if (command instanceof OnOffType) {
                     return;
                 } else if (command instanceof HSBType) {
-                    secondaryColor = new HSBType(command.toString());
+                    secondaryColor = (HSBType) command;
                     sendGetRequest("/win&C2=" + createColorHex(secondaryColor));
                 } else if (command instanceof IncreaseDecreaseType) {
                     return;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -345,14 +345,7 @@ public class WLedHandler extends BaseThingHandler {
                 sendGetRequest("/win&FX=" + command);
                 break;
             case CHANNEL_SPEED:
-                BigDecimal bigTemp = new BigDecimal(command.toString());
-                if (OnOffType.OFF.equals(command)) {
-                    bigTemp = BigDecimal.ZERO;
-                } else if (OnOffType.ON.equals(command)) {
-                    bigTemp = new BigDecimal(255);
-                } else {
-                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(2.55));
-                }
+                BigDecimal bigTemp = ((State)command).as(PercentType.class).multiply(BIG_DECIMAL_2_55));
                 sendGetRequest("/win&SX=" + bigTemp);
                 break;
             case CHANNEL_INTENSITY:

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -360,7 +360,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_SLEEP:
                 if (OnOffType.ON.equals(command)) {
-                    sendGetRequest("/win&ND");
+                    sendGetRequest("/win&NL=1");// was &ND
                 } else {
                     sendGetRequest("/win&NL=0");
                 }
@@ -370,23 +370,24 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_PRESET_DURATION:
                 if (OnOffType.OFF.equals(command)) {
-                    bigTemp = BigDecimal.ZERO;
+                    bigTemp = new BigDecimal(50);
                 } else if (OnOffType.ON.equals(command)) {
-                    bigTemp = new BigDecimal(255);
+                    bigTemp = new BigDecimal(65000);
                 } else {
-                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(600)).add(new BigDecimal(500));
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(1000));
                 }
-                sendGetRequest("/win&PT=" + bigTemp);
+                sendGetRequest("/win&PT=" + bigTemp.intValue());
                 break;
             case CHANNEL_TRANS_TIME:
+                logger.warn("Command is {}", command);
                 if (OnOffType.OFF.equals(command)) {
                     bigTemp = BigDecimal.ZERO;
                 } else if (OnOffType.ON.equals(command)) {
-                    bigTemp = new BigDecimal(255);
+                    bigTemp = new BigDecimal(65000);
                 } else {
-                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(600)).add(new BigDecimal(500));
+                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(1000));
                 }
-                sendGetRequest("/win&TT=" + bigTemp);
+                sendGetRequest("/win&TT=" + bigTemp.intValue());
                 break;
             case CHANNEL_PRESET_CYCLE:
                 if (OnOffType.ON.equals(command)) {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -423,7 +423,7 @@ public class WLedHandler extends BaseThingHandler {
             logger.debug("Address was not entered in correct format, it may be the raw IP so adding http:// to start");
             config.address = "http://" + config.address;
         }
-        pollingFuture = threadPool.scheduleWithFixedDelay(this::pollLED, 1, config.pollTime, TimeUnit.SECONDS);
+        pollingFuture = scheduler.scheduleWithFixedDelay(this::pollLED, 1, config.pollTime, TimeUnit.SECONDS);
     }
 
     @Override

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -346,7 +346,7 @@ public class WLedHandler extends BaseThingHandler {
             case CHANNEL_SPEED:
                 BigDecimal bigTemp = new BigDecimal(command.toString());
                 if (OnOffType.OFF.equals(command)) {
-                    bigTemp = new BigDecimal(0);
+                    bigTemp = BigDecimal.ZERO;
                 } else if (OnOffType.ON.equals(command)) {
                     bigTemp = new BigDecimal(255);
                 } else {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -21,8 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -64,7 +62,6 @@ public class WLedHandler extends BaseThingHandler {
     private final HttpClient httpClient;
     private final WledDynamicStateDescriptionProvider stateDescriptionProvider;
     private @Nullable ScheduledFuture<?> pollingFuture = null;
-    private ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(1);
     private BigDecimal masterBrightness = new BigDecimal(0);
     private HSBType primaryColor = new HSBType();
     private BigDecimal primaryWhite = new BigDecimal(0);

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -177,7 +177,7 @@ public class WLedHandler extends BaseThingHandler {
         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_FX), fxOptions);
         counter = 0;
         for (String value : (WLedHelper.getValue(message, "\"palettes\":[", "]").replace("\"", "")).split(",")) {
-            palleteOptions.add(new StateOption("" + counter++, value));
+            palleteOptions.add(new StateOption(Integer.toString(counter++), value));
         }
         stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_PALETTES), palleteOptions);
     }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -63,7 +63,6 @@ import org.slf4j.LoggerFactory;
 public class WLedHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final HttpClient httpClient;
-    private final BigDecimal BIG_DECIMAL_2_55 = new BigDecimal(2.55);
     private final WledDynamicStateDescriptionProvider stateDescriptionProvider;
     private @Nullable ScheduledFuture<?> pollingFuture = null;
     private BigDecimal masterBrightness255 = BigDecimal.ZERO;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -319,8 +319,7 @@ public class WLedHandler extends BaseThingHandler {
                 } else if (command instanceof IncreaseDecreaseType) {
                     return;
                 } else {// Percentype
-                    primaryColor = new HSBType(primaryColor.getHue().toString() + ","
-                            + primaryColor.getSaturation().toString() + ",command");
+                    primaryColor = new HSBType(primaryColor.getHue(), primaryColor.getSaturation(),  ((State)command).as(PercentType.class));
                     sendGetRequest("/win&CL=" + createColorHex(primaryColor));
                 }
                 return;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -83,7 +83,7 @@ public class WLedHandler extends BaseThingHandler {
         request.timeout(3, TimeUnit.SECONDS);
         request.method(HttpMethod.GET);
         request.header(HttpHeader.ACCEPT_ENCODING, "gzip");
-        logger.debug("Sending WLED GET:{}", url);
+        logger.trace("Sending WLED GET:{}", url);
         String errorReason = "";
         try {
             ContentResponse contentResponse = request.send();
@@ -308,12 +308,12 @@ public class WLedHandler extends BaseThingHandler {
                 return;
             case CHANNEL_PRIMARY_COLOR:
                 if (command instanceof OnOffType) {
-                    logger.info("OnOffType commands should use masterControls channel");
+                    return;
                 } else if (command instanceof HSBType) {
                     primaryColor = new HSBType(command.toString());
                     sendGetRequest("/win&CL=" + createColorHex(primaryColor));
                 } else if (command instanceof IncreaseDecreaseType) {
-                    logger.info("IncreaseDecrease commands should use masterControls channel");
+                    return;
                 } else {// Percentype
                     primaryColor = new HSBType(primaryColor.getHue().toString() + ","
                             + primaryColor.getSaturation().toString() + ",command");
@@ -322,12 +322,12 @@ public class WLedHandler extends BaseThingHandler {
                 return;
             case CHANNEL_SECONDARY_COLOR:
                 if (command instanceof OnOffType) {
-                    logger.info("OnOffType commands should use masterControls channel");
+                    return;
                 } else if (command instanceof HSBType) {
                     secondaryColor = new HSBType(command.toString());
                     sendGetRequest("/win&C2=" + createColorHex(secondaryColor));
                 } else if (command instanceof IncreaseDecreaseType) {
-                    logger.info("IncreaseDecrease commands should use masterControls channel");
+                    return;
                 } else {// Percentype
                     secondaryColor = new HSBType(secondaryColor.getHue().toString() + ","
                             + secondaryColor.getSaturation().toString() + ",command");

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -99,6 +99,7 @@ public class WLedHandler extends BaseThingHandler {
         } catch (ExecutionException e) {
             errorReason = String.format("ExecutionException: %s", e.getMessage());
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             errorReason = String.format("InterruptedException: %s", e.getMessage());
         }
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorReason);
@@ -235,11 +236,7 @@ public class WLedHandler extends BaseThingHandler {
      * @return WLED needs the letter h followed by 2 digit HEX code for RRGGBB
      */
     private String createColorHex(HSBType hsb) {
-        String hex = Integer.toHexString(hsb.getRGB() & 0xffffff);
-        while (hex.length() < 6) {
-            hex = "0" + hex;
-        }
-        return "h" + hex;
+        return String.format("h%06X", hsb.getRGB());
     }
 
     @Override
@@ -266,22 +263,22 @@ public class WLedHandler extends BaseThingHandler {
             case CHANNEL_MASTER_CONTROLS:
                 if (command instanceof OnOffType) {
                     if (OnOffType.OFF.equals(command)) {
-                        sendGetRequest("/win&TT=500&T=0");
+                        sendGetRequest("/win&TT=250&T=0");
                     } else {
-                        sendGetRequest("/win&TT=2000&T=1");
+                        sendGetRequest("/win&TT=1000&T=1");
                     }
                 } else if (command instanceof IncreaseDecreaseType) {
                     if (IncreaseDecreaseType.INCREASE.equals(command)) {
                         if (masterBrightness.intValue() < 240) {
-                            sendGetRequest("/win&TT=2000&A=~15"); // 255 divided by 15 = 17 different levels
+                            sendGetRequest("/win&TT=1000&A=~15"); // 255 divided by 15 = 17 different levels
                         } else {
-                            sendGetRequest("/win&TT=2000&A=255");
+                            sendGetRequest("/win&TT=1000&A=255");
                         }
                     } else {
                         if (masterBrightness.intValue() > 15) {
-                            sendGetRequest("/win&TT=2000&A=~-15");
+                            sendGetRequest("/win&TT=1000&A=~-15");
                         } else {
-                            sendGetRequest("/win&TT=2000&A=0");
+                            sendGetRequest("/win&TT=1000&A=0");
                         }
                     }
                 } else if (command instanceof HSBType) {
@@ -303,7 +300,7 @@ public class WLedHandler extends BaseThingHandler {
                     }
                 } else {// should only be PercentType left
                     masterBrightness = new BigDecimal(command.toString()).multiply(new BigDecimal(2.55));
-                    sendGetRequest("/win&TT=2000&A=" + masterBrightness);
+                    sendGetRequest("/win&TT=1000&A=" + masterBrightness);
                 }
                 return;
             case CHANNEL_PRIMARY_COLOR:

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -36,7 +36,9 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -374,25 +376,22 @@ public class WLedHandler extends BaseThingHandler {
                 sendGetRequest("/win&PL=" + command);
                 break;
             case CHANNEL_PRESET_DURATION:
-                if (OnOffType.OFF.equals(command)) {
-                    bigTemp = new BigDecimal(50);
-                } else if (OnOffType.ON.equals(command)) {
-                    bigTemp = new BigDecimal(65000);
-                } else {
-                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(1000));
+                if (command instanceof QuantityType) {
+                    QuantityType<?> seconds = ((QuantityType<?>) command).toUnit(SmartHomeUnits.SECOND);
+                    if (seconds != null) {
+                        bigTemp = new BigDecimal(seconds.intValue()).multiply(new BigDecimal(1000));
+                        sendGetRequest("/win&PT=" + bigTemp.intValue());
+                    }
                 }
-                sendGetRequest("/win&PT=" + bigTemp.intValue());
                 break;
             case CHANNEL_TRANS_TIME:
-                logger.warn("Command is {}", command);
-                if (OnOffType.OFF.equals(command)) {
-                    bigTemp = BigDecimal.ZERO;
-                } else if (OnOffType.ON.equals(command)) {
-                    bigTemp = new BigDecimal(65000);
-                } else {
-                    bigTemp = new BigDecimal(command.toString()).multiply(new BigDecimal(1000));
+                if (command instanceof QuantityType) {
+                    QuantityType<?> seconds = ((QuantityType<?>) command).toUnit(SmartHomeUnits.SECOND);
+                    if (seconds != null) {
+                        bigTemp = new BigDecimal(seconds.intValue()).multiply(new BigDecimal(1000));
+                        sendGetRequest("/win&TT=" + bigTemp.intValue());
+                    }
                 }
-                sendGetRequest("/win&TT=" + bigTemp.intValue());
                 break;
             case CHANNEL_PRESET_CYCLE:
                 if (OnOffType.ON.equals(command)) {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -314,7 +314,7 @@ public class WLedHandler extends BaseThingHandler {
                 if (command instanceof OnOffType) {
                     return;
                 } else if (command instanceof HSBType) {
-                    primaryColor = new HSBType(command.toString());
+                    primaryColor = (HSBType) command;
                     sendGetRequest("/win&CL=" + createColorHex(primaryColor));
                 } else if (command instanceof IncreaseDecreaseType) {
                     return;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -259,6 +260,7 @@ public class WLedHandler extends BaseThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         BigDecimal bigTemp;
+        PercentType localPercentType;
         if (command instanceof RefreshType) {
             switch (channelUID.getId()) {
                 case CHANNEL_MASTER_CONTROLS:
@@ -361,12 +363,18 @@ public class WLedHandler extends BaseThingHandler {
                 sendGetRequest("/win&FX=" + command);
                 break;
             case CHANNEL_SPEED:
-                bigTemp = ((State) command).as(PercentType.class).toBigDecimal().multiply(BIG_DECIMAL_2_55);
-                sendGetRequest("/win&SX=" + bigTemp);
+                localPercentType = ((State) command).as(PercentType.class);
+                if (localPercentType != null) {
+                    bigTemp = localPercentType.toBigDecimal().multiply(BIG_DECIMAL_2_55);
+                    sendGetRequest("/win&SX=" + bigTemp);
+                }
                 break;
             case CHANNEL_INTENSITY:
-                bigTemp = ((State) command).as(PercentType.class).toBigDecimal().multiply(BIG_DECIMAL_2_55);
-                sendGetRequest("/win&IX=" + bigTemp);
+                localPercentType = ((State) command).as(PercentType.class);
+                if (localPercentType != null) {
+                    bigTemp = localPercentType.toBigDecimal().multiply(BIG_DECIMAL_2_55);
+                    sendGetRequest("/win&IX=" + bigTemp);
+                }
                 break;
             case CHANNEL_SLEEP:
                 if (OnOffType.ON.equals(command)) {

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
@@ -18,12 +18,12 @@ import static org.openhab.binding.wled.internal.WLedBindingConstants.SUPPORTED_T
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
-import org.openhab.core.io.net.http.HttpClientFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(configurationPid = "binding.wled", service = ThingHandlerFactory.class)
 public class WLedHandlerFactory extends BaseThingHandlerFactory {
     private final HttpClient httpClient;
-    private final WledDynamicStateDescriptionProvider stateDescriptionProvider;;
+    private final WledDynamicStateDescriptionProvider stateDescriptionProvider;
 
     @Activate
     public WLedHandlerFactory(@Reference HttpClientFactory httpClientFactory,

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandlerFactory.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.wled.internal;
+
+import static org.openhab.binding.wled.internal.WLedBindingConstants.SUPPORTED_THING_TYPES;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link WLedHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.wled", service = ThingHandlerFactory.class)
+public class WLedHandlerFactory extends BaseThingHandlerFactory {
+    private final HttpClient httpClient;
+    private final WledDynamicStateDescriptionProvider stateDescriptionProvider;;
+
+    @Activate
+    public WLedHandlerFactory(@Reference HttpClientFactory httpClientFactory,
+            final @Reference WledDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        if (SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        if (SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            return new WLedHandler(thing, httpClient, stateDescriptionProvider);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.wled.internal;
 
+import java.util.LinkedList;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -36,5 +38,21 @@ public class WLedHelper {
             }
         }
         return "";
+    }
+
+    static LinkedList<String> listOfResults(String message, String element, String end) {
+        LinkedList<String> results = new LinkedList<String>();
+        String temp = "";
+        for (int startLookingFromIndex = 0; startLookingFromIndex != -1;) {
+            startLookingFromIndex = message.indexOf(element, startLookingFromIndex);
+            if (startLookingFromIndex >= 0) {
+                temp = getValue(message.substring(startLookingFromIndex), element, end);
+                if (!temp.isEmpty()) {
+                    results.add(temp);
+                    ++startLookingFromIndex;
+                }
+            }
+        }
+        return results;
     }
 }

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
@@ -40,8 +40,8 @@ public class WLedHelper {
         return "";
     }
 
-    static LinkedList<String> listOfResults(String message, String element, String end) {
-        LinkedList<String> results = new LinkedList<String>();
+    static List<String> listOfResults(String message, String element, String end) {
+        List<String> results = new LinkedList<>();
         String temp = "";
         for (int startLookingFromIndex = 0; startLookingFromIndex != -1;) {
             startLookingFromIndex = message.indexOf(element, startLookingFromIndex);

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wled.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link WLedHelper} Provides helper classes that are used from multiple classes in the binding.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class WLedHelper {
+
+    /**
+     * @return A string that starts after finding the element and terminates when it finds the first occurrence of the
+     *         end string after the element.
+     */
+    static String getValue(String message, String element, String end) {
+        int startIndex = message.indexOf(element);
+        if (startIndex != -1) // -1 means "not found"
+        {
+            int endIndex = message.indexOf(end, startIndex + element.length());
+            if (endIndex != -1) {
+                return message.substring(startIndex + element.length(), endIndex);
+            }
+        }
+        return "";
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHelper.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.wled.internal;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -40,6 +41,10 @@ public class WLedHelper {
         return "";
     }
 
+    /**
+     * @return A List that holds the values from a heading/element that re-occurs in a message multiple times.
+     *
+     */
     static List<String> listOfResults(String message, String element, String end) {
         List<String> results = new LinkedList<>();
         String temp = "";
@@ -49,8 +54,10 @@ public class WLedHelper {
                 temp = getValue(message.substring(startLookingFromIndex), element, end);
                 if (!temp.isEmpty()) {
                     results.add(temp);
-                    ++startLookingFromIndex;
+                } else {
+                    return results;// end string must not exist so stop looking.
                 }
+                startLookingFromIndex += temp.length();
             }
         }
         return results;

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WledDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WledDynamicStateDescriptionProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wled.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link WledDynamicStateDescriptionProvider} Allows the dynamic updating of the FX and Palletes that WLED keep
+ * changing between firmware versions.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, WledDynamicStateDescriptionProvider.class })
+@NonNullByDefault
+public class WledDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+    @Activate
+    public WledDynamicStateDescriptionProvider(
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+}

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="wled" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>WLED Binding</name>
+	<description>This is the binding for WLED</description>
+	<author>Matthew Skinner</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -26,7 +26,6 @@
 		</channels>
 		<config-description>
 			<parameter name="address" type="text" required="true">
-				<context>network-address</context>
 				<label>Address</label>
 				<description>Use this format http://192.168.1.2:80</description>
 			</parameter>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -128,7 +128,7 @@
 	<channel-type id="presetDuration" advanced="true">
 		<item-type>Number:Time</item-type>
 		<label>Preset Duration</label>
-		<description>Time in seconds for how long to show each preset for before moving to the next</description>
+		<description>Time for how long to show each preset for before moving to the next</description>
 		<category>Time</category>
 		<state min="0.1" max="65" step="0.1" pattern="%.1f s" readOnly="false"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -34,6 +34,12 @@
 				<description>Time in seconds of how often to fetch the state of the LEDs.</description>
 				<default>10</default>
 			</parameter>
+			<parameter name="segmentIndex" type="integer" required="true" min="0">
+				<label>Segment Index</label>
+				<description>Leave this as 0 if you are not using segments, otherwise set this to the segment index number that you
+					wish to control.</description>
+				<default>0</default>
+			</parameter>
 			<parameter name="saturationThreshold" type="integer" required="true" min="0" max="99">
 				<label>Saturation Threshold</label>
 				<description>This feature allows you to specify a number that if the saturation drops below, will trigger white.
@@ -53,28 +59,28 @@
 		</tags>
 	</channel-type>
 
-	<channel-type id="primaryColor">
+	<channel-type id="primaryColor" advanced="true">
 		<item-type>Color</item-type>
 		<label>Primary Color</label>
 		<description>Allows you to change the primary color used in FX</description>
 		<category>ColorLight</category>
 	</channel-type>
 
-	<channel-type id="primaryWhite">
+	<channel-type id="primaryWhite" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Primary White</label>
 		<description>Changes the brightness of the primary white LED</description>
 		<category>DimmableLight</category>
 	</channel-type>
 
-	<channel-type id="secondaryColor">
+	<channel-type id="secondaryColor" advanced="true">
 		<item-type>Color</item-type>
 		<label>Secondary Color</label>
 		<description>Allows you to change the secondary color used in FX</description>
 		<category>ColorLight</category>
 	</channel-type>
 
-	<channel-type id="secondaryWhite">
+	<channel-type id="secondaryWhite" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Secondary White</label>
 		<description>Changes the brightness of the white LED</description>
@@ -119,7 +125,7 @@
 		</state>
 	</channel-type>
 
-	<channel-type id="presetDuration">
+	<channel-type id="presetDuration" advanced="true">
 		<item-type>Number:Time</item-type>
 		<label>Preset Duration</label>
 		<description>Time in seconds for how long to show each preset for before moving to the next</description>
@@ -127,7 +133,7 @@
 		<state min="0.1" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
 	</channel-type>
 
-	<channel-type id="transformTime">
+	<channel-type id="transformTime" advanced="true">
 		<item-type>Number:Time</item-type>
 		<label>Transform Time</label>
 		<description>Time it takes to change/fade from one look to the next.</description>
@@ -135,19 +141,19 @@
 		<state min="0" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
 	</channel-type>
 
-	<channel-type id="speed">
+	<channel-type id="speed" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>FX Speed</label>
 		<description>Change the speed of the FX</description>
 	</channel-type>
 
-	<channel-type id="intensity">
+	<channel-type id="intensity" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>FX Intensity</label>
 		<description>Change the intensity of the FX</description>
 	</channel-type>
 
-	<channel-type id="sleep">
+	<channel-type id="sleep" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Sleep Timer</label>
 		<description>Fade the level of light and turn off after set time</description>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="wled"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="wled">
+		<label>WLED String</label>
+		<description>A WLED string of LEDs</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="masterControls" typeId="masterControls"/>
+			<channel id="primaryColor" typeId="primaryColor"/>
+			<channel id="primaryWhite" typeId="primaryWhite"/>
+			<channel id="secondaryColor" typeId="secondaryColor"/>
+			<channel id="secondaryWhite" typeId="secondaryWhite"/>
+			<channel id="presets" typeId="presets"/>
+			<channel id="presetDuration" typeId="presetDuration"/>
+			<channel id="transformTime" typeId="transformTime"/>
+			<channel id="presetCycle" typeId="presetCycle"/>
+			<channel id="palettes" typeId="palettes"/>
+			<channel id="fx" typeId="fx"/>
+			<channel id="speed" typeId="speed"/>
+			<channel id="intensity" typeId="intensity"/>
+			<channel id="sleep" typeId="sleep"/>
+		</channels>
+		<config-description>
+			<parameter name="address" type="text" required="true">
+				<context>network-address</context>
+				<label>Address</label>
+				<description>Use this format http://192.168.1.2:80</description>
+			</parameter>
+			<parameter name="pollTime" type="integer" required="true" min="1" max="9999999" unit="s">
+				<label>Poll States</label>
+				<description>Time in seconds of how often to fetch the state of the LEDs.</description>
+				<default>10</default>
+			</parameter>
+			<parameter name="saturationThreshold" type="integer" required="true" min="0" max="99">
+				<label>Saturation Threshold</label>
+				<description>This feature allows you to specify a number that if the saturation drops below, will trigger white.
+				</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="masterControls">
+		<item-type>Color</item-type>
+		<label>Master Controls</label>
+		<description>Allows you to exit FX mode and use the LEDS like a normal light</description>
+		<category>ColorLight</category>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="primaryColor">
+		<item-type>Color</item-type>
+		<label>Primary Color</label>
+		<description>Allows you to change the primary color used in FX</description>
+		<category>ColorLight</category>
+	</channel-type>
+
+	<channel-type id="primaryWhite">
+		<item-type>Dimmer</item-type>
+		<label>Primary White</label>
+		<description>Changes the brightness of the primary white LED</description>
+		<category>DimmableLight</category>
+	</channel-type>
+
+	<channel-type id="secondaryColor">
+		<item-type>Color</item-type>
+		<label>Secondary Color</label>
+		<description>Allows you to change the secondary color used in FX</description>
+		<category>ColorLight</category>
+	</channel-type>
+
+	<channel-type id="secondaryWhite">
+		<item-type>Dimmer</item-type>
+		<label>Secondary White</label>
+		<description>Changes the brightness of the white LED</description>
+		<category>DimmableLight</category>
+	</channel-type>
+
+	<channel-type id="palettes">
+		<item-type>String</item-type>
+		<label>Palettes</label>
+		<description>Change the colours used by the FX</description>
+	</channel-type>
+
+	<channel-type id="fx">
+		<item-type>String</item-type>
+		<label>Effect</label>
+		<description>Use the built in FX</description>
+	</channel-type>
+
+	<channel-type id="presets">
+		<item-type>String</item-type>
+		<label>Presets</label>
+		<description>Auto rotate or change to a saved preset</description>
+		<state>
+			<options>
+				<option value="1">Preset 1</option>
+				<option value="2">Preset 2</option>
+				<option value="3">Preset 3</option>
+				<option value="4">Preset 4</option>
+				<option value="5">Preset 5</option>
+				<option value="6">Preset 6</option>
+				<option value="7">Preset 7</option>
+				<option value="8">Preset 8</option>
+				<option value="9">Preset 9</option>
+				<option value="10">Preset 10</option>
+				<option value="11">Preset 11</option>
+				<option value="12">Preset 12</option>
+				<option value="13">Preset 13</option>
+				<option value="14">Preset 14</option>
+				<option value="15">Preset 15</option>
+				<option value="16">Preset 16</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="presetDuration">
+		<item-type>Dimmer</item-type>
+		<label>Preset Duration</label>
+		<description>Time to show each preset for before moving to the next</description>
+		<category>Time</category>
+	</channel-type>
+
+	<channel-type id="transformTime">
+		<item-type>Dimmer</item-type>
+		<label>Transform Time</label>
+		<description>Time it takes to change/fade from one look to the next.</description>
+		<category>Time</category>
+	</channel-type>
+
+	<channel-type id="speed">
+		<item-type>Dimmer</item-type>
+		<label>FX Speed</label>
+		<description>Change the speed of the FX</description>
+	</channel-type>
+
+	<channel-type id="intensity">
+		<item-type>Dimmer</item-type>
+		<label>FX Intensity</label>
+		<description>Change the intensity of the FX</description>
+	</channel-type>
+
+	<channel-type id="sleep">
+		<item-type>Switch</item-type>
+		<label>Sleep Timer</label>
+		<description>Fade the level of light and turn off after set time</description>
+		<category>Time</category>
+	</channel-type>
+
+	<channel-type id="presetCycle">
+		<item-type>Switch</item-type>
+		<label>Preset Cycle</label>
+		<description>Cycle through the saved presets</description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -120,17 +120,19 @@
 	</channel-type>
 
 	<channel-type id="presetDuration">
-		<item-type>Dimmer</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Preset Duration</label>
-		<description>Time to show each preset for before moving to the next</description>
+		<description>Time in seconds for how long to show each preset for before moving to the next</description>
 		<category>Time</category>
+		<state min="0.1" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="transformTime">
-		<item-type>Dimmer</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Transform Time</label>
 		<description>Time it takes to change/fade from one look to the next.</description>
 		<category>Time</category>
+		<state min="0" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="speed">

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,7 +7,7 @@
 	<thing-type id="wled">
 		<label>WLED String</label>
 		<description>A WLED string of LEDs</description>
-		<category>Lightbulb</category>
+		<category>ColorLight</category>
 		<channels>
 			<channel id="masterControls" typeId="masterControls"/>
 			<channel id="primaryColor" typeId="primaryColor"/>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -34,11 +34,11 @@
 				<description>Time in seconds of how often to fetch the state of the LEDs.</description>
 				<default>10</default>
 			</parameter>
-			<parameter name="segmentIndex" type="integer" required="true" min="0">
+			<parameter name="segmentIndex" type="integer" required="true" min="-1">
 				<label>Segment Index</label>
-				<description>Leave this as 0 if you are not using segments, otherwise set this to the segment index number that you
+				<description>Leave this as -1 if you are not using segments, otherwise set this to the segment index number that you
 					wish to control.</description>
-				<default>0</default>
+				<default>-1</default>
 			</parameter>
 			<parameter name="saturationThreshold" type="integer" required="true" min="0" max="99">
 				<label>Saturation Threshold</label>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -130,7 +130,7 @@
 		<label>Preset Duration</label>
 		<description>Time for how long to show each preset for before moving to the next</description>
 		<category>Time</category>
-		<state min="0.1" max="65" step="0.1" pattern="%.1f s" readOnly="false"/>
+		<state min="0.1" max="65" step="0.1" pattern="%.1f %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="transformTime" advanced="true">
@@ -138,7 +138,7 @@
 		<label>Transform Time</label>
 		<description>Time it takes to change/fade from one look to the next.</description>
 		<category>Time</category>
-		<state min="0" max="65" step="0.1" pattern="%.1f s" readOnly="false"/>
+		<state min="0" max="65" step="0.1" pattern="%.1f %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="speed" advanced="true">

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -30,7 +30,7 @@
 				<label>Address</label>
 				<description>Use this format http://192.168.1.2:80</description>
 			</parameter>
-			<parameter name="pollTime" type="integer" required="true" min="1" max="9999999" unit="s">
+			<parameter name="pollTime" type="integer" required="true" min="1" unit="s">
 				<label>Poll States</label>
 				<description>Time in seconds of how often to fetch the state of the LEDs.</description>
 				<default>10</default>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -130,7 +130,7 @@
 		<label>Preset Duration</label>
 		<description>Time in seconds for how long to show each preset for before moving to the next</description>
 		<category>Time</category>
-		<state min="0.1" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
+		<state min="0.1" max="65" step="0.1" pattern="%.1f Second" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="transformTime" advanced="true">
@@ -138,7 +138,7 @@
 		<label>Transform Time</label>
 		<description>Time it takes to change/fade from one look to the next.</description>
 		<category>Time</category>
-		<state min="0" max="65" step="0.1" pattern="%d %unit%" readOnly="false"/>
+		<state min="0" max="65" step="0.1" pattern="%.1f Second" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="speed" advanced="true">

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -23,6 +23,8 @@
 			<channel id="speed" typeId="speed"/>
 			<channel id="intensity" typeId="intensity"/>
 			<channel id="sleep" typeId="sleep"/>
+			<channel id="syncSend" typeId="syncSend"/>
+			<channel id="syncReceive" typeId="syncReceive"/>
 		</channels>
 		<config-description>
 			<parameter name="address" type="text" required="true">
@@ -164,6 +166,18 @@
 		<item-type>Switch</item-type>
 		<label>Preset Cycle</label>
 		<description>Cycle through the saved presets</description>
+	</channel-type>
+
+	<channel-type id="syncSend" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Sync Send</label>
+		<description>Sends UDP packets that tell other WLED lights to follow this one.</description>
+	</channel-type>
+
+	<channel-type id="syncReceive" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Sync Receive</label>
+		<description>Allows UDP packets from other WLED lights to control this one.</description>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -130,7 +130,7 @@
 		<label>Preset Duration</label>
 		<description>Time in seconds for how long to show each preset for before moving to the next</description>
 		<category>Time</category>
-		<state min="0.1" max="65" step="0.1" pattern="%.1f Second" readOnly="false"/>
+		<state min="0.1" max="65" step="0.1" pattern="%.1f s" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="transformTime" advanced="true">
@@ -138,7 +138,7 @@
 		<label>Transform Time</label>
 		<description>Time it takes to change/fade from one look to the next.</description>
 		<category>Time</category>
-		<state min="0" max="65" step="0.1" pattern="%.1f Second" readOnly="false"/>
+		<state min="0" max="65" step="0.1" pattern="%.1f s" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="speed" advanced="true">

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -83,7 +83,7 @@
 	<channel-type id="secondaryWhite" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Secondary White</label>
-		<description>Changes the brightness of the white LED</description>
+		<description>Changes the brightness of the secondary white LED</description>
 		<category>DimmableLight</category>
 	</channel-type>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -291,6 +291,7 @@
     <module>org.openhab.binding.wifiled</module>
     <module>org.openhab.binding.windcentrale</module>
     <module>org.openhab.binding.wlanthermo</module>
+    <module>org.openhab.binding.wled</module>
     <module>org.openhab.binding.xmltv</module>
     <module>org.openhab.binding.xmppclient</module>
     <module>org.openhab.binding.yamahareceiver</module>


### PR DESCRIPTION
This new openHAB binding allows you to auto discover (using mDNS) and control LED strings based on the opensource WLED project:
https://github.com/Aircoookie/WLED

It uses a Jetty HttpClientFactory instance and needs no dependencies and a number of users are reporting the 2.5.9 version is working here on the forum:
https://community.openhab.org/t/wled-a-binding-for-controlling-led-strips-and-strings-from-an-opensource-esp8266-project/87286

Precompiled jar for 2.5.9
https://github.com/Skinah/wled/releases/download/2020-10-05/wled-2.5.9.zip

Precompiled jar for 3.0.0
http://www.pcmus.com/openhab/wled/org.openhab.binding.wled-3.0.0-SNAPSHOT.zip

Signed-off-by: Matthew Skinner <matt@pcmus.com>