### PR TITLE
[Automower] added support for planner data and doc cleanup

### DIFF
--- a/bundles/org.openhab.binding.automower/README.md
+++ b/bundles/org.openhab.binding.automower/README.md
@@ -1,26 +1,26 @@
 # Automower Binding
 
-This binding communicates to the Husqvarna Automower Connect API in order to send commands and query the state of Husqvarna Automower robots.
+This is the binding for [Husqvarna Automower a robotic lawn mowers](https://www.husqvarna.com/uk/products/robotic-lawn-mowers/).
+This binding allows you to integrate, view and control Automower lawn mowers in the openHAB environment.
 
 ## Supported Things
 
-`bridge:` The bridge needs to be configured with credentials and an application key that allows communicating with the Automower Connect Api
+`bridge:` The bridge needs to be configured with credentials and an application key that allows communicating with the Automower Connect API
 
 `automower:` A single Husqvarna Automower robot
 
-Basically all Husqvarna Automower models with "Automower Connect" support should be supported. It was tested only with a Husqvarna Automower 450X
+All Husqvarna Automower models with "Automower Connect" should be supported. It was tested only with a Husqvarna Automower 430X and 450X.
 
 
 ## Discovery
 
-Once the bridge is created and configured, registered automowers will be discovered automatically
-
+Once the bridge is created and configured, OpenHab will automatically discover all Automowers registered on your account.
 
 ## Thing Configuration
 
 `bridge:`
 
-- appKey (mandatory): The Application Key is required to communication with the Automower Connect Api. It can be obtained by registering an Application on the Husqvarna Website. This application also needs to be connected to the "Authentication API" and the "Automower Connect API"
+- appKey (mandatory): The Application Key is required to communicate with the Automower Connect API. It can be obtained by registering an Application on [the Husqvarna Website](https://developer.husqvarnagroup.cloud/). This application also needs to be connected to the ["Authentication API" and the "Automower Connect API"](https://developer.husqvarnagroup.cloud/docs/getting-started)
 - userName (mandatory): The user name for which the application key has been issued
 - password (mandatory): The password for the given user
 - pollingInterval (optional): How often the bridge state should be queried in seconds. Default is 1h (3600s)
@@ -34,23 +34,24 @@ With the default value of 1h this would mean ~720 requests per month for the bri
 - mowerId (mandatory): The Id of an automower as used by the Automower Connect Api to identify a mower. This is automatically filled when the thing is discovered
 - pollingInterval (optional): How often the current automower state should be polled in seconds. Default is 10min (600s)
 
-Keep in mind that the status of the automowers should not be queried too often.
-According to the Husqvarna documentation not more than 10000 requests per month and application key are allowed.
-With the default value of 10min this would mean ~4300 requests per month per automower
+Keep in mind that the status of the Automowers should not be queried too often.
+According to the Husqvarna documentation, no more than 10000 requests per month and application key are allowed.
+With the default value of 10min this would mean ~4300 requests per month per single Automower
 
 ## Channels
 
 
-| channel         | type     | description                                                                                                                                                                 |
-|-----------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name            | String   | (readonly) The name of the Automower                                                                                                                                        |
-| mode            | String   | (readonly) The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                |
-| activity        | String   | (readonly) The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                           |
-| state           | String   | (readonly) The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP) |
-| last-update     | DateTime | (readonly) The time when the automower updated its states                                                                                                                   |
-| battery         | Number   | (readonly) The battery state of charge in percent                                                                                                                           |
-| error-code      | Number   | (readonly) The current error code                                                                                                                                           |
-| error-timestamp | DateTime | (readonly) The timestamp when the current error occurred                                                                                                                    |
+| channel                 | type     | description                                                                                                                                                                                                                                                                      |
+|-------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| mode                    | String   | (readonly) The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                                                                                                                     |
+| activity                | String   | (readonly) The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                                                                                                                                |
+| state                   | String   | (readonly) The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED_NONE, RESTRICTED_WEEK_SCHEDULE, RESTRICTED_PARK_OVERRIDE, RESTRICTED_SENSOR, RESTRICTED_DAILY_LIMIT, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP)  |
+| last-update             | DateTime | (readonly) The time when the automower updated its states                                                                                                                                                                                                                        |
+| battery                 | Number   | (readonly) The battery state of charge in percent                                                                                                                                                                                                                                |
+| error-code              | Number   | (readonly) The current error code                                                                                                                                                                                                                                                |
+| error-timestamp         | DateTime | (readonly) The timestamp when the current error occurred                                                                                                                                                                                                                         |
+| planner-next-start      | DateTime | (readonly) The time for the next auto start. If the mower is charging then the value is the estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.                                                                  |
+| planner-override-action | String   | (readonly) The action that overrides current planner operation.                                                                                                                                                                                                                  |
 
 
 ## Actions
@@ -79,7 +80,6 @@ The following actions are available for `automower`things:
 
 ### automower.items
 
