### PR TITLE
[influxdb] Fixes issue 8798 and 8697 problems storing integer types

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/README.md
+++ b/bundles/org.openhab.persistence.influxdb/README.md
@@ -1,14 +1,19 @@
 # InfluxDB (0.9 and newer) Persistence
 
-This service allows you to persist and query states using the [InfluxDB](https://www.influxdata.com/products/influxdb-overview/) and [InfluxDB 2.0](https://v2.docs.influxdata.com/v2.0/) time series database. The persisted values can be queried from within openHAB. There also are nice tools on the web for visualizing InfluxDB time series, such as [Grafana](http://grafana.org/).
+This service allows you to persist and query states using the [InfluxDB](https://www.influxdata.com/products/influxdb-overview/) and [InfluxDB 2.0](https://v2.docs.influxdata.com/v2.0/) time series database. The persisted values can be queried from within openHAB. 
+There also are nice tools on the web for visualizing InfluxDB time series, such as [Grafana](http://grafana.org/) and new Influx DB 2.0 version introduces [powerful data processing features.](https://docs.influxdata.com/influxdb/v2.0/process-data/get-started/)
 
 ## Database Structure
 
 
 - This service allows you to persist and query states using the time series database.
 - The states of an item are persisted in *measurements* points with names equal to the name of the item, or the alias, if one is provided. In both variants, a *tag* named "item" is added, containing the item name.
- All values are stored in a *field* called "value" using integers or doubles if possible,`OnOffType` and `OpenClosedType` values are stored using 0 or 1.
-- If configured extra tags for item category, label or type can be added fore each point.
+ All values are stored in a *field* called "value" using the following types:
+    - **float** for DecimalType and QuantityType
+    - **integer** for `OnOffType` and `OpenClosedType`  (values are stored using 0 or 1) and `DateTimeType` (milliseconds since 1970-01-01T00:00:00Z)
+    - **string** for the rest of types
+    
+- If configured, extra tags for item category, label or type can be added fore each point.
 
 Some example entries for an item with the name "speedtest" without any further configuration would look like this:
 

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtils.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtils.java
@@ -69,9 +69,9 @@ public class InfluxDBStateConvertUtils {
         } else if (state instanceof PointType) {
             value = point2String((PointType) state);
         } else if (state instanceof DecimalType) {
-            value = convertBigDecimalToNum(((DecimalType) state).toBigDecimal());
+            value = ((DecimalType) state).toBigDecimal();
         } else if (state instanceof QuantityType<?>) {
-            value = convertBigDecimalToNum(((QuantityType<?>) state).toBigDecimal());
+            value = ((QuantityType<?>) state).toBigDecimal();
         } else if (state instanceof OnOffType) {
             value = state == OnOffType.ON ? DIGITAL_VALUE_ON : DIGITAL_VALUE_OFF;
         } else if (state instanceof OpenClosedType) {
@@ -165,22 +165,5 @@ public class InfluxDBStateConvertUtils {
             buf.append(point.getAltitude().toString());
         }
         return buf.toString(); // latitude, longitude, altitude
-    }
-
-    /**
-     * This method returns an integer if possible if not a double is returned. This is an optimization
-     * for influxdb because integers have less overhead.
-     *
-     * @param value the BigDecimal to be converted
-     * @return A double if possible else a double is returned.
-     */
-    private static Object convertBigDecimalToNum(BigDecimal value) {
-        Object convertedValue;
-        if (value.scale() == 0) {
-            convertedValue = value.toBigInteger();
-        } else {
-            convertedValue = value.doubleValue();
-        }
-        return convertedValue;
     }
 }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxPoint.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxPoint.java
@@ -88,4 +88,10 @@ public class InfluxPoint {
             return new InfluxPoint(this);
         }
     }
+
+    @Override
+    public String toString() {
+        return "InfluxPoint{" + "measurementName='" + measurementName + '\'' + ", time=" + time + ", value=" + value
+                + ", tags=" + tags + '}';
+    }
 }

--- a/bundles/org.openhab.persistence.influxdb/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.persistence.influxdb/src/main/resources/OH-INF/config/config.xml
@@ -27,7 +27,7 @@
 		<parameter name="url" type="text" required="true" groupName="connection">
 			<context>url</context>
 			<label>Database URL</label>
