### PR TITLE
[ecobee] Fixed setHold action when using holdHours

### DIFF
--- a/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/action/EcobeeActions.java
+++ b/bundles/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/action/EcobeeActions.java
@@ -341,9 +341,7 @@ public class EcobeeActions implements ThingActions, IEcobeeActions {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("coolHoldTemp", coolHoldTemp);
         params.put("heatHoldTemp", heatHoldTemp);
-        params.put("holdType", HoldType.HOLD_HOURS);
-        params.put("holdHours", Integer.valueOf(holdHours.intValue()));
-        return setHold(params, null, null, null, null);
+        return setHold(params, HoldType.HOLD_HOURS.toString(), holdHours, null, null);
     }
 
     public static boolean setHold(@Nullable ThingActions actions, @Nullable QuantityType<Temperature> coolHoldTemp,
@@ -396,9 +394,7 @@ public class EcobeeActions implements ThingActions, IEcobeeActions {
         }
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("holdClimateRef", holdClimateRef);
-        params.put("holdType", HoldType.HOLD_HOURS);
-        params.put("holdHours", Integer.valueOf(holdHours.intValue()));
-        return setHold(params, null, null, null, null);
+        return setHold(params, HoldType.HOLD_HOURS.toString(), holdHours, null, null);
     }
 
     public static boolean setHold(@Nullable ThingActions actions, @Nullable String holdClimateRef,


### PR DESCRIPTION
Applying 3.0 fix to 2.5.x

Fixed an issue when the hold time is not properly handled when setting a temperature hold for a defined number of hours.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
