### PR TITLE
[insteon] handle cases when channelLinked is not called after initialization

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
@@ -314,6 +314,12 @@ public class InsteonDeviceHandler extends BaseThingHandler {
 
                 getInsteonNetworkHandler().initialized(getThing().getUID(), msg);
 
+                channels.forEach(channel -> {
+                    if (isLinked(channel.getUID())) {
+                        channelLinked(channel.getUID());
+                    }
+                });
+
                 updateStatus(ThingStatus.ONLINE);
             } else {
                 String msg = "Product key '" + productKey
@@ -358,6 +364,10 @@ public class InsteonDeviceHandler extends BaseThingHandler {
 
     @Override
     public void channelLinked(ChannelUID channelUID) {
+        if (getInsteonNetworkHandler().isChannelLinked(channelUID)) {
+            return;
+        }
+
         Map<String, @Nullable String> params = new HashMap<>();
         Channel channel = getThing().getChannel(channelUID.getId());
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
@@ -201,6 +201,10 @@ public class InsteonNetworkHandler extends BaseBridgeHandler {
         deviceInfo.remove(uid.getAsString());
     }
 
+    public boolean isChannelLinked(ChannelUID uid) {
+        return channelInfo.containsKey(uid.getAsString());
+    }
+
     public void linked(ChannelUID uid, String msg) {
         channelInfo.put(uid.getAsString(), msg);
     }


### PR DESCRIPTION
This addresses changes in behavior from OH2 to OH3 as described at https://github.com/openhab/openhab-core/issues/1707.