### PR TITLE
[lcn] Fix status message of RollerShutter inverting

### DIFF
--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
@@ -131,8 +131,7 @@ public class LcnModuleHandler extends BaseThingHandler {
                 }
 
                 // Initialize inversion converter
-                if (invertState instanceof Boolean && invertState.equals(true)
-                        || invertUpDown instanceof Boolean && invertUpDown.equals(true)) {
+                if (Boolean.TRUE.equals(invertState) || Boolean.TRUE.equals(invertUpDown)) {
                     converters.put(channel.getUID(), INVERSION_CONVERTER);
                 }
 

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
@@ -112,7 +112,8 @@ public class LcnModuleHandler extends BaseThingHandler {
             for (Channel channel : thing.getChannels()) {
                 Object unitObject = channel.getConfiguration().get("unit");
                 Object parameterObject = channel.getConfiguration().get("parameter");
-                Object invertConfig = channel.getConfiguration().get("invertState");
+                Object invertState = channel.getConfiguration().get("invertState");
+                Object invertUpDown = channel.getConfiguration().get("invertUpDown");
 
                 // Initialize value converters
                 if (unitObject instanceof String) {
@@ -130,7 +131,8 @@ public class LcnModuleHandler extends BaseThingHandler {
                 }
 
                 // Initialize inversion converter
-                if (invertConfig instanceof Boolean && invertConfig.equals(true)) {
+                if (invertState instanceof Boolean && invertState.equals(true)
+                        || invertUpDown instanceof Boolean && invertUpDown.equals(true)) {
                     converters.put(channel.getUID(), INVERSION_CONVERTER);
                 }
 


### PR DESCRIPTION
The status of RollerShutter was not inverted when invertUpDown=true. Fixes #8680

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>