### PR TITLE
[velux] fix discovery service de- and re- registration

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -71,8 +71,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         boolean createNew = false;
         VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService == null) {
-            discoveryService = new VeluxDiscoveryService(localization);
-            this.discoveryService = discoveryService;
+            discoveryService = this.discoveryService = new VeluxDiscoveryService(localization);
             createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -71,12 +71,8 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         boolean createNew = false;
         VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService == null) {
-<<<<<<< HEAD
             discoveryService = new VeluxDiscoveryService(localization);
             this.discoveryService = discoveryService;
-=======
-            discoveryService = this.discoveryService = new VeluxDiscoveryService(localization);
->>>>>>> [velux] class variable was not being initialized
             createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -71,8 +71,12 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         boolean createNew = false;
         VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService == null) {
+<<<<<<< HEAD
             discoveryService = new VeluxDiscoveryService(localization);
             this.discoveryService = discoveryService;
+=======
+            discoveryService = this.discoveryService = new VeluxDiscoveryService(localization);
+>>>>>>> [velux] class variable was not being initialized
             createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -72,6 +72,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService == null) {
             discoveryService = new VeluxDiscoveryService(localization);
+            this.discoveryService = discoveryService;
             createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -68,14 +68,12 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
 
     private void registerDeviceDiscoveryService(VeluxBridgeHandler bridgeHandler) {
         logger.trace("registerDeviceDiscoveryService({}) called.", bridgeHandler);
-        boolean createNew = false;
         VeluxDiscoveryService discoveryService = this.discoveryService;
         if (discoveryService == null) {
             discoveryService = this.discoveryService = new VeluxDiscoveryService(localization);
-            createNew = true;
         }
         discoveryService.addBridge(bridgeHandler);
-        if (createNew) {
+        if (discoveryServiceRegistration == null) {
             discoveryServiceRegistration = bundleContext.registerService(DiscoveryService.class.getName(),
                     discoveryService, new Hashtable<>());
         }
@@ -90,6 +88,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
                 ServiceRegistration<?> discoveryServiceRegistration = this.discoveryServiceRegistration;
                 if (discoveryServiceRegistration != null) {
                     discoveryServiceRegistration.unregister();
+                    this.discoveryServiceRegistration = null;
                 }
             }
         }


### PR DESCRIPTION
Silly errors:  
- the variable `this.discoveryService` was not being initialized..
- the discoveryServiceRegistration was not being destroyed and recreated after de- and re-registration