### PR TITLE
[daikinmadoka] removed duplicate channel RSSI

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.daikinmadoka/src/main/resources/OH-INF/thing/daikinmadoka.xml
+++ b/bundles/org.openhab.binding.bluetooth.daikinmadoka/src/main/resources/OH-INF/thing/daikinmadoka.xml
@@ -6,14 +6,13 @@
 
 	<thing-type id="brc1h">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="dbusbluez"/>
+			<bridge-type-ref id="bluez"/>
 		</supported-bridge-type-refs>
 
 		<label>Daikin BRC1H Thermostat</label>
 		<description>A Daikin Madoka BRC1H Thermostat (BLE)</description>
 
 		<channels>
-			<channel id="rssi" typeId="rssi"/>
 			<channel id="onOffStatus" typeId="brc1h_onOffStatus"/>
 			<channel id="indoorTemperature" typeId="brc1h_indoorTemperature"/>
 			<channel id="outdoorTemperature" typeId="brc1h_outdoorTemperature"/>


### PR DESCRIPTION
This PR fixes a minor bug, where a duplicate RSSI channel was created, in addition to the one provided by the BlueZ binding.