### PR TITLE
[snmp] Fix memory leak in SNMP

### DIFF
--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -175,6 +175,15 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
         if (event == null) {
             return;
         }
+
+        if (event.getSource() instanceof org.snmp4j.Snmp) {
+            // Always cancel async request when response has been received
+            // otherwise a memory leak is created! Not canceling a request
+            // immediately can be useful when sending a request to a broadcast
+            // address.
+            ((org.snmp4j.Snmp) event.getSource()).cancel(event.getRequest(), this);
+        }
+
         PDU response = event.getResponse();
         if (response == null) {
             Exception e = event.getError();

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -52,6 +52,7 @@ import org.snmp4j.CommandResponderEvent;
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.PDU;
 import org.snmp4j.PDUv1;
+import org.snmp4j.Snmp;
 import org.snmp4j.event.ResponseEvent;
 import org.snmp4j.event.ResponseListener;
 import org.snmp4j.mp.SnmpConstants;
@@ -181,7 +182,7 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
             // otherwise a memory leak is created! Not canceling a request
             // immediately can be useful when sending a request to a broadcast
             // address.
-            ((org.snmp4j.Snmp) event.getSource()).cancel(event.getRequest(), this);
+            ((Snmp) event.getSource()).cancel(event.getRequest(), this);
         }
 
         PDU response = event.getResponse();

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -177,7 +177,7 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
             return;
         }
 
-        if (event.getSource() instanceof org.snmp4j.Snmp) {
+        if (event.getSource() instanceof Snmp) {
             // Always cancel async request when response has been received
             // otherwise a memory leak is created! Not canceling a request
             // immediately can be useful when sending a request to a broadcast

--- a/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
+++ b/bundles/org.openhab.binding.snmp/src/main/java/org/openhab/binding/snmp/internal/SnmpTargetHandler.java
@@ -181,7 +181,7 @@ public class SnmpTargetHandler extends BaseThingHandler implements ResponseListe
             // Always cancel async request when response has been received
             // otherwise a memory leak is created! Not canceling a request
             // immediately can be useful when sending a request to a broadcast
-            // address.
+            // address (Comment is taken from the snmp4j API doc).
             ((Snmp) event.getSource()).cancel(event.getRequest(), this);
         }
 

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -24,6 +24,7 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.snmp4j.PDU;
+import org.snmp4j.Snmp;
 import org.snmp4j.event.ResponseEvent;
 import org.snmp4j.smi.Counter64;
 import org.snmp4j.smi.Integer32;
@@ -119,7 +120,7 @@ public class SnmpTargetHandlerTest extends AbstractSnmpTargetHandlerTest {
         assertEquals(1, source.cancelCallCounter);
     }
 
-    class SnmpMock extends org.snmp4j.Snmp {
+    class SnmpMock extends Snmp {
         public int cancelCallCounter = 0;
 
         @Override

--- a/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.openhab.binding.snmp/src/test/java/org/openhab/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -104,4 +104,27 @@ public class SnmpTargetHandlerTest extends AbstractSnmpTargetHandlerTest {
         thingHandler.onResponse(event);
         verify(thingHandlerCallback, atLeast(1)).stateUpdated(eq(CHANNEL_UID), eq(new DecimalType("12.4")));
     }
+
+    @Test
+    public void testCancelingAsyncRequest() {
+        setup(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpChannelMode.READ, SnmpDatatype.FLOAT);
+        PDU responsePDU = new PDU(PDU.RESPONSE,
+                Collections.singletonList(new VariableBinding(new OID(TEST_OID), new OctetString("12.4"))));
+
+        SnmpMock source = new SnmpMock();
+
+        ResponseEvent event = new ResponseEvent(source, null, null, responsePDU, null);
+
+        thingHandler.onResponse(event);
+        assertEquals(1, source.cancelCallCounter);
+    }
+
+    class SnmpMock extends org.snmp4j.Snmp {
+        public int cancelCallCounter = 0;
+
+        @Override
+        public void cancel(PDU request, org.snmp4j.event.ResponseListener listener) {
+            ++cancelCallCounter;
+        }
+    }
 }


### PR DESCRIPTION
When receiving an async request it is placed in a pending request queue. Not canceling it leads to infinty life cycle for those requests, filling up memory.
