### PR TITLE
[rrd4j] Corrected the default configurations

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -367,7 +367,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         // 3. granularity of 15m for the last year
         // 4. granularity of 1h for the last 5 years
         // 5. granularity of 1d for the last 10 years
-        defaultNumeric.addArchives("LAST,0.5,1,360:LAST,0.5,6,10080:LAST,0.5,90,36500:LAST,0.5,8640,3650");
+        defaultNumeric.addArchives("LAST,0.5,1,360:LAST,0.5,6,10080:LAST,0.5,90,36500:LAST,0.5,360,43800:LAST,0.5,8640,3650");
         rrdDefs.put(DEFAULT_NUMERIC, defaultNumeric);
 
         RrdDefConfig defaultQuantifiable = new RrdDefConfig(DEFAULT_QUANTIFIABLE);
@@ -379,8 +379,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         // 3. granularity of 15m for the last year
         // 4. granularity of 1h for the last 5 years
         // 5. granularity of 1d for the last 10 years
-        defaultQuantifiable
-                .addArchives("AVERAGE,0.5,1,360:AVERAGE,0.5,6,10080:LAST,0.5,90,36500:AVERAGE,0.5,8640,3650");
+        defaultQuantifiable.addArchives("AVERAGE,0.5,1,360:AVERAGE,0.5,6,10080:AVERAGE,0.5,90,36500:AVERAGE,0.5,360,43800:AVERAGE,0.5,8640,3650");
         rrdDefs.put(DEFAULT_QUANTIFIABLE, defaultQuantifiable);
 
         RrdDefConfig defaultOther = new RrdDefConfig(DEFAULT_OTHER);
@@ -391,7 +390,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
         // 2. granularity of 1m for the last week
         // 3. granularity of 15m for the last year
         // 4. granularity of 4h for the last 10 years
-        defaultOther.addArchives("LAST,0.5,1,1440:LAST,0.5,12,10080:LAST,0.5,180,35040:LAST,0.5,240,21900");
+        defaultOther.addArchives("LAST,0.5,1,720:LAST,0.5,12,10080:LAST,0.5,180,35040:LAST,0.5,2880,21900");
         rrdDefs.put(DEFAULT_OTHER, defaultOther);
 
         if (config.isEmpty()) {


### PR DESCRIPTION
According the comments DEFAULT_NUMERIC, DEFAULT_QUANTIFIABLE config should have 5 archives, the 4th was missing. Additionally the ConsolFunction changed in the DEFAULT_QUANTIFIABLE.
The DEFAULT_OTHER config had false computed archives.


Signed-off-by: Jürgen Baginski opus42@gmx.de

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
