### PR TITLE
[hue] Added channel to enable / disable a motion sensor

### DIFF
--- a/bundles/org.openhab.binding.hue/README.md
+++ b/bundles/org.openhab.binding.hue/README.md
@@ -165,27 +165,28 @@ The group type also have an optional configuration value to specify the fade tim
 
 The devices support some of the following channels:
 
-| Channel Type ID   | Item Type          | Description                                                                                                                             | Thing types supporting this channel |
-|-------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| switch            | Switch             | This channel supports switching the device on and off.                                                                                  | 0000, 0010, group                   |
-| color             | Color              | This channel supports full color control with hue, saturation and brightness values.                                                    | 0200, 0210, group                   |
-| brightness        | Dimmer             | This channel supports adjusting the brightness value. Note that this is not available, if the color channel is supported.               | 0100, 0110, 0220, group             |
-| color_temperature | Dimmer             | This channel supports adjusting the color temperature from cold (0%) to warm (100%).                                                    | 0210, 0220, group                   |
-| alert             | String             | This channel supports displaying alerts by flashing the bulb either once or multiple times. Valid values are: NONE, SELECT and LSELECT. | 0000, 0100, 0200, 0210, 0220, group |
-| effect            | Switch             | This channel supports color looping.                                                                                                    | 0200, 0210, 0220                    |
-| dimmer_switch     | Number             | This channel shows which button was last pressed on the dimmer switch.                                                                  | 0820                                |
-| illuminance       | Number:Illuminance | This channel shows the current illuminance measured by the sensor.                                                                      | 0106                                |
-| light_level       | Number             | This channel shows the current light level measured by the sensor. **Advanced**                                                         | 0106                                |
-| dark              | Switch             | This channel indicates whether the light level is below the darkness threshold or not.                                                  | 0106                                |
-| daylight          | Switch             | This channel indicates whether the light level is below the daylight threshold or not.                                                  | 0106                                |
-| presence          | Switch             | This channel indicates whether a motion is detected by the sensor or not.                                                               | 0107                                |
-| temperature       | Number:Temperature | This channel shows the current temperature measured by the sensor.                                                                      | 0302                                |
-| flag              | Switch             | This channel save flag state for a CLIP sensor.                                                                                         | 0850                                |
-| status            | Number             | This channel save status state for a CLIP sensor.                                                                                       | 0840                                |
-| last_updated      | DateTime           | This channel the date and time when the sensor was last updated.                                                                        | 0820, 0830, 0840, 0850, 0106, 0107, 0302|
-| battery_level     | Number             | This channel shows the battery level.                                                                                                   | 0820, 0106, 0107, 0302              |
-| battery_low       | Switch             | This channel indicates whether the battery is low or not.                                                                               | 0820, 0106, 0107, 0302              |
-| scene             | String             | This channel activates the scene with the given ID String. The ID String of each scene is assigned by the Hue bridge.                   | bridge, group |
+| Channel Type ID   | Item Type          | Description                                                                                                                             | Thing types supporting this channel      |
+|-------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| switch            | Switch             | This channel supports switching the device on and off.                                                                                  | 0000, 0010, group                        |
+| color             | Color              | This channel supports full color control with hue, saturation and brightness values.                                                    | 0200, 0210, group                        |
+| brightness        | Dimmer             | This channel supports adjusting the brightness value. Note that this is not available, if the color channel is supported.               | 0100, 0110, 0220, group                  |
+| color_temperature | Dimmer             | This channel supports adjusting the color temperature from cold (0%) to warm (100%).                                                    | 0210, 0220, group                        |
+| alert             | String             | This channel supports displaying alerts by flashing the bulb either once or multiple times. Valid values are: NONE, SELECT and LSELECT. | 0000, 0100, 0200, 0210, 0220, group      |
+| effect            | Switch             | This channel supports color looping.                                                                                                    | 0200, 0210, 0220                         |
+| dimmer_switch     | Number             | This channel shows which button was last pressed on the dimmer switch.                                                                  | 0820                                     |
+| illuminance       | Number:Illuminance | This channel shows the current illuminance measured by the sensor.                                                                      | 0106                                     |
+| light_level       | Number             | This channel shows the current light level measured by the sensor. **Advanced**                                                         | 0106                                     |
+| dark              | Switch             | This channel indicates whether the light level is below the darkness threshold or not.                                                  | 0106                                     |
+| daylight          | Switch             | This channel indicates whether the light level is below the daylight threshold or not.                                                  | 0106                                     |
+| presence          | Switch             | This channel indicates whether a motion is detected by the sensor or not.                                                               | 0107                                     |
+| enabled           | Switch             | This channel activated or deactivates the sensor                                                                                        | 0107                                     |
+| temperature       | Number:Temperature | This channel shows the current temperature measured by the sensor.                                                                      | 0302                                     |
+| flag              | Switch             | This channel save flag state for a CLIP sensor.                                                                                         | 0850                                     |
+| status            | Number             | This channel save status state for a CLIP sensor.                                                                                       | 0840                                     |
+| last_updated      | DateTime           | This channel the date and time when the sensor was last updated.                                                                        | 0820, 0830, 0840, 0850, 0106, 0107, 0302 |
+| battery_level     | Number             | This channel shows the battery level.                                                                                                   | 0820, 0106, 0107, 0302                   |
+| battery_low       | Switch             | This channel indicates whether the battery is low or not.                                                                               | 0820, 0106, 0107, 0302                   |
+| scene             | String             | This channel activates the scene with the given ID String. The ID String of each scene is assigned by the Hue bridge.                   | bridge, group                            |
 
 To load a hue scene inside a rule for example, the ID of the scene will be required.
 You can list all the scene IDs with the following console commands: `hue <bridgeUID> scenes` and `hue <groupThingUID> scenes`.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -66,6 +66,7 @@ public class HueBindingConstants {
     public static final String CHANNEL_DIMMER_SWITCH = "dimmer_switch";
     public static final String CHANNEL_TAP_SWITCH = "tap_switch";
     public static final String CHANNEL_PRESENCE = "presence";
+    public static final String CHANNEL_ENABLED = "enabled";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_LAST_UPDATED = "last_updated";
     public static final String CHANNEL_BATTERY_LEVEL = "battery_level";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueSensorHandler.java
@@ -64,7 +64,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
     private @Nullable HueClient hueClient;
 
-    private @Nullable FullSensor lastFullSensor;
+    protected @Nullable FullSensor lastFullSensor;
 
     public HueSensorHandler(Thing thing) {
         super(thing);
@@ -164,7 +164,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         handleCommand(channelUID.getId(), command);
     }
 
-    public void handleCommand(String channel, Command command) {
+    protected void handleCommand(String channel, Command command) {
         HueClient bridgeHandler = getHueClient();
         if (bridgeHandler == null) {
             logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
@@ -172,7 +172,6 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         }
 
         final FullSensor sensor = lastFullSensor;
-
         if (sensor == null) {
             logger.debug("hue sensor not known on bridge. Cannot handle command.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -213,7 +212,7 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
 
             final FullSensor sensor = lastFullSensor;
             if (sensor == null) {
-                logger.debug("hue sensor not known on bridge. Cannot handle command.");
+                logger.debug("hue sensor not known on bridge. Cannot handle configuration update.");
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "@text/offline.conf-error-wrong-sensor-id");
                 return;

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/PresenceHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/sensors/PresenceHandler.java
@@ -23,11 +23,17 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.hue.internal.FullSensor;
 import org.openhab.binding.hue.internal.PresenceConfigUpdate;
 import org.openhab.binding.hue.internal.SensorConfigUpdate;
+import org.openhab.binding.hue.internal.handler.HueClient;
 import org.openhab.binding.hue.internal.handler.HueSensorHandler;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Presence Sensor
@@ -39,8 +45,36 @@ import org.openhab.core.thing.ThingTypeUID;
 public class PresenceHandler extends HueSensorHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_PRESENCE_SENSOR);
 
+    private final Logger logger = LoggerFactory.getLogger(PresenceHandler.class);
+
     public PresenceHandler(Thing thing) {
         super(thing);
+    }
+
+    @Override
+    public void handleCommand(String channel, Command command) {
+        HueClient hueBridge = getHueClient();
+        if (hueBridge == null) {
+            logger.warn("hue bridge handler not found. Cannot handle command without bridge.");
+            return;
+        }
+
+        final FullSensor sensor = lastFullSensor;
+        if (sensor == null) {
+            logger.debug("hue sensor not known on bridge. Cannot handle command.");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-wrong-sensor-id");
+            return;
+        }
+
+        SensorConfigUpdate configUpdate = new SensorConfigUpdate();
+        switch (channel) {
+            case CHANNEL_ENABLED:
+                configUpdate.setOn(OnOffType.ON.equals(command));
+                break;
+        }
+
+        hueBridge.updateSensorConfig(sensor, configUpdate);
     }
 
     @Override

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/PresenceSensor.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/PresenceSensor.xml
@@ -6,18 +6,18 @@
 	<!-- Hue Presence Sensor -->
 	<thing-type id="0107">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="bridge" />
+			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>
 
 		<label>Presence Sensor</label>
 		<description>A motion sensor providing presence detection.</description>
 
 		<channels>
-			<channel id="presence" typeId="system.motion" />
-			<channel id="last_updated" typeId="last_updated" />
-			<channel id="enabled" typeId="system.power" />
-			<channel id="battery_level" typeId="system.battery-level" />
-			<channel id="battery_low" typeId="system.low-battery" />
+			<channel id="presence" typeId="system.motion"/>
+			<channel id="last_updated" typeId="last_updated"/>
+			<channel id="enabled" typeId="system.power"/>
+			<channel id="battery_level" typeId="system.battery-level"/>
+			<channel id="battery_low" typeId="system.low-battery"/>
 		</channels>
 
 		<representation-property>uniqueId</representation-property>

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/PresenceSensor.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/PresenceSensor.xml
@@ -6,17 +6,18 @@
 	<!-- Hue Presence Sensor -->
 	<thing-type id="0107">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="bridge"/>
+			<bridge-type-ref id="bridge" />
 		</supported-bridge-type-refs>
 
 		<label>Presence Sensor</label>
 		<description>A motion sensor providing presence detection.</description>
 
 		<channels>
-			<channel id="presence" typeId="system.motion"/>
-			<channel id="last_updated" typeId="last_updated"/>
-			<channel id="battery_level" typeId="system.battery-level"/>
-			<channel id="battery_low" typeId="system.low-battery"/>
+			<channel id="presence" typeId="system.motion" />
+			<channel id="last_updated" typeId="last_updated" />
+			<channel id="enabled" typeId="system.power" />
+			<channel id="battery_level" typeId="system.battery-level" />
+			<channel id="battery_low" typeId="system.low-battery" />
 		</channels>
 
 		<representation-property>uniqueId</representation-property>


### PR DESCRIPTION
Added channel to enable / disable a motion sensor

Closes #8389 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
