### PR TITLE
[haywardomnilogic] Replacement for Hayward Omnilogic Pool Automation Binding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -91,6 +91,7 @@
 /bundles/org.openhab.binding.gree/ @markus7017
 /bundles/org.openhab.binding.groheondus/ @FlorianSW
 /bundles/org.openhab.binding.harmonyhub/ @digitaldan
+/bundles/org.openhab.binding.haywardomnilogic/ @matchews
 /bundles/org.openhab.binding.hdanywhere/ @kgoderis
 /bundles/org.openhab.binding.hdpowerview/ @beowulfe
 /bundles/org.openhab.binding.helios/ @kgoderis

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -441,7 +441,12 @@
       <artifactId>org.openhab.binding.harmonyhub</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
+     <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.haywardomnilogic</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+	<dependency>
       <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.hdanywhere</artifactId>
       <version>${project.version}</version>

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -441,12 +441,12 @@
       <artifactId>org.openhab.binding.harmonyhub</artifactId>
       <version>${project.version}</version>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.haywardomnilogic</artifactId>
       <version>${project.version}</version>
     </dependency>
-	<dependency>
+    <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.hdanywhere</artifactId>
       <version>${project.version}</version>

--- a/bundles/org.openhab.binding.haywardomnilogic/NOTICE
+++ b/bundles/org.openhab.binding.haywardomnilogic/NOTICE
@@ -1,0 +1,14 @@
+  
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -66,19 +66,19 @@ Hayward OmniLogic Connection Parameters:
 
 ### Chlorinator Channels
 
-| Channel Type ID       		| Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| chlorEnable       			| Switch    | Chlorinator enable														|     R/W    |
-| chlorOperatingMode    		| String    | Chlorinator operating mode												|      R     |
-| chlorTimedPercent 			| Number	| Chlorinator timed percent					                                |     R/W    |
-| chlorOperatingState   		| Number    | Chlorinator operating state												|      R     |
-| chlorScMode    				| String    | Chlorinator mode															|      R     |
-| chlorError     				| Number    | Chlorinator error															|      R     |
-| chlorAlert        			| String    | Chlorinator alert															|      R     |
-| chlorAvgSaltLevel     		| Number    | Chlorinator average salt level in Part per Million (ppm)					|      R     |
-| chlorInstantSaltLevel 		| Number    | Chlorinator instant salt level in Part per Million (ppm)    				|      R     |
-| chlorStatus     				| Number    | Chlorinator K1/K2 relay status      									    |      R     |
-		
+| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
+|-------------------------------|-----------			|---------------------------------------------------------------|:----------:|
+| chlorEnable       			| Switch    			| Chlorinator enable											|     R/W    |
+| chlorOperatingMode    		| String     			| Chlorinator operating mode									|      R     |
+| chlorTimedPercent 			| Number:Dimensionless	| Chlorinator timed percent					                    |     R/W    |
+| chlorOperatingState   		| Number    			| Chlorinator operating state									|      R     |
+ chlorScMode    				| String    			| Chlorinator mode												|      R     |
+| chlorError     				| Number    			| Chlorinator error												|      R     |
+| chlorAlert        			| String    			| Chlorinator alert												|      R     |
+| chlorAvgSaltLevel     		| Number:Dimensionless  | Chlorinator average salt level in Part per Million (ppm)		|      R     |
+| chlorInstantSaltLevel 		| Number:Dimensionless  | Chlorinator instant salt level in Part per Million (ppm)    	|      R     |
+| chlorStatus     				| Number    			| Chlorinator K1/K2 relay status      							|      R     |
+
 ### Colorlogic Light Channels
 
 | Channel Type ID       		| Item Type | Description                                                               | Read Write |
@@ -87,17 +87,13 @@ Hayward OmniLogic Connection Parameters:
 | colorLogicLightState    		| Number    | Colorlogic Light state													|      R     |
 | colorLogicLightCurrentShow 	| Number	| Colorlogic Light current show					                            |     R/W    |
 
-### Chlorine Sense and Dispense (CSAD/ORP) Channels
-
-To be developed
-
 ### Filter Channels
 
 | Channel Type ID       		| Item Type | Description                                                               | Read Write |
 |-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
 | filterEnable	    			| Switch    | Filter enable																|     R/W    |
 | filterValvePosition    		| Number    | Filter valve position														|      R     |
-| filterSpeed 					| Number	| Filter speed								                                |     R/W    |
+| filterSpeed 					| Dimmer	| Filter speed								                                |     R/W    |
 | filterState   				| Number    | Filter state																|      R     |
 | filterLastSpeed       		| Number    | Filter last speed															|      R     |
 
@@ -116,7 +112,7 @@ To be developed
 | Channel Type ID               | Item Type | Description                                                               | Read Write |
 |-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
 | pumpEnable                    | Switch    | Pump enable                                                               |      R     |
-| pumpSpeed                     | Number    | Pump speed                                                                |      R     |
+| pumpSpeed                     | Dimmer    | Pump speed                                                                |      R     |
 
 ### Relay Channels
 

--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -1,0 +1,258 @@
+# Hayward Omnilogic Binding
+
+The Hayward Omnilogic binding integrates the Omnilogic pool controller using the Hayward API.
+
+The Hayward Omnilogic API interacts with Hayward's cloud server requiring a connection with the Internet for sending and receiving information.
+
+## Supported Things
+
+The table below lists the Hayward OmniLogic binding thing types:
+
+| Things                                  | Description                                                                                                  | Thing Type     |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------|
+| Hayward OmniLogix Connection            | Connection to Hayward's Server                                                                               | bridge         |
+| Backyard                                | Backyard                                                                                                     | backyard       |
+| Body of Water                           | Body of Water                                                                                                | bow            |
+| Chlorinator                             | Chlorinator																									 | chlorinator    |
+| Colorlogic Light                        | Colorlogic Light                                                                                             | colorlogic     |
+| Chlorine Sense and Dispense             | CSAD/ORP Control (under development)                                                                         | csad           |
+| Filter                                  | Filter control                                                                                               | filter         |
+| Heater Equipment                        | Actual heater (i.e. gas, solar, electric)                                                                    | heater         |
+| Pump                                    | Auxillary pump control (i.e. spillover)                                                                      | pump           |
+| Relay                                   | Accessory relay control (deck jet sprinklers, lights, etc.)                                                  | relay          |
+| Virtaul Heater                          | A Virtual Heater that can control all of the heater equipment based on priority                              | virtualHeater  |
+
+## Discovery
+
+The binding will automatically discover the Omnilogic pool things from the cloud server using your Hayward Omnilogic credentials.
+
+## Thing Configuration
+
+Hayward OmniLogic Connection Parameters:
+
+| Property			    | Default															| Required 	| Description 								|
+|-----------------------|-------------------------------------------------------------------|-----------|:-----------------------------------------:|
+| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ashx	| Yes		| Host name of the Hayward API server 		|
+| User Name       		| None    															| Yes		| Your Hayward User Name (not email address)|
+| Password 				| None																| Yes		| Your Hayward User Password				|
+| Telemetry Poll Delay  | 12    															| Yes		| Telemetry Poll Delay (seconds)			|
+| Alarm Poll Delay    	| 60    															| Yes		| Alarm Poll Delay (seconds)				|
+| Command Poll Delay	| 12    															| Yes		| Command Poll Delay (seconds)				|
+
+## Channels
+
+### Backyard Channels
+
+| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
+|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
+| backyardAirTemp       		| Number:Temperature	| Backyard air temp sensor reading								|      R     |
+| backyardStatus       			| String    			| Backyard status												|      R     |
+| backyardState 				| String				| Backyard state								                |      R     |
+| backyardAlarm1        		| String    			| Backyard alarm #1												|      R     |
+| backyardAlarm2    			| String    			| Backyard alarm #2												|      R     |
+| backyardAlarm3     			| String    			| Backyard alarm #3												|      R     |
+| backyardAlarm4        		| String    			| Backyard alarm #4												|      R     |
+| backyardAlarm5        		| String    			| Backyard alarm #5												|      R     |
+
+
+### Body of Water Channels
+
+| Channel Type ID       		| Item Type 			| Description                                                    | Read Write |
+|-------------------------------|-----------------------|----------------------------------------------------------------|:----------:|
+| bowFlow       				| Number    			| Body of Water flow sensor feedback							 |      R     |
+| bowWaterTemp       			| Number:Temperature    | Body of Water temperature  									 |      R     |
+
+
+### Chlorinator Channels
+
+| Channel Type ID       		| Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| chlorEnable       			| Switch    | Chlorinator enable														|     R/W    |
+| chlorOperatingMode    		| String    | Chlorinator operating mode												|      R     |
+| chlorTimedPercent 			| Number	| Chlorinator timed percent					                                |     R/W    |
+| chlorOperatingState   		| Number    | Chlorinator operating state												|      R     |
+| chlorScMode    				| String    | Chlorinator mode															|      R     |
+| chlorError     				| Number    | Chlorinator error															|      R     |
+| chlorAlert        			| String    | Chlorinator alert															|      R     |
+| chlorAvgSaltLevel     		| Number    | Chlorinator average salt level in Part per Million (ppm)					|      R     |
+| chlorInstantSaltLevel 		| Number    | Chlorinator instant salt level in Part per Million (ppm)    				|      R     |
+| chlorStatus     				| Number    | Chlorinator K1/K2 relay status      									    |      R     |
+		
+### Colorlogic Light Channels
+
+| Channel Type ID       		| Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| colorLogicLightEnable       	| Switch    | Colorlogic Light enable													|     R/W    |
+| colorLogicLightState    		| Number    | Colorlogic Light state													|      R     |
+| colorLogicLightCurrentShow 	| Number	| Colorlogic Light current show					                            |     R/W    |
+
+### Chlorine Sense and Dispense (CSAD/ORP) Channels
+
+To be developed
+
+### Filter Channels
+
+| Channel Type ID       		| Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| filterEnable	    			| Switch    | Filter enable																|     R/W    |
+| filterValvePosition    		| Number    | Filter valve position														|      R     |
+| filterSpeed 					| Number	| Filter speed								                                |     R/W    |
+| filterState   				| Number    | Filter state																|      R     |
+| filterLastSpeed       		| Number    | Filter last speed															|      R     |
+
+### Heater Channels
+
+| Channel Type ID               | Item Type 			| Description                                                   | Read Write |
+|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
+| heaterState                   | Number    			| Heater state                                                  |      R     |
+| heaterTemp                    | Number:Temperature	| Heater temperature                                            |      R     |
+| heaterEnable                  | Number    			| Heater enable                                                 |      R     |
+| heaterPriority                | Number    			| Heater priority                                               |      R     |
+| heaterMaintainFor             | Number    			| Heater maintain for                                           |      R     |
+
+### Pump Channels
+
+| Channel Type ID               | Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| pumpEnable                    | Switch    | Pump enable                                                               |      R     |
+| pumpSpeed                     | Number    | Pump speed                                                                |      R     |
+
+### Relay Channels
+
+| Channel Type ID       		| Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| relayState	    			| Switch    | Relay state																|     R/W    |
+
+### Virtual Heater Channels
+
+| Channel Type ID               | Item Type | Description                                                               | Read Write |
+|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
+| heaterState                   | Number    | Heater state                                                              |      R     |
+| heaterEnable                  | Number    | Heater enable                                                             |      R     |
+
+
+## Full Example
+
+After installing the binding, you will need to manually add the Hayward Connection thing and enter your credentials.  All pool items will then be automatically discovered.
+Goto the inbox and add the things.
+
+### demo.items:
+
+```
+Number:Temperature   PoolBackyardAirTemp "Air Temp [%1.0f °F]"                  { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAirTemp"}
+String   PoolBackyardStatus "Status [%s]"                                       { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardStatus"}
+String   PoolBackyardState "State [%s]"                                         { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardState"}
+String   PoolBackyardAlarm1 "Alarm #1 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm1"}
+String   PoolBackyardAlarm2 "Alarm #2 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm2"}
+String   PoolBackyardAlarm3 "Alarm #3 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm3"}
+String   PoolBackyardAlarm4 "Alarm #4 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm4"}
+String   PoolBackyardAlarm5 "Alarm #5 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm5"}
+  
+Number   PoolBOWFlow "Flow Switch"                      						{ channel = "haywardomnilogic:bow:2ee76053:30:bowFlow"}
+Number:Temperature   PoolBOWWaterTemp "Water Temp [%1.0f °F]"                   { channel = "haywardomnilogic:bow:2ee76053:30:bowWaterTemp"}
+ 
+Switch   PoolChlorEnable "Enable"                                               { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorEnable"}
+String   PoolChlorOperatingMode "Operating Mode [%s]"                           { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorOperatingMode"}
+Number   PoolChlorSaltOutput "Salt Output [%1.0f %%]"           				{ channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorTimedPercent"}
+String   PoolChlorOperatingState "Operating State [%s]"                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorOperatingState"}
+String   PoolChlorScMode "SC Mode [%s]"                                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorScMode"}
+Number   PoolChlorError "Error [%s]"                                            { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorError"}
+String   PoolChlorAlert "Alert"             									{ channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorAlert"}
+Number   PoolChlorAverageSalt "Average Salt[%1.0f ppm]"                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorAvgSaltLevel"}
+Number   PoolChlorInstantSalt "Instant Salt [%1.0f ppm]"                        { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorInstantSaltLevel"}
+Number   PoolChlorStatus "K1/K2 Relay Status"                                   { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorStatus"}
+
+Number   PoolHeaterState "State [%s]"                                           { channel = "haywardomnilogic:heater:2ee76053:33:heaterState"}
+Number   PoolHeaterEnable "Power [%s]"                                          { channel = "haywardomnilogic:heater:2ee76053:33:heaterEnable"}
+
+Switch   PoolLightEnable "Enable"                                               { channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightEnable"}
+String   PoolLightState "State"                   								{ channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightState"}
+String   PoolLightCurrentShow "Show"                                            { channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightCurrentShow"}
+
+Switch   PoolFilterEnable "Power"                                               { channel = "haywardomnilogic:filter:2ee76053:31:filterPowerSwitch"}
+Number   PoolFilterValve "Valve Position [%s]"                                  { channel = "haywardomnilogic:filter:2ee76053:31:filterValvePosition"}
+Number   PoolFilterSpeed "Speed[%1.0f %%]"                                      { channel = "haywardomnilogic:filter:2ee76053:31:filterSpeed"}
+Number   PoolFilterState "State"                 								{ channel = "haywardomnilogic:filter:2ee76053:31:filterState"}
+Number   PoolFilterLastSpeed "Speed[%1.0f %%]"                                  { channel = "haywardomnilogic:filter:2ee76053:31:filterLastSpeed"}
+
+Switch   PoolVirtualHeaterEnable "Power"                                        { channel = "haywardomnilogic:virtualHeater:2ee76053:32:virtualHeaterEnable"}
+Number:Temperature   PoolVirtualHeaterTemp "Temp [%1.0f °F]"                    { channel = "haywardomnilogic:virtualHeater:2ee76053:32:virtualHeaterCurrentSetpoint"}
+  
+Switch   PoolRelay1 "Deck Jets"                                                 { channel = "haywardomnilogic:relay:2ee76053:37:relayState"}
+Switch   PoolRelay2 "Vacuum"                                                    { channel = "haywardomnilogic:relay:2ee76053:36:relayState"}
+```
+
+
+### demo.sitemap:
+
+```
+sitemap demo label="Demo Sitemap" {
+
+            Frame label="Backyard" 
+                {
+                Text item=PoolBackyardAirTemp icon="temperature"     
+                Text item=PoolBackyardStatus                               
+                Text item=PoolBackyardState 
+                Text item=PoolBackyardAlarm1 label="Alarm 1" visibility=[PoolBackyardAlarm1!=""]  icon="alarm"                        
+                Text item=PoolBackyardAlarm2 label="Alarm 2" visibility=[PoolBackyardAlarm2!=""]  icon="alarm"    
+                Text item=PoolBackyardAlarm3 label="Alarm 3" visibility=[PoolBackyardAlarm3!=""]  icon="alarm"     
+                Text item=PoolBackyardAlarm4 label="Alarm 4" visibility=[PoolBackyardAlarm4!=""]  icon="alarm"      
+                Text item=PoolBackyardAlarm5 label="Alarm 5" visibility=[PoolBackyardAlarm5!=""]  icon="alarm"   
+                }
+                
+            Frame label="Pool"     
+                {
+                Text item=PoolBOWFlow     
+                Text item=PoolBOWWaterTemp icon="temperature" 
+                }
+                                                                               
+            Frame label="Pump"  
+                {     
+                Switch item=PoolFilterEnable 
+                Text item=PoolFilterValve 
+                Setpoint item=PoolFilterSpeed minValue=0 maxValue=100 step=5
+                Text item=PoolFilterState 
+				Text item=PoolFilterLastSpeed
+                }
+ 
+             Frame label="Heater"  
+                {
+                Text item=PoolHeaterState
+                Text item=PoolHeaterTemp 
+                }
+
+            Frame label="Virtual Heater"    
+                {
+                Switch item=PoolVirtualHeaterEnable
+                Setpoint item=PoolVirtualHeaterTemp                           
+                }
+                                
+            Frame label="Chlorinator"   
+                {
+                Switch item=PoolChlorEnable
+                Text item=PoolChlorOperatingMode
+                Setpoint item=PoolChlorSaltOutput
+                Text item=PoolChlorOperatingState
+                Text item=PoolChlorScMode
+                Text item=PoolChlorError
+                Text item=PoolChlorAlert
+                Text item=PoolChlorAverageSalt
+                Text item=PoolChlorInstantSalt
+                Text item=PoolChlorStatus                             
+                }
+                
+            Frame label="ColorLogic Light"  
+                {
+                Switch item=PoolLightEnable
+                Selection item=PoolLightCurrentShow
+                Text item=PoolLightState
+                }
+  
+            Frame label="Relays"    
+                {
+                Switch item=PoolRelay1
+                Switch item=PoolRelay2                            
+                }
+  }
+```
+

--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -8,19 +8,18 @@ The Hayward Omnilogic API interacts with Hayward's cloud server requiring a conn
 
 The table below lists the Hayward OmniLogic binding thing types:
 
-| Things                                  | Description                                                                     | Thing Type     |
-|-----------------------------------------|---------------------------------------------------------------------------------|----------------|
-| Hayward OmniLogix Connection            | Connection to Hayward's Server                                                  | bridge         |
-| Backyard                                | Backyard                                                                        | backyard       |
-| Body of Water                           | Body of Water                                                                   | bow            |
-| Chlorinator                             | Chlorinator																		| chlorinator    |
-| Colorlogic Light                        | Colorlogic Light                                                                | colorlogic     |
-| Chlorine Sense and Dispense             | CSAD/ORP Control (under development)                                            | csad           |
-| Filter                                  | Filter control                                                                  | filter         |
-| Heater Equipment                        | Actual heater (i.e. gas, solar, electric)                                       | heater         |
-| Pump                                    | Auxillary pump control (i.e. spillover)                                         | pump           |
-| Relay                                   | Accessory relay control (deck jet sprinklers, lights, etc.)                     | relay          |
-| Virtaul Heater                          | A Virtual Heater that can control all of the heater equipment based on priority | virtualHeater  |
+| Things                       | Description                                                                     | Thing Type    |
+|------------------------------|---------------------------------------------------------------------------------|---------------|
+| Hayward OmniLogix Connection | Connection to Hayward's Server                                                  | bridge        |
+| Backyard                     | Backyard                                                                        | backyard      |
+| Body of Water                | Body of Water                                                                   | bow           |
+| Chlorinator                  | Chlorinator                                                                     | chlorinator   |
+| Colorlogic Light             | Colorlogic Light                                                                | colorlogic    |
+| Filter                       | Filter control                                                                  | filter        |
+| Heater Equipment             | Actual heater (i.e. gas, solar, electric)                                       | heater        |
+| Pump                         | Auxillary pump control (i.e. spillover)                                         | pump          |
+| Relay                        | Accessory relay control (deck jet sprinklers, lights, etc.)                     | relay         |
+| Virtaul Heater               | A Virtual Heater that can control all of the heater equipment based on priority | virtualHeater |
 
 ## Discovery
 
@@ -30,226 +29,143 @@ The binding will automatically discover the Omnilogic pool things from the cloud
 
 Hayward OmniLogic Connection Parameters:
 
-| Property			    | Default												      | Required | Description 								 |
-|-----------------------|-------------------------------------------------------------|----------|-------------------------------------------|
-| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ash  | Yes		 | Host name of the Hayward API server 		 |
-| User Name       		| None    													  | Yes		 | Your Hayward User Name (not email address)|
-| Password 				| None													      | Yes		 | Your Hayward User Password				 |
-| Telemetry Poll Delay  | 12    													  | Yes		 | Telemetry Poll Delay (seconds)			 |
-| Alarm Poll Delay    	| 60    													  | Yes		 | Alarm Poll Delay (seconds)				 |
-| Command Poll Delay	| 12    													  | Yes		 | Command Poll Delay (seconds)				 |
+| Property             | Default                                                        | Required | Description                                  |
+|----------------------|----------------------------------------------------------------|----------|----------------------------------------------|
+| Host Name            | https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ash | Yes      | Host name of the Hayward API server          |
+| User Name            | None                                                           | Yes      | Your Hayward User Name (not email address)   |
+| Password             | None                                                           | Yes      | Your Hayward User Password                   |
+| Telemetry Poll Delay | 12                                                             | Yes      | Telemetry Poll Delay (10-60 seconds)         |
+| Alarm Poll Delay     | 60                                                             | Yes      | Alarm Poll Delay (0-120 seconds, 0 disabled) |
 
 ## Channels
 
 ### Backyard Channels
 
-| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
-|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
-| backyardAirTemp       		| Number:Temperature	| Backyard air temp sensor reading								|      R     |
-| backyardStatus       			| String    			| Backyard status												|      R     |
-| backyardState 				| String				| Backyard state								                |      R     |
-| backyardAlarm1        		| String    			| Backyard alarm #1												|      R     |
-| backyardAlarm2    			| String    			| Backyard alarm #2												|      R     |
-| backyardAlarm3     			| String    			| Backyard alarm #3												|      R     |
-| backyardAlarm4        		| String    			| Backyard alarm #4												|      R     |
-| backyardAlarm5        		| String    			| Backyard alarm #5												|      R     |
-
+| backyardAirTemp | Number:Temperature | Backyard air temp sensor reading | R |
+|-----------------|--------------------|----------------------------------|:-:|
+| backyardStatus  | String             | Backyard status                  | R |
+| backyardState   | String             | Backyard state                   | R |
+| backyardAlarm1  | String             | Backyard alarm #1                | R |
+| backyardAlarm2  | String             | Backyard alarm #2                | R |
+| backyardAlarm3  | String             | Backyard alarm #3                | R |
+| backyardAlarm4  | String             | Backyard alarm #4                | R |
+| backyardAlarm5  | String             | Backyard alarm #5                | R |
 
 ### Body of Water Channels
 
-| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
-|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
-| bowFlow       				| Number    			| Body of Water flow sensor feedback						    |      R     |
-| bowWaterTemp       			| Number:Temperature    | Body of Water temperature  								    |      R     |
-
+| Channel Type ID | Item Type          | Description                        | Read Write |
+|-----------------|--------------------|------------------------------------|:----------:|
+| bowFlow         | Switch             | Body of Water flow sensor feedback |      R     |
+| bowWaterTemp    | Number:Temperature | Body of Water temperature          |      R     |
 
 ### Chlorinator Channels
 
-| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
-|-------------------------------|-----------			|---------------------------------------------------------------|:----------:|
-| chlorEnable       			| Switch    			| Chlorinator enable											|     R/W    |
-| chlorOperatingMode    		| String     			| Chlorinator operating mode									|      R     |
-| chlorTimedPercent 			| Number:Dimensionless	| Chlorinator timed percent					                    |     R/W    |
-| chlorOperatingState   		| Number    			| Chlorinator operating state									|      R     |
- chlorScMode    				| String    			| Chlorinator mode												|      R     |
-| chlorError     				| Number    			| Chlorinator error												|      R     |
-| chlorAlert        			| String    			| Chlorinator alert												|      R     |
-| chlorAvgSaltLevel     		| Number:Dimensionless  | Chlorinator average salt level in Part per Million (ppm)		|      R     |
-| chlorInstantSaltLevel 		| Number:Dimensionless  | Chlorinator instant salt level in Part per Million (ppm)    	|      R     |
-| chlorStatus     				| Number    			| Chlorinator K1/K2 relay status      							|      R     |
+| Channel Type ID       | Item Type            | Description                                              | Read Write |
+|-----------------------|----------------------|----------------------------------------------------------|:----------:|
+| chlorEnable           | Switch               | Chlorinator enable                                       |     R/W    |
+| chlorOperatingMode    | String               | Chlorinator operating mode                               |      R     |
+| chlorTimedPercent     | Number:Dimensionless | Chlorinator timed percent                                |     R/W    |
+| chlorOperatingState   | Number               | Chlorinator operating state                              |      R     |
+| chlorScMode           | String               | Chlorinator super chlorinate mode                        |      R     |
+| chlorError            | Number               | Chlorinator error                                        |      R     |
+| chlorAlert            | String               | Chlorinator alert                                        |      R     |
+| chlorAvgSaltLevel     | Number:Dimensionless | Chlorinator average salt level in Part per Million (ppm) |      R     |
+| chlorInstantSaltLevel | Number:Dimensionless | Chlorinator instant salt level in Part per Million (ppm) |      R     |
+| chlorStatus           | Number               | Chlorinator K1/K2 relay status                           |      R     |
 
 ### Colorlogic Light Channels
 
-| Channel Type ID       		| Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| colorLogicLightEnable       	| Switch    | Colorlogic Light enable													|     R/W    |
-| colorLogicLightState    		| Number    | Colorlogic Light state													|      R     |
-| colorLogicLightCurrentShow 	| Number	| Colorlogic Light current show					                            |     R/W    |
+| Channel Type ID            | Item Type | Description                   | Read Write |
+|----------------------------|-----------|-------------------------------|:----------:|
+| colorLogicLightEnable      | Switch    | Colorlogic Light enable       |     R/W    |
+| colorLogicLightState       | String    | Colorlogic Light state        |      R     |
+| colorLogicLightCurrentShow | String    | Colorlogic Light current show |     R/W    |
 
 ### Filter Channels
 
-| Channel Type ID       		| Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| filterEnable	    			| Switch    | Filter enable																|     R/W    |
-| filterValvePosition    		| Number    | Filter valve position														|      R     |
-| filterSpeed 					| Dimmer	| Filter speed								                                |     R/W    |
-| filterState   				| Number    | Filter state																|      R     |
-| filterLastSpeed       		| Number    | Filter last speed															|      R     |
+| Channel Type ID     | Item Type            | Description            | Read Write |
+|---------------------|----------------------|------------------------|:----------:|
+| filterEnable        | Switch               | Filter enable          |     R/W    |
+| filterValvePosition | String               | Filter valve position  |      R     |
+| filterSpeed         | Number:Dimensionless | Filter speed in %      |     R/W    |
+| filterState         | String               | Filter state           |      R     |
+| filterLastSpeed     | Number:Dimensionless | Filter last speed in % |      R     |
 
 ### Heater Channels
 
