### PR TITLE
[mapdb] Avoid ArrayIndexOutOfBoundsExceptions being thrown

### DIFF
--- a/bundles/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/StateTypeAdapter.java
+++ b/bundles/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/StateTypeAdapter.java
@@ -43,11 +43,12 @@ public class StateTypeAdapter extends TypeAdapter<State> {
             return null;
         }
         String value = reader.nextString();
-        String[] parts = value.split(TYPE_SEPARATOR);
-        String valueTypeName = parts[0];
-        String valueAsString = parts[1];
 
         try {
+            String[] parts = value.split(TYPE_SEPARATOR);
+            String valueTypeName = parts[0];
+            String valueAsString = parts[1];
+
             @SuppressWarnings("unchecked")
             Class<? extends State> valueType = (Class<? extends State>) Class.forName(valueTypeName);
             List<Class<? extends State>> types = Collections.singletonList(valueType);


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-addons/issues/8790

While it does not fix #8790, this PR will suppress the exception being thrown and instead do a warn logging with the state that cannot be deserialized.

Signed-off-by: Kai Kreuzer <kai@openhab.org>