### PR TITLE
[hpprinter] eliminate auto discovery duplicates

### DIFF
--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterConfiguration.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterConfiguration.java
@@ -25,8 +25,10 @@ public class HPPrinterConfiguration {
     public static final String IP_ADDRESS = "ipAddress";
     public static final String USAGE_INTERVAL = "usageInterval";
     public static final String STATUS_INTERVAL = "statusInterval";
+    public static final String UUID = "uuid";
 
     public @Nullable String ipAddress;
     public int usageInterval;
     public int statusInterval;
+    public @Nullable String uuid;
 }

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterDiscoveryParticipant.java
@@ -71,8 +71,9 @@ public class HPPrinterDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 String label = service.getName();
 
                 properties.put(HPPrinterConfiguration.IP_ADDRESS, inetAddress);
-                DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
-                        .build();
+                properties.put(HPPrinterConfiguration.UUID, service.getPropertyString("UUID"));
+                DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                        .withRepresentationProperty(HPPrinterConfiguration.UUID).withLabel(label).build();
                 logger.trace("Created a DiscoveryResult {} for printer on host '{}' name '{}'", result, inetAddress,
                         label);
                 return result;

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPProperties.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/api/HPProperties.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.hpprinter.internal.HPPrinterConfiguration;
 import org.openhab.core.thing.Thing;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -42,6 +43,8 @@ public class HPProperties {
                     element.getElementsByTagName("dd:SerialNumber").item(0).getTextContent());
             properties.put(Thing.PROPERTY_MODEL_ID,
                     element.getElementsByTagName("dd:ProductNumber").item(0).getTextContent());
+            properties.put(HPPrinterConfiguration.UUID,
+                    element.getElementsByTagName("dd:UUID").item(0).getTextContent());
             Node firmwareDate = element.getElementsByTagName("dd:Version").item(0);
             properties.put(Thing.PROPERTY_FIRMWARE_VERSION, firmwareDate.getChildNodes().item(0).getTextContent());
         }

--- a/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/thing/thing-printer.xml
+++ b/bundles/org.openhab.binding.hpprinter/src/main/resources/OH-INF/thing/thing-printer.xml
@@ -19,8 +19,9 @@
 		</channel-groups>
 		<properties>
 			<property name="vendor">HP</property>
+			<property name="uuid"></property>
 		</properties>
-		<representation-property>serialNumber</representation-property>
+		<representation-property>uuid</representation-property>
 		<config-description-ref uri="thing-type:hpprinter:config"/>
 	</thing-type>
 


### PR DESCRIPTION
Changed the `representation property` from `serialNumber` to `uuid` to eliminate auto discovery duplicates.

Background: the `serialNumber` property, although discovered in the Bridge manual creation process, is not discovered in the mDNS auto- discovery process. Whereas, on the other hand, `uuid` is discovered in both processes.