### PR TITLE
[MPD] Fix MPD not updating current song on player events

### DIFF
--- a/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnection.java
+++ b/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/protocol/MPDConnection.java
@@ -193,6 +193,7 @@ public class MPDConnection implements MPDResponseListener {
                 switch (line) {
                     case "player":
                         updateStatus = true;
+                        updateCurrentSong = true;
                         break;
                     case "mixer":
                         updateStatus = true;


### PR DESCRIPTION
Details of the issue are described here #8817

This PR update current song on player events (song changes). 

Original log in issue, updated log below showing current song is requested on player change events:
```
2020-10-20 23:33:35.853 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'changed: player'
2020-10-20 23:33:35.853 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'OK'
2020-10-20 23:33:35.854 [DEBUG] [nternal.protocol.MPDConnectionThread] - insert command 'status' at position -1
2020-10-20 23:33:35.854 [DEBUG] [nternal.protocol.MPDConnectionThread] - insert command 'currentsong' at position -1
2020-10-20 23:33:35.854 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'status'
2020-10-20 23:33:35.854 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'status'
2020-10-20 23:33:35.897 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'volume: 48'
2020-10-20 23:33:35.897 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'repeat: 0'
2020-10-20 23:33:35.897 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'random: 1'
2020-10-20 23:33:35.897 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'single: 0'
2020-10-20 23:33:35.898 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'consume: 0'
2020-10-20 23:33:35.898 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'playlist: 53'
2020-10-20 23:33:35.898 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'playlistlength: 236'
2020-10-20 23:33:35.898 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'xfade: 0'
2020-10-20 23:33:35.898 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'state: play'
2020-10-20 23:33:35.899 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'song: 107'
2020-10-20 23:33:35.899 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'songid: 192'
2020-10-20 23:33:35.899 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'nextsong: 231'
2020-10-20 23:33:35.899 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'nextsongid: 82'
2020-10-20 23:33:35.899 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'time: 0:233'
2020-10-20 23:33:35.900 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'elapsed: 0.000'
2020-10-20 23:33:35.900 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'bitrate: 160'
2020-10-20 23:33:35.900 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'OK'
2020-10-20 23:33:35.900 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'currentsong'
2020-10-20 23:33:35.900 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'currentsong'
2020-10-20 23:33:35.928 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'file: spotify:track:2wO8aOvN1ogLy1N8XT1WJE'
2020-10-20 23:33:35.928 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Time: 233'
2020-10-20 23:33:35.928 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Artist: Foo Fighters'
2020-10-20 23:33:35.928 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Album: Foo Fighters'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Title: This Is a Call'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Date: 1995'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Track: 1'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Pos: 107'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'Id: 192'
2020-10-20 23:33:35.929 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'AlbumArtist: Foo Fighters'
2020-10-20 23:33:35.930 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'X-AlbumUri: spotify:album:4EnNuo8fG7dMoxMefbApRY'
2020-10-20 23:33:35.930 [TRACE] [nternal.protocol.MPDConnectionThread] - received line 'OK'
2020-10-20 23:33:35.930 [TRACE] [nternal.protocol.MPDConnectionThread] - send command 'idle'
2020-10-20 23:33:35.931 [TRACE] [nternal.protocol.MPDConnectionThread] - read response for command 'idle'
```

MPD song metadata is now updated on song changes.