-	String Automower_Name               "Name"                   { channel="automower:automower:mybridge:myAutomower:name" }
 	String Automower_Mode               "Mode"                   { channel="automower:automower:mybridge:myAutomower:mode" }
 	String Automower_Activity           "Activity"         	     { channel="automower:automower:mybridge:myAutomower:activity" }
 	String Automower_State              "State"            	     { channel="automower:automower:mybridge:myAutomower:state" }
@@ -87,7 +87,8 @@ The following actions are available for `automower`things:
 	Number Automower_Battery            "Battery"                { channel="automower:automower:mybridge:myAutomower:battery" }
 	Number Automower_Error_Code         "Error Code"             { channel="automower:automower:mybridge:myAutomower:error-code" }
 	DateTime Automower_Error_Time       "Error Time"             { channel="automower:automower:mybridge:myAutomower:error-timestamp" }
-
+	String Automower_Override_Action    "Override Action"        { channel="automower:automower:mybridge:myAutomower:planner-override-action" }
+	DateTime Automower_Next_Start_Time  "Next Start Time"        { channel="automower:automower:mybridge:myAutomower:planner-next-start" }
 
 	String Automower_Command            "Command"          	     { channel="automower:automower:mybridge:myAutomower:command" }
 	Number Automower_Command_Duration   "Command Duration"       { channel="automower:automower:mybridge:myAutomower:command-duration" }
