### PR TITLE
[groovyscripting] Add Groovy scripting support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 *       @openhab/add-ons-maintainers
 
 # Add-on maintainers:
+/bundles/org.openhab.automation.groovyscripting/ @wborn
 /bundles/org.openhab.binding.adorne/ @theiding
 /bundles/org.openhab.binding.airquality/ @kubawolanin
 /bundles/org.openhab.binding.airvisualnode/ @3cky

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -18,6 +18,11 @@
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.automation.groovyscripting</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.adorne</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.automation.groovyscripting/NOTICE
+++ b/bundles/org.openhab.automation.groovyscripting/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.automation.groovyscripting/README.md
+++ b/bundles/org.openhab.automation.groovyscripting/README.md
@@ -1,0 +1,3 @@
+# Groovy Scripting
+
+This add-on provides support for [Groovy](https://groovy-lang.org/) 3.x scripts in openHAB.

--- a/bundles/org.openhab.automation.groovyscripting/pom.xml
+++ b/bundles/org.openhab.automation.groovyscripting/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.automation.groovyscripting</artifactId>
+
+  <name>openHAB Add-ons :: Automation :: Groovy Scripting</name>
+
+  <properties>
+    <bnd.importpackage>
+      com.ibm.icu.*;resolution:=optional,
+      groovy.runtime.metaclass;resolution:=optional,
+      groovyjarjarantlr4.stringtemplate;resolution:=optional,
+      org.abego.treelayout.*;resolution:=optional,
+      org.apache.ivy.*;resolution:=optional,
+      org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
+    <groovy.version>3.0.6</groovy.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>${groovy.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jsr223</artifactId>
+      <version>${groovy.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.automation.groovyscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.automation.groovyscripting-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-automation-groovyscripting" description="Groovy Scripting" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature dependency="true">openhab-core-automation-module-script-rulesupport</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.groovyscripting/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.automation.groovyscripting/src/main/feature/feature.xml
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-automation-groovyscripting" description="Groovy Scripting" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<feature dependency="true">openhab-core-automation-module-script-rulesupport</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.automation.groovyscripting/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/GroovyScriptEngineFactory.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.groovyscripting.internal;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.script.ScriptEngine;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
+import org.openhab.core.automation.module.script.ScriptEngineFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This is an implementation of a {@link ScriptEngineFactory} for Groovy.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@Component(service = ScriptEngineFactory.class)
+@NonNullByDefault
+public class GroovyScriptEngineFactory extends AbstractScriptEngineFactory {
+
+    private final org.codehaus.groovy.jsr223.GroovyScriptEngineFactory factory = new org.codehaus.groovy.jsr223.GroovyScriptEngineFactory();
+
+    private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(), factory.getMimeTypes())
+            .flatMap(List::stream) //
+            .collect(Collectors.toUnmodifiableList());
+
+    @Override
+    public List<String> getScriptTypes() {
+        return scriptTypes;
+    }
+
+    @Override
+    public @Nullable ScriptEngine createScriptEngine(String scriptType) {
+        return scriptTypes.contains(scriptType) ? factory.getScriptEngine() : null;
+    }
+}

--- a/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/package-info.java
+++ b/bundles/org.openhab.automation.groovyscripting/src/main/java/org/openhab/automation/groovyscripting/internal/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+@org.osgi.annotation.bundle.Header(name = org.osgi.framework.Constants.DYNAMICIMPORT_PACKAGE, value = "*")
+package org.openhab.automation.groovyscripting.internal;
+
+/**
+ * Additional information for the Groovy Scripting package
+ *
+ * @author Wouter Born - Initial contribution
+ */

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -17,6 +17,8 @@
   <name>openHAB Add-ons :: Bundles</name>
 
   <modules>
+    <!-- automation -->
+    <module>org.openhab.automation.groovyscripting</module>
     <!-- io -->
     <module>org.openhab.io.homekit</module>
     <module>org.openhab.io.hueemulation</module>


### PR DESCRIPTION
This makes it really easy to start using [Groovy](https://groovy-lang.org/) 3.x scripts with openHAB!

---

![1](https://user-images.githubusercontent.com/12213581/96293589-48eaa300-0feb-11eb-92fd-7398647550f2.png)

![2](https://user-images.githubusercontent.com/12213581/96293595-4b4cfd00-0feb-11eb-91cd-88639765df48.png)

```shell
openhab> log:set info jsr223.groovy
openhab> log:tail
20:05:00.470 [INFO ] [jsr223.groovy                        ] - Hello World!
```