### PR TITLE
[miio] eliminate warning org.apache.commons.io.FileUtils in readmemaker

### DIFF
--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
@@ -18,11 +18,12 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Disabled;
@@ -52,6 +53,7 @@ import com.google.gson.JsonParser;
 public class ReadmeHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReadmeHelper.class);
     private static final String BASEFILE = "./README.base.md";
+    private static final String OUTPUTFILE = "./README.md";
 
     @Disabled
     public static void main(String[] args) {
@@ -65,14 +67,11 @@ public class ReadmeHelper {
         StringWriter itemFileExamples = rm.itemFileExamples();
         LOGGER.info("## Done");
         try {
-            File file = new File(BASEFILE);
-            String baseDoc = FileUtils.readFileToString(file, "UTF-8");
+            String baseDoc = new String(Files.readAllBytes(Paths.get(BASEFILE)));
             String nw = baseDoc.replaceAll("!!!devices", deviceList.toString())
                     .replaceAll("!!!channelList", channelList.toString())
                     .replaceAll("!!!itemFileExamples", itemFileExamples.toString());
-
-            File newDocfile = new File("README.md");
-            FileUtils.writeStringToFile(newDocfile, nw, "UTF-8");
+            Files.write(Paths.get(OUTPUTFILE), nw.getBytes());
         } catch (IOException e) {
             LOGGER.warn("IO exception", e);
         }
@@ -211,8 +210,7 @@ public class ReadmeHelper {
                         arrayList.add(devdb);
                     }
                 } catch (Exception e) {
-                    LOGGER.debug("Error while searching  in database '{}': {}", file.getName(), e.getMessage());
-                    LOGGER.info(e.getMessage());
+                    LOGGER.info("Error while searching  in database '{}': {}", file.getName(), e.getMessage());
                 }
             }
         }

--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/ReadmeHelper.java
@@ -18,6 +18,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -67,11 +68,11 @@ public class ReadmeHelper {
         StringWriter itemFileExamples = rm.itemFileExamples();
         LOGGER.info("## Done");
         try {
-            String baseDoc = new String(Files.readAllBytes(Paths.get(BASEFILE)));
-            String nw = baseDoc.replaceAll("!!!devices", deviceList.toString())
+            String baseDoc = new String(Files.readAllBytes(Paths.get(BASEFILE)), StandardCharsets.UTF_8);
+            String newDoc = baseDoc.replaceAll("!!!devices", deviceList.toString())
                     .replaceAll("!!!channelList", channelList.toString())
                     .replaceAll("!!!itemFileExamples", itemFileExamples.toString());
-            Files.write(Paths.get(OUTPUTFILE), nw.getBytes());
+            Files.write(Paths.get(OUTPUTFILE), newDoc.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             LOGGER.warn("IO exception", e);
         }


### PR DESCRIPTION
Eliminate
[WARNING] org.openhab.binding.miio.internal.ReadmeHelper.java:[25]
The package org.apache.commons.io.FileUtils should not be used.


Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
