### PR TITLE
[Telegram] Improved sending to a particular chat section

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -155,10 +155,17 @@ These actions will send a message to all chat ids configured for this bot.
 
 ### Actions to send messages to a particular chat
 
-Just put the chat id (must be a long value!) as the first argument to one of the above mentioned APIs:
+Just put the chat id (must be a long value!) followed by an "L" as the first argument to one of the above mentioned APIs:
 
 ```
 telegramAction.sendTelegram(1234567L, "Hello world!")
+```
+
+You can also define a global variable to use in all your rules file:
+
+```
+val Id = 1234567L
+telegramAction.sendTelegram(Id, "Hello world!")
 ```
 
 ## Full Example

--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -161,13 +161,6 @@ Just put the chat id (must be a long value!) followed by an "L" as the first arg
 telegramAction.sendTelegram(1234567L, "Hello world!")
 ```
 
-You can also define a global variable to use in all your rules file:
-
-```
-val Id = 1234567L
-telegramAction.sendTelegram(Id, "Hello world!")
-```
-
 ## Full Example
 
 ### Send a text message to telegram chat


### PR DESCRIPTION
Changed the README.md file to include more information:

Specified that the chatId in the APIs must be followed by an "L" or it won't work (at least, not for group chats).
Also mentioned that you can store the chatId inside a variable so that you can write it only once for the entire rules file.