-| Channel Type ID               | Item Type 			| Description                                                   | Read Write |
-|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
-| heaterState                   | Number    			| Heater state                                                  |      R     |
-| heaterTemp                    | Number:Temperature	| Heater temperature                                            |      R     |
-| heaterEnable                  | Number    			| Heater enable                                                 |      R     |
-| heaterPriority                | Number    			| Heater priority                                               |      R     |
-| heaterMaintainFor             | Number    			| Heater maintain for                                           |      R     |
+| Channel Type ID | Item Type | Description   | Read Write |
+|-----------------|-----------|---------------|:----------:|
+| heaterState     | Number    | Heater state  |      R     |
+| heaterEnable    | Switch    | Heater enable |      R     |
 
 ### Pump Channels
 
-| Channel Type ID               | Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| pumpEnable                    | Switch    | Pump enable                                                               |      R     |
-| pumpSpeed                     | Dimmer    | Pump speed                                                                |      R     |
+| Channel Type ID | Item Type            | Description     | Read Write |
+|-----------------|----------------------|-----------------|:----------:|
+| pumpEnable      | Switch               | Pump enable     |      R     |
+| pumpSpeed       | Number:Dimensionless | Pump speed in % |      R     |
 
 ### Relay Channels
 
-| Channel Type ID       		| Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| relayState	    			| Switch    | Relay state																|     R/W    |
+| Channel Type ID | Item Type | Description | Read Write |
+|-----------------|-----------|-------------|:----------:|
+| relayState      | Switch    | Relay state |     R/W    |
 
 ### Virtual Heater Channels
 
-| Channel Type ID               | Item Type | Description                                                               | Read Write |
-|-------------------------------|-----------|---------------------------------------------------------------------------|:----------:|
-| heaterState                   | Number    | Heater state                                                              |      R     |
-| heaterEnable                  | Number    | Heater enable                                                             |      R     |
-
+| Channel Type ID       | Item Type          | Description             | Read Write |
+|-----------------------|--------------------|-------------------------|:----------:|
+| heaterEnable          | Number             | Heater enable           |      R     |
+| heaterCurrentSetpoint | Number:Temperature | Heater Current Setpoint |     R/W    |
 
 ## Full Example
 
 After installing the binding, you will need to manually add the Hayward Connection thing and enter your credentials.
-All pool items will then be automatically discovered.
+All pool items can be autmatically discovered by scanning the bridge
 Goto the inbox and add the things.
 
 ### demo.items:
 
-```
-Number:Temperature   PoolBackyardAirTemp "Air Temp [%1.0f °F]"                  { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAirTemp"}
-String   PoolBackyardStatus "Status [%s]"                                       { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardStatus"}
-String   PoolBackyardState "State [%s]"                                         { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardState"}
-String   PoolBackyardAlarm1 "Alarm #1 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm1"}
-String   PoolBackyardAlarm2 "Alarm #2 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm2"}
-String   PoolBackyardAlarm3 "Alarm #3 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm3"}
-String   PoolBackyardAlarm4 "Alarm #4 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm4"}
-String   PoolBackyardAlarm5 "Alarm #5 [%s]"                                     { channel = "haywardomnilogic:backyard:2ee76053:35940:backyardAlarm5"}
-  
-Number   PoolBOWFlow "Flow Switch"                      						{ channel = "haywardomnilogic:bow:2ee76053:30:bowFlow"}
-Number:Temperature   PoolBOWWaterTemp "Water Temp [%1.0f °F]"                   { channel = "haywardomnilogic:bow:2ee76053:30:bowWaterTemp"}
- 
-Switch   PoolChlorEnable "Enable"                                               { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorEnable"}
-String   PoolChlorOperatingMode "Operating Mode [%s]"                           { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorOperatingMode"}
-Number   PoolChlorSaltOutput "Salt Output [%1.0f %%]"           				{ channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorTimedPercent"}
-String   PoolChlorOperatingState "Operating State [%s]"                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorOperatingState"}
-String   PoolChlorScMode "SC Mode [%s]"                                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorScMode"}
-Number   PoolChlorError "Error [%s]"                                            { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorError"}
-String   PoolChlorAlert "Alert"             									{ channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorAlert"}
-Number   PoolChlorAverageSalt "Average Salt[%1.0f ppm]"                         { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorAvgSaltLevel"}
-Number   PoolChlorInstantSalt "Instant Salt [%1.0f ppm]"                        { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorInstantSaltLevel"}
-Number   PoolChlorStatus "K1/K2 Relay Status"                                   { channel = "haywardomnilogic:chlorinator:2ee76053:34:chlorStatus"}
+```text
+Group gPool "Pool" ["Location"]
 
