### PR TITLE
[icalendar] Updated biweekly to 0.6.4

### DIFF
--- a/bundles/org.openhab.binding.icalendar/pom.xml
+++ b/bundles/org.openhab.binding.icalendar/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>net.sf.biweekly</groupId>
       <artifactId>biweekly</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4</version>
       <scope>compile</scope>
     </dependency>
     <!-- dependencies of biweekly -->

--- a/bundles/org.openhab.binding.icalendar/pom.xml
+++ b/bundles/org.openhab.binding.icalendar/pom.xml
@@ -11,7 +11,7 @@
   <name>openHAB Add-ons :: Bundles :: iCalendar Binding</name>
   <properties>
     <dep.noembedding>jackson-core,jackson-annotations,jackson-databind</dep.noembedding>
-    <jackson.version>2.9.10</jackson.version>
+    <jackson.version>2.10.3</jackson.version>
   </properties>
   <dependencies>
     <!-- own dependencies -->


### PR DESCRIPTION
Fixes #8647 by just updating the dependency version, which is now released.