@@ -100,7 +101,6 @@ The following actions are available for `automower`things:
 sitemap demo label="Automower"
 {
     Frame {
-        Text        item=Automower_Name
         Text        item=Automower_Mode
         Text        item=Automower_Activity
         Text        item=Automower_State
@@ -108,6 +108,8 @@ sitemap demo label="Automower"
         Text        item=Automower_Battery
         Text        item=Automower_Error_Code
         Text        item=Automower_Error_Time
+        Text        item=Automower_Override_Action
+        Text        item=Automower_Next_Start_Time
     }
 }
 ```

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Markus Pfleger - Initial contribution
+ * @author Marcin Czeczko - Added support for planner data
  */
 @NonNullByDefault
 public class AutomowerBindingConstants {
@@ -32,7 +33,6 @@ public class AutomowerBindingConstants {
     public static final ThingTypeUID THING_TYPE_AUTOMOWER = new ThingTypeUID(BINDING_ID, "automower");
 
     // List of all Channel ids
-    public static final String CHANNEL_MOWER_NAME = "name";
     public static final String CHANNEL_STATUS_MODE = "mode";
     public static final String CHANNEL_STATUS_ACTIVITY = "activity";
     public static final String CHANNEL_STATUS_STATE = "state";
@@ -40,6 +40,8 @@ public class AutomowerBindingConstants {
     public static final String CHANNEL_STATUS_BATTERY = "battery";
     public static final String CHANNEL_STATUS_ERROR_CODE = "error-code";
     public static final String CHANNEL_STATUS_ERROR_TIMESTAMP = "error-timestamp";
+    public static final String CHANNEL_PLANNER_NEXT_START = "planner-next-start";
+    public static final String CHANNEL_PLANNER_OVERRIDE_ACTION = "planner-override-action";
 
     // Automower properties
     public static final String AUTOMOWER_ID = "mowerId";

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Planner.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Planner.java
@@ -14,7 +14,37 @@ package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
 
 /**
  * @author Markus Pfleger - Initial contribution
+ * @author Marcin Czeczko - Added support for planner data
  */
 public class Planner {
+    private long nextStartTimestamp;
+    private RestrictedReason restrictedReason;
+    private PlannerOverride override;
 
+    public long getNextStartTimestamp() {
+        return nextStartTimestamp;
+    }
+
+    public Planner setNextStartTimestamp(long nextStartTimestamp) {
+        this.nextStartTimestamp = nextStartTimestamp;
+        return this;
+    }
+
+    public RestrictedReason getRestrictedReason() {
+        return restrictedReason;
+    }
+
+    public Planner setRestrictedReason(RestrictedReason restrictedReason) {
+        this.restrictedReason = restrictedReason;
+        return this;
+    }
+
+    public PlannerOverride getOverride() {
+        return override;
+    }
+
+    public Planner setOverride(PlannerOverride override) {
+        this.override = override;
+        return this;
+    }
 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/PlannerOverride.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/PlannerOverride.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
+
+/**
+ * @author Marcin Czeczko - Added support for planner data
+ */
+public class PlannerOverride {
+    private String action;
+
+    public String getAction() {
+        return action;
+    }
+
+    public PlannerOverride setAction(String action) {
+        this.action = action;
+        return this;
+    }
+}

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/RestrictedReason.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/RestrictedReason.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
+
+/**
+ * @author Marcin Czeczko - Added support for planner data
+ */
+public enum RestrictedReason {
+    NONE,
+    WEEK_SCHEDULE,
+    PARK_OVERRIDE,
+    SENSOR,
+    DAILY_LIMIT,
+    NOT_APPLICABLE
+}

--- a/bundles/org.openhab.binding.automower/src/main/resources/ESH-INF/i18n/automower.properties
+++ b/bundles/org.openhab.binding.automower/src/main/resources/ESH-INF/i18n/automower.properties
@@ -13,8 +13,6 @@ thing-type.config.automower.automower.timestamp.label = Last State Update
 thing-type.config.automower.automower.batteryPct.label = Battery Percentage
 
 # channel types
-channel-type.automower.name.label = Name
-channel-type.automower.name.description = Automower name
 channel-type.automower.mode.label = Mode
 channel-type.automower.mode.description = Mode
 channel-type.automower.activity.label = Activity
@@ -23,7 +21,12 @@ channel-type.automower.state.label = State
 channel-type.automower.state.description = State
 channel-type.automower.last-update.label = Last Update
 channel-type.automower.last-update.description = Last Update
-
+channel-type.automower.planner-next-start.label= Next planned start
+channel-type.automower.planner-next-start.description= Next planned start
+channel-type.automower.planner-override-action.label = Planner override action
+channel-type.automower.planner-override-action.description = Planner override action
+channel-type.automower.planner-restricted-reason.label = Planner restriction
+channel-type.automower.planner-restricted-reason.description = Planner restriction
 
 conf-error-no-app-key = Cannot connect to Automower bridge as no app key is available in the configuration
 conf-error-no-username = Cannot connect to Automower bridge as no username is available in the configuration

--- a/bundles/org.openhab.binding.automower/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -12,8 +12,10 @@
 		<config-description>
 			<parameter name="appKey" type="text" required="true">
 				<label>Application Key</label>
-				<description>The Application Key is required to communication with the Automower Connect Api. It can be obtained by
-					registering an Application on the Husqvarna Website. This application also needs to be connected to the
+				<description>The Application Key is required to communication with the Automower Connect Api at
+					https://developer.husqvarnagroup.cloud/. It can be obtained by
+					registering an Application on the Husqvarna Website.
+					This application also needs to be connected to the
 					"Authentication API" and the "Automower Connect API"</description>
 			</parameter>
 			<parameter name="userName" type="text" required="true">
@@ -43,7 +45,6 @@
 		<description>An automatic lawn mower</description>
 
 		<channels>
-			<channel id="name" typeId="nameType"/>
 			<channel id="mode" typeId="modeType"/>
 			<channel id="activity" typeId="activityType"/>
 			<channel id="state" typeId="stateType"/>
@@ -51,6 +52,8 @@
 			<channel id="battery" typeId="batteryType"/>
 			<channel id="error-code" typeId="errorCodeType"/>
 			<channel id="error-timestamp" typeId="errorTimestampType"/>
+			<channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
+			<channel id="planner-override-action" typeId="plannerOverrideActionType"/>
 		</channels>
 
 		<properties>
@@ -126,7 +129,11 @@
 				<option value="IN_OPERATION">Working</option>
 				<option value="WAIT_UPDATING">Downloading new firmware</option>
 				<option value="WAIT_POWER_UP">Booting mower</option>
-				<option value="RESTRICTED">Waiting</option>
+				<option value="RESTRICTED_NONE">Waiting</option>
+				<option value="RESTRICTED_WEEK_SCHEDULE">Restricted by week schedule</option>
+				<option value="RESTRICTED_PARK_OVERRIDE">Forced to park</option>
+				<option value="RESTRICTED_SENSOR">Restricted by sensor</option>
+				<option value="RESTRICTED_DAILY_LIMIT">Restricted by daily limit</option>
 				<option value="OFF">Off</option>
 				<option value="STOPPED">Stopped- Manual intervention required</option>
 				<option value="ERROR">Error</option>
@@ -161,6 +168,21 @@
 		<item-type>DateTime</item-type>
 		<label>Error Time</label>
 		<description>The time when the error occurred</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="plannerNextStartTimestampType">
+		<item-type>DateTime</item-type>
+		<label>The time for the next auto start</label>
+		<description>The channel providing the time for the next auto start. If the mower is charging then the value is the
+			estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="plannerOverrideActionType">
+		<item-type>String</item-type>
+		<label>The override action</label>
+		<description>The channel providing an action that overrides current planner operation.</description>
 		<state readOnly="true"/>
 	</channel-type>
 


### PR DESCRIPTION
I'd like to propose couple of improvements to the Automower binding
- Added support for the planner data available via API - that extends a little bit the range of states available for the user as well as information about any overrides (manual park, etc.) and the next estimated start time
- Additionally, proposed to remove `name` channel as it might not be quite useful as it's just name of the mower and it's present in thing properties anyway
- I updated doc with some rewordings.
- Also added my mower model I used for testing.