-Number   PoolHeaterState "State [%s]"                                           { channel = "haywardomnilogic:heater:2ee76053:33:heaterState"}
-Number   PoolHeaterEnable "Power [%s]"                                          { channel = "haywardomnilogic:heater:2ee76053:33:heaterEnable"}
-
-Switch   PoolLightEnable "Enable"                                               { channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightEnable"}
-String   PoolLightState "State"                   								{ channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightState"}
-String   PoolLightCurrentShow "Show"                                            { channel = "haywardomnilogic:colorlogic:2ee76053:38:colorLogicLightCurrentShow"}
-
-Switch   PoolFilterEnable "Power"                                               { channel = "haywardomnilogic:filter:2ee76053:31:filterPowerSwitch"}
-Number   PoolFilterValve "Valve Position [%s]"                                  { channel = "haywardomnilogic:filter:2ee76053:31:filterValvePosition"}
-Number   PoolFilterSpeed "Speed[%1.0f %%]"                                      { channel = "haywardomnilogic:filter:2ee76053:31:filterSpeed"}
-Number   PoolFilterState "State"                 								{ channel = "haywardomnilogic:filter:2ee76053:31:filterState"}
-Number   PoolFilterLastSpeed "Speed[%1.0f %%]"                                  { channel = "haywardomnilogic:filter:2ee76053:31:filterLastSpeed"}
-
-Switch   PoolVirtualHeaterEnable "Power"                                        { channel = "haywardomnilogic:virtualHeater:2ee76053:32:virtualHeaterEnable"}
-Number:Temperature   PoolVirtualHeaterTemp "Temp [%1.0f °F]"                    { channel = "haywardomnilogic:virtualHeater:2ee76053:32:virtualHeaterCurrentSetpoint"}
-  
-Switch   PoolRelay1 "Deck Jets"                                                 { channel = "haywardomnilogic:relay:2ee76053:37:relayState"}
-Switch   PoolRelay2 "Vacuum"                                                    { channel = "haywardomnilogic:relay:2ee76053:36:relayState"}
-```
+Group gHaywardChlorinator "Hayward Chlorinator" (gPool) ["Equipment"] 
+Switch               HaywardChlorinator_Power            "Power"                (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorEnable" }           
+String               HaywardChlorinator_OperatingMode    "Operating Mode"       (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorOperatingMode" }    
+Number:Dimensionless HaywardChlorinator_SaltOutput       "Salt Output (%)"      (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorTimedPercent" }     
+String               HaywardChlorinator_scMode           "scMode"               (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorScMode" }           
+Number               HaywardChlorinator_ChlorinatorError "Chlorinator Error"    (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorError" }            
+String               HaywardChlorinator_ChlorinatorAlert "Chlorinator Alert"    (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorAlert" }            
+Number:Dimensionless HaywardChlorinator_AverageSaltLevel "Average Salt Level"   (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorAvgSaltLevel" }     
+Number:Dimensionless HaywardChlorinator_InstantSaltLevel "Instant Salt Level"   (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorInstantSaltLevel" } 
+Number               HaywardChlorinator_Status           "Status"               (gHaywardChlorinator) ["Point"]  { channel="haywardomnilogic:chlorinator:3766402f00:34:chlorStatus" }           
 
 
-### demo.sitemap:
+Group gHaywardBackyard "Hayward Backyard" (gPool) ["Equipment"]
+Number:Temperature  HaywardBackyard_AirTemp        "Air Temp"                   (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAirTemp" } 
+String              HaywardBackyard_Status         "Status"                     (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardStatus" }  
+String              HaywardBackyard_State          "State"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardState" }   
+String              HaywardBackyard_BackyardAlarm1 "Alarm"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAlarm1" }  
+String              HaywardBackyard_BackyardAlarm2 "Alarm"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAlarm2" }  
+String              HaywardBackyard_BackyardAlarm3 "Alarm"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAlarm3" }  
+String              HaywardBackyard_BackyardAlarm4 "Alarm"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAlarm4" }  
+String              HaywardBackyard_BackyardAlarm5 "Alarm"                      (gHaywardBackyard) ["Point"]  { channel="haywardomnilogic:backyard:3766402f00:35940:backyardAlarm5" }  
 
-```
-sitemap demo label="Demo Sitemap" {
+Group gHaywardGas "Hayward Gas" (gPool) ["Equipment"]
+Number              HaywardGas_HeaterState  "Heater State"                      (gHaywardGas) ["Point"]  { channel="haywardomnilogic:heater:3766402f00:33:heaterState" }  
+Switch              HaywardGas_HeaterEnable "Heater Enable"                     (gHaywardGas) ["Point"]  { channel="haywardomnilogic:heater:3766402f00:33:heaterEnable" } 
 
-            Frame label="Backyard" 
-                {
-                Text item=PoolBackyardAirTemp icon="temperature"     
-                Text item=PoolBackyardStatus                               
-                Text item=PoolBackyardState 
-                Text item=PoolBackyardAlarm1 label="Alarm 1" visibility=[PoolBackyardAlarm1!=""]  icon="alarm"                        
-                Text item=PoolBackyardAlarm2 label="Alarm 2" visibility=[PoolBackyardAlarm2!=""]  icon="alarm"    
-                Text item=PoolBackyardAlarm3 label="Alarm 3" visibility=[PoolBackyardAlarm3!=""]  icon="alarm"     
-                Text item=PoolBackyardAlarm4 label="Alarm 4" visibility=[PoolBackyardAlarm4!=""]  icon="alarm"      
-                Text item=PoolBackyardAlarm5 label="Alarm 5" visibility=[PoolBackyardAlarm5!=""]  icon="alarm"   
-                }
-                
-            Frame label="Pool"     
-                {
-                Text item=PoolBOWFlow     
-                Text item=PoolBOWWaterTemp icon="temperature" 
-                }
-                                                                               
-            Frame label="Pump"  
-                {     
-                Switch item=PoolFilterEnable 
-                Text item=PoolFilterValve 
-                Setpoint item=PoolFilterSpeed minValue=0 maxValue=100 step=5
-                Text item=PoolFilterState 
-				Text item=PoolFilterLastSpeed
-                }
- 
-             Frame label="Heater"  
-                {
-                Text item=PoolHeaterState
-                Text item=PoolHeaterTemp 
-                }
+Group gHaywardJets "Hayward Jets" (gPool) ["Equipment"]
+Switch              HaywardJets_Power "Power"                                   (gHaywardJets) ["Point"]  { channel="haywardomnilogic:relay:3766402f00:37:relayState" } 
 
-            Frame label="Virtual Heater"    
-                {
-                Switch item=PoolVirtualHeaterEnable
-                Setpoint item=PoolVirtualHeaterTemp                           
-                }
-                                
-            Frame label="Chlorinator"   
-                {
-                Switch item=PoolChlorEnable
-                Text item=PoolChlorOperatingMode
-                Setpoint item=PoolChlorSaltOutput
-                Text item=PoolChlorOperatingState
-                Text item=PoolChlorScMode
-                Text item=PoolChlorError
-                Text item=PoolChlorAlert
-                Text item=PoolChlorAverageSalt
-                Text item=PoolChlorInstantSalt
-                Text item=PoolChlorStatus                             
-                }
-                
-            Frame label="ColorLogic Light"  
-                {
-                Switch item=PoolLightEnable
-                Selection item=PoolLightCurrentShow
-                Text item=PoolLightState
-                }
-  
-            Frame label="Relays"    
-                {
-                Switch item=PoolRelay1
-                Switch item=PoolRelay2                            
-                }
-  }
+Group gHaywardPool "Hayward Pool" (gPool) ["Equipment"]
+Switch              HaywardPool_FlowSensor "Flow Sensor"                        (gHaywardPool) ["Point"]  { channel="haywardomnilogic:bow:3766402f00:30:bowFlow" }      
+Number:Temperature  HaywardPool_WaterTemp  "Water Temp"                         (gHaywardPool) ["Point"]  { channel="haywardomnilogic:bow:3766402f00:30:bowWaterTemp" } 
+
+Group gHaywardPoolLight "Hayward Pool Light" (gPool) ["Equipment"]
+Switch              HaywardPoolLight_Power       "Power"                        (gHaywardPoolLight) ["Point"]  { channel="haywardomnilogic:colorlogic:3766402f00:38:colorLogicLightEnable" }      
+String              HaywardPoolLight_LightState  "Light State"                  (gHaywardPoolLight) ["Point"]  { channel="haywardomnilogic:colorlogic:3766402f00:38:colorLogicLightState" }       
+String              HaywardPoolLight_CurrentShow "Current Show"                 (gHaywardPoolLight) ["Point"]  { channel="haywardomnilogic:colorlogic:3766402f00:38:colorLogicLightCurrentShow" } 
+
 ```
 

--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -32,8 +32,7 @@ Hayward OmniLogic Connection Parameters:
 
 | Property			    | Default												      | Required | Description 								 |
 |-----------------------|-------------------------------------------------------------|----------|-------------------------------------------|
-| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/	                  | Yes		 | Host name of the Hayward API server 		 |
-|                       | HomeAutomation/API.ashx                                     |          |                                           |
+| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ash  | Yes		 | Host name of the Hayward API server 		 |
 | User Name       		| None    													  | Yes		 | Your Hayward User Name (not email address)|
 | Password 				| None													      | Yes		 | Your Hayward User Password				 |
 | Telemetry Poll Delay  | 12    													  | Yes		 | Telemetry Poll Delay (seconds)			 |

--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -8,19 +8,19 @@ The Hayward Omnilogic API interacts with Hayward's cloud server requiring a conn
 
 The table below lists the Hayward OmniLogic binding thing types:
 
-| Things                                  | Description                                                                                                  | Thing Type     |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------|
-| Hayward OmniLogix Connection            | Connection to Hayward's Server                                                                               | bridge         |
-| Backyard                                | Backyard                                                                                                     | backyard       |
-| Body of Water                           | Body of Water                                                                                                | bow            |
-| Chlorinator                             | Chlorinator																									 | chlorinator    |
-| Colorlogic Light                        | Colorlogic Light                                                                                             | colorlogic     |
-| Chlorine Sense and Dispense             | CSAD/ORP Control (under development)                                                                         | csad           |
-| Filter                                  | Filter control                                                                                               | filter         |
-| Heater Equipment                        | Actual heater (i.e. gas, solar, electric)                                                                    | heater         |
-| Pump                                    | Auxillary pump control (i.e. spillover)                                                                      | pump           |
-| Relay                                   | Accessory relay control (deck jet sprinklers, lights, etc.)                                                  | relay          |
-| Virtaul Heater                          | A Virtual Heater that can control all of the heater equipment based on priority                              | virtualHeater  |
+| Things                                  | Description                                                                     | Thing Type     |
+|-----------------------------------------|---------------------------------------------------------------------------------|----------------|
+| Hayward OmniLogix Connection            | Connection to Hayward's Server                                                  | bridge         |
+| Backyard                                | Backyard                                                                        | backyard       |
+| Body of Water                           | Body of Water                                                                   | bow            |
+| Chlorinator                             | Chlorinator																		| chlorinator    |
+| Colorlogic Light                        | Colorlogic Light                                                                | colorlogic     |
+| Chlorine Sense and Dispense             | CSAD/ORP Control (under development)                                            | csad           |
+| Filter                                  | Filter control                                                                  | filter         |
+| Heater Equipment                        | Actual heater (i.e. gas, solar, electric)                                       | heater         |
+| Pump                                    | Auxillary pump control (i.e. spillover)                                         | pump           |
+| Relay                                   | Accessory relay control (deck jet sprinklers, lights, etc.)                     | relay          |
+| Virtaul Heater                          | A Virtual Heater that can control all of the heater equipment based on priority | virtualHeater  |
 
 ## Discovery
 
@@ -30,14 +30,15 @@ The binding will automatically discover the Omnilogic pool things from the cloud
 
 Hayward OmniLogic Connection Parameters:
 
-| Property			    | Default															| Required 	| Description 								|
-|-----------------------|-------------------------------------------------------------------|-----------|:-----------------------------------------:|
-| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ashx	| Yes		| Host name of the Hayward API server 		|
-| User Name       		| None    															| Yes		| Your Hayward User Name (not email address)|
-| Password 				| None																| Yes		| Your Hayward User Password				|
-| Telemetry Poll Delay  | 12    															| Yes		| Telemetry Poll Delay (seconds)			|
-| Alarm Poll Delay    	| 60    															| Yes		| Alarm Poll Delay (seconds)				|
-| Command Poll Delay	| 12    															| Yes		| Command Poll Delay (seconds)				|
+| Property			    | Default												      | Required | Description 								 |
+|-----------------------|-------------------------------------------------------------|----------|-------------------------------------------|
+| Host Name      		| https://app1.haywardomnilogic.com/HAAPI/	                  | Yes		 | Host name of the Hayward API server 		 |
+|                       | HomeAutomation/API.ashx                                     |          |                                           |
+| User Name       		| None    													  | Yes		 | Your Hayward User Name (not email address)|
+| Password 				| None													      | Yes		 | Your Hayward User Password				 |
+| Telemetry Poll Delay  | 12    													  | Yes		 | Telemetry Poll Delay (seconds)			 |
+| Alarm Poll Delay    	| 60    													  | Yes		 | Alarm Poll Delay (seconds)				 |
+| Command Poll Delay	| 12    													  | Yes		 | Command Poll Delay (seconds)				 |
 
 ## Channels
 
@@ -57,10 +58,10 @@ Hayward OmniLogic Connection Parameters:
 
 ### Body of Water Channels
 
-| Channel Type ID       		| Item Type 			| Description                                                    | Read Write |
-|-------------------------------|-----------------------|----------------------------------------------------------------|:----------:|
-| bowFlow       				| Number    			| Body of Water flow sensor feedback							 |      R     |
-| bowWaterTemp       			| Number:Temperature    | Body of Water temperature  									 |      R     |
+| Channel Type ID       		| Item Type 			| Description                                                   | Read Write |
+|-------------------------------|-----------------------|---------------------------------------------------------------|:----------:|
+| bowFlow       				| Number    			| Body of Water flow sensor feedback						    |      R     |
+| bowWaterTemp       			| Number:Temperature    | Body of Water temperature  								    |      R     |
 
 
 ### Chlorinator Channels
@@ -133,7 +134,8 @@ To be developed
 
 ## Full Example
 
-After installing the binding, you will need to manually add the Hayward Connection thing and enter your credentials.  All pool items will then be automatically discovered.
+After installing the binding, you will need to manually add the Hayward Connection thing and enter your credentials.
+All pool items will then be automatically discovered.
 Goto the inbox and add the things.
 
 ### demo.items:

--- a/bundles/org.openhab.binding.haywardomnilogic/pom.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.haywardomnilogic</artifactId>

--- a/bundles/org.openhab.binding.haywardomnilogic/pom.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.haywardomnilogic</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Hayward OmniLogic Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
@@ -16,8 +16,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardAccount} class contains fields mapping thing configuration parameters.
- *
- * @author Matt Myers - Initial Contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HaywardAccount} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+
+@NonNullByDefault
+public class HaywardAccount {
+    public String token = "";
+    public String mspSystemID = "";
+    public String userID = "";
+    public String backyardName = "";
+    public String address = "";
+    public String firstName = "";
+    public String lastName = "";
+    public String roleType = "";
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
@@ -30,4 +30,6 @@ public class HaywardAccount {
     public String firstName = "";
     public String lastName = "";
     public String roleType = "";
+    public String units = "";
+    public String vspSpeedFormat = "";
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardAccount.java
@@ -16,6 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardAccount} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -56,6 +56,8 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_BACKYARD_AIRTEMP = "backyardAirTemp";
     public static final String CHANNEL_BACKYARD_STATUS = "backyardStatus";
     public static final String CHANNEL_BACKYARD_STATE = "backyardState";
+    public static final String PROPERTY_BOW_UNITS = "Units";
+    public static final String PROPERTY_VSP_SPEED_FORMAT = "VSP Speed Format";
 
     // List of all Channel ids (bow)
     public static final String CHANNEL_BOW_WATERTEMP = "bowWaterTemp";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -21,8 +21,6 @@ import org.openhab.core.thing.ThingTypeUID;
 /**
  * The {@link HaywardBindingConstants} class defines common constants, which are
  * used across the whole binding.
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardBindingConstants {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -13,9 +13,6 @@
 
 package org.openhab.binding.haywardomnilogic.internal;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -45,15 +42,14 @@ public class HaywardBindingConstants {
     public static final ThingTypeUID THING_TYPE_SENSOR = new ThingTypeUID(BINDING_ID, "sensor");
     public static final ThingTypeUID THING_TYPE_VIRTUALHEATER = new ThingTypeUID(BINDING_ID, "virtualHeater");
 
-    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BRIDGE);
+    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Set.of(THING_TYPE_BRIDGE);
 
-    public static final Set<ThingTypeUID> THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
-            Arrays.asList(HaywardBindingConstants.THING_TYPE_BACKYARD, HaywardBindingConstants.THING_TYPE_BOW,
-                    HaywardBindingConstants.THING_TYPE_BRIDGE, HaywardBindingConstants.THING_TYPE_CHLORINATOR,
-                    HaywardBindingConstants.THING_TYPE_COLORLOGIC, HaywardBindingConstants.THING_TYPE_FILTER,
-                    HaywardBindingConstants.THING_TYPE_HEATER, HaywardBindingConstants.THING_TYPE_PUMP,
-                    HaywardBindingConstants.THING_TYPE_RELAY, HaywardBindingConstants.THING_TYPE_SENSOR,
-                    HaywardBindingConstants.THING_TYPE_VIRTUALHEATER));
+    public static final Set<ThingTypeUID> THING_TYPES_UIDS = Set.of(HaywardBindingConstants.THING_TYPE_BACKYARD,
+            HaywardBindingConstants.THING_TYPE_BOW, HaywardBindingConstants.THING_TYPE_BRIDGE,
+            HaywardBindingConstants.THING_TYPE_CHLORINATOR, HaywardBindingConstants.THING_TYPE_COLORLOGIC,
+            HaywardBindingConstants.THING_TYPE_FILTER, HaywardBindingConstants.THING_TYPE_HEATER,
+            HaywardBindingConstants.THING_TYPE_PUMP, HaywardBindingConstants.THING_TYPE_RELAY,
+            HaywardBindingConstants.THING_TYPE_SENSOR, HaywardBindingConstants.THING_TYPE_VIRTUALHEATER);
 
     // List of all Channel ids (bridge)
     // No Channels
@@ -62,11 +58,6 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_BACKYARD_AIRTEMP = "backyardAirTemp";
     public static final String CHANNEL_BACKYARD_STATUS = "backyardStatus";
     public static final String CHANNEL_BACKYARD_STATE = "backyardState";
-    public static final String CHANNEL_BACKYARD_ALARM1 = "backyardAlarm1";
-    public static final String CHANNEL_BACKYARD_ALARM2 = "backyardAlarm2";
-    public static final String CHANNEL_BACKYARD_ALARM3 = "backyardAlarm3";
-    public static final String CHANNEL_BACKYARD_ALARM4 = "backyardAlarm4";
-    public static final String CHANNEL_BACKYARD_ALARM5 = "backyardAlarm5";
 
     // List of all Channel ids (bow)
     public static final String CHANNEL_BOW_WATERTEMP = "bowWaterTemp";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.haywardomnilogic.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link HaywardBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardBindingConstants {
+
+    private static final String BINDING_ID = "haywardomnilogic";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_BACKYARD = new ThingTypeUID(BINDING_ID, "backyard");
+    public static final ThingTypeUID THING_TYPE_BOW = new ThingTypeUID(BINDING_ID, "bow");
+    public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
+    public static final ThingTypeUID THING_TYPE_CHLORINATOR = new ThingTypeUID(BINDING_ID, "chlorinator");
+    public static final ThingTypeUID THING_TYPE_COLORLOGIC = new ThingTypeUID(BINDING_ID, "colorlogic");
+    public static final ThingTypeUID THING_TYPE_FILTER = new ThingTypeUID(BINDING_ID, "filter");
+    public static final ThingTypeUID THING_TYPE_HEATER = new ThingTypeUID(BINDING_ID, "heater");
+    public static final ThingTypeUID THING_TYPE_PUMP = new ThingTypeUID(BINDING_ID, "pump");
+    public static final ThingTypeUID THING_TYPE_RELAY = new ThingTypeUID(BINDING_ID, "relay");
+    public static final ThingTypeUID THING_TYPE_SENSOR = new ThingTypeUID(BINDING_ID, "sensor");
+    public static final ThingTypeUID THING_TYPE_VIRTUALHEATER = new ThingTypeUID(BINDING_ID, "virtualHeater");
+
+    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BRIDGE);
+
+    // public static final Set<ThingTypeUID> ZONE_THING_TYPES_UIDS = Collections.singleton(ZONE_THING_TYPE);
+
+    public static final Set<ThingTypeUID> THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
+            Arrays.asList(HaywardBindingConstants.THING_TYPE_BACKYARD, HaywardBindingConstants.THING_TYPE_BOW,
+                    HaywardBindingConstants.THING_TYPE_BRIDGE, HaywardBindingConstants.THING_TYPE_CHLORINATOR,
+                    HaywardBindingConstants.THING_TYPE_COLORLOGIC, HaywardBindingConstants.THING_TYPE_FILTER,
+                    HaywardBindingConstants.THING_TYPE_HEATER, HaywardBindingConstants.THING_TYPE_PUMP,
+                    HaywardBindingConstants.THING_TYPE_RELAY, HaywardBindingConstants.THING_TYPE_SENSOR,
+                    HaywardBindingConstants.THING_TYPE_VIRTUALHEATER));
+
+    // List of all Channel ids (bridge)
+    // No Channels
+
+    // List of all Channel ids (backyard)
+    public static final String CHANNEL_BACKYARD_AIRTEMP = "backyardAirTemp";
+    public static final String CHANNEL_BACKYARD_STATUS = "backyardStatus";
+    public static final String CHANNEL_BACKYARD_STATE = "backyardState";
+    public static final String CHANNEL_BACKYARD_ALARM1 = "backyardAlarm1";
+    public static final String CHANNEL_BACKYARD_ALARM2 = "backyardAlarm2";
+    public static final String CHANNEL_BACKYARD_ALARM3 = "backyardAlarm3";
+    public static final String CHANNEL_BACKYARD_ALARM4 = "backyardAlarm4";
+    public static final String CHANNEL_BACKYARD_ALARM5 = "backyardAlarm5";
+
+    // List of all Channel ids (bow)
+    public static final String CHANNEL_BOW_WATERTEMP = "bowWaterTemp";
+    public static final String CHANNEL_BOW_FLOW = "bowFlow";
+
+    // List of all Channel ids (chlorinator)
+    public static final String CHANNEL_CHLORINATOR_ENABLE = "chlorEnable";
+    public static final String CHANNEL_CHLORINATOR_OPERATINGMODE = "chlorOperatingMode";
+    public static final String CHANNEL_CHLORINATOR_TIMEDPERCENT = "chlorTimedPercent";
+    public static final String CHANNEL_CHLORINATOR_SCMODE = "chlorScMode";
+    public static final String CHANNEL_CHLORINATOR_ERROR = "chlorError";
+    public static final String CHANNEL_CHLORINATOR_ALERT = "chlorAlert";
+    public static final String CHANNEL_CHLORINATOR_AVGSALTLEVEL = "chlorAvgSaltLevel";
+    public static final String CHANNEL_CHLORINATOR_INSTANTSALTLEVEL = "chlorInstantSaltLevel";
+    public static final String CHANNEL_CHLORINATOR_STATUS = "chlorStatus";
+
+    // List of all Channel ids (colorlogic)
+    public static final String CHANNEL_COLORLOGIC_ENABLE = "colorLogicLightEnable";
+    public static final String CHANNEL_COLORLOGIC_LIGHTSTATE = "colorLogicLightState";
+    public static final String CHANNEL_COLORLOGIC_CURRENTSHOW = "colorLogicLightCurrentShow";
+
+    // List of all Channel ids (filter)
+    public static final String CHANNEL_FILTER_ENABLE = "filterEnable";
+    public static final String CHANNEL_FILTER_VALVEPOSITION = "filterValvePosition";
+    public static final String CHANNEL_FILTER_SPEED = "filterSpeed";
+    public static final String CHANNEL_FILTER_STATE = "filterState";
+    public static final String CHANNEL_FILTER_LASTSPEED = "filterLastSpeed";
+
+    public static final String PROPERTY_FILTER_MINPUMPSPEED = "minPumpSpeed";
+    public static final String PROPERTY_FILTER_MAXPUMPSPEED = "maxPumpSpeed";
+    public static final String PROPERTY_FILTER_MINPUMPRPM = "minPumpRPM";
+    public static final String PROPERTY_FILTER_MAXPUMPRPM = "maxPumpRPM";
+
+    // List of all Channel ids (heater)
+    public static final String CHANNEL_HEATER_STATE = "heaterState";
+    public static final String CHANNEL_HEATER_TEMP = "heaterTemp";
+    public static final String CHANNEL_HEATER_ENABLE = "heaterEnable";
+
+    // List of all Channel ids (pump)
+    public static final String CHANNEL_PUMP_ENABLE = "pumpEnable";
+    public static final String CHANNEL_PUMP_SPEED = "pumpSpeed";
+
+    public static final String PROPERTY_PUMP_MINPUMPSPEED = "minPumpSpeed";
+    public static final String PROPERTY_PUMP_MAXPUMPSPEED = "minPumpSpeed";
+    public static final String PROPERTY_PUMP_MINPUMPRPM = "minPumpRPM";
+    public static final String PROPERTY_PUMP_MAXPUMPRPM = "maxPumpRPM";
+
+    // List of all Channel ids (relay)
+    public static final String CHANNEL_RELAY_STATE = "relayState";
+
+    // List of all Channel ids (sensor)
+    public static final String CHANNEL_SENSOR_DATA = "sensorData";
+
+    // List of all Channel ids (virtualHeater)
+    public static final String CHANNEL_VIRTUALHEATER_CURRENTSETPOINT = "virtualHeaterCurrentSetpoint";
+    public static final String CHANNEL_VIRTUALHEATER_ENABLE = "virtualHeaterEnable";
+
+    // The properties associated with the thing
+    public static final String PROPERTY_VERSION = "Property Version";
+    public static final String PROPERTY_STATUSVERSION = "Property Status Version";
+    public static final String PROPERTY_CONFIGUPDATEDTIME = "Property Configuration Last Updated Date/Time";
+    public static final String MESSAGEVERSION = "Property Message Version";
+    public static final String PROPERTY_SYSTEM_ID = "Property system ID";
+    public static final String PROPERTY_TYPE = "propertyType";
+    public static final String PROPERTY_BOWNAME = "BOW Name";
+    public static final String PROPERTY_BOWID = "BOW ID";
+
+    // Hayward Command html
+    public static final String COMMAND_PARAMETERS = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request>";
+
+    public static final String COMMAND_SCHEDULE = "<Parameter name=\"IsCountDownTimer\" dataType=\"bool\">false</Parameter>"
+            + "<Parameter name=\"StartTimeHours\" dataType=\"int\">0</Parameter>"
+            + "<Parameter name=\"StartTimeMinutes\" dataType=\"int\">0</Parameter>"
+            + "<Parameter name=\"EndTimeHours\" dataType=\"int\">0</Parameter>"
+            + "<Parameter name=\"EndTimeMinutes\" dataType=\"int\">0</Parameter>"
+            + "<Parameter name=\"DaysActive\" dataType=\"int\">0</Parameter>"
+            + "<Parameter name=\"Recurring\" dataType=\"bool\">false</Parameter>";
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -58,8 +58,6 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_BACKYARD_AIRTEMP = "backyardAirTemp";
     public static final String CHANNEL_BACKYARD_STATUS = "backyardStatus";
     public static final String CHANNEL_BACKYARD_STATE = "backyardState";
-    public static final String PROPERTY_BOW_UNITS = "Units";
-    public static final String PROPERTY_VSP_SPEED_FORMAT = "VSP Speed Format";
 
     // List of all Channel ids (bow)
     public static final String CHANNEL_BOW_WATERTEMP = "bowWaterTemp";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -115,11 +115,7 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_VIRTUALHEATER_CURRENTSETPOINT = "virtualHeaterCurrentSetpoint";
     public static final String CHANNEL_VIRTUALHEATER_ENABLE = "virtualHeaterEnable";
 
-    // The properties associated with the thing
-    public static final String PROPERTY_VERSION = "Property Version";
-    public static final String PROPERTY_STATUSVERSION = "Property Status Version";
-    public static final String PROPERTY_CONFIGUPDATEDTIME = "Property Configuration Last Updated Date/Time";
-    public static final String MESSAGEVERSION = "Property Message Version";
+    // The properties associated with all things
     public static final String PROPERTY_SYSTEM_ID = "Property system ID";
     public static final String PROPERTY_TYPE = "propertyType";
     public static final String PROPERTY_BOWNAME = "BOW Name";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -47,8 +47,6 @@ public class HaywardBindingConstants {
 
     public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BRIDGE);
 
-    // public static final Set<ThingTypeUID> ZONE_THING_TYPES_UIDS = Collections.singleton(ZONE_THING_TYPE);
-
     public static final Set<ThingTypeUID> THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
             Arrays.asList(HaywardBindingConstants.THING_TYPE_BACKYARD, HaywardBindingConstants.THING_TYPE_BOW,
                     HaywardBindingConstants.THING_TYPE_BRIDGE, HaywardBindingConstants.THING_TYPE_CHLORINATOR,

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -95,10 +95,10 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_FILTER_STATE = "filterState";
     public static final String CHANNEL_FILTER_LASTSPEED = "filterLastSpeed";
 
-    public static final String PROPERTY_FILTER_MINPUMPSPEED = "minPumpSpeed";
-    public static final String PROPERTY_FILTER_MAXPUMPSPEED = "maxPumpSpeed";
-    public static final String PROPERTY_FILTER_MINPUMPRPM = "minPumpRPM";
-    public static final String PROPERTY_FILTER_MAXPUMPRPM = "maxPumpRPM";
+    public static final String PROPERTY_FILTER_MINPUMPSPEED = "Min Pump Percent";
+    public static final String PROPERTY_FILTER_MAXPUMPSPEED = "Max Pump Percent";
+    public static final String PROPERTY_FILTER_MINPUMPRPM = "Min Pump RPM";
+    public static final String PROPERTY_FILTER_MAXPUMPRPM = "Max Pump RPM";
 
     // List of all Channel ids (heater)
     public static final String CHANNEL_HEATER_STATE = "heaterState";
@@ -109,10 +109,10 @@ public class HaywardBindingConstants {
     public static final String CHANNEL_PUMP_ENABLE = "pumpEnable";
     public static final String CHANNEL_PUMP_SPEED = "pumpSpeed";
 
-    public static final String PROPERTY_PUMP_MINPUMPSPEED = "minPumpSpeed";
-    public static final String PROPERTY_PUMP_MAXPUMPSPEED = "minPumpSpeed";
-    public static final String PROPERTY_PUMP_MINPUMPRPM = "minPumpRPM";
-    public static final String PROPERTY_PUMP_MAXPUMPRPM = "maxPumpRPM";
+    public static final String PROPERTY_PUMP_MINPUMPSPEED = "Min Pump Speed";
+    public static final String PROPERTY_PUMP_MAXPUMPSPEED = "Min Pump Speed";
+    public static final String PROPERTY_PUMP_MINPUMPRPM = "Min Pump RPM";
+    public static final String PROPERTY_PUMP_MAXPUMPRPM = "Max Pump RPM";
 
     // List of all Channel ids (relay)
     public static final String CHANNEL_RELAY_STATE = "relayState";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -21,6 +21,8 @@ import org.openhab.core.thing.ThingTypeUID;
 /**
  * The {@link HaywardBindingConstants} class defines common constants, which are
  * used across the whole binding.
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardBindingConstants {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HaywardException} is thrown during the getMspConfig, mspConfigDiscovery, getTelemetry,
+ * evaluateXPath and httpXmlResponse methods
+ */
+@NonNullByDefault
+public class HaywardException extends Exception {
+
+    /**
+     * The {@link HaywardException} is thrown by getMspConfig() and mspConfigDiscovery()
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor.
+     *
+     * @param message Hayward error message
+     */
+    public HaywardException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardException.java
@@ -17,6 +17,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 /**
  * The {@link HaywardException} is thrown during the getMspConfig, mspConfigDiscovery, getTelemetry,
  * evaluateXPath and httpXmlResponse methods
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardException extends Exception {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -46,6 +46,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * The {@link HaywardHandlerFactory} is responsible for creating things and thing
  * handlers.
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.haywardomnilogic")

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -54,13 +54,12 @@ public class HaywardHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
             Stream.concat(BRIDGE_THING_TYPES_UIDS.stream(), THING_TYPES_UIDS.stream()).collect(Collectors.toSet()));
+    private final HttpClient httpClient;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
-
-    private final HttpClient httpClient;
 
     @Activate
     public HaywardHandlerFactory(@Reference HttpClientFactory httpClientFactory) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal;
+
+import static org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants.*;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBackyardHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBowHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBridgeHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardChlorinatorHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardColorLogicHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardFilterHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardHeaterHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardRelayHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardSensorHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardVirtualHeaterHandler;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link HaywardHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.haywardomnilogic")
+@NonNullByDefault
+public class HaywardHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            Stream.concat(BRIDGE_THING_TYPES_UIDS.stream(), THING_TYPES_UIDS.stream()).collect(Collectors.toSet()));
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    private final HttpClient httpClient;
+
+    @Activate
+    public HaywardHandlerFactory(@Reference HttpClientFactory httpClientFactory) {
+        this.httpClient = httpClientFactory.getCommonHttpClient();
+    }
+
+    /**
+     * Creates the specific handler for this thing.
+     */
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_BRIDGE)) {
+            return new HaywardBridgeHandler((Bridge) thing, httpClient);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_BACKYARD)) {
+            return new HaywardBackyardHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_BOW)) {
+            return new HaywardBowHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_CHLORINATOR)) {
+            return new HaywardChlorinatorHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_COLORLOGIC)) {
+            return new HaywardColorLogicHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_FILTER)) {
+            return new HaywardFilterHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_HEATER)) {
+            return new HaywardHeaterHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_RELAY)) {
+            return new HaywardRelayHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_SENSOR)) {
+            return new HaywardSensorHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER)) {
+            return new HaywardVirtualHeaterHandler(thing);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -46,8 +46,6 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * The {@link HaywardHandlerFactory} is responsible for creating things and thing
  * handlers.
- *
- * @author Matt Myers - Initial Contribution
  */
 
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.haywardomnilogic")

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -69,6 +69,7 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
                     case "chlorTimedPercent":
                     case "filterSpeed":
                     case "pumpSpeed":
+                    case "filterLastSpeed":
                         return new QuantityType<>(Integer.parseInt(value), Units.PERCENT);
                     case "chlorAvgSaltLevel":
                     case "chlorInstantSaltLevel":

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -14,11 +14,13 @@
 package org.openhab.binding.haywardomnilogic.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBridgeHandler;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -55,6 +57,8 @@ public class HaywardThingHandler extends BaseThingHandler {
     }
 
     public State toState(String type, String channelID, String value) throws NumberFormatException {
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+
         switch (type) {
             case "Number":
                 return new DecimalType(value);
@@ -73,7 +77,11 @@ public class HaywardThingHandler extends BaseThingHandler {
                         return new QuantityType<>(Integer.parseInt(value), SmartHomeUnits.PARTS_PER_MILLION);
                 }
             case "Number:Temperature":
-                return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
+                if (bridgehandler.account.units.equals("Standard")) {
+                    return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
+                } else {
+                    return new QuantityType<>(Integer.parseInt(value), SIUnits.CELSIUS);
+                }
             default:
                 return StringType.valueOf(value);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -33,8 +33,6 @@ import org.openhab.core.types.State;
 /**
  * The {@link HaywarThingHandler} is a subclass of the BaseThingHandler and a Super
  * Class to each Hayward Thing Handler
- *
- * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -13,7 +13,6 @@
 
 package org.openhab.binding.haywardomnilogic.internal;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -52,11 +51,10 @@ public class HaywardThingHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    public void getTelemetry(@NonNull String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws Exception {
     }
 
     public State toState(String type, String channelID, String value) throws NumberFormatException {
-
         switch (type) {
             case "Number":
                 return new DecimalType(value);
@@ -82,7 +80,6 @@ public class HaywardThingHandler extends BaseThingHandler {
     }
 
     public String cmdToString(Command command) {
-
         if (command == OnOffType.OFF) {
             return "0";
         } else if (command == OnOffType.ON) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -80,6 +80,7 @@ public class HaywardThingHandler extends BaseThingHandler {
     }
 
     public String cmdToString(Command command) {
+
         if (command == OnOffType.OFF) {
             return "0";
         } else if (command == OnOffType.ON) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -21,7 +21,7 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
-import org.openhab.core.library.unit.SmartHomeUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -71,10 +71,10 @@ public class HaywardThingHandler extends BaseThingHandler {
                     case "chlorTimedPercent":
                     case "filterSpeed":
                     case "pumpSpeed":
-                        return new QuantityType<>(Integer.parseInt(value), SmartHomeUnits.PERCENT);
+                        return new QuantityType<>(Integer.parseInt(value), Units.PERCENT);
                     case "chlorAvgSaltLevel":
                     case "chlorInstantSaltLevel":
-                        return new QuantityType<>(Integer.parseInt(value), SmartHomeUnits.PARTS_PER_MILLION);
+                        return new QuantityType<>(Integer.parseInt(value), Units.PARTS_PER_MILLION);
                 }
             case "Number:Temperature":
                 if (bridgehandler.account.units.equals("Standard")) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -33,6 +33,8 @@ import org.openhab.core.types.State;
 /**
  * The {@link HaywarThingHandler} is a subclass of the BaseThingHandler and a Super
  * Class to each Hayward Thing Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.haywardomnilogic.internal;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+
+/**
+ * The {@link HaywarThingHandler} is a subclass of the BaseThingHandler and a Super
+ * Class to each Hayward Thing Handler
+ *
+ * @author Matt Myers - Initial contribution
+ */
+
+public class HaywardThingHandler extends BaseThingHandler {
+    protected Thing thing;
+
+    public HaywardThingHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    public void getTelemetry(@NonNull String xmlResponse) throws Exception {
+    }
+
+    public State toState(String type, String value) throws NumberFormatException {
+        if ("Number".equals(type)) {
+            return new DecimalType(value);
+        } else if ("Switch".equals(type)) {
+            return Integer.parseInt(value) > 0 ? OnOffType.ON : OnOffType.OFF;
+        } else if ("system.power".equals(type)) {
+            return Integer.parseInt(value) > 0 ? OnOffType.ON : OnOffType.OFF;
+        } else if ("Number:Dimensionless".equals(type)) {
+            return new DecimalType(value);
+        } else if ("Number:Temperature".equals(type)) {
+            return new DecimalType(value);
+        } else {
+            return StringType.valueOf(value);
+        }
+    }
+
+    public String cmdToString(Command command) {
+        if (command == OnOffType.OFF) {
+            return "0";
+        } else if (command == OnOffType.ON) {
+            return "1";
+        } else if (command instanceof DecimalType) {
+            return ((DecimalType) command).toString();
+        } else if (command instanceof QuantityType) {
+            return ((QuantityType<?>) command).format("%1.0f");
+        } else {
+            return ((StringType) command).toString();
+        }
+    }
+
+    public void updateData(String channelID, String data) {
+        Channel chan = getThing().getChannel(channelID);
+        if (chan != null) {
+            String acceptedItemType = chan.getAcceptedItemType();
+            if (acceptedItemType != null) {
+                State state = toState(acceptedItemType, data);
+                updateState(chan.getUID(), state);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -61,7 +61,6 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
             case "Number":
                 return new DecimalType(value);
             case "Switch":
-                return Integer.parseInt(value) > 0 ? OnOffType.ON : OnOffType.OFF;
             case "system.power":
                 return Integer.parseInt(value) > 0 ? OnOffType.ON : OnOffType.OFF;
             case "Number:Dimensionless":
@@ -75,6 +74,7 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
                     case "chlorInstantSaltLevel":
                         return new QuantityType<>(Integer.parseInt(value), Units.PARTS_PER_MILLION);
                 }
+                return StringType.valueOf(value);
             case "Number:Temperature":
                 Bridge bridge = getBridge();
                 if (bridge != null) {
@@ -85,11 +85,10 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
                         } else {
                             return new QuantityType<>(Integer.parseInt(value), SIUnits.CELSIUS);
                         }
-                    } else {
-                        // default to imperial if no bridge
-                        return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
                     }
                 }
+                // default to imperial if no bridge
+                return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
             default:
                 return StringType.valueOf(value);
         }
@@ -105,7 +104,7 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
         } else if (command instanceof QuantityType) {
             return ((QuantityType<?>) command).format("%1.0f");
         } else {
-            return ((StringType) command).toString();
+            return command.toString();
         }
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -22,6 +22,7 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -56,8 +57,6 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
     public abstract void getTelemetry(String xmlResponse) throws HaywardException;
 
     public State toState(String type, String channelID, String value) throws NumberFormatException {
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-
         switch (type) {
             case "Number":
                 return new DecimalType(value);
@@ -76,10 +75,19 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
                         return new QuantityType<>(Integer.parseInt(value), Units.PARTS_PER_MILLION);
                 }
             case "Number:Temperature":
-                if (bridgehandler.account.units.equals("Standard")) {
-                    return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
-                } else {
-                    return new QuantityType<>(Integer.parseInt(value), SIUnits.CELSIUS);
+                Bridge bridge = getBridge();
+                if (bridge != null) {
+                    HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+                    if (bridgehandler != null) {
+                        if (bridgehandler.account.units.equals("Standard")) {
+                            return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
+                        } else {
+                            return new QuantityType<>(Integer.parseInt(value), SIUnits.CELSIUS);
+                        }
+                    } else {
+                        // default to imperial if no bridge
+                        return new QuantityType<>(Integer.parseInt(value), ImperialUnits.FAHRENHEIT);
+                    }
                 }
             default:
                 return StringType.valueOf(value);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -38,7 +38,7 @@ import org.openhab.core.types.State;
  */
 
 @NonNullByDefault
-public class HaywardThingHandler extends BaseThingHandler {
+public abstract class HaywardThingHandler extends BaseThingHandler {
 
     public HaywardThingHandler(Thing thing) {
         super(thing);
@@ -53,8 +53,7 @@ public class HaywardThingHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    public void getTelemetry(String xmlResponse) throws HaywardException {
-    }
+    public abstract void getTelemetry(String xmlResponse) throws HaywardException;
 
     public State toState(String type, String channelID, String value) throws NumberFormatException {
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -51,7 +51,7 @@ public class HaywardThingHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
     }
 
     public State toState(String type, String channelID, String value) throws NumberFormatException {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -14,6 +14,7 @@
 package org.openhab.binding.haywardomnilogic.internal;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
@@ -33,8 +34,8 @@ import org.openhab.core.types.State;
  * @author Matt Myers - Initial contribution
  */
 
+@NonNullByDefault
 public class HaywardThingHandler extends BaseThingHandler {
-    protected Thing thing;
 
     public HaywardThingHandler(Thing thing) {
         super(thing);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingHandler.java
@@ -80,7 +80,6 @@ public class HaywardThingHandler extends BaseThingHandler {
     }
 
     public String cmdToString(Command command) {
-
         if (command == OnOffType.OFF) {
             return "0";
         } else if (command == OnOffType.ON) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
@@ -16,8 +16,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardThingProperties} class contains fields mapping thing configuration parameters.
- *
- * @author Matt Myers - Initial Contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
@@ -16,6 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardThingProperties} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardThingProperties.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HaywardThingProperties} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+
+@NonNullByDefault
+public class HaywardThingProperties {
+    public String systemID = "";
+    public String poolID = "";
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal;
+
+/**
+ * The type to request.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+public enum HaywardTypeToRequest {
+    BACKYARD,
+    BOW,
+    CHLORINATOR,
+    COLORLOGIC,
+    CSAD,
+    FILTER,
+    HEATER,
+    PUMP,
+    RELAY,
+    SENSOR,
+    VIRTUALHEATER
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
@@ -16,6 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The type to request.
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public enum HaywardTypeToRequest {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.haywardomnilogic.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The type to request.
  *
  * @author Matt Myers - Initial Contribution
  */
+@NonNullByDefault
 public enum HaywardTypeToRequest {
     BACKYARD,
     BOW,

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardTypeToRequest.java
@@ -16,8 +16,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The type to request.
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public enum HaywardTypeToRequest {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link HaywardConfig} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+
+@NonNullByDefault
+public class HaywardConfig {
+    public String hostname = "";
+    public String username = "";
+    public String password = "";
+    public int alarmPollTime = 60;
+    public int telemetryPollTime = 10;
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 @NonNullByDefault
 public class HaywardConfig {
-    public String hostname = "";
+    public String endpointUrl = "";
     public String username = "";
     public String password = "";
     public int alarmPollTime = 60;

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
@@ -16,8 +16,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardConfig} class contains fields mapping thing configuration parameters.
- *
- * @author Matt Myers - Initial Contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/config/HaywardConfig.java
@@ -16,6 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The {@link HaywardConfig} class contains fields mapping thing configuration parameters.
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -84,7 +84,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         }
     }
 
-    public synchronized boolean mspConfigDiscovery(String xmlResponse) throws HaywardException {
+    public synchronized boolean mspConfigDiscovery(String xmlResponse) {
         List<String> systemIDs = new ArrayList<>();
         List<String> names = new ArrayList<>();
         List<String> bowName = new ArrayList<>();
@@ -442,7 +442,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     public void setThingHandler(@Nullable ThingHandler handler) {
         if (handler instanceof HaywardBridgeHandler) {
             this.discoveryBridgehandler = (HaywardBridgeHandler) handler;
-            this.discoveryBridgehandler.setHaywardDiscoveryService(this);
         }
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -103,8 +103,9 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             // Find Backyard
             names = bridgehandler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 
-            for (String name : names) {
-                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), name);
+            for (int i = 0; i < names.size(); i++) {
+                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), names.get(i),
+                        property1.get(i), property2.get(i));
             }
 
             // Find Bodies of Water
@@ -244,13 +245,15 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         return true;
     }
 
-    public void onBackyardDiscovered(int systemID, String label) {
+    public void onBackyardDiscovered(int systemID, String label, String units, String vspFormat) {
         logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
+        properties.put(HaywardBindingConstants.PROPERTY_BOW_UNITS, String.valueOf(units));
+        properties.put(HaywardBindingConstants.PROPERTY_VSP_SPEED_FORMAT, String.valueOf(vspFormat));
         DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Sets up the discovery results and details
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -137,8 +137,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                 HaywardBindingConstants.THING_TYPE_HEATER, null);
 
         // Find Pumps
-        systemIDs = bridgehandler.evaluateXPath("//Pump/System-Id/text()", xmlResponse);
-        names = bridgehandler.evaluateXPath("//Pump/Name/text()", xmlResponse);
         final List<String> pumpProperty1 = bridgehandler.evaluateXPath("//Pump/Min-Pump-Speed/text()", xmlResponse);
         final List<String> pumpProperty2 = bridgehandler.evaluateXPath("//Pump/Max-Pump-Speed/text()", xmlResponse);
         final List<String> pumpProperty3 = bridgehandler.evaluateXPath("//Pump/Min-Pump-RPM/text()", xmlResponse);
@@ -163,16 +161,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         // Find Sensors
         discoverDevices(bridgehandler, xmlResponse, "Sensor", HaywardTypeToRequest.SENSOR,
                 HaywardBindingConstants.THING_TYPE_SENSOR, null);
-        return;
     }
 
     private void discoverDevices(HaywardBridgeHandler bridgehandler, String xmlResponse, String xmlSearchTerm,
             HaywardTypeToRequest type, ThingTypeUID thingType,
             @Nullable BiConsumer<Map<String, Object>, Integer> additionalPropertyConsumer) {
-        List<String> systemIDs = new ArrayList<>();
-        List<String> names = new ArrayList<>();
 
-        systemIDs = bridgehandler.evaluateXPath("//" + xmlSearchTerm + "/System-Id/text()", xmlResponse);
+        List<String> systemIDs = bridgehandler.evaluateXPath("//" + xmlSearchTerm + "/System-Id/text()", xmlResponse);
+        List<String> names;
 
         // Set Virtual Heater Name
         if (thingType == HaywardBindingConstants.THING_TYPE_VIRTUALHEATER) {
@@ -183,13 +179,10 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         }
 
         for (int i = 0; i < systemIDs.size(); i++) {
-            List<String> bowName = new ArrayList<>();
-            List<String> bowID = new ArrayList<>();
-
             // get Body of Water for each item
-            bowID = bridgehandler.evaluateXPath(
+            List<String> bowID = bridgehandler.evaluateXPath(
                     "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = bridgehandler.evaluateXPath(
+            List<String> bowName = bridgehandler.evaluateXPath(
                     "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
 
             // skip system sensors with no BOW

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -166,7 +166,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     private void discoverDevices(HaywardBridgeHandler bridgehandler, String xmlResponse, String xmlSearchTerm,
             HaywardTypeToRequest type, ThingTypeUID thingType,
             @Nullable BiConsumer<Map<String, Object>, Integer> additionalPropertyConsumer) {
-
         List<String> systemIDs = bridgehandler.evaluateXPath("//" + xmlSearchTerm + "/System-Id/text()", xmlResponse);
         List<String> names;
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardTypeToRequest;
 import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBridgeHandler;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
@@ -75,12 +76,12 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                 String xmlResults = bridgehandler.getMspConfig();
                 mspConfigDiscovery(xmlResults);
             }
-        } catch (Exception e) {
-            logger.warn("Exception during discovery scan", e);
+        } catch (HaywardException e) {
+            logger.warn("Exception during discovery scan: {}", e.getMessage());
         }
     }
 
-    public synchronized boolean mspConfigDiscovery(String xmlResponse) throws Exception {
+    public synchronized boolean mspConfigDiscovery(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> names = new ArrayList<>();
         List<String> bowName = new ArrayList<>();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -42,11 +42,9 @@ import org.slf4j.LoggerFactory;
  */
 
 @NonNullByDefault
-@SuppressWarnings("null")
 public class HaywardDiscoveryService extends AbstractDiscoveryService implements DiscoveryService, ThingHandlerService {
-
     private final Logger logger = LoggerFactory.getLogger(HaywardDiscoveryService.class);
-    private @Nullable HaywardBridgeHandler bridgehandler;
+    private @Nullable HaywardBridgeHandler discoveryBridgehandler;
 
     public HaywardDiscoveryService() {
         super(THING_TYPES_UIDS, 0, false);
@@ -73,6 +71,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     @Override
     protected void startScan() {
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
         try {
             if (bridgehandler != null) {
                 String xmlResults = bridgehandler.getMspConfig();
@@ -92,6 +91,8 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         List<String> property2 = new ArrayList<>();
         List<String> property3 = new ArrayList<>();
         List<String> property4 = new ArrayList<>();
+
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
 
         if (bridgehandler != null) {
             // Get Units (Standard, Metric)
@@ -249,172 +250,213 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onBackyardDiscovered(int systemID, String label, String units, String vspFormat) {
         logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
-        properties.put(HaywardBindingConstants.PROPERTY_BOW_UNITS, String.valueOf(units));
-        properties.put(HaywardBindingConstants.PROPERTY_VSP_SPEED_FORMAT, String.valueOf(vspFormat));
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
+            properties.put(HaywardBindingConstants.PROPERTY_BOW_UNITS, String.valueOf(units));
+            properties.put(HaywardBindingConstants.PROPERTY_VSP_SPEED_FORMAT, String.valueOf(vspFormat));
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onBOWDiscovered(int systemID, String label) {
         logger.trace("Hayward BOW {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, bridgehandler.getThing().getUID(),
+                    Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onChlorinatorDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Chlorinator {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR,
-                bridgehandler.getThing().getUID(), Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onColorLogicDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Color Logic Light {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC,
-                bridgehandler.getThing().getUID(), Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onFilterDiscovered(int systemID, String label, String bowID, String bowName, String minPumpSpeed,
             String maxPumpSpeed, String minPumpRpm, String maxPumpRpm) {
         logger.trace("Hayward Filter {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, minPumpSpeed);
-        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, maxPumpSpeed);
-        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, minPumpRpm);
-        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, maxPumpRpm);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, minPumpSpeed);
+            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, maxPumpSpeed);
+            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, minPumpRpm);
+            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, maxPumpRpm);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Heater {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onPumpDiscovered(int systemID, String label, String bowID, String bowName, String property1,
             String property2, String property3, String property4) {
         logger.trace("Hayward Pump {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPSPEED, property1);
-        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPSPEED, property2);
-        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPRPM, property3);
-        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPRPM, property4);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, bridgehandler.getThing().getUID(),
+                    Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPSPEED, property1);
+            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPSPEED, property2);
+            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPRPM, property3);
+            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPRPM, property4);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onRelayDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Relay {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onSensorDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Sensor {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, bridgehandler.getThing().getUID(),
-                Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     public void onVirtualHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Virtual Heater {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER,
-                bridgehandler.getThing().getUID(), Integer.toString(systemID));
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
-        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
-                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
-                .withProperties(properties).build();
-        thingDiscovered(result);
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        if (bridgehandler != null) {
+            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER,
+                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
+            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                    .withBridge(bridgehandler.getThing().getUID())
+                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                    .withLabel("Hayward " + label).withProperties(properties).build();
+            thingDiscovered(result);
+        }
     }
 
     @Override
     public void setThingHandler(@Nullable ThingHandler handler) {
         if (handler instanceof HaywardBridgeHandler) {
-            this.bridgehandler = (HaywardBridgeHandler) handler;
-            this.bridgehandler.setHaywardDiscoveryService(this);
+            this.discoveryBridgehandler = (HaywardBridgeHandler) handler;
+            this.discoveryBridgehandler.setHaywardDiscoveryService(this);
         }
     }
 
     @Override
     public @Nullable ThingHandler getThingHandler() {
+        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
         return bridgehandler;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -1,0 +1,411 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.discovery;
+
+import static org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants.THING_TYPES_UIDS;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardTypeToRequest;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardBridgeHandler;
+import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sets up the discovery results and details
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+
+// public class HaywardDiscoveryService extends AbstractDiscoveryService implements HaywardHandlerListener {
+@NonNullByDefault
+public class HaywardDiscoveryService extends AbstractDiscoveryService implements DiscoveryService, ThingHandlerService {
+
+    private final Logger logger = LoggerFactory.getLogger(HaywardDiscoveryService.class);
+    private @Nullable HaywardBridgeHandler handler;
+
+    public HaywardDiscoveryService() {
+        super(THING_TYPES_UIDS, 0, false);
+    }
+
+    /**
+     * Constructs a zone discovery service.
+     * Registers this zone discovery service programmatically.
+     * Call {@link ZoneDiscoveryService#destroy()} to unregister the service after use.
+     */
+    public HaywardDiscoveryService(HaywardBridgeHandler bridge) throws IllegalArgumentException {
+        super(THING_TYPES_UIDS, 0, false);
+        // this.bridge = bridge;
+    }
+
+    @Override
+    public void activate() {
+        super.activate(null);
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+
+    @Override
+    protected void startScan() {
+        try {
+            String xmlResults = handler.getMspConfig();
+            mspConfigDiscovery(xmlResults);
+        } catch (Exception e) {
+            logger.debug("Exception during discovery scan", e);
+        }
+    }
+
+    public synchronized boolean mspConfigDiscovery(String xmlResponse) throws Exception {
+        List<String> systemIDs = new ArrayList<>();
+        List<String> names = new ArrayList<>();
+        List<String> bowName = new ArrayList<>();
+        List<String> bowID = new ArrayList<>();
+        List<String> property1 = new ArrayList<>();
+        List<String> property2 = new ArrayList<>();
+        List<String> property3 = new ArrayList<>();
+        List<String> property4 = new ArrayList<>();
+
+        // Find Backyard
+        names = handler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
+
+        for (String name : names) {
+            onBackyardDiscovered(Integer.parseInt(handler.account.mspSystemID), name);
+        }
+
+        // Find Bodies of Water
+        systemIDs = handler.evaluateXPath("//Body-of-water/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Body-of-water/Name/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            onBOWDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i));
+        }
+
+        // Find Chlorinators
+        systemIDs = handler.evaluateXPath("//Chlorinator/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Chlorinator/Name/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            onChlorinatorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+        }
+
+        // Find ColorLogic Lights
+        systemIDs = handler.evaluateXPath("//ColorLogic-Light/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//ColorLogic-Light/Name/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            onColorLogicDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+        }
+
+        // Find Filters
+        systemIDs = handler.evaluateXPath("//Filter/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Filter/Name/text()", xmlResponse);
+        property1 = handler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
+        property2 = handler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
+        property3 = handler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
+        property4 = handler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            onFilterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
+                    property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+        }
+
+        // Find Heaters
+        systemIDs = handler.evaluateXPath("//Heater-Equipment/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Heater-Equipment/Name/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
+            onHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+        }
+
+        // Find Pumps
+        systemIDs = handler.evaluateXPath("//Pump/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Pump/Name/text()", xmlResponse);
+        names = handler.evaluateXPath("//Filter/Name/text()", xmlResponse);
+        property1 = handler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
+        property2 = handler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
+        property3 = handler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
+        property4 = handler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
+            onPumpDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
+                    property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+        }
+
+        // Find Relays
+        systemIDs = handler.evaluateXPath("//Relay/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Relay/Name/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            if (!(bowID.isEmpty())) {
+                onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            } else {
+                onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), "", "");
+            }
+
+        }
+
+        // Find Virtual Heaters
+        systemIDs = handler.evaluateXPath("//Heater/System-Id/text()", xmlResponse);
+
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            onVirtualHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), "Virtual Heater", bowID.get(0),
+                    bowName.get(0));
+        }
+
+        // Find Sensors
+        // Flow and water temp sensor aren't showing up in telemetry. Need example to determine how to differentiate
+        // "system" sensors
+        // that are reported in the BOW water temp, Filter flow switch, ORP, etc.
+        systemIDs = handler.evaluateXPath("//Sensor/System-Id/text()", xmlResponse);
+        names = handler.evaluateXPath("//Sensor/Name/text()", xmlResponse);
+        for (int i = 0; i < systemIDs.size(); i++) {
+            // get Body of Water for each item
+            bowID = handler.evaluateXPath(
+                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
+                    xmlResponse);
+            // Do not add backyard sensors that do not exist in the BOW thus bowID is null
+            if (!(bowID.isEmpty())) {
+                onSensorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            }
+        }
+        return true;
+    }
+
+    public void onBackyardDiscovered(int systemID, String label) {
+        logger.debug("Hayward Backyard {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onBOWDiscovered(int systemID, String label) {
+        logger.debug("Hayward BOW {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onChlorinatorDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Chlorinator {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onColorLogicDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Color Logic Light {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onFilterDiscovered(int systemID, String label, String bowID, String bowName, String minPumpSpeed,
+            String maxPumpSpeed, String minPumpRpm, String maxPumpRpm) {
+        logger.debug("Hayward Filter {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, minPumpSpeed);
+        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, maxPumpSpeed);
+        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, minPumpRpm);
+        properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, maxPumpRpm);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Heater {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onPumpDiscovered(int systemID, String label, String bowID, String bowName, String property1,
+            String property2, String property3, String property4) {
+        logger.debug("Hayward Pump {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPSPEED, property1);
+        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPSPEED, property2);
+        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPRPM, property3);
+        properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPRPM, property4);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onRelayDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Relay {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onSensorDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Sensor {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    public void onVirtualHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
+        logger.debug("Hayward Virtual Heater {} Discovered: {}", systemID, label);
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, handler.getThing().getUID(),
+                Integer.toString(systemID));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
+        properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
+        properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+                .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
+                .withProperties(properties).build();
+        thingDiscovered(result);
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof HaywardBridgeHandler) {
+            this.handler = (HaywardBridgeHandler) handler;
+            this.handler.setHaywardDiscoveryService(this);
+        }
+    }
+
+    // @Override
+    // public void setThingHandler(@Nullable ThingHandler handler) {
+    // if (handler instanceof YamahaBridgeHandler) {
+    // this.handler = (YamahaBridgeHandler) handler;
+    // this.handler.setZoneDiscoveryService(this);
+    // }
+    // }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -29,6 +29,7 @@ import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
@@ -93,6 +94,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         List<String> property2 = new ArrayList<>();
         List<String> property3 = new ArrayList<>();
         List<String> property4 = new ArrayList<>();
+        Map<String, Object> properties = new HashMap<>();
 
         HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
 
@@ -101,7 +103,11 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             names = bridgehandler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 
             for (int i = 0; i < names.size(); i++) {
-                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), names.get(i));
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, bridgehandler.account.mspSystemID);
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_BACKYARD, names.get(i), properties);
             }
 
             // Find Bodies of Water
@@ -109,7 +115,11 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             names = bridgehandler.evaluateXPath("//Body-of-water/Name/text()", xmlResponse);
 
             for (int i = 0; i < systemIDs.size(); i++) {
-                onBOWDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i));
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_BOW, names.get(i), properties);
             }
 
             // Find Chlorinators
@@ -122,7 +132,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
-                onChlorinatorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_CHLORINATOR, names.get(i), properties);
             }
 
             // Find ColorLogic Lights
@@ -135,7 +152,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
-                onColorLogicDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_CHLORINATOR, names.get(i), properties);
             }
 
             // Find Filters
@@ -151,8 +175,18 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
-                onFilterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
-                        property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, property1.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, property2.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, property3.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, property4.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_FILTER, names.get(i), properties);
             }
 
             // Find Heaters
@@ -166,7 +200,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
-                onHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_HEATER, names.get(i), properties);
             }
 
             // Find Pumps
@@ -185,8 +226,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
-                onPumpDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
-                        property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, names.get(i), properties);
             }
 
             // Find Relays
@@ -199,12 +246,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
-                if (!(bowID.isEmpty())) {
-                    onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
-                } else {
-                    onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), "", "");
-                }
 
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(0));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(0));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_RELAY, names.get(i), properties);
             }
 
             // Find Virtual Heaters
@@ -216,8 +265,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
                 bowName = bridgehandler.evaluateXPath(
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
-                onVirtualHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), "Virtual Heater", bowID.get(0),
-                        bowName.get(0));
+
+                properties.clear();
+                properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER);
+                properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(i));
+                properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(i));
+
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, "Heater", properties);
             }
 
             // Find Sensors
@@ -234,206 +289,31 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
                         "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
                 // Do not add backyard sensors that do not exist in the BOW thus bowID is null
                 if (!(bowID.isEmpty())) {
-                    onSensorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+                    properties.clear();
+                    properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
+                    properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
+                    properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(0));
+                    properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(0));
+
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_SENSOR, names.get(i), properties);
                 }
             }
         }
         return true;
     }
 
-    public void onBackyardDiscovered(int systemID, String label) {
-        logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
+    public void onDeviceDiscovered(ThingTypeUID thingType, String label, Map<String, Object> properties) {
         HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
+        String systemID = (String) properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
         if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onBOWDiscovered(int systemID, String label) {
-        logger.trace("Hayward BOW {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, bridgehandler.getThing().getUID(),
-                    Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onChlorinatorDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Chlorinator {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onColorLogicDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Color Logic Light {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onFilterDiscovered(int systemID, String label, String bowID, String bowName, String minPumpSpeed,
-            String maxPumpSpeed, String minPumpRpm, String maxPumpRpm) {
-        logger.trace("Hayward Filter {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, minPumpSpeed);
-            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, maxPumpSpeed);
-            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, minPumpRpm);
-            properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, maxPumpRpm);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Heater {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onPumpDiscovered(int systemID, String label, String bowID, String bowName, String property1,
-            String property2, String property3, String property4) {
-        logger.trace("Hayward Pump {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, bridgehandler.getThing().getUID(),
-                    Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPSPEED, property1);
-            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPSPEED, property2);
-            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPRPM, property3);
-            properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPRPM, property4);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onRelayDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Relay {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onSensorDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Sensor {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
-        }
-    }
-
-    public void onVirtualHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.trace("Hayward Virtual Heater {} Discovered: {}", systemID, label);
-        HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
-        if (bridgehandler != null) {
-            ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER,
-                    bridgehandler.getThing().getUID(), Integer.toString(systemID));
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
-            properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-            DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
-                    .withBridge(bridgehandler.getThing().getUID())
-                    .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
-                    .withLabel("Hayward " + label).withProperties(properties).build();
-            thingDiscovered(result);
+            if (systemID != null) {
+                ThingUID thingUID = new ThingUID(thingType, bridgehandler.getThing().getUID(), systemID);
+                DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
+                        .withBridge(bridgehandler.getThing().getUID())
+                        .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)
+                        .withLabel("Hayward " + label).withProperties(properties).build();
+                thingDiscovered(result);
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -237,7 +237,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
         DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
@@ -250,7 +250,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
         DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
@@ -263,7 +263,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -278,7 +278,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -294,7 +294,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -313,7 +313,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -329,7 +329,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -348,7 +348,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -363,7 +363,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
@@ -378,7 +378,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
-        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemID);
+        properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -97,20 +97,12 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
 
         if (bridgehandler != null) {
-            // Get Units (Standard, Metric)
-            property1 = bridgehandler.evaluateXPath("//System/Units/text()", xmlResponse);
-            bridgehandler.account.units = property1.get(0);
-
-            // Get Variable Speed Pump Units (percent, RPM)
-            property2 = bridgehandler.evaluateXPath("//System/Msp-Vsp-Speed-Format/text()", xmlResponse);
-            bridgehandler.account.vspSpeedFormat = property2.get(0);
 
             // Find Backyard
             names = bridgehandler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 
             for (int i = 0; i < names.size(); i++) {
-                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), names.get(i),
-                        property1.get(i), property2.get(i));
+                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), names.get(i));
             }
 
             // Find Bodies of Water
@@ -250,7 +242,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         return true;
     }
 
-    public void onBackyardDiscovered(int systemID, String label, String units, String vspFormat) {
+    public void onBackyardDiscovered(int systemID, String label) {
         logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
         HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
         if (bridgehandler != null) {
@@ -259,8 +251,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             Map<String, Object> properties = new HashMap<>();
             properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
             properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
-            properties.put(HaywardBindingConstants.PROPERTY_BOW_UNITS, String.valueOf(units));
-            properties.put(HaywardBindingConstants.PROPERTY_VSP_SPEED_FORMAT, String.valueOf(vspFormat));
             DiscoveryResult result = DiscoveryResultBuilder.create(thingUID)
                     .withBridge(bridgehandler.getThing().getUID())
                     .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID)

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -36,15 +36,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Sets up the discovery results and details
- *
- * @author Matt Myers - Initial Contribution
  */
 
 @NonNullByDefault
+@SuppressWarnings("null")
 public class HaywardDiscoveryService extends AbstractDiscoveryService implements DiscoveryService, ThingHandlerService {
 
     private final Logger logger = LoggerFactory.getLogger(HaywardDiscoveryService.class);
-    private @Nullable HaywardBridgeHandler handler;
+    private @Nullable HaywardBridgeHandler bridgehandler;
 
     public HaywardDiscoveryService() {
         super(THING_TYPES_UIDS, 0, false);
@@ -57,7 +56,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
      */
     public HaywardDiscoveryService(HaywardBridgeHandler bridge) throws IllegalArgumentException {
         super(THING_TYPES_UIDS, 0, false);
-        // this.bridge = bridge;
     }
 
     @Override
@@ -73,8 +71,10 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     @Override
     protected void startScan() {
         try {
-            String xmlResults = handler.getMspConfig();
-            mspConfigDiscovery(xmlResults);
+            if (bridgehandler != null) {
+                String xmlResults = bridgehandler.getMspConfig();
+                mspConfigDiscovery(xmlResults);
+            }
         } catch (Exception e) {
             logger.warn("Exception during discovery scan", e);
         }
@@ -90,150 +90,154 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         List<String> property3 = new ArrayList<>();
         List<String> property4 = new ArrayList<>();
 
-        // Get Units (Standard, Metric)
-        property1 = handler.evaluateXPath("//System/Units/text()", xmlResponse);
-        handler.account.units = property1.get(0);
+        if (bridgehandler != null) {
+            // Get Units (Standard, Metric)
+            property1 = bridgehandler.evaluateXPath("//System/Units/text()", xmlResponse);
+            bridgehandler.account.units = property1.get(0);
 
-        // Get Variable Speed Pump Units (percent, RPM)
-        property2 = handler.evaluateXPath("//System/Msp-Vsp-Speed-Format/text()", xmlResponse);
-        handler.account.vspSpeedFormat = property2.get(0);
+            // Get Variable Speed Pump Units (percent, RPM)
+            property2 = bridgehandler.evaluateXPath("//System/Msp-Vsp-Speed-Format/text()", xmlResponse);
+            bridgehandler.account.vspSpeedFormat = property2.get(0);
 
-        // Find Backyard
-        names = handler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
+            // Find Backyard
+            names = bridgehandler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 
-        for (String name : names) {
-            onBackyardDiscovered(Integer.parseInt(handler.account.mspSystemID), name);
-        }
-
-        // Find Bodies of Water
-        systemIDs = handler.evaluateXPath("//Body-of-water/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Body-of-water/Name/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            onBOWDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i));
-        }
-
-        // Find Chlorinators
-        systemIDs = handler.evaluateXPath("//Chlorinator/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Chlorinator/Name/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            onChlorinatorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
-        }
-
-        // Find ColorLogic Lights
-        systemIDs = handler.evaluateXPath("//ColorLogic-Light/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//ColorLogic-Light/Name/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            onColorLogicDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
-        }
-
-        // Find Filters
-        systemIDs = handler.evaluateXPath("//Filter/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Filter/Name/text()", xmlResponse);
-        property1 = handler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
-        property2 = handler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
-        property3 = handler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
-        property4 = handler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            onFilterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
-                    property1.get(i), property2.get(i), property3.get(i), property4.get(i));
-        }
-
-        // Find Heaters
-        systemIDs = handler.evaluateXPath("//Heater-Equipment/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Heater-Equipment/Name/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
-            onHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
-        }
-
-        // Find Pumps
-        systemIDs = handler.evaluateXPath("//Pump/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Pump/Name/text()", xmlResponse);
-        names = handler.evaluateXPath("//Filter/Name/text()", xmlResponse);
-        property1 = handler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
-        property2 = handler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
-        property3 = handler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
-        property4 = handler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
-            onPumpDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
-                    property1.get(i), property2.get(i), property3.get(i), property4.get(i));
-        }
-
-        // Find Relays
-        systemIDs = handler.evaluateXPath("//Relay/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Relay/Name/text()", xmlResponse);
-
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            if (!(bowID.isEmpty())) {
-                onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
-            } else {
-                onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), "", "");
+            for (String name : names) {
+                onBackyardDiscovered(Integer.parseInt(bridgehandler.account.mspSystemID), name);
             }
 
-        }
+            // Find Bodies of Water
+            systemIDs = bridgehandler.evaluateXPath("//Body-of-water/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Body-of-water/Name/text()", xmlResponse);
 
-        // Find Virtual Heaters
-        systemIDs = handler.evaluateXPath("//Heater/System-Id/text()", xmlResponse);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                onBOWDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i));
+            }
 
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            onVirtualHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), "Virtual Heater", bowID.get(0),
-                    bowName.get(0));
-        }
+            // Find Chlorinators
+            systemIDs = bridgehandler.evaluateXPath("//Chlorinator/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Chlorinator/Name/text()", xmlResponse);
 
-        // Find Sensors
-        // Flow and water temp sensor aren't showing up in telemetry. Need example to determine how to differentiate
-        // "system" sensors
-        // that are reported in the BOW water temp, Filter flow switch, ORP, etc.
-        systemIDs = handler.evaluateXPath("//Sensor/System-Id/text()", xmlResponse);
-        names = handler.evaluateXPath("//Sensor/Name/text()", xmlResponse);
-        for (int i = 0; i < systemIDs.size(); i++) {
-            // get Body of Water for each item
-            bowID = handler.evaluateXPath(
-                    "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
-            bowName = handler.evaluateXPath("//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()",
-                    xmlResponse);
-            // Do not add backyard sensors that do not exist in the BOW thus bowID is null
-            if (!(bowID.isEmpty())) {
-                onSensorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                onChlorinatorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            }
+
+            // Find ColorLogic Lights
+            systemIDs = bridgehandler.evaluateXPath("//ColorLogic-Light/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//ColorLogic-Light/Name/text()", xmlResponse);
+
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                onColorLogicDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            }
+
+            // Find Filters
+            systemIDs = bridgehandler.evaluateXPath("//Filter/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Filter/Name/text()", xmlResponse);
+            property1 = bridgehandler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
+            property2 = bridgehandler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
+            property3 = bridgehandler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
+            property4 = bridgehandler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                onFilterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
+                        property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+            }
+
+            // Find Heaters
+            systemIDs = bridgehandler.evaluateXPath("//Heater-Equipment/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Heater-Equipment/Name/text()", xmlResponse);
+
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()",
+                        xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
+                onHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+            }
+
+            // Find Pumps
+            systemIDs = bridgehandler.evaluateXPath("//Pump/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Pump/Name/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Filter/Name/text()", xmlResponse);
+            property1 = bridgehandler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
+            property2 = bridgehandler.evaluateXPath("//Filter/Max-Pump-Speed/text()", xmlResponse);
+            property3 = bridgehandler.evaluateXPath("//Filter/Min-Pump-RPM/text()", xmlResponse);
+            property4 = bridgehandler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
+
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/System-Id/text()",
+                        xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/ancestor::Body-of-water/Name/text()", xmlResponse);
+                onPumpDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0),
+                        property1.get(i), property2.get(i), property3.get(i), property4.get(i));
+            }
+
+            // Find Relays
+            systemIDs = bridgehandler.evaluateXPath("//Relay/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Relay/Name/text()", xmlResponse);
+
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                if (!(bowID.isEmpty())) {
+                    onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+                } else {
+                    onRelayDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), "", "");
+                }
+
+            }
+
+            // Find Virtual Heaters
+            systemIDs = bridgehandler.evaluateXPath("//Heater/System-Id/text()", xmlResponse);
+
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                onVirtualHeaterDiscovered(Integer.parseInt(systemIDs.get(i)), "Virtual Heater", bowID.get(0),
+                        bowName.get(0));
+            }
+
+            // Find Sensors
+            // Flow and water temp sensor aren't showing up in telemetry. Need example to determine how to differentiate
+            // "system" sensors
+            // that are reported in the BOW water temp, Filter flow switch, ORP, etc.
+            systemIDs = bridgehandler.evaluateXPath("//Sensor/System-Id/text()", xmlResponse);
+            names = bridgehandler.evaluateXPath("//Sensor/Name/text()", xmlResponse);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                // get Body of Water for each item
+                bowID = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/System-Id/text()", xmlResponse);
+                bowName = bridgehandler.evaluateXPath(
+                        "//*[System-Id=" + systemIDs.get(i) + "]/parent::Body-of-water/Name/text()", xmlResponse);
+                // Do not add backyard sensors that do not exist in the BOW thus bowID is null
+                if (!(bowID.isEmpty())) {
+                    onSensorDiscovered(Integer.parseInt(systemIDs.get(i)), names.get(i), bowID.get(0), bowName.get(0));
+                }
             }
         }
         return true;
@@ -241,12 +245,12 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onBackyardDiscovered(int systemID, String label) {
         logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -254,12 +258,12 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onBOWDiscovered(int systemID, String label) {
         logger.trace("Hayward BOW {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -267,14 +271,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onChlorinatorDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Chlorinator {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR, handler.getThing().getUID(),
-                Integer.toString(systemID));
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR,
+                bridgehandler.getThing().getUID(), Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -282,14 +286,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onColorLogicDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Color Logic Light {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC, handler.getThing().getUID(),
-                Integer.toString(systemID));
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC,
+                bridgehandler.getThing().getUID(), Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -298,7 +302,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     public void onFilterDiscovered(int systemID, String label, String bowID, String bowName, String minPumpSpeed,
             String maxPumpSpeed, String minPumpRpm, String maxPumpRpm) {
         logger.trace("Hayward Filter {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
@@ -309,7 +313,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, maxPumpSpeed);
         properties.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, minPumpRpm);
         properties.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPRPM, maxPumpRpm);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -317,14 +321,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Heater {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -333,7 +337,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     public void onPumpDiscovered(int systemID, String label, String bowID, String bowName, String property1,
             String property2, String property3, String property4) {
         logger.trace("Hayward Pump {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
@@ -344,7 +348,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPSPEED, property2);
         properties.put(HaywardBindingConstants.PROPERTY_PUMP_MINPUMPRPM, property3);
         properties.put(HaywardBindingConstants.PROPERTY_PUMP_MAXPUMPRPM, property4);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -352,14 +356,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onRelayDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Relay {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -367,14 +371,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onSensorDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Sensor {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, handler.getThing().getUID(),
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, bridgehandler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -382,14 +386,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onVirtualHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
         logger.trace("Hayward Virtual Heater {} Discovered: {}", systemID, label);
-        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, handler.getThing().getUID(),
-                Integer.toString(systemID));
+        ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER,
+                bridgehandler.getThing().getUID(), Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
         properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, String.valueOf(systemID));
         properties.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER.toString());
         properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID);
         properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
-        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(handler.getThing().getUID())
+        DiscoveryResult result = DiscoveryResultBuilder.create(thingUID).withBridge(bridgehandler.getThing().getUID())
                 .withRepresentationProperty(HaywardBindingConstants.PROPERTY_SYSTEM_ID).withLabel("Hayward " + label)
                 .withProperties(properties).build();
         thingDiscovered(result);
@@ -398,13 +402,13 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     @Override
     public void setThingHandler(@Nullable ThingHandler handler) {
         if (handler instanceof HaywardBridgeHandler) {
-            this.handler = (HaywardBridgeHandler) handler;
-            this.handler.setHaywardDiscoveryService(this);
+            this.bridgehandler = (HaywardBridgeHandler) handler;
+            this.bridgehandler.setHaywardDiscoveryService(this);
         }
     }
 
     @Override
     public @Nullable ThingHandler getThingHandler() {
-        return handler;
+        return bridgehandler;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -76,7 +76,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             String xmlResults = handler.getMspConfig();
             mspConfigDiscovery(xmlResults);
         } catch (Exception e) {
-            logger.debug("Exception during discovery scan", e);
+            logger.warn("Exception during discovery scan", e);
         }
     }
 
@@ -232,7 +232,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onBackyardDiscovered(int systemID, String label) {
-        logger.debug("Hayward Backyard {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Backyard {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BACKYARD, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -245,7 +245,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onBOWDiscovered(int systemID, String label) {
-        logger.debug("Hayward BOW {} Discovered: {}", systemID, label);
+        logger.trace("Hayward BOW {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_BOW, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -258,7 +258,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onChlorinatorDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Chlorinator {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Chlorinator {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_CHLORINATOR, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -273,7 +273,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onColorLogicDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Color Logic Light {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Color Logic Light {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_COLORLOGIC, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -289,7 +289,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onFilterDiscovered(int systemID, String label, String bowID, String bowName, String minPumpSpeed,
             String maxPumpSpeed, String minPumpRpm, String maxPumpRpm) {
-        logger.debug("Hayward Filter {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Filter {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_FILTER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -308,7 +308,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Heater {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Heater {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_HEATER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -324,7 +324,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
     public void onPumpDiscovered(int systemID, String label, String bowID, String bowName, String property1,
             String property2, String property3, String property4) {
-        logger.debug("Hayward Pump {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Pump {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_PUMP, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -343,7 +343,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onRelayDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Relay {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Relay {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_RELAY, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -358,7 +358,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onSensorDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Sensor {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Sensor {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_SENSOR, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();
@@ -373,7 +373,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void onVirtualHeaterDiscovered(int systemID, String label, String bowID, String bowName) {
-        logger.debug("Hayward Virtual Heater {} Discovered: {}", systemID, label);
+        logger.trace("Hayward Virtual Heater {} Discovered: {}", systemID, label);
         ThingUID thingUID = new ThingUID(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, handler.getThing().getUID(),
                 Integer.toString(systemID));
         Map<String, Object> properties = new HashMap<>();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -90,6 +90,14 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         List<String> property3 = new ArrayList<>();
         List<String> property4 = new ArrayList<>();
 
+        // Get Units (Standard, Metric)
+        property1 = handler.evaluateXPath("//System/Units/text()", xmlResponse);
+        handler.account.units = property1.get(0);
+
+        // Get Variable Speed Pump Units (percent, RPM)
+        property2 = handler.evaluateXPath("//System/Msp-Vsp-Speed-Format/text()", xmlResponse);
+        handler.account.vspSpeedFormat = property2.get(0);
+
         // Find Backyard
         names = handler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -79,6 +79,8 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             }
         } catch (HaywardException e) {
             logger.warn("Exception during discovery scan: {}", e.getMessage());
+        } catch (InterruptedException e) {
+            return;
         }
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -112,11 +112,11 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
         // Find Chlorinators
         discoverDevices(bridgehandler, xmlResponse, "Chlorinator", HaywardTypeToRequest.CHLORINATOR,
-                HaywardBindingConstants.THING_TYPE_CHLORINATOR, false, null);
+                HaywardBindingConstants.THING_TYPE_CHLORINATOR, null);
 
         // Find ColorLogic Lights
         discoverDevices(bridgehandler, xmlResponse, "ColorLogic-Light", HaywardTypeToRequest.COLORLOGIC,
-                HaywardBindingConstants.THING_TYPE_COLORLOGIC, false, null);
+                HaywardBindingConstants.THING_TYPE_COLORLOGIC, null);
 
         // Find Filters
         final List<String> filterProperty1 = bridgehandler.evaluateXPath("//Filter/Min-Pump-Speed/text()", xmlResponse);
@@ -125,7 +125,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         final List<String> filterProperty4 = bridgehandler.evaluateXPath("//Filter/Max-Pump-RPM/text()", xmlResponse);
 
         discoverDevices(bridgehandler, xmlResponse, "Filter", HaywardTypeToRequest.FILTER,
-                HaywardBindingConstants.THING_TYPE_FILTER, false, (props, i) -> {
+                HaywardBindingConstants.THING_TYPE_FILTER, (props, i) -> {
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, filterProperty1.get(i));
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, filterProperty2.get(i));
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, filterProperty3.get(i));
@@ -134,7 +134,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
         // Find Heaters
         discoverDevices(bridgehandler, xmlResponse, "Heater-Equipment", HaywardTypeToRequest.HEATER,
-                HaywardBindingConstants.THING_TYPE_HEATER, false, null);
+                HaywardBindingConstants.THING_TYPE_HEATER, null);
 
         // Find Pumps
         systemIDs = bridgehandler.evaluateXPath("//Pump/System-Id/text()", xmlResponse);
@@ -145,7 +145,7 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         final List<String> pumpProperty4 = bridgehandler.evaluateXPath("//Pump/Max-Pump-RPM/text()", xmlResponse);
 
         discoverDevices(bridgehandler, xmlResponse, "Pump", HaywardTypeToRequest.PUMP,
-                HaywardBindingConstants.THING_TYPE_FILTER, false, (props, i) -> {
+                HaywardBindingConstants.THING_TYPE_FILTER, (props, i) -> {
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPSPEED, pumpProperty1.get(i));
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MAXPUMPSPEED, pumpProperty2.get(i));
                     props.put(HaywardBindingConstants.PROPERTY_FILTER_MINPUMPRPM, pumpProperty3.get(i));
@@ -154,20 +154,20 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
 
         // Find Relays
         discoverDevices(bridgehandler, xmlResponse, "Relay", HaywardTypeToRequest.RELAY,
-                HaywardBindingConstants.THING_TYPE_RELAY, true, null);
+                HaywardBindingConstants.THING_TYPE_RELAY, null);
 
         // Find Virtual Heaters
         discoverDevices(bridgehandler, xmlResponse, "Heater", HaywardTypeToRequest.VIRTUALHEATER,
-                HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, false, null);
+                HaywardBindingConstants.THING_TYPE_VIRTUALHEATER, null);
 
         // Find Sensors
         discoverDevices(bridgehandler, xmlResponse, "Sensor", HaywardTypeToRequest.SENSOR,
-                HaywardBindingConstants.THING_TYPE_SENSOR, true, null);
+                HaywardBindingConstants.THING_TYPE_SENSOR, null);
         return;
     }
 
     private void discoverDevices(HaywardBridgeHandler bridgehandler, String xmlResponse, String xmlSearchTerm,
-            HaywardTypeToRequest type, ThingTypeUID thingType, boolean useZeroForBowIndex,
+            HaywardTypeToRequest type, ThingTypeUID thingType,
             @Nullable BiConsumer<Map<String, Object>, Integer> additionalPropertyConsumer) {
         List<String> systemIDs = new ArrayList<>();
         List<String> names = new ArrayList<>();
@@ -200,9 +200,8 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             Map<String, Object> properties = new HashMap<>();
             properties.put(HaywardBindingConstants.PROPERTY_TYPE, type);
             properties.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemIDs.get(i));
-            int bowIndex = useZeroForBowIndex ? 0 : i;
-            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(bowIndex));
-            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(bowIndex));
+            properties.put(HaywardBindingConstants.PROPERTY_BOWID, bowID.get(0));
+            properties.put(HaywardBindingConstants.PROPERTY_BOWNAME, bowName.get(0));
             if (additionalPropertyConsumer != null) {
                 additionalPropertyConsumer.accept(properties, i);
             }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -97,7 +97,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
         HaywardBridgeHandler bridgehandler = discoveryBridgehandler;
 
         if (bridgehandler != null) {
-
             // Find Backyard
             names = bridgehandler.evaluateXPath("//Backyard/Name/text()", xmlResponse);
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/discovery/HaywardDiscoveryService.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
  * @author Matt Myers - Initial Contribution
  */
 
-// public class HaywardDiscoveryService extends AbstractDiscoveryService implements HaywardHandlerListener {
 @NonNullByDefault
 public class HaywardDiscoveryService extends AbstractDiscoveryService implements DiscoveryService, ThingHandlerService {
 
@@ -395,14 +394,6 @@ public class HaywardDiscoveryService extends AbstractDiscoveryService implements
             this.handler.setHaywardDiscoveryService(this);
         }
     }
-
-    // @Override
-    // public void setThingHandler(@Nullable ThingHandler handler) {
-    // if (handler instanceof YamahaBridgeHandler) {
-    // this.handler = (YamahaBridgeHandler) handler;
-    // this.handler.setZoneDiscoveryService(this);
-    // }
-    // }
 
     @Override
     public @Nullable ThingHandler getThingHandler() {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -95,22 +95,17 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
             return false;
         }
 
-        if (status.equals("0")) {
-            bowID = bridgehandler.evaluateXPath("//Property[@name='BowID']/text()", xmlResponse);
-            parameter1 = bridgehandler.evaluateXPath("//Property[@name='Parameter1']/text()", xmlResponse);
-            message = bridgehandler.evaluateXPath("//Property[@name='Message']/text()", xmlResponse);
+        bowID = bridgehandler.evaluateXPath("//Property[@name='BowID']/text()", xmlResponse);
+        parameter1 = bridgehandler.evaluateXPath("//Property[@name='Parameter1']/text()", xmlResponse);
+        message = bridgehandler.evaluateXPath("//Property[@name='Message']/text()", xmlResponse);
 
-            for (int i = 0; i < 5; i++) {
-                if (i < bowID.size()) {
-                    alarmStr = parameter1.get(i) + ": " + message.get(i);
-                } else {
-                    alarmStr = "";
-                }
-                updateData("backyardAlarm" + String.format("%01d", i + 1), alarmStr);
+        for (int i = 0; i < 5; i++) {
+            if (i < bowID.size()) {
+                alarmStr = parameter1.get(i) + ": " + message.get(i);
+            } else {
+                alarmStr = "";
             }
-        } else {
-            logger.trace("Hayward getAlarms XML response: {}", xmlResponse);
-            return false;
+            updateData("backyardAlarm" + String.format("%01d", i + 1), alarmStr);
         }
         return true;
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -60,6 +60,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATE, data.get(0));
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -108,6 +109,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
                 }
                 updateData("backyardAlarm" + String.format("%01d", i + 1), alarmStr);
             }
+            this.updateStatus(ThingStatus.ONLINE);
             return true;
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Backyard Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardBackyardHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -36,7 +37,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -72,7 +72,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
         }
     }
 
-    public boolean getAlarmList(String systemID) throws Exception {
+    public boolean getAlarmList(String systemID) throws HaywardException {
         List<String> bowID = new ArrayList<>();
         List<String> parameter1 = new ArrayList<>();
         List<String> message = new ArrayList<>();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Thing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Backyard Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardBackyardHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardBackyardHandler.class);
+
+    public HaywardBackyardHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Backyard/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Air temp
+                    data = bridgehandler.evaluateXPath("//Backyard/@airTemp", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_AIRTEMP, data.get(0));
+
+                    // Status
+                    data = bridgehandler.evaluateXPath("//Backyard/@status", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATUS, data.get(0));
+
+                    // State
+                    data = bridgehandler.evaluateXPath("//Backyard/@state", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATE, data.get(0));
+                }
+            }
+        }
+    }
+
+    public boolean getAlarmList(String systemID) throws Exception {
+        List<String> bowID = new ArrayList<>();
+        List<String> parameter1 = new ArrayList<>();
+        List<String> message = new ArrayList<>();
+        String alarmStr;
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+
+        // *****Request Alarm List from Hayward server
+        @SuppressWarnings("null")
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetAlarmList</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token + "</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">" + bridgehandler.account.mspSystemID
+                + "</Parameter>"
+                + "<Parameter name=\"CultureInfoName\" dataType=\"String\">en-us</Parameter></Parameters></Request>";
+
+        String xmlResponse = bridgehandler.httpXmlResponse(urlParameters);
+
+        if (xmlResponse.isEmpty()) {
+            logger.error("Hayward getAlarmList XML response was empty");
+            return false;
+        }
+
+        String status = bridgehandler
+                .evaluateXPath("/Response/Parameters//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+        if (!(status.equals("0"))) {
+            logger.error("Hayward getAlarm XML response: {}", xmlResponse);
+            return false;
+        }
+
+        if (status.equals("0")) {
+            bowID = bridgehandler.evaluateXPath("//Property[@name='BowID']/text()", xmlResponse);
+            parameter1 = bridgehandler.evaluateXPath("//Property[@name='Parameter1']/text()", xmlResponse);
+            message = bridgehandler.evaluateXPath("//Property[@name='Message']/text()", xmlResponse);
+
+            for (int i = 0; i < 5; i++) {
+                if (i < bowID.size()) {
+                    alarmStr = parameter1.get(i) + ": " + message.get(i);
+                } else {
+                    alarmStr = "";
+                }
+                updateData("backyardAlarm" + String.format("%01d", i + 1), alarmStr);
+            }
+        } else {
+            logger.error("Hayward getAlarms XML response: {}", xmlResponse);
+            return false;
+        }
+        return true;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -44,7 +44,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Backyard/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Air temp

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBackyardHandler.java
@@ -83,7 +83,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
         String xmlResponse = bridgehandler.httpXmlResponse(urlParameters);
 
         if (xmlResponse.isEmpty()) {
-            logger.error("Hayward getAlarmList XML response was empty");
+            logger.debug("Hayward getAlarmList XML response was empty");
             return false;
         }
 
@@ -91,7 +91,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
                 .evaluateXPath("/Response/Parameters//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
         if (!(status.equals("0"))) {
-            logger.error("Hayward getAlarm XML response: {}", xmlResponse);
+            logger.trace("Hayward getAlarm XML response: {}", xmlResponse);
             return false;
         }
 
@@ -109,7 +109,7 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
                 updateData("backyardAlarm" + String.format("%01d", i + 1), alarmStr);
             }
         } else {
-            logger.error("Hayward getAlarms XML response: {}", xmlResponse);
+            logger.trace("Hayward getAlarms XML response: {}", xmlResponse);
             return false;
         }
         return true;

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
@@ -40,26 +41,28 @@ public class HaywardBowHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//BodyOfWater/@systemId", xmlResponse);
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//BodyOfWater/@systemId", xmlResponse);
 
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    // Flow
-                    data = bridgehandler.evaluateXPath("//BodyOfWater/@flow", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_BOW_FLOW, data.get(i));
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        // Flow
+                        data = bridgehandler.evaluateXPath("//BodyOfWater/@flow", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_BOW_FLOW, data.get(i));
 
-                    // Water Temp
-                    data = bridgehandler.evaluateXPath("//BodyOfWater/@waterTemp", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, data.get(i));
+                        // Water Temp
+                        data = bridgehandler.evaluateXPath("//BodyOfWater/@waterTemp", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, data.get(i));
+                    }
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -19,11 +19,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Body of Water Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardBowHandler extends HaywardThingHandler {
@@ -54,6 +54,9 @@ public class HaywardBowHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, data.get(i));
                 }
             }
+
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -25,6 +25,8 @@ import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Body of Water Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardBowHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -34,14 +34,15 @@ public class HaywardBowHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//BodyOfWater/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Flow

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -33,7 +34,7 @@ public class HaywardBowHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -54,7 +54,7 @@ public class HaywardBowHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, data.get(i));
                 }
             }
-
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBowHandler.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Thing;
+
+/**
+ * The Body of Water Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardBowHandler extends HaywardThingHandler {
+
+    public HaywardBowHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//BodyOfWater/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Flow
+                    data = bridgehandler.evaluateXPath("//BodyOfWater/@flow", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_BOW_FLOW, data.get(i));
+
+                    // Water Temp
+                    data = bridgehandler.evaluateXPath("//BodyOfWater/@waterTemp", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, data.get(i));
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -73,7 +73,6 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     private @Nullable ScheduledFuture<?> pollTelemetryFuture;
     private @Nullable ScheduledFuture<?> pollAlarmsFuture;
     private int commFailureCount;
-    private @Nullable HaywardDiscoveryService haywardDiscoveryService;
     public HaywardConfig config = getConfig().as(HaywardConfig.class);
     public HaywardAccount account = getConfig().as(HaywardAccount.class);
 
@@ -85,13 +84,6 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     public HaywardBridgeHandler(Bridge bridge, HttpClient httpClient) {
         super(bridge);
         this.httpClient = httpClient;
-    }
-
-    /**
-     * Called by the zone discovery service to let this handler have a reference.
-     */
-    public void setHaywardDiscoveryService(HaywardDiscoveryService s) {
-        haywardDiscoveryService = s;
     }
 
     @Override

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -72,7 +72,6 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     private @Nullable ScheduledFuture<?> pollAlarmsFuture;
     private int commFailureCount;
     private @Nullable HaywardDiscoveryService haywardDiscoveryService;
-
     public HaywardConfig config = getConfig().as(HaywardConfig.class);
     public HaywardAccount account = getConfig().as(HaywardAccount.class);
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -91,7 +91,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
      * Called by the zone discovery service to let this handler have a reference.
      */
     public void setHaywardDiscoveryService(HaywardDiscoveryService s) {
-        this.haywardDiscoveryService = s;
+        haywardDiscoveryService = s;
     }
 
     @Override

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -450,11 +450,11 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             }
         } catch (ExecutionException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Unable to resolve host.  Check Hayward hostname and your internet connection.");
+                    "Unable to resolve host.  Check Hayward hostname and your internet connection. " + e);
             return "";
         } catch (TimeoutException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Connection Timeout.  Check Hayward hostname and your internet connection.");
+                    "Connection Timeout.  Check Hayward hostname and your internet connection. " + e);
             return "";
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -159,10 +159,12 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             commFailureCount = 50;
             initPolling(60);
             return;
+        } catch (InterruptedException e) {
+            return;
         }
     }
 
-    public synchronized boolean login() throws HaywardException {
+    public synchronized boolean login() throws HaywardException, InterruptedException {
         String xmlResponse;
         String status;
 
@@ -190,7 +192,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized boolean getApiDef() throws HaywardException {
+    public synchronized boolean getApiDef() throws HaywardException, InterruptedException {
         String xmlResponse;
 
         // *****getConfig from Hayward server
@@ -209,7 +211,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized boolean getSiteList() throws HaywardException {
+    public synchronized boolean getSiteList() throws HaywardException, InterruptedException {
         String xmlResponse;
         String status;
 
@@ -242,7 +244,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized String getMspConfig() throws HaywardException {
+    public synchronized String getMspConfig() throws HaywardException, InterruptedException {
         // *****getMspConfig from Hayward server
         String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetMspConfigFile</Name><Parameters>"
                 + "<Parameter name=\"Token\" dataType=\"String\">" + account.token + "</Parameter>"
@@ -269,7 +271,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return xmlResponse;
     }
 
-    public synchronized boolean getTelemetryData() throws HaywardException {
+    public synchronized boolean getTelemetryData() throws HaywardException, InterruptedException {
         // *****getTelemetry from Hayward server
         String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetTelemetryData</Name><Parameters>"
                 + "<Parameter name=\"Token\" dataType=\"String\">" + account.token + "</Parameter>"
@@ -331,6 +333,8 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                 }
             } catch (HaywardException e) {
                 logger.debug("Hayward Connection thing: Exception during poll: {}", e.getMessage());
+            } catch (InterruptedException e) {
+                return;
             }
         }, initalDelay, config.telemetryPollTime, TimeUnit.SECONDS);
         return;
@@ -389,7 +393,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                 .timeout(10, TimeUnit.SECONDS);
     }
 
-    public synchronized String httpXmlResponse(String urlParameters) throws HaywardException {
+    public synchronized String httpXmlResponse(String urlParameters) throws HaywardException, InterruptedException {
         String urlParameterslength = Integer.toString(urlParameters.length());
         String statusMessage;
 
@@ -430,10 +434,6 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                     "Unable to resolve host.  Check Hayward hostname and your internet connection.");
             return "";
         } catch (TimeoutException e) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Connection Timeout.  Check Hayward hostname and your internet connection.");
-            return "";
-        } catch (InterruptedException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Connection Timeout.  Check Hayward hostname and your internet connection.");
             return "";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -150,11 +150,8 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
 
             if (config.alarmPollTime > 0) {
                 initAlarmPolling(1);
-                logger.trace("Hayward Alarm polling scheduled");
-            } else {
-                logger.trace("Hayward Alarm polling disabled");
             }
-        } catch (Exception e) {
+        } catch (HaywardException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
                     "scheduledInitialize exception: " + e.getMessage());
             clearPolling(pollTelemetryFuture);
@@ -165,7 +162,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         }
     }
 
-    public synchronized boolean login() throws Exception {
+    public synchronized boolean login() throws HaywardException {
         String xmlResponse;
         String status;
 
@@ -193,7 +190,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized boolean getApiDef() throws Exception {
+    public synchronized boolean getApiDef() throws HaywardException {
         String xmlResponse;
 
         // *****getConfig from Hayward server
@@ -212,7 +209,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized boolean getSiteList() throws Exception {
+    public synchronized boolean getSiteList() throws HaywardException {
         String xmlResponse;
         String status;
 
@@ -302,7 +299,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return true;
     }
 
-    public synchronized boolean getAlarmList() throws Exception {
+    public synchronized boolean getAlarmList() throws HaywardException {
         for (Thing thing : getThing().getThings()) {
             Map<String, String> properties = thing.getProperties();
             if ("BACKYARD".equals(properties.get(HaywardBindingConstants.PROPERTY_TYPE))) {
@@ -332,7 +329,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                     commFailureCount++;
                     return;
                 }
-            } catch (Exception e) {
+            } catch (HaywardException e) {
                 logger.debug("Hayward Connection thing: Exception during poll: {}", e.getMessage());
             }
         }, initalDelay, config.telemetryPollTime, TimeUnit.SECONDS);
@@ -343,7 +340,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         pollAlarmsFuture = scheduler.scheduleWithFixedDelay(() -> {
             try {
                 getAlarmList();
-            } catch (Exception e) {
+            } catch (HaywardException e) {
                 logger.debug("Hayward Connection thing: Exception during poll: {}", e.getMessage());
             }
         }, initalDelay, config.alarmPollTime, TimeUnit.SECONDS);
@@ -368,7 +365,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         return null;
     }
 
-    public List<String> evaluateXPath(String xpathExp, String xmlResponse) throws HaywardException {
+    public List<String> evaluateXPath(String xpathExp, String xmlResponse) {
         List<String> values = new ArrayList<>();
         try {
             InputSource inputXML = new InputSource(new StringReader(xmlResponse));

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -141,7 +141,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             }
 
             updateStatus(ThingStatus.ONLINE);
-            logger.trace("Succesfully opened connection to Hayward's server: {} Username:{}", config.endpointUrl,
+            logger.debug("Succesfully opened connection to Hayward's server: {} Username:{}", config.endpointUrl,
                     config.username);
 
             initPolling(0);
@@ -377,7 +377,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                 values.add(nodes.item(i).getNodeValue());
             }
         } catch (XPathExpressionException e) {
-            logger.error("XPathExpression exception:", e);
+            logger.warn("XPathExpression exception:", e);
         }
         return values;
     }
@@ -416,9 +416,6 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
                             urlParameters);
                     logger.trace("Hayward Connection thing:  {} Hayward http response: {} {}", getCallingMethod(),
                             statusMessage, xmlResponse);
-                } else if (logger.isDebugEnabled()) {
-                    logger.debug("Hayward Connection thing:  {} Hayward http response: {}", getCallingMethod(),
-                            statusMessage);
                 }
                 return xmlResponse;
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -307,7 +307,10 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             if (properties.get(HaywardBindingConstants.PROPERTY_TYPE).equals("BACKYARD")) {
                 HaywardBackyardHandler handler = (HaywardBackyardHandler) thing.getHandler();
                 if (handler != null) {
-                    return handler.getAlarmList(properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID));
+                    String systemID = properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+                    if (systemID != null) {
+                        return handler.getAlarmList(systemID);
+                    }
                 }
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -305,7 +305,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     public synchronized boolean getAlarmList() throws Exception {
         for (Thing thing : getThing().getThings()) {
             Map<String, String> properties = thing.getProperties();
-            if (properties.get(HaywardBindingConstants.PROPERTY_TYPE).equals("BACKYARD")) {
+            if ("BACKYARD".equals(properties.get(HaywardBindingConstants.PROPERTY_TYPE))) {
                 HaywardBackyardHandler handler = (HaywardBackyardHandler) thing.getHandler();
                 if (handler != null) {
                     String systemID = properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
@@ -359,8 +359,8 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     Thing getThingForType(HaywardTypeToRequest type, int num) {
         for (Thing thing : getThing().getThings()) {
             Map<String, String> properties = thing.getProperties();
-            if (properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID).equals(Integer.toString(num))) {
-                if (properties.get(HaywardBindingConstants.PROPERTY_TYPE).equals(type.toString())) {
+            if (Integer.toString(num).equals(properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID))) {
+                if (type.toString().equals(properties.get(HaywardBindingConstants.PROPERTY_TYPE))) {
                     return thing;
                 }
             }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -61,6 +61,8 @@ import org.xml.sax.InputSource;
 /**
  * The {@link HaywardBridgeHandler} is responsible for handling commands, which are
  * sent to one of the channels.
+ *
+ * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -59,8 +59,6 @@ import org.xml.sax.InputSource;
 /**
  * The {@link HaywardBridgeHandler} is responsible for handling commands, which are
  * sent to one of the channels.
- *
- * @author Matt Myers - Initial contribution
  */
 
 @NonNullByDefault
@@ -155,9 +153,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             }
         } catch (Exception e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
-                    "scheduledInitialize exception");
-            logger.debug("Hayward Connection thing: Unable to open connection to Hayward Server: {} Username: {}",
-                    config.endpointUrl, config.username, e);
+                    "scheduledInitialize exception: " + e);
             clearPolling(pollTelemetryFuture);
             clearPolling(pollAlarmsFuture);
             commFailureCount = 50;
@@ -263,12 +259,12 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
 
         if (xmlResponse.isEmpty()) {
             logger.debug("Hayward Connection thing: requestConfig XML response was null");
-            return "";
+            return "Fail";
         }
 
         if (evaluateXPath("//Backyard/Name/text()", xmlResponse).isEmpty()) {
             logger.debug("Hayward Connection thing: requestConfiguration XML response: {}", xmlResponse);
-            return "";
+            return "Fail";
         }
         return xmlResponse;
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -141,7 +141,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             }
 
             updateStatus(ThingStatus.ONLINE);
-            logger.trace("Succesfully opened connection to Hayward's server: {} Username:{}", config.hostname,
+            logger.trace("Succesfully opened connection to Hayward's server: {} Username:{}", config.endpointUrl,
                     config.username);
 
             initPolling(0);
@@ -157,7 +157,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
                     "scheduledInitialize exception");
             logger.debug("Hayward Connection thing: Unable to open connection to Hayward Server: {} Username: {}",
-                    config.hostname, config.username, e);
+                    config.endpointUrl, config.username, e);
             clearPolling(pollTelemetryFuture);
             clearPolling(pollAlarmsFuture);
             commFailureCount = 50;
@@ -395,7 +395,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         String statusMessage;
 
         try {
-            ContentResponse httpResponse = sendRequestBuilder(config.hostname, HttpMethod.POST)
+            ContentResponse httpResponse = sendRequestBuilder(config.endpointUrl, HttpMethod.POST)
                     .content(new StringContentProvider(urlParameters), "text/xml; charset=utf-8")
                     .header(HttpHeader.CONTENT_LENGTH, urlParameterslength).send();
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardBridgeHandler.java
@@ -1,0 +1,456 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpVersion;
+import org.openhab.binding.haywardomnilogic.internal.HaywardAccount;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardTypeToRequest;
+import org.openhab.binding.haywardomnilogic.internal.config.HaywardConfig;
+import org.openhab.binding.haywardomnilogic.internal.discovery.HaywardDiscoveryService;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * The {@link HaywardBridgeHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Matt Myers - Initial contribution
+ */
+
+@NonNullByDefault
+public class HaywardBridgeHandler extends BaseBridgeHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardBridgeHandler.class);
+    private final HttpClient httpClient;
+    private @Nullable ScheduledFuture<?> initializeFuture;
+    private @Nullable ScheduledFuture<?> pollTelemetryFuture;
+    private @Nullable ScheduledFuture<?> pollAlarmsFuture;
+    private int commFailureCount;
+    private @Nullable HaywardDiscoveryService haywardDiscoveryService;
+
+    public HaywardConfig config = getConfig().as(HaywardConfig.class);
+    public HaywardAccount account = getConfig().as(HaywardAccount.class);
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(HaywardDiscoveryService.class);
+    }
+
+    public HaywardBridgeHandler(Bridge bridge, HttpClient httpClient) {
+        super(bridge);
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Called by the zone discovery service to let this handler have a reference.
+     */
+    public void setHaywardDiscoveryService(HaywardDiscoveryService s) {
+        this.haywardDiscoveryService = s;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void dispose() {
+        clearPolling(initializeFuture);
+        clearPolling(pollTelemetryFuture);
+        clearPolling(pollAlarmsFuture);
+        logger.trace("Hayward polling cancelled");
+        super.dispose();
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.UNKNOWN);
+        initializeFuture = scheduler.schedule(this::scheduledInitialize, 1, TimeUnit.SECONDS);
+        return;
+    }
+
+    public void scheduledInitialize() {
+        config = getConfigAs(HaywardConfig.class);
+
+        try {
+            clearPolling(pollTelemetryFuture);
+            clearPolling(pollAlarmsFuture);
+
+            if (!(login())) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Unable to Login to Hayward's server");
+                clearPolling(pollTelemetryFuture);
+                clearPolling(pollAlarmsFuture);
+                commFailureCount = 50;
+                initPolling(60);
+                return;
+            }
+
+            if (!(getSiteList())) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Unable to getMSP from Hayward's server");
+                clearPolling(pollTelemetryFuture);
+                clearPolling(pollAlarmsFuture);
+                commFailureCount = 50;
+                initPolling(60);
+                return;
+            }
+
+            updateStatus(ThingStatus.ONLINE);
+            logger.trace("Succesfully opened connection to Hayward's server: {} Username:{}", config.hostname,
+                    config.username);
+
+            initPolling(0);
+            logger.trace("Hayward Telemetry polling scheduled");
+
+            if (config.alarmPollTime > 0) {
+                initAlarmPolling(1);
+                logger.trace("Hayward Alarm polling scheduled");
+            } else {
+                logger.trace("Hayward Alarm polling disabled");
+            }
+        } catch (Exception e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
+                    "scheduledInitialize exception");
+            logger.debug("Hayward Connection thing: Unable to open connection to Hayward Server: {} Username: {}",
+                    config.hostname, config.username, e);
+            clearPolling(pollTelemetryFuture);
+            clearPolling(pollAlarmsFuture);
+            commFailureCount = 50;
+            initPolling(60);
+            return;
+        }
+    }
+
+    public synchronized boolean login() throws Exception {
+        String xmlResponse;
+        String status;
+
+        // *****Login to Hayward server
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request>" + "<Name>Login</Name><Parameters>"
+                + "<Parameter name=\"UserName\" dataType=\"String\">" + config.username + "</Parameter>"
+                + "<Parameter name=\"Password\" dataType=\"String\">" + config.password + "</Parameter>"
+                + "</Parameters></Request>";
+
+        xmlResponse = httpXmlResponse(urlParameters);
+
+        if (xmlResponse.isEmpty()) {
+            return false;
+        }
+
+        status = evaluateXPath("/Response/Parameters//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+        if (!(status.equals("0"))) {
+            logger.debug("Hayward Connection thing: Login XML response: {}", xmlResponse);
+            return false;
+        }
+
+        account.token = evaluateXPath("/Response/Parameters//Parameter[@name='Token']/text()", xmlResponse).get(0);
+        account.userID = evaluateXPath("/Response/Parameters//Parameter[@name='UserID']/text()", xmlResponse).get(0);
+        return true;
+    }
+
+    public synchronized boolean getApiDef() throws Exception {
+        String xmlResponse;
+
+        // *****getConfig from Hayward server
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetAPIDef</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">" + account.token + "</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">" + account.mspSystemID + "</Parameter>;"
+                + "<Parameter name=\"Version\" dataType=\"string\">0.4</Parameter >\r\n"
+                + "<Parameter name=\"Language\" dataType=\"string\">en</Parameter >\r\n" + "</Parameters></Request>";
+
+        xmlResponse = httpXmlResponse(urlParameters);
+
+        if (xmlResponse.isEmpty()) {
+            logger.debug("Hayward Connection thing: Login XML response was null");
+            return false;
+        }
+        return true;
+    }
+
+    public synchronized boolean getSiteList() throws Exception {
+        String xmlResponse;
+        String status;
+
+        // *****Get MSP
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetSiteList</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">" + account.token
+                + "</Parameter><Parameter name=\"UserID\" dataType=\"String\">" + account.userID
+                + "</Parameter></Parameters></Request>";
+
+        xmlResponse = httpXmlResponse(urlParameters);
+
+        if (xmlResponse.isEmpty()) {
+            logger.debug("Hayward Connection thing: getSiteList XML response was null");
+            return false;
+        }
+
+        status = evaluateXPath("/Response/Parameters//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+        if (!(status.equals("0"))) {
+            logger.debug("Hayward Connection thing: getSiteList XML response: {}", xmlResponse);
+            return false;
+        }
+
+        account.mspSystemID = evaluateXPath("/Response/Parameters/Parameter/Item//Property[@name='MspSystemID']/text()",
+                xmlResponse).get(0);
+        account.backyardName = evaluateXPath(
+                "/Response/Parameters/Parameter/Item//Property[@name='BackyardName']/text()", xmlResponse).get(0);
+        account.address = evaluateXPath("/Response/Parameters/Parameter/Item//Property[@name='Address']/text()",
+                xmlResponse).get(0);
+        return true;
+    }
+
+    public synchronized String getMspConfig() throws Exception {
+        // *****getMspConfig from Hayward server
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetMspConfigFile</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">" + account.token + "</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">" + account.mspSystemID
+                + "</Parameter><Parameter name=\"Version\" dataType=\"string\">0</Parameter>\r\n"
+                + "</Parameters></Request>";
+
+        String xmlResponse = httpXmlResponse(urlParameters);
+
+        // Debug: Inject xml file for testing
+        // String path =
+        // "C:/Users/Controls/openhab-2-5-x/git/openhab-addons/bundles/org.openhab.binding.haywardomnilogic/getConfig.xml";
+        // xmlResponse = new String(Files.readAllBytes(Paths.get(path)));
+
+        if (xmlResponse.isEmpty()) {
+            logger.debug("Hayward Connection thing: requestConfig XML response was null");
+            return "";
+        }
+
+        if (evaluateXPath("//Backyard/Name/text()", xmlResponse).isEmpty()) {
+            logger.debug("Hayward Connection thing: requestConfiguration XML response: {}", xmlResponse);
+            return "";
+        }
+        return xmlResponse;
+    }
+
+    public synchronized boolean getTelemetryData() throws Exception {
+        // *****getTelemetry from Hayward server
+        String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetTelemetryData</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">" + account.token + "</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">" + account.mspSystemID
+                + "</Parameter></Parameters></Request>";
+
+        String xmlResponse = httpXmlResponse(urlParameters);
+
+        if (xmlResponse.isEmpty()) {
+            logger.debug("Hayward Connection thing: getTelemetry XML response was null");
+            return false;
+        }
+
+        if (!evaluateXPath("/Response/Parameters//Parameter[@name='StatusMessage']/text()", xmlResponse).isEmpty()) {
+            logger.debug("Hayward Connection thing: getTelemetry XML response: {}", xmlResponse);
+            return false;
+        }
+
+        for (Thing thing : getThing().getThings()) {
+            if (thing.getHandler() instanceof HaywardThingHandler) {
+                HaywardThingHandler handler = (HaywardThingHandler) thing.getHandler();
+                if (handler != null) {
+                    handler.getTelemetry(xmlResponse);
+                }
+            }
+        }
+        return true;
+    }
+
+    public synchronized boolean getAlarmList() throws Exception {
+        for (Thing thing : getThing().getThings()) {
+            Map<String, String> properties = thing.getProperties();
+            if (properties.get(HaywardBindingConstants.PROPERTY_TYPE).equals("BACKYARD")) {
+                HaywardBackyardHandler handler = (HaywardBackyardHandler) thing.getHandler();
+                if (handler != null) {
+                    return handler.getAlarmList(properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID));
+                }
+            }
+        }
+        return false;
+    }
+
+    private synchronized void initPolling(int initalDelay) {
+        pollTelemetryFuture = scheduler.scheduleWithFixedDelay(() -> {
+            try {
+                if (commFailureCount >= 5) {
+                    commFailureCount = 0;
+                    clearPolling(pollTelemetryFuture);
+                    clearPolling(pollAlarmsFuture);
+                    initialize();
+                    return;
+                }
+                if (!(getTelemetryData())) {
+                    commFailureCount++;
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Hayward Connection thing: Exception during poll", e);
+            }
+        }, initalDelay, config.telemetryPollTime, TimeUnit.SECONDS);
+        return;
+    }
+
+    private synchronized void initAlarmPolling(int initalDelay) {
+        pollAlarmsFuture = scheduler.scheduleWithFixedDelay(() -> {
+            try {
+                getAlarmList();
+            } catch (Exception e) {
+                logger.debug("Hayward Connection thing: Exception during poll", e);
+            }
+        }, initalDelay, config.alarmPollTime, TimeUnit.SECONDS);
+    }
+
+    private void clearPolling(@Nullable ScheduledFuture<?> pollJob) {
+        if (pollJob != null) {
+            pollJob.cancel(false);
+        }
+    }
+
+    @Nullable
+    Thing getThingForType(HaywardTypeToRequest type, int num) {
+        for (Thing thing : getThing().getThings()) {
+            Map<String, String> properties = thing.getProperties();
+            if (properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID).equals(Integer.toString(num))) {
+                if (properties.get(HaywardBindingConstants.PROPERTY_TYPE).equals(type.toString())) {
+                    return thing;
+                }
+            }
+        }
+        return null;
+    }
+
+    public List<String> evaluateXPath(String xpathExp, String xmlResponse) throws Exception {
+        List<String> values = new ArrayList<>();
+        try {
+            InputSource inputXML = new InputSource(new StringReader(xmlResponse));
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            NodeList nodes = (NodeList) xPath.evaluate(xpathExp, inputXML, XPathConstants.NODESET);
+
+            for (int i = 0; i < nodes.getLength(); i++) {
+                values.add(nodes.item(i).getNodeValue());
+            }
+        } catch (XPathExpressionException e) {
+            logger.error("XPathExpression exception:", e);
+        }
+        return values;
+    }
+
+    private Request sendRequestBuilder(String url, HttpMethod method) {
+        return this.httpClient.newRequest(url).agent("NextGenForIPhone/16565 CFNetwork/887 Darwin/17.0.0")
+                .method(method).header(HttpHeader.ACCEPT_LANGUAGE, "en-us").header(HttpHeader.ACCEPT, "*/*")
+                .header(HttpHeader.ACCEPT_ENCODING, "gzip, deflate").version(HttpVersion.HTTP_1_1)
+                .header(HttpHeader.CONNECTION, "keep-alive").header(HttpHeader.HOST, "www.haywardomnilogic.com:80")
+                .timeout(10, TimeUnit.SECONDS);
+    }
+
+    public synchronized String httpXmlResponse(String urlParameters) throws Exception {
+        String urlParameterslength = Integer.toString(urlParameters.length());
+        String statusMessage;
+
+        try {
+            ContentResponse httpResponse = sendRequestBuilder(config.hostname, HttpMethod.POST)
+                    .content(new StringContentProvider(urlParameters), "text/xml; charset=utf-8")
+                    .header(HttpHeader.CONTENT_LENGTH, urlParameterslength).send();
+
+            int status = httpResponse.getStatus();
+            String xmlResponse = httpResponse.getContentAsString();
+
+            List<String> statusMessages = evaluateXPath("/Response/Parameters//Parameter[@name='StatusMessage']/text()",
+                    xmlResponse);
+            if (!(statusMessages.isEmpty())) {
+                statusMessage = statusMessages.get(0);
+            } else {
+                statusMessage = httpResponse.getReason();
+            }
+
+            if (status == 200) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Hayward Connection thing:  {} Hayward http command: {}", getCallingMethod(),
+                            urlParameters);
+                    logger.trace("Hayward Connection thing:  {} Hayward http response: {} {}", getCallingMethod(),
+                            statusMessage, xmlResponse);
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Hayward Connection thing:  {} Hayward http response: {}", getCallingMethod(),
+                            statusMessage);
+                }
+                return xmlResponse;
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Hayward Connection thing:  {} Hayward http command: {}", getCallingMethod(),
+                            urlParameters);
+                    logger.debug("Hayward Connection thing:  {} Hayward http response: {}", getCallingMethod(), status);
+                }
+                return "";
+            }
+        } catch (java.net.UnknownHostException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Unable to resolve host.  Check Hayward hostname and your internet connection.");
+            return "";
+        } catch (TimeoutException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Connection Timeout.  Check Hayward hostname and your internet connection.");
+            return "";
+        }
+    }
+
+    private String getCallingMethod() {
+        StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
+        StackTraceElement e = stacktrace[3];
+        return e.getMethodName();
+    }
+
+    public int convertCommand(Command command) {
+        if (command == OnOffType.ON) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -45,50 +45,50 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Chlorinator/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Operating Mode
                     data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
 
                     // Timed Percent
                     data = bridgehandler.evaluateXPath("//Chlorinator/@Timed-Percent", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT, data.get(i));
                     this.chlorTimedPercent = data.get(0);
 
                     // scMode
                     data = bridgehandler.evaluateXPath("//Chlorinator/@scMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_SCMODE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_SCMODE, data.get(i));
 
                     // Error
                     data = bridgehandler.evaluateXPath("//Chlorinator/@chlrError", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ERROR, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ERROR, data.get(i));
 
                     // Alert
                     data = bridgehandler.evaluateXPath("//Chlorinator/@chlrAlert", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ALERT, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ALERT, data.get(i));
 
                     // Average Salt Level
                     data = bridgehandler.evaluateXPath("//Chlorinator/@avgSaltLevel", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_AVGSALTLEVEL, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_AVGSALTLEVEL, data.get(i));
 
                     // Instant Salt Level
                     data = bridgehandler.evaluateXPath("//Chlorinator/@instantSaltLevel", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_INSTANTSALTLEVEL, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_INSTANTSALTLEVEL, data.get(i));
 
                     // Status
                     data = bridgehandler.evaluateXPath("//Chlorinator/@status", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_STATUS, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_STATUS, data.get(i));
 
-                    if (data.get(0).equals("0")) {
+                    if (data.get(i).equals("0")) {
                         updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "0");
                         // chlorState is used to set the chlorinator cfgState in the timedPercent command
                         this.chlorState = "2";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Chlorinator Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardChlorinatorHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardChlorinatorHandler.class);
+    public String chlorTimedPercent = "";
+    public String chlorState = "";
+
+    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
+
+    public HaywardChlorinatorHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Chlorinator/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Operating Mode
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+
+                    // Timed Percent
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@Timed-Percent", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT, data.get(0));
+                    this.chlorTimedPercent = data.get(0);
+
+                    // scMode
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@scMode", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_SCMODE, data.get(0));
+
+                    // Error
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@chlrError", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ERROR, data.get(0));
+
+                    // Alert
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@chlrAlert", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ALERT, data.get(0));
+
+                    // Average Salt Level
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@avgSaltLevel", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_AVGSALTLEVEL, data.get(0));
+
+                    // Instant Salt Level
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@instantSaltLevel", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_INSTANTSALTLEVEL, data.get(0));
+
+                    // Status
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@status", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_STATUS, data.get(0));
+
+                    if (data.get(0).equals("0")) {
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "0");
+                        // chlorState is used to set the chlorinator cfgState in the timedPercent command
+                        this.chlorState = "2";
+                    } else {
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "1");
+                        // chlorState is used to set the chlorinator cfgState in the timedPercent command
+                        this.chlorState = "3";
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if ((command instanceof RefreshType)) {
+            return;
+        }
+
+        String chlorCfgState = null;
+        String chlorTimedPercent = "0";
+
+        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            String cmdString = this.cmdToString(command);
+            try {
+                switch (channelUID.getId()) {
+                    case HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE:
+                        if (cmdString.equals("1")) {
+                            chlorCfgState = "3";
+                            chlorTimedPercent = this.chlorTimedPercent;
+                        } else {
+                            chlorCfgState = "2";
+                            chlorTimedPercent = this.chlorTimedPercent;
+                        }
+                        break;
+                    case HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT:
+                        chlorCfgState = this.chlorState;
+                        chlorTimedPercent = cmdString;
+                        break;
+                    default:
+                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        return;
+                }
+
+                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetCHLORParams</Name><Parameters>"
+                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                        + bridgehandler.account.mspSystemID + "</Parameter>"
+                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                        + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + prop.systemID
+                        + "</Parameter>" + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">"
+                        + chlorCfgState + "</Parameter>"
+                        + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"
+                        + "<Parameter name=\"BOWType\" dataType=\"byte\" alias=\"Data3\">1</Parameter>"
+                        + "<Parameter name=\"CellType\" dataType=\"byte\" alias=\"Data4\">4</Parameter>"
+                        + "<Parameter name=\"TimedPercent\" dataType=\"byte\" alias=\"Data5\">" + chlorTimedPercent
+                        + "</Parameter>"
+                        + "<Parameter name=\"SCTimeout\" dataType=\"byte\" unit=\"hour\" alias=\"Data6\">24</Parameter>"
+                        + "<Parameter name=\"ORPTimout\" dataType=\"byte\" unit=\"hour\" alias=\"Data7\">24</Parameter>"
+                        + "</Parameters></Request>";
+
+                // *****Send Command to Hayward server
+                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+                if (!(status.equals("0"))) {
+                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                        bridgehandler.config.username);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -185,6 +185,8 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                 } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
+                } catch (InterruptedException e) {
+                    return;
                 }
                 this.updateStatus(ThingStatus.ONLINE);
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -165,7 +165,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                 }
             } catch (Exception e) {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username);
+                        bridgehandler.config.username, e);
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
-import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -40,8 +39,6 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HaywardChlorinatorHandler.class);
     public String chlorTimedPercent = "";
     public String chlorState = "";
-
-    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
 
     public HaywardChlorinatorHandler(Thing thing) {
         super(thing);
@@ -121,14 +118,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
         String chlorTimedPercent = "0";
 
         String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        if (systemID != null) {
-            prop.systemID = systemID;
-        }
-
         String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
-        if (poolID != null) {
-            prop.poolID = poolID;
-        }
 
         Bridge bridge = getBridge();
         if (bridge != null) {
@@ -160,8 +150,8 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                             + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                             + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                             + bridgehandler.account.mspSystemID + "</Parameter>"
-                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                            + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + prop.systemID
+                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                            + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + systemID
                             + "</Parameter>" + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">"
                             + chlorCfgState + "</Parameter>"
                             + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -99,6 +99,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                     }
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -169,6 +170,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -182,7 +182,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                         logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
                     }
-                } catch (Exception e) {
+                } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Chlorinator Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardChlorinatorHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -134,7 +134,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                         chlorTimedPercent = cmdString;
                         break;
                     default:
-                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        logger.warn("haywardCommand Unsupported type {}", channelUID);
                         return;
                 }
 
@@ -160,7 +160,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                 String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
                 if (!(status.equals("0"))) {
-                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    logger.debug("haywardCommand XML response: {}", xmlResponse);
                     return;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -115,8 +115,15 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
         String chlorCfgState = null;
         String chlorTimedPercent = "0";
 
-        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        if (systemID != null) {
+            prop.systemID = systemID;
+        }
+
+        String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        if (poolID != null) {
+            prop.poolID = poolID;
+        }
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -20,6 +20,7 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -51,60 +52,62 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//Chlorinator/@systemId", xmlResponse);
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    // Operating Mode
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//Chlorinator/@systemId", xmlResponse);
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        // Operating Mode
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
 
-                    // Timed Percent
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@Timed-Percent", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT, data.get(i));
-                    this.chlorTimedPercent = data.get(0);
+                        // Timed Percent
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@Timed-Percent", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT, data.get(i));
+                        this.chlorTimedPercent = data.get(0);
 
-                    // scMode
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@scMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_SCMODE, data.get(i));
+                        // scMode
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@scMode", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_SCMODE, data.get(i));
 
-                    // Error
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@chlrError", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ERROR, data.get(i));
+                        // Error
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@chlrError", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ERROR, data.get(i));
 
-                    // Alert
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@chlrAlert", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ALERT, data.get(i));
+                        // Alert
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@chlrAlert", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ALERT, data.get(i));
 
-                    // Average Salt Level
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@avgSaltLevel", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_AVGSALTLEVEL, data.get(i));
+                        // Average Salt Level
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@avgSaltLevel", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_AVGSALTLEVEL, data.get(i));
 
-                    // Instant Salt Level
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@instantSaltLevel", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_INSTANTSALTLEVEL, data.get(i));
+                        // Instant Salt Level
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@instantSaltLevel", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_INSTANTSALTLEVEL, data.get(i));
 
-                    // Status
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@status", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_STATUS, data.get(i));
+                        // Status
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@status", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_STATUS, data.get(i));
 
-                    if (data.get(i).equals("0")) {
-                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "0");
-                        // chlorState is used to set the chlorinator cfgState in the timedPercent command
-                        this.chlorState = "2";
-                    } else {
-                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "1");
-                        // chlorState is used to set the chlorinator cfgState in the timedPercent command
-                        this.chlorState = "3";
+                        if (data.get(i).equals("0")) {
+                            updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "0");
+                            // chlorState is used to set the chlorinator cfgState in the timedPercent command
+                            this.chlorState = "2";
+                        } else {
+                            updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE, "1");
+                            // chlorState is used to set the chlorinator cfgState in the timedPercent command
+                            this.chlorState = "3";
+                        }
                     }
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -127,62 +130,66 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
             prop.poolID = poolID;
         }
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            String cmdString = this.cmdToString(command);
-            try {
-                switch (channelUID.getId()) {
-                    case HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE:
-                        if (cmdString.equals("1")) {
-                            chlorCfgState = "3";
-                            chlorTimedPercent = this.chlorTimedPercent;
-                        } else {
-                            chlorCfgState = "2";
-                            chlorTimedPercent = this.chlorTimedPercent;
-                        }
-                        break;
-                    case HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT:
-                        chlorCfgState = this.chlorState;
-                        chlorTimedPercent = cmdString;
-                        break;
-                    default:
-                        logger.warn("haywardCommand Unsupported type {}", channelUID);
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                String cmdString = this.cmdToString(command);
+                try {
+                    switch (channelUID.getId()) {
+                        case HaywardBindingConstants.CHANNEL_CHLORINATOR_ENABLE:
+                            if (cmdString.equals("1")) {
+                                chlorCfgState = "3";
+                                chlorTimedPercent = this.chlorTimedPercent;
+                            } else {
+                                chlorCfgState = "2";
+                                chlorTimedPercent = this.chlorTimedPercent;
+                            }
+                            break;
+                        case HaywardBindingConstants.CHANNEL_CHLORINATOR_TIMEDPERCENT:
+                            chlorCfgState = this.chlorState;
+                            chlorTimedPercent = cmdString;
+                            break;
+                        default:
+                            logger.warn("haywardCommand Unsupported type {}", channelUID);
+                            return;
+                    }
+
+                    String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                            + "<Name>SetCHLORParams</Name><Parameters>"
+                            + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                            + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                            + bridgehandler.account.mspSystemID + "</Parameter>"
+                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                            + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + prop.systemID
+                            + "</Parameter>" + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">"
+                            + chlorCfgState + "</Parameter>"
+                            + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"
+                            + "<Parameter name=\"BOWType\" dataType=\"byte\" alias=\"Data3\">1</Parameter>"
+                            + "<Parameter name=\"CellType\" dataType=\"byte\" alias=\"Data4\">4</Parameter>"
+                            + "<Parameter name=\"TimedPercent\" dataType=\"byte\" alias=\"Data5\">" + chlorTimedPercent
+                            + "</Parameter>"
+                            + "<Parameter name=\"SCTimeout\" dataType=\"byte\" unit=\"hour\" alias=\"Data6\">24</Parameter>"
+                            + "<Parameter name=\"ORPTimout\" dataType=\"byte\" unit=\"hour\" alias=\"Data7\">24</Parameter>"
+                            + "</Parameters></Request>";
+
+                    // *****Send Command to Hayward server
+                    String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                    String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse)
+                            .get(0);
+
+                    if (!(status.equals("0"))) {
+                        logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Unable to send command to Hayward's server {}:{}:{}",
+                            bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }
-
-                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetCHLORParams</Name><Parameters>"
-                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                        + bridgehandler.account.mspSystemID + "</Parameter>"
-                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                        + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + prop.systemID
-                        + "</Parameter>" + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">"
-                        + chlorCfgState + "</Parameter>"
-                        + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"
-                        + "<Parameter name=\"BOWType\" dataType=\"byte\" alias=\"Data3\">1</Parameter>"
-                        + "<Parameter name=\"CellType\" dataType=\"byte\" alias=\"Data4\">4</Parameter>"
-                        + "<Parameter name=\"TimedPercent\" dataType=\"byte\" alias=\"Data5\">" + chlorTimedPercent
-                        + "</Parameter>"
-                        + "<Parameter name=\"SCTimeout\" dataType=\"byte\" unit=\"hour\" alias=\"Data6\">24</Parameter>"
-                        + "<Parameter name=\"ORPTimout\" dataType=\"byte\" unit=\"hour\" alias=\"Data7\">24</Parameter>"
-                        + "</Parameters></Request>";
-
-                // *****Send Command to Hayward server
-                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
-                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
-
-                if (!(status.equals("0"))) {
-                    logger.debug("haywardCommand XML response: {}", xmlResponse);
-                    return;
-                }
-            } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e.getMessage());
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -21,6 +21,8 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -28,8 +30,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Chlorinator Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardChlorinatorHandler extends HaywardThingHandler {
@@ -99,6 +99,8 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                     }
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -167,6 +169,8 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -164,7 +164,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username);
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.ChannelUID;
@@ -44,7 +45,7 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
@@ -167,8 +168,8 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e);
+                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
+                        bridgehandler.config.username, e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -82,8 +82,15 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
             return;
         }
 
-        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        if (systemID != null) {
+            prop.systemID = systemID;
+        }
+
+        String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        if (poolID != null) {
+            prop.poolID = poolID;
+        }
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -44,21 +44,21 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//ColorLogic-Light/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Light State
                     data = bridgehandler.evaluateXPath("//ColorLogic-Light/@lightState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_LIGHTSTATE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_LIGHTSTATE, data.get(i));
 
-                    if (data.get(0).equals("0")) {
+                    if (data.get(i).equals("0")) {
                         updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "0");
                     } else {
                         updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "1");

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -119,7 +119,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                                 + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
                         break;
                     default:
-                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        logger.warn("haywardCommand Unsupported type {}", channelUID);
                         return;
                 }
 
@@ -128,7 +128,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                 String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
                 if (!(status.equals("0"))) {
-                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    logger.debug("haywardCommand XML response: {}", xmlResponse);
                     return;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -21,6 +21,7 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -50,31 +51,33 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//ColorLogic-Light/@systemId", xmlResponse);
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    // Light State
-                    data = bridgehandler.evaluateXPath("//ColorLogic-Light/@lightState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_LIGHTSTATE, data.get(i));
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//ColorLogic-Light/@systemId", xmlResponse);
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        // Light State
+                        data = bridgehandler.evaluateXPath("//ColorLogic-Light/@lightState", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_LIGHTSTATE, data.get(i));
 
-                    if (data.get(i).equals("0")) {
-                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "0");
-                    } else {
-                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "1");
+                        if (data.get(i).equals("0")) {
+                            updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "0");
+                        } else {
+                            updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "1");
+                        }
+
+                        // Current Show
+                        data = bridgehandler.evaluateXPath("//ColorLogic-Light/@currentShow", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW, data.get(0));
                     }
-
-                    // Current Show
-                    data = bridgehandler.evaluateXPath("//ColorLogic-Light/@currentShow", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW, data.get(0));
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -94,63 +97,67 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
             prop.poolID = poolID;
         }
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            String cmdString = this.cmdToString(command);
-            String cmdURL = null;
-            try {
-                switch (channelUID.getId()) {
-                    case HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE:
-                        if (command == OnOffType.ON) {
-                            cmdString = "1";
-                        } else {
-                            cmdString = "0";
-                        }
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
-                                + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
-                        break;
-                    case HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW:
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                + "<Name>SetStandAloneLightShow</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                + "<Parameter name=\"LightID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
-                                + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + "<Parameter name=\"Speed\" dataType=\"byte\">4</Parameter>"
-                                + "<Parameter name=\"Brightness\" dataType=\"byte\">4</Parameter>"
-                                + "<Parameter name=\"Reserved\" dataType=\"byte\">0</Parameter>"
-                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
-                        break;
-                    default:
-                        logger.warn("haywardCommand Unsupported type {}", channelUID);
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                String cmdString = this.cmdToString(command);
+                String cmdURL = null;
+                try {
+                    switch (channelUID.getId()) {
+                        case HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE:
+                            if (command == OnOffType.ON) {
+                                cmdString = "1";
+                            } else {
+                                cmdString = "0";
+                            }
+                            cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                                    + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                                    + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                    + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                    + bridgehandler.account.mspSystemID + "</Parameter>"
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID
+                                    + "</Parameter>" + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString
+                                    + "</Parameter>" + HaywardBindingConstants.COMMAND_SCHEDULE
+                                    + "</Parameters></Request>";
+                            break;
+                        case HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW:
+                            cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                                    + "<Name>SetStandAloneLightShow</Name><Parameters>"
+                                    + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                    + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                    + bridgehandler.account.mspSystemID + "</Parameter>"
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                    + "<Parameter name=\"LightID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                    + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                    + "<Parameter name=\"Speed\" dataType=\"byte\">4</Parameter>"
+                                    + "<Parameter name=\"Brightness\" dataType=\"byte\">4</Parameter>"
+                                    + "<Parameter name=\"Reserved\" dataType=\"byte\">0</Parameter>"
+                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                            break;
+                        default:
+                            logger.warn("haywardCommand Unsupported type {}", channelUID);
+                            return;
+                    }
+
+                    // *****Send Command to Hayward server
+                    String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                    String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse)
+                            .get(0);
+
+                    if (!(status.equals("0"))) {
+                        logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Unable to send command to Hayward's server {}:{}:{}",
+                            bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }
-
-                // *****Send Command to Hayward server
-                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
-                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
-
-                if (!(status.equals("0"))) {
-                    logger.debug("haywardCommand XML response: {}", xmlResponse);
-                    return;
-                }
-            } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e.getMessage());
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The ColorLogic Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardColorLogicHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardColorLogicHandler.class);
+
+    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
+
+    public HaywardColorLogicHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//ColorLogic-Light/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Light State
+                    data = bridgehandler.evaluateXPath("//ColorLogic-Light/@lightState", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_LIGHTSTATE, data.get(0));
+
+                    if (data.get(0).equals("0")) {
+                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "0");
+                    } else {
+                        updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE, "1");
+                    }
+
+                    // Current Show
+                    data = bridgehandler.evaluateXPath("//ColorLogic-Light/@currentShow", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW, data.get(0));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if ((command instanceof RefreshType)) {
+            return;
+        }
+
+        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            String cmdString = this.cmdToString(command);
+            String cmdURL = null;
+            try {
+                switch (channelUID.getId()) {
+                    case HaywardBindingConstants.CHANNEL_COLORLOGIC_ENABLE:
+                        if (command == OnOffType.ON) {
+                            cmdString = "1";
+                        } else {
+                            cmdString = "0";
+                        }
+                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                                + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                + bridgehandler.account.mspSystemID + "</Parameter>"
+                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                        break;
+                    case HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW:
+                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                                + "<Name>SetStandAloneLightShow</Name><Parameters>"
+                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                + bridgehandler.account.mspSystemID + "</Parameter>"
+                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                + "<Parameter name=\"LightID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                + "<Parameter name=\"Speed\" dataType=\"byte\">4</Parameter>"
+                                + "<Parameter name=\"Brightness\" dataType=\"byte\">4</Parameter>"
+                                + "<Parameter name=\"Reserved\" dataType=\"byte\">0</Parameter>"
+                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                        break;
+                    default:
+                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        return;
+                }
+
+                // *****Send Command to Hayward server
+                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+                if (!(status.equals("0"))) {
+                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                        bridgehandler.config.username);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The ColorLogic Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardColorLogicHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
@@ -43,7 +44,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
@@ -135,8 +136,8 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e);
+                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
+                        bridgehandler.config.username, e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -150,7 +150,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                         logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
                     }
-                } catch (Exception e) {
+                } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -133,7 +133,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                 }
             } catch (Exception e) {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username);
+                        bridgehandler.config.username, e);
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -132,7 +132,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username);
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -153,6 +153,8 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                 } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
+                } catch (InterruptedException e) {
+                    return;
                 }
                 this.updateStatus(ThingStatus.ONLINE);
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -22,6 +22,8 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -29,8 +31,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The ColorLogic Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardColorLogicHandler extends HaywardThingHandler {
@@ -69,6 +69,8 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW, data.get(0));
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -135,6 +137,9 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -69,6 +69,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW, data.get(0));
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -137,7 +138,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
-
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
-import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -39,8 +38,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HaywardColorLogicHandler extends HaywardThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HaywardColorLogicHandler.class);
-
-    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
 
     public HaywardColorLogicHandler(Thing thing) {
         super(thing);
@@ -88,14 +85,7 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
         }
 
         String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        if (systemID != null) {
-            prop.systemID = systemID;
-        }
-
         String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
-        if (poolID != null) {
-            prop.poolID = poolID;
-        }
 
         Bridge bridge = getBridge();
         if (bridge != null) {
@@ -116,11 +106,10 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                                     + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                                     + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                                     + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID
-                                    + "</Parameter>" + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString
-                                    + "</Parameter>" + HaywardBindingConstants.COMMAND_SCHEDULE
-                                    + "</Parameters></Request>";
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
+                                    + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
                             break;
                         case HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW:
                             cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
@@ -128,8 +117,8 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                                     + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                                     + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                                     + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                    + "<Parameter name=\"LightID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                                    + "<Parameter name=\"LightID\" dataType=\"int\">" + systemID + "</Parameter>"
                                     + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString + "</Parameter>"
                                     + "<Parameter name=\"Speed\" dataType=\"byte\">4</Parameter>"
                                     + "<Parameter name=\"Brightness\" dataType=\"byte\">4</Parameter>"

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -115,7 +115,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                     case HaywardBindingConstants.CHANNEL_FILTER_SPEED:
                         break;
                     default:
-                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        logger.warn("haywardCommand Unsupported type {}", channelUID);
                         return;
                 }
 
@@ -134,7 +134,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                 String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
                 if (!(status.equals("0"))) {
-                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    logger.debug("haywardCommand XML response: {}", xmlResponse);
                     return;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -23,6 +23,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -30,8 +31,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Filter Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardFilterHandler extends HaywardThingHandler {
@@ -87,6 +86,9 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(i));
                 }
             }
+
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -141,6 +143,8 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Filter Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardFilterHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
@@ -48,7 +49,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
@@ -140,8 +141,8 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e);
+                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
+                        bridgehandler.config.username, e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -50,29 +50,29 @@ public class HaywardFilterHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Filter/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Operating Mode
                     data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
 
                     // Valve Position
                     data = bridgehandler.evaluateXPath("//Filter/@valvePosition", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_VALVEPOSITION, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_VALVEPOSITION, data.get(i));
 
                     // Speed
                     data = bridgehandler.evaluateXPath("//Filter/@filterSpeed", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_SPEED, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_SPEED, data.get(i));
 
-                    if (data.get(0).equals("0")) {
+                    if (data.get(i).equals("0")) {
                         updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "0");
                     } else {
                         updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "1");
@@ -80,11 +80,11 @@ public class HaywardFilterHandler extends HaywardThingHandler {
 
                     // State
                     data = bridgehandler.evaluateXPath("//Filter/@filterState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_STATE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_STATE, data.get(i));
 
                     // lastSpeed
                     data = bridgehandler.evaluateXPath("//Filter/@lastSpeed", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(i));
                 }
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -139,7 +139,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                 }
             } catch (Exception e) {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username);
+                        bridgehandler.config.username, e);
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
-import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -39,8 +38,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HaywardFilterHandler extends HaywardThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HaywardFilterHandler.class);
-
-    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
 
     public HaywardFilterHandler(Thing thing) {
         super(thing);
@@ -105,14 +102,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
         }
 
         String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        if (systemID != null) {
-            prop.systemID = systemID;
-        }
-
         String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
-        if (poolID != null) {
-            prop.poolID = poolID;
-        }
 
         Bridge bridge = getBridge();
         if (bridge != null) {
@@ -140,8 +130,8 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                             + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                             + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                             + bridgehandler.account.mspSystemID + "</Parameter>"
-                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                            + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                            + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
                             + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
                             + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -157,6 +157,8 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                 } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
+                } catch (InterruptedException e) {
+                    return;
                 }
                 this.updateStatus(ThingStatus.ONLINE);
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -138,7 +138,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username);
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -154,7 +154,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                         logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
                     }
-                } catch (Exception e) {
+                } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -86,7 +86,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(i));
                 }
             }
-
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -143,6 +143,7 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Filter Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardFilterHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardFilterHandler.class);
+
+    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
+
+    public HaywardFilterHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Filter/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Operating Mode
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+
+                    // Valve Position
+                    data = bridgehandler.evaluateXPath("//Filter/@valvePosition", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_VALVEPOSITION, data.get(0));
+
+                    // Speed
+                    data = bridgehandler.evaluateXPath("//Filter/@filterSpeed", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_SPEED, data.get(0));
+
+                    if (data.get(0).equals("0")) {
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "0");
+                    } else {
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "1");
+                    }
+
+                    // State
+                    data = bridgehandler.evaluateXPath("//Filter/@filterState", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_STATE, data.get(0));
+
+                    // lastSpeed
+                    data = bridgehandler.evaluateXPath("//Filter/@lastSpeed", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(0));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if ((command instanceof RefreshType)) {
+            return;
+        }
+
+        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            String cmdString = this.cmdToString(command);
+            try {
+                switch (channelUID.getId()) {
+                    case HaywardBindingConstants.CHANNEL_FILTER_ENABLE:
+                        if (command == OnOffType.ON) {
+                            cmdString = "100";
+                        } else {
+                            cmdString = "0";
+                        }
+                        break;
+                    case HaywardBindingConstants.CHANNEL_FILTER_SPEED:
+                        break;
+                    default:
+                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        return;
+                }
+
+                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                        + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                        + bridgehandler.account.mspSystemID + "</Parameter>"
+                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                        + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                        + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                        + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+
+                // *****Send Command to Hayward server
+                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+                if (!(status.equals("0"))) {
+                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                        bridgehandler.config.username);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -21,6 +21,7 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -55,43 +56,45 @@ public class HaywardFilterHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//Filter/@systemId", xmlResponse);
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    // Operating Mode
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//Filter/@systemId", xmlResponse);
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        // Operating Mode
+                        data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
 
-                    // Valve Position
-                    data = bridgehandler.evaluateXPath("//Filter/@valvePosition", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_VALVEPOSITION, data.get(i));
+                        // Valve Position
+                        data = bridgehandler.evaluateXPath("//Filter/@valvePosition", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_VALVEPOSITION, data.get(i));
 
-                    // Speed
-                    data = bridgehandler.evaluateXPath("//Filter/@filterSpeed", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_SPEED, data.get(i));
+                        // Speed
+                        data = bridgehandler.evaluateXPath("//Filter/@filterSpeed", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_SPEED, data.get(i));
 
-                    if (data.get(i).equals("0")) {
-                        updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "0");
-                    } else {
-                        updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "1");
+                        if (data.get(i).equals("0")) {
+                            updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "0");
+                        } else {
+                            updateData(HaywardBindingConstants.CHANNEL_FILTER_ENABLE, "1");
+                        }
+
+                        // State
+                        data = bridgehandler.evaluateXPath("//Filter/@filterState", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_STATE, data.get(i));
+
+                        // lastSpeed
+                        data = bridgehandler.evaluateXPath("//Filter/@lastSpeed", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(i));
                     }
-
-                    // State
-                    data = bridgehandler.evaluateXPath("//Filter/@filterState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_STATE, data.get(i));
-
-                    // lastSpeed
-                    data = bridgehandler.evaluateXPath("//Filter/@lastSpeed", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_FILTER_LASTSPEED, data.get(i));
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -111,51 +114,54 @@ public class HaywardFilterHandler extends HaywardThingHandler {
             prop.poolID = poolID;
         }
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            String cmdString = this.cmdToString(command);
-            try {
-                switch (channelUID.getId()) {
-                    case HaywardBindingConstants.CHANNEL_FILTER_ENABLE:
-                        if (command == OnOffType.ON) {
-                            cmdString = "100";
-                        } else {
-                            cmdString = "0";
-                        }
-                        break;
-                    case HaywardBindingConstants.CHANNEL_FILTER_SPEED:
-                        break;
-                    default:
-                        logger.warn("haywardCommand Unsupported type {}", channelUID);
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                String cmdString = this.cmdToString(command);
+                try {
+                    switch (channelUID.getId()) {
+                        case HaywardBindingConstants.CHANNEL_FILTER_ENABLE:
+                            if (command == OnOffType.ON) {
+                                cmdString = "100";
+                            } else {
+                                cmdString = "0";
+                            }
+                            break;
+                        case HaywardBindingConstants.CHANNEL_FILTER_SPEED:
+                            break;
+                        default:
+                            logger.warn("haywardCommand Unsupported type {}", channelUID);
+                            return;
+                    }
+
+                    String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                            + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                            + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                            + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                            + bridgehandler.account.mspSystemID + "</Parameter>"
+                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                            + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                            + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                            + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+
+                    // *****Send Command to Hayward server
+                    String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                    String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse)
+                            .get(0);
+
+                    if (!(status.equals("0"))) {
+                        logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Unable to send command to Hayward's server {}:{}:{}",
+                            bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }
-
-                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                        + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                        + bridgehandler.account.mspSystemID + "</Parameter>"
-                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                        + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
-                        + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                        + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
-
-                // *****Send Command to Hayward server
-                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
-                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
-
-                if (!(status.equals("0"))) {
-                    logger.debug("haywardCommand XML response: {}", xmlResponse);
-                    return;
-                }
-            } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e.getMessage());
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -99,8 +99,15 @@ public class HaywardFilterHandler extends HaywardThingHandler {
             return;
         }
 
-        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        if (systemID != null) {
+            prop.systemID = systemID;
+        }
+
+        String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        if (poolID != null) {
+            prop.poolID = poolID;
+        }
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -47,10 +47,6 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
             String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
-                    // Operating Mode
-                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
-
                     // State
                     data = bridgehandler.evaluateXPath("//Heater/@heaterState", xmlResponse);
                     updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(i));

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -20,6 +20,7 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.config.HaywardConfig;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
@@ -43,29 +44,31 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//Heater/@systemId", xmlResponse);
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    // State
-                    data = bridgehandler.evaluateXPath("//Heater/@heaterState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(i));
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//Heater/@systemId", xmlResponse);
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        // State
+                        data = bridgehandler.evaluateXPath("//Heater/@heaterState", xmlResponse);
+                        updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(i));
 
-                    // Enable
-                    data = bridgehandler.evaluateXPath("//Heater/@enable", xmlResponse);
-                    if (data.get(i).equals("0")) {
-                        updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "0");
-                    } else {
-                        updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "1");
+                        // Enable
+                        data = bridgehandler.evaluateXPath("//Heater/@enable", xmlResponse);
+                        if (data.get(i).equals("0")) {
+                            updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "0");
+                        } else {
+                            updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "1");
+                        }
                     }
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -20,11 +20,11 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.config.HaywardConfig;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Heater Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardHeaterHandler extends HaywardThingHandler {
@@ -60,6 +60,8 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
                     }
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -60,6 +60,7 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
                     }
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.config.HaywardConfig;
+import org.openhab.core.thing.Thing;
+
+/**
+ * The Heater Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardHeaterHandler extends HaywardThingHandler {
+
+    HaywardConfig config = getConfig().as(HaywardConfig.class);
+
+    public HaywardHeaterHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Heater/@systemId", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    // Operating Mode
+                    data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+
+                    // State
+                    data = bridgehandler.evaluateXPath("//Heater/@heaterState", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(0));
+
+                    // Enable
+                    data = bridgehandler.evaluateXPath("//Heater/@enable", xmlResponse);
+                    if (data.get(0).equals("0")) {
+                        updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "0");
+                    } else {
+                        updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "1");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -37,27 +37,27 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Heater/@systemId", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     // Operating Mode
                     data = bridgehandler.evaluateXPath("//Chlorinator/@operatingMode", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_CHLORINATOR_OPERATINGMODE, data.get(i));
 
                     // State
                     data = bridgehandler.evaluateXPath("//Heater/@heaterState", xmlResponse);
-                    updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(0));
+                    updateData(HaywardBindingConstants.CHANNEL_HEATER_STATE, data.get(i));
 
                     // Enable
                     data = bridgehandler.evaluateXPath("//Heater/@enable", xmlResponse);
-                    if (data.get(0).equals("0")) {
+                    if (data.get(i).equals("0")) {
                         updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "0");
                     } else {
                         updateData(HaywardBindingConstants.CHANNEL_HEATER_ENABLE, "1");

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.config.HaywardConfig;
 import org.openhab.core.thing.Thing;
@@ -36,7 +37,7 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardHeaterHandler.java
@@ -26,6 +26,8 @@ import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Heater Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardHeaterHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -70,8 +70,15 @@ public class HaywardRelayHandler extends HaywardThingHandler {
             return;
         }
 
-        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        if (systemID != null) {
+            prop.systemID = systemID;
+        }
+
+        String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        if (poolID != null) {
+            prop.poolID = poolID;
+        }
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -122,6 +122,8 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                 } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
+                } catch (InterruptedException e) {
+                    return;
                 }
                 this.updateStatus(ThingStatus.ONLINE);
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Relay Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardRelayHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardRelayHandler.class);
+
+    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
+
+    public HaywardRelayHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Relay/@systemId", xmlResponse);
+            data = bridgehandler.evaluateXPath("//Relay/@relayState", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if ((command instanceof RefreshType)) {
+            return;
+        }
+
+        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            String cmdString = this.cmdToString(command);
+            String cmdURL = null;
+            try {
+                switch (channelUID.getId()) {
+                    case HaywardBindingConstants.CHANNEL_RELAY_STATE:
+                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
+                                + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                + bridgehandler.account.mspSystemID + "</Parameter>"
+                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                        break;
+                    default:
+                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        return;
+                }
+
+                // *****Send Command to Hayward server
+                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+                if (!(status.equals("0"))) {
+                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                        bridgehandler.config.username);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -57,6 +57,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -106,7 +107,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
-
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
-import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -38,8 +37,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HaywardRelayHandler extends HaywardThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HaywardRelayHandler.class);
-
-    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
 
     public HaywardRelayHandler(Thing thing) {
         super(thing);
@@ -76,14 +73,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
         }
 
         String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        if (systemID != null) {
-            prop.systemID = systemID;
-        }
-
         String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
-        if (poolID != null) {
-            prop.poolID = poolID;
-        }
 
         Bridge bridge = getBridge();
         if (bridge != null) {
@@ -99,11 +89,10 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                                     + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                                     + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                                     + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + prop.systemID
-                                    + "</Parameter>" + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString
-                                    + "</Parameter>" + HaywardBindingConstants.COMMAND_SCHEDULE
-                                    + "</Parameters></Request>";
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
+                                    + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
                             break;
                         default:
                             logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -101,7 +101,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username);
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -88,7 +88,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                                 + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
                         break;
                     default:
-                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        logger.warn("haywardCommand Unsupported type {}", channelUID);
                         return;
                 }
 
@@ -97,7 +97,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                 String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
                 if (!(status.equals("0"))) {
-                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    logger.debug("haywardCommand XML response: {}", xmlResponse);
                     return;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -21,6 +21,8 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -28,8 +30,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Relay Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardRelayHandler extends HaywardThingHandler {
@@ -57,6 +57,8 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -104,6 +106,9 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.thing.ChannelUID;
@@ -42,7 +43,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
@@ -104,8 +105,8 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e);
+                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
+                        bridgehandler.config.username, e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -43,15 +43,15 @@ public class HaywardRelayHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Relay/@systemId", xmlResponse);
             data = bridgehandler.evaluateXPath("//Relay/@relayState", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -102,7 +102,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                 }
             } catch (Exception e) {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username);
+                        bridgehandler.config.username, e);
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -119,7 +119,7 @@ public class HaywardRelayHandler extends HaywardThingHandler {
                         logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
                     }
-                } catch (Exception e) {
+                } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Relay Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardRelayHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -19,11 +19,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Sensor Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardSensorHandler extends HaywardThingHandler {
@@ -48,6 +48,8 @@ public class HaywardSensorHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
@@ -40,20 +41,22 @@ public class HaywardSensorHandler extends HaywardThingHandler {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
-        @SuppressWarnings("null")
-        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-        if (bridgehandler != null) {
-            systemIDs = bridgehandler.evaluateXPath("//Sensor/@systemId", xmlResponse);
-            data = bridgehandler.evaluateXPath("//Sensor/@relayState", xmlResponse);
-            String thingSystemID = getThing().getUID().getId();
-            for (int i = 0; i < systemIDs.size(); i++) {
-                if (systemIDs.get(i).equals(thingSystemID)) {
-                    updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) bridge.getHandler();
+            if (bridgehandler != null) {
+                systemIDs = bridgehandler.evaluateXPath("//Sensor/@systemId", xmlResponse);
+                data = bridgehandler.evaluateXPath("//Sensor/@relayState", xmlResponse);
+                String thingSystemID = getThing().getUID().getId();
+                for (int i = 0; i < systemIDs.size(); i++) {
+                    if (systemIDs.get(i).equals(thingSystemID)) {
+                        updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
+                    }
                 }
+                this.updateStatus(ThingStatus.ONLINE);
+            } else {
+                this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             }
-            this.updateStatus(ThingStatus.ONLINE);
-        } else {
-            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Thing;
+
+/**
+ * The Sensor Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardSensorHandler extends HaywardThingHandler {
+
+    public HaywardSensorHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+        List<String> systemIDs = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            systemIDs = bridgehandler.evaluateXPath("//Sensor/@systemId", xmlResponse);
+            data = bridgehandler.evaluateXPath("//Sensor/@relayState", xmlResponse);
+            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -48,6 +48,7 @@ public class HaywardSensorHandler extends HaywardThingHandler {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -34,15 +34,15 @@ public class HaywardSensorHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
-        List<String> data = new ArrayList<>();
         List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
         if (bridgehandler != null) {
             systemIDs = bridgehandler.evaluateXPath("//Sensor/@systemId", xmlResponse);
             data = bridgehandler.evaluateXPath("//Sensor/@relayState", xmlResponse);
-            String thingSystemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+            String thingSystemID = getThing().getUID().getId();
             for (int i = 0; i < systemIDs.size(); i++) {
                 if (systemIDs.get(i).equals(thingSystemID)) {
                     updateData(HaywardBindingConstants.CHANNEL_RELAY_STATE, data.get(i));

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -25,6 +25,8 @@ import org.openhab.core.thing.ThingStatusDetail;
 
 /**
  * The Sensor Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardSensorHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardSensorHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -33,7 +34,7 @@ public class HaywardSensorHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Virtual Heater Handler
+ *
+ * @author Matt Myers - Initial Contribution
+ */
+@NonNullByDefault
+public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
+    private final Logger logger = LoggerFactory.getLogger(HaywardVirtualHeaterHandler.class);
+
+    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
+
+    public HaywardVirtualHeaterHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> data = new ArrayList<>();
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+
+        if (bridgehandler != null) {
+            // Current Setpoint
+            data = bridgehandler.evaluateXPath("//VirtualHeater/@Current-Set-Point", xmlResponse);
+            updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT, data.get(0));
+
+            // Enable
+            data = bridgehandler.evaluateXPath("//VirtualHeater/@enable", xmlResponse);
+
+            if (data.get(0).equals("yes")) {
+                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "1");
+            } else if (data.get(0).equals("no")) {
+                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "0");
+            }
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if ((command instanceof RefreshType)) {
+            return;
+        }
+
+        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+
+        @SuppressWarnings("null")
+        HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
+        if (bridgehandler != null) {
+            String cmdString = this.cmdToString(command);
+            String cmdURL = null;
+
+            if (command == OnOffType.ON) {
+                cmdString = "True";
+            } else {
+                cmdString = "False";
+            }
+
+            try {
+                switch (channelUID.getId()) {
+                    case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
+                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetHeaterEnable</Name><Parameters>"
+                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                + bridgehandler.account.mspSystemID + "</Parameter>"
+                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                + "<Parameter name=\"Enabled\" dataType=\"bool\">" + cmdString + "</Parameter>"
+                                + "</Parameters></Request>";
+                        break;
+
+                    case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
+                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetUIHeaterCmd</Name><Parameters>"
+                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
+                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
+                                + bridgehandler.account.mspSystemID + "</Parameter>"
+                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
+                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                + "<Parameter name=\"Temp\" dataType=\"int\">" + cmdString + "</Parameter>"
+                                + "</Parameters></Request>";
+                        break;
+                    default:
+                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        return;
+                }
+
+                // *****Send Command to Hayward server
+                String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);
+                String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
+
+                if (!(status.equals("0"))) {
+                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                        bridgehandler.config.username);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -78,8 +78,15 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
             return;
         }
 
-        prop.systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        prop.poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
+        if (systemID != null) {
+            prop.systemID = systemID;
+        }
+
+        String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
+        if (poolID != null) {
+            prop.poolID = poolID;
+        }
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -128,7 +128,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 }
             } catch (Exception e) {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username);
+                        bridgehandler.config.username, e);
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -123,7 +123,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.hostname,
+                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username);
             }
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
@@ -43,7 +44,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
     }
 
     @Override
-    public void getTelemetry(String xmlResponse) throws Exception {
+    public void getTelemetry(String xmlResponse) throws HaywardException {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
 
@@ -129,8 +130,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (Exception e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
-                        bridgehandler.config.username, e);
+                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.config.endpointUrl,
+                        bridgehandler.config.username, e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -44,23 +44,27 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
 
     @Override
     public void getTelemetry(String xmlResponse) throws Exception {
+        List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
+        List<String> currentSetpoint = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
-
         if (bridgehandler != null) {
-            // Current Setpoint
-            data = bridgehandler.evaluateXPath("//VirtualHeater/@Current-Set-Point", xmlResponse);
-            updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT, data.get(0));
+            systemIDs = bridgehandler.evaluateXPath("//VirtualHeater/@systemId", xmlResponse);
+            String thingSystemID = getThing().getUID().getId();
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    data = bridgehandler.evaluateXPath("//VirtualHeater/@Current-Set-Point", xmlResponse);
+                    updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT, data.get(i));
 
-            // Enable
-            data = bridgehandler.evaluateXPath("//VirtualHeater/@enable", xmlResponse);
-
-            if (data.get(0).equals("yes")) {
-                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "1");
-            } else if (data.get(0).equals("no")) {
-                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "0");
+                    data = bridgehandler.evaluateXPath("//VirtualHeater/@enable", xmlResponse);
+                    if (data.get(i).equals("yes")) {
+                        updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "1");
+                    } else if (data.get(i).equals("no")) {
+                        updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, "0");
+                    }
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -114,7 +114,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                                 + "</Parameters></Request>";
                         break;
                     default:
-                        logger.error("haywardCommand Unsupported type {}", channelUID);
+                        logger.warn("haywardCommand Unsupported type {}", channelUID);
                         return;
                 }
 
@@ -123,7 +123,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 String status = bridgehandler.evaluateXPath("//Parameter[@name='Status']/text()", xmlResponse).get(0);
 
                 if (!(status.equals("0"))) {
-                    logger.error("haywardCommand XML response: {}", xmlResponse);
+                    logger.debug("haywardCommand XML response: {}", xmlResponse);
                     return;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -148,6 +148,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
+                } catch (InterruptedException e) {
+                    return;
                 }
                 this.updateStatus(ThingStatus.ONLINE);
             } else {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -145,7 +145,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                         logger.debug("haywardCommand XML response: {}", xmlResponse);
                         return;
                     }
-                } catch (Exception e) {
+                } catch (HaywardException e) {
                     logger.debug("Unable to send command to Hayward's server {}:{}:{}",
                             bridgehandler.config.endpointUrl, bridgehandler.config.username, e.getMessage());
                 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -22,6 +22,8 @@ import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -29,8 +31,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Virtual Heater Handler
- *
- * @author Matt Myers - Initial Contribution
  */
 @NonNullByDefault
 public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
@@ -46,7 +46,6 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
     public void getTelemetry(String xmlResponse) throws Exception {
         List<String> systemIDs = new ArrayList<>();
         List<String> data = new ArrayList<>();
-        List<String> currentSetpoint = new ArrayList<>();
 
         @SuppressWarnings("null")
         HaywardBridgeHandler bridgehandler = (HaywardBridgeHandler) getBridge().getHandler();
@@ -66,6 +65,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                     }
                 }
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 
@@ -130,6 +131,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
-import org.openhab.binding.haywardomnilogic.internal.HaywardThingProperties;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -39,8 +38,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
     private final Logger logger = LoggerFactory.getLogger(HaywardVirtualHeaterHandler.class);
-
-    HaywardThingProperties prop = getConfig().as(HaywardThingProperties.class);
 
     public HaywardVirtualHeaterHandler(Thing thing) {
         super(thing);
@@ -84,14 +81,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
         }
 
         String systemID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_SYSTEM_ID);
-        if (systemID != null) {
-            prop.systemID = systemID;
-        }
-
         String poolID = getThing().getProperties().get(HaywardBindingConstants.PROPERTY_BOWID);
-        if (poolID != null) {
-            prop.poolID = poolID;
-        }
 
         Bridge bridge = getBridge();
         if (bridge != null) {
@@ -114,8 +104,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                                     + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                                     + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                                     + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                    + "<Parameter name=\"HeaterID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                                    + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
                                     + "<Parameter name=\"Enabled\" dataType=\"bool\">" + cmdString + "</Parameter>"
                                     + "</Parameters></Request>";
                             break;
@@ -126,8 +116,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                                     + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
                                     + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
                                     + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + prop.poolID + "</Parameter>"
-                                    + "<Parameter name=\"HeaterID\" dataType=\"int\">" + prop.systemID + "</Parameter>"
+                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
+                                    + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
                                     + "<Parameter name=\"Temp\" dataType=\"int\">" + cmdString + "</Parameter>"
                                     + "</Parameters></Request>";
                             break;

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -82,7 +82,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
 
             if (command == OnOffType.ON) {
                 cmdString = "True";
-            } else {
+            } else if (command == OnOffType.OFF) {
                 cmdString = "False";
             }
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Virtual Heater Handler
+ *
+ * @author Matt Myers - Initial contribution
  */
 @NonNullByDefault
 public class HaywardVirtualHeaterHandler extends HaywardThingHandler {

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -65,6 +65,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                     }
                 }
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }
@@ -131,6 +132,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 logger.debug("Unable to send command to Hayward's server {}:{}", bridgehandler.config.endpointUrl,
                         bridgehandler.config.username, e);
             }
+            this.updateStatus(ThingStatus.ONLINE);
         } else {
             this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
         }

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="haywardomnilogic" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Hayward OmniLogix Binding</name>
+	<description>Binding for the Hayward OmniLogix swimming pool automation controller.</description>
+	<author>Matt Myers</author>
+</binding:binding>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
@@ -57,7 +57,7 @@
 		<description>State</description>
 		<state readOnly="true">
 			<options>
-				<option value="0">0</option>
+				<option value="0">Powered Off</option>
 				<option value="1">Normal</option>
 				<option value="2">Service Mode</option>
 				<option value="3">Config Mode</option>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
@@ -33,7 +33,7 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Air Temp</label>
 		<description>Air Temp</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="backyardstatus">

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
@@ -23,7 +23,9 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
+			<property name="Units"></property>
+			<property name="VSP Speed Format"></property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
@@ -24,8 +24,6 @@
 
 		<properties>
 			<property name="Vendor">Hayward</property>
-			<property name="Units"></property>
-			<property name="VSP Speed Format"></property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/backyard.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="backyard" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Backyard</label>
+		<description>The Hayward Backyard</description>
+		<channels>
+			<channel id="backyardAirTemp" typeId="airTemp"/>
+			<channel id="backyardStatus" typeId="backyardstatus"/>
+			<channel id="backyardState" typeId="backyardstate"/>
+			<channel id="backyardAlarm1" typeId="alarm"/>
+			<channel id="backyardAlarm2" typeId="alarm"/>
+			<channel id="backyardAlarm3" typeId="alarm"/>
+			<channel id="backyardAlarm4" typeId="alarm"/>
+			<channel id="backyardAlarm5" typeId="alarm"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="airTemp">
+		<item-type>Number:Temperature</item-type>
+		<label>Air Temp</label>
+		<description>Air Temp</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="backyardstatus">
+		<item-type>String</item-type>
+		<label>Status</label>
+		<description>Status</description>
+		<state readOnly="true">
+			<options>
+				<option value="1">Normal</option>
+				<option value="2">Alarm</option>
+				<option value="3">Expired</option>
+				<option value="4">Lost Link</option>
+				<option value="5">Service Mode</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="backyardstate">
+		<item-type>String</item-type>
+		<label>State</label>
+		<description>State</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">0</option>
+				<option value="1">Normal</option>
+				<option value="2">Service Mode</option>
+				<option value="3">Config Mode</option>
+				<option value="4">Timed Service Mode</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="alarm">
+		<item-type>String</item-type>
+		<label>Alarm</label>
+		<description>Alarm</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
@@ -34,7 +34,7 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Water Temp</label>
 		<description>Water Temp</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
@@ -17,7 +17,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bow.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="bow" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Body of Water</label>
+		<description>The Hayward Body of Water</description>
+		<channels>
+			<channel id="bowFlow" typeId="waterFlow"/>
+			<channel id="bowWaterTemp" typeId="waterTemp"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="waterFlow">
+		<item-type>system.power</item-type>
+		<label>Flow Sensor</label>
+		<description>Flow Sensor</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="waterTemp">
+		<item-type>Number:Temperature</item-type>
+		<label>Water Temp</label>
+		<description>Water Temp</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
@@ -10,12 +10,11 @@
 		<description>Connection to Hayward's Server</description>
 
 		<config-description>
-			<parameter name="hostname" type="text" required="true">
+			<parameter name="endpointUrl" type="text" required="true">
 				<context>url</context>
-				<label>Host Name</label>
-				<!-- API Hostname -->
+				<label>Endpoint URL</label>
 				<default>https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ashx</default>
-				<description>The host name of the server.</description>
+				<description>The URL of the Hayward API Server</description>
 			</parameter>
 			<parameter name="username" type="text" required="true">
 				<label>User Name</label>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- The bridge to communicate with Hayward's server -->
+	<bridge-type id="bridge">
+		<label>Hayward OmniLogix Connection</label>
+		<description>Connection to Hayward's Server</description>
+
+		<config-description>
+			<parameter name="hostname" type="text" required="true">
+				<context>url</context>
+				<label>Host Name</label>
+				<!-- API Hostname -->
+				<default>https://app1.haywardomnilogic.com/HAAPI/HomeAutomation/API.ashx</default>
+				<description>The host name of the server.</description>
+			</parameter>
+			<parameter name="username" type="text" required="true">
+				<label>User Name</label>
+				<description>The username to connect to the server.</description>
+			</parameter>
+			<parameter name="password" type="text" required="true">
+				<context>password</context>
+				<label>Password</label>
+				<description>The password to connect to the server.</description>
+			</parameter>
+			<parameter name="telemetryPollTime" type="integer" min="10" max="60" unit="s" required="true">
+				<label>Telemetry Poll Delay</label>
+				<default>12</default>
+				<description>How often to request telemetry data from Hayward Server</description>
+			</parameter>
+			<parameter name="alarmPollTime" type="integer" min="0" max="120" required="true">
+				<label>Alarm Poll Delay</label>
+				<default>60</default>
+				<description>How often to request alarm data from Hayward Server. Enter 0 to disable.</description>
+			</parameter>
+		</config-description>
+	</bridge-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/bridge.xml
@@ -30,7 +30,7 @@
 				<default>12</default>
 				<description>How often to request telemetry data from Hayward Server</description>
 			</parameter>
-			<parameter name="alarmPollTime" type="integer" min="0" max="120" required="true">
+			<parameter name="alarmPollTime" type="integer" min="0" max="120" unit="s" required="true">
 				<label>Alarm Poll Delay</label>
 				<default>60</default>
 				<description>How often to request alarm data from Hayward Server. Enter 0 to disable.</description>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="chlorinator" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Chlorinator</label>
+		<description>Chlorinator</description>
+		<channels>
+			<channel id="chlorEnable" typeId="system.power"/>
+			<channel id="chlorOperatingMode" typeId="chlorOperatingMode"/>
+			<channel id="chlorTimedPercent" typeId="timedPercent"/>
+			<channel id="chlorScMode" typeId="scMode"/>
+			<channel id="chlorError" typeId="chlorError"/>
+			<channel id="chlorAlert" typeId="chlorAlert"/>
+			<channel id="chlorAvgSaltLevel" typeId="avgSaltLevel"/>
+			<channel id="chlorInstantSaltLevel" typeId="instantSaltLevel"/>
+			<channel id="chlorStatus" typeId="status"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="chlorOperatingMode">
+		<item-type>String</item-type>
+		<label>Operating Mode</label>
+		<description>Operating Mode</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">Timed Percent</option>
+				<option value="2">ORP Autosense</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="timedPercent">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Salt Output (%)</label>
+		<description>Current salt output setting for the chlorinator (%).</description>
+		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="scMode">
+		<item-type>String</item-type>
+		<label>scMode</label>
+		<description>scMode</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">Super Chlorinating</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="chlorError">
+		<item-type>Number</item-type>
+		<label>Chlorinator Error</label>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="chlorAlert">
+		<item-type>String</item-type>
+		<label>Chlorinator Alert</label>
+		<description>Chlorinator Alert</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">None</option>
+				<option value="16">Low T-Cell Temperature</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="avgSaltLevel">
+		<item-type>Number</item-type>
+		<label>Average Salt Level</label>
+		<description>Average Salt Level</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="instantSaltLevel">
+		<item-type>Number</item-type>
+		<label>Instant Salt Level (ppm)</label>
+		<description>Instant Salt Level (ppm)</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="status">
+		<item-type>Number</item-type>
+		<label>Status</label>
+		<description>Status</description>
+		<state readOnly="true"/>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -89,8 +89,8 @@
 
 	<channel-type id="instantSaltLevel">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Instant Salt Level (ppm)</label>
-		<description>Instant Salt Level (ppm)</description>
+		<label>Instant Salt Level</label>
+		<description>Instant Salt Level</description>
 		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -47,7 +47,7 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Salt Output (%)</label>
 		<description>Current salt output setting for the chlorinator (%).</description>
-		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+		<state min="0" max="100" step="1.0" pattern="%1f %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="scMode">
@@ -81,23 +81,23 @@
 	</channel-type>
 
 	<channel-type id="avgSaltLevel">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Average Salt Level</label>
 		<description>Average Salt Level</description>
 		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="instantSaltLevel">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Instant Salt Level (ppm)</label>
 		<description>Instant Salt Level (ppm)</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="status">
 		<item-type>Number</item-type>
 		<label>Status</label>
 		<description>Status</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -84,7 +84,7 @@
 		<item-type>Number:Dimensionless</item-type>
 		<label>Average Salt Level</label>
 		<description>Average Salt Level</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="instantSaltLevel">
@@ -98,6 +98,6 @@
 		<item-type>Number</item-type>
 		<label>Status</label>
 		<description>Status</description>
-		<state pattern="%1f %unit%" readOnly="true"/>
+		<state pattern="%1f" readOnly="true"/>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -89,8 +89,8 @@
 
 	<channel-type id="instantSaltLevel">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Instant Salt Level</label>
-		<description>Instant Salt Level</description>
+		<label>Instant Salt Level (ppm)</label>
+		<description>Instant Salt Level (ppm)</description>
 		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -24,7 +24,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="colorlogic" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Color Logic Light</label>
+		<description>Color Logic Light</description>
+		<channels>
+			<channel id="colorLogicLightEnable" typeId="system.power"/>
+			<channel id="colorLogicLightState" typeId="lightState"/>
+			<channel id="colorLogicLightCurrentShow" typeId="currentShow"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="lightState">
+		<item-type>String</item-type>
+		<label>Light State</label>
+		<description>Light State</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">On</option>
+				<option value="4">15 Sec White Light</option>
+				<option value="7">Powering Off</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="currentShow">
+		<item-type>String</item-type>
+		<label>Current Show</label>
+		<description>Current Show</description>
+		<state readOnly="false">
+			<options>
+				<option value="0">Voodoo Lounge</option>
+				<option value="1">Deep Blue Sea</option>
+				<option value="2">Royal Blue</option>
+				<option value="3">Afternoon Sky</option>
+				<option value="4">Aqua Green</option>
+				<option value="5">Emerald</option>
+				<option value="6">Cloud White</option>
+				<option value="7">Warm Red</option>
+				<option value="8">Flamingo</option>
+				<option value="9">Vivid Violet</option>
+				<option value="10">Sangria</option>
+				<option value="11">Twilight</option>
+				<option value="12">Tranquility</option>
+				<option value="13">Gemstone</option>
+				<option value="14">USA</option>
+				<option value="15">Mardi Gras</option>
+				<option value="16">Cool Cabaret</option>
+			</options>
+		</state>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/colorlogic.xml
@@ -18,7 +18,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -20,11 +20,11 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
-			<property name="minPumpSpeed"></property>
-			<property name="maxPumpSpeed"></property>
-			<property name="minPumpRPM"></property>
-			<property name="maxPumpRPM"></property>
+			<property name="Vendor">Hayward</property>
+			<property name="Min Pump Percent"></property>
+			<property name="Max Pump Percent"></property>
+			<property name="Min Pump RPM"></property>
+			<property name="Max Pump RPM"></property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -45,10 +45,10 @@
 	</channel-type>
 
 	<channel-type id="filterSpeed">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Filter Speed</label>
 		<description>Filter Speed in %</description>
-		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+		<state min="0" max="100" step="1.0" pattern="%1f %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="filterState">

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="filter" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Filter</label>
+		<description>Filter Equipment</description>
+		<channels>
+			<channel id="filterEnable" typeId="system.power"/>
+			<channel id="filterValvePosition" typeId="valvePosition"/>
+			<channel id="filterSpeed" typeId="filterSpeed"/>
+			<channel id="filterState" typeId="filterState"/>
+			<channel id="filterLastSpeed" typeId="filterLastSpeed"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+			<property name="minPumpSpeed"></property>
+			<property name="maxPumpSpeed"></property>
+			<property name="minPumpRPM"></property>
+			<property name="maxPumpRPM"></property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="valvePosition">
+		<item-type>String</item-type>
+		<label>Valve Position</label>
+		<description>Valve Position</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">Pool Only</option>
+				<option value="2">Spa Only</option>
+				<option value="3">Spill Over</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="filterSpeed">
+		<item-type>Number</item-type>
+		<label>Filter Speed</label>
+		<description>Filter Speed in %</description>
+		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="filterState">
+		<item-type>String</item-type>
+		<label>Filter State</label>
+		<description>Filter State</description>
+		<state readOnly="true">
+			<options>
+				<option value="0">Off</option>
+				<option value="1">Running</option>
+				<option value="2">Priming</option>
+				<option value="3">Waiting to Turn Off</option>
+				<option value="4">Waiting to Turn Off Manual</option>
+				<option value="5">Heater Extend</option>
+				<option value="6">Heater Cool Down</option>
+				<option value="7">Suspended</option>
+				<option value="8">CSAD Extend</option>
+				<option value="9">Filter Superchlorinate</option>
+				<option value="10">Filter Force Priming</option>
+				<option value="11">Filter Waiting for Pump to Turn Off</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="filterLastSpeed">
+		<item-type>Number</item-type>
+		<label>Last Speed</label>
+		<description>Last Speed</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/filter.xml
@@ -74,10 +74,10 @@
 	</channel-type>
 
 	<channel-type id="filterLastSpeed">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Last Speed</label>
 		<description>Last Speed</description>
-		<state readOnly="true"/>
+		<state pattern="%1f %unit%" readOnly="true"/>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="heater" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Heater</label>
+		<description>Heater</description>
+		<channels>
+			<channel id="heaterState" typeId="state"/>
+			<channel id="heaterEnable" typeId="enable"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+	</thing-type>
+
+	<channel-type id="state">
+		<item-type>Number</item-type>
+		<label>Heater State</label>
+		<description>Heater State</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="enable">
+		<item-type>system.power</item-type>
+		<label>Heater Enable</label>
+		<description>Heater Enable</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/heater.xml
@@ -17,7 +17,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 	</thing-type>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -19,7 +19,7 @@
 		<properties>
 			<property name="vendor">Hayward</property>
 			<property name="minPumpSpeed"></property>
-			<property name="maxPumpSPeed"></property>
+			<property name="maxPumpSpeed"></property>
 			<property name="minPumpRPM"></property>
 			<property name="maxPumpRPM"></property>
 		</properties>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="pump" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Pump</label>
+		<description>Pump</description>
+		<channels>
+			<channel id="pumpEnable" typeId="system.power"/>
+			<channel id="pumpSpeed" typeId="pumpSpeed"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+			<property name="minPumpSpeed"></property>
+			<property name="maxPumpSPeed"></property>
+			<property name="minPumpRPM"></property>
+			<property name="maxPumpRPM"></property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="pumpSpeed">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Pump Speed</label>
+		<description>Pump Speed</description>
+		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -29,9 +29,9 @@
 
 	<channel-type id="pumpSpeed">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Pump Speed</label>
+		<label>Pump Speed in %</label>
 		<description>Pump Speed</description>
-		<state min="0" max="100" step="1.0" pattern="%1f" readOnly="false"/>
+		<state min="0" max="100" step="1.0" pattern="%1f %unit%" readOnly="false"/>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/pump.xml
@@ -17,11 +17,11 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
-			<property name="minPumpSpeed"></property>
-			<property name="maxPumpSpeed"></property>
-			<property name="minPumpRPM"></property>
-			<property name="maxPumpRPM"></property>
+			<property name="Vendor">Hayward</property>
+			<property name="Min Pump Percent"></property>
+			<property name="Max Pump Percent"></property>
+			<property name="Min Pump RPM"></property>
+			<property name="Max Pump RPM"></property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/relay.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/relay.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="relay" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Relay</label>
+		<description>Relay</description>
+		<channels>
+			<channel id="relayState" typeId="system.power"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/relay.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/relay.xml
@@ -16,7 +16,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="sensor" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Sensor</label>
+		<description>Sensor</description>
+		<channels>
+			<channel id="sensorData" typeId="data"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+
+	</thing-type>
+
+	<channel-type id="bow">
+		<item-type>Number</item-type>
+		<label>Body of Water</label>
+		<description>The Body of Water</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="data">
+		<item-type>Number</item-type>
+		<label>Data</label>
+		<description>Sensor Data</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
@@ -16,7 +16,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/sensor.xml
@@ -25,7 +25,7 @@
 	<channel-type id="bow">
 		<item-type>Number</item-type>
 		<label>Body of Water</label>
-		<description>The Body of Water</description>
+		<description>The Body of Water ID</description>
 		<state readOnly="true"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="virtualHeater" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Virtual Heater</label>
+		<description>Virtual Heater</description>
+
+		<channels>
+			<channel id="virtualHeaterEnable" typeId="system.power"/>
+			<channel id="virtualHeaterCurrentSetpoint" typeId="currentSetpoint"/>
+		</channels>
+
+		<properties>
+			<property name="vendor">Hayward</property>
+		</properties>
+		<representation-property>systemID</representation-property>
+	</thing-type>
+
+	<channel-type id="currentSetpoint">
+		<item-type>Number</item-type>
+		<label>Current Setpoint</label>
+		<description>Current Setpoint</description>
+		<category>Temperature</category>
+		<state min="65" max="90" step="1.0" pattern="%1f %unit%" readOnly="false"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
@@ -18,7 +18,7 @@
 		</channels>
 
 		<properties>
-			<property name="vendor">Hayward</property>
+			<property name="Vendor">Hayward</property>
 		</properties>
 		<representation-property>systemID</representation-property>
 	</thing-type>

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/virtualHeater.xml
@@ -24,7 +24,7 @@
 	</thing-type>
 
 	<channel-type id="currentSetpoint">
-		<item-type>Number</item-type>
+		<item-type>Number:Temperature</item-type>
 		<label>Current Setpoint</label>
 		<description>Current Setpoint</description>
 		<category>Temperature</category>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -122,6 +122,7 @@
     <module>org.openhab.binding.gree</module>
     <module>org.openhab.binding.groheondus</module>
     <module>org.openhab.binding.harmonyhub</module>
+    <module>org.openhab.binding.haywardomnilogic</module>
     <module>org.openhab.binding.hdanywhere</module>
     <module>org.openhab.binding.hdpowerview</module>
     <module>org.openhab.binding.helios</module>


### PR DESCRIPTION
This PR is a replacement for PR #[8338](https://github.com/openhab/openhab-addons/pull/8338) , which was submitted against the 2.5.x branch. The 2.5.x version of the binding has been reviewed by @Hilbrand and @fwolter . There are still a couple open issues and changes that are awaiting review by @Hilbrand . 

**Background**
Hayward Omnilogic binding initial contribution
The Hayward Omnilogic binding integrates the Hayward Omnilogic pool controller using the Hayward API.

Forum discussion can be found [here.](https://community.openhab.org/t/hayward-omnilogic-pool-automation-binding/104105)

Signed-off-by: Matt Myers mmyers75@icloud.com