### PR TITLE
Fix Tradfri itest

### DIFF
--- a/itests/org.openhab.binding.tradfri.tests/itest.bndrun
+++ b/itests/org.openhab.binding.tradfri.tests/itest.bndrun
@@ -24,7 +24,7 @@ Fragment-Host: org.openhab.binding.tradfri
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	javax.jmdns;version='[3.5.5,3.5.6)',\
+	javax.jmdns;version='[3.5.6,3.5.7)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\


### PR DESCRIPTION
Related to openhab/openhab-core#1721

It causes the build to fail, see: https://ci.openhab.org/job/openHAB-Addons/100/