### PR TITLE
[Telegram] Improved sending to a particular chat

### DIFF
--- a/bundles/org.openhab.binding.telegram/README.md
+++ b/bundles/org.openhab.binding.telegram/README.md
@@ -155,7 +155,7 @@ These actions will send a message to all chat ids configured for this bot.
 
 ### Actions to send messages to a particular chat
 
-Just put the chat id (must be a long value!) as the first argument to one of the above mentioned APIs:
+Just put the chat id (must be a long value!) followed by an "L" as the first argument to one of the above mentioned APIs:
 
 ```
 telegramAction.sendTelegram(1234567L, "Hello world!")


### PR DESCRIPTION
Changed the README.md file to include more information as in #8733:

Specified that the chatId in the APIs must be followed by an "L" or it won't work (at least, not for group chats).
