### PR TITLE
[hdpowerview] discovery could wrongly return a ThingUID based on a hub's Ipv6 address instead of its Ipv4 address

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/discovery/HDPowerViewHubDiscoveryParticipant.java
@@ -75,7 +75,9 @@ public class HDPowerViewHubDiscoveryParticipant implements MDNSDiscoveryParticip
     @Override
     public @Nullable ThingUID getThingUID(ServiceInfo service) {
         for (String host : service.getHostAddresses()) {
-            return new ThingUID(THING_TYPE_HUB, host.replace('.', '_'));
+            if (VALID_IP_V4_ADDRESS.matcher(host).matches()) {
+                return new ThingUID(THING_TYPE_HUB, host.replace('.', '_'));
+            }
         }
         return null;
     }


### PR DESCRIPTION
minor bug fix