-			<description>The database URL, e.g. http://127.0.0.1:8086 or http://127.0.0.1:9999</description>
+			<description>The database URL, e.g. http://127.0.0.1:8086</description>
 			<default>http://127.0.0.1:8086</default>
 		</parameter>
 

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ConfigurationTestHelper.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ConfigurationTestHelper.java
@@ -32,7 +32,7 @@ public class ConfigurationTestHelper {
 
     public static Map<String, @Nullable Object> createValidConfigurationParameters() {
         Map<String, @Nullable Object> config = new HashMap<>();
-        config.put(URL_PARAM, "http://localhost:9999");
+        config.put(URL_PARAM, "http://localhost:8086");
         config.put(VERSION_PARAM, InfluxDBVersion.V2.name());
         config.put(TOKEN_PARAM, "sampletoken");
         config.put(DATABASE_PARAM, "openhab");

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtilsTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtilsTest.java
@@ -13,7 +13,8 @@
 package org.openhab.persistence.influxdb.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -22,6 +23,8 @@ import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.DateTimeItem;
 import org.openhab.core.library.items.NumberItem;
@@ -40,7 +43,13 @@ public class InfluxDBStateConvertUtilsTest {
     @Test
     public void convertDecimalState() {
         DecimalType decimalType = new DecimalType(new BigDecimal("1.12"));
-        assertThat((Double) InfluxDBStateConvertUtils.stateToObject(decimalType), closeTo(1.12, 0.01));
+        assertThat(InfluxDBStateConvertUtils.stateToObject(decimalType), is(new BigDecimal("1.12")));
+    }
+
+    @Test
+    public void convertIntegerDecimalState() {
+        DecimalType decimalType = new DecimalType(12L);
+        assertThat(InfluxDBStateConvertUtils.stateToObject(decimalType), is(new BigDecimal("12")));
     }
 
     @Test
@@ -57,9 +66,10 @@ public class InfluxDBStateConvertUtilsTest {
         assertThat(InfluxDBStateConvertUtils.stateToObject(type), equalTo(nowInMillis));
     }
 
-    @Test
-    public void convertDecimalToState() {
-        BigDecimal val = new BigDecimal("1.12");
+    @ParameterizedTest
+    @ValueSource(strings = { "1.12", "25" })
+    public void convertDecimalToState(String number) {
+        BigDecimal val = new BigDecimal(number);
         NumberItem item = new NumberItem("name");
         assertThat(InfluxDBStateConvertUtils.objectToState(val, item), equalTo(new DecimalType(val)));
     }

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemTestHelper.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemTestHelper.java
@@ -22,9 +22,12 @@ import org.openhab.core.library.types.DecimalType;
 @NonNullByDefault
 public class ItemTestHelper {
 
-    public static NumberItem createNumberItem(String name, int value) {
+    public static NumberItem createNumberItem(String name, Number value) {
         NumberItem numberItem = new NumberItem(name);
-        numberItem.setState(new DecimalType(value));
+        if (value instanceof Integer || value instanceof Long)
+            numberItem.setState(new DecimalType(value.longValue()));
+        else
+            numberItem.setState(new DecimalType(value.doubleValue()));
         return numberItem;
     }
 }

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ItemToStorePointCreatorTest.java
@@ -16,8 +16,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.DefaultLocation;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.items.Metadata;
@@ -62,14 +65,19 @@ public class ItemToStorePointCreatorTest {
         metadataRegistry = null;
     }
 
-    @Test
-    public void convertBasicItem() {
-        NumberItem item = ItemTestHelper.createNumberItem("myitem", 5);
+    @ParameterizedTest
+    @MethodSource
+    public void convertBasicItem(Number number) {
+        NumberItem item = ItemTestHelper.createNumberItem("myitem", number);
         InfluxPoint point = instance.convert(item, null);
 
         assertThat(point.getMeasurementName(), equalTo(item.getName()));
         assertThat("Must Store item name", point.getTags(), hasEntry("item", item.getName()));
-        assertThat(point.getValue(), equalTo(new BigInteger("5")));
+        assertThat(point.getValue(), equalTo(new BigDecimal(number.toString())));
+    }
+
+    private static Stream<Number> convertBasicItem() {
+        return Stream.of(5, 5.5, 5L);
     }
 
     @Test


### PR DESCRIPTION
This PR mainly solves issue #8798 that was detected with OH 3.0 milestone 1 testing.

The issue has a long discussion/explanation on the problem, but summing up this PR ensures that always doubles are used to store numerical values. That is the safe way to store them due to the combination that OH doesn't have an IntegerType and Influx doesn't support different field types in the same series and shard.
This is compatible with old behavior because the old addon had the intent to use different types for integers but in the end it doesn't.

It also solves #8697 reflecting that with Influx2 RC version the port is the same as Influx1

And changes toString for `InfluxPoint`  because some trace logs that logged the point were unuseful without this.

I attach the build addon for more easy testing:
[org.openhab.persistence.influxdb-3.0.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab-addons/files/5418770/org.openhab.persistence.influxdb-3.0.0-SNAPSHOT.jar.zip)

**Important note if testing addon**:
If you already used the previous addon version you can still have problems. You need to start with a new database or from a copy of OH 2 database where the 3.0 persistence addon was never used.


