### PR TITLE
[intesis] [Bug] Fixed error channels not being updated

### DIFF
--- a/bundles/org.openhab.binding.intesis/README.md
+++ b/bundles/org.openhab.binding.intesis/README.md
@@ -68,14 +68,17 @@ Thing intesis:intesisBox:acOffice  "AC Unit Adapter" @ "AC" [ipAddress="192.168.
 **Items**
 
 ```intesishome.items
-Switch              ac              "Power"                                 { channel="intesis:intesisHome:acOffice:power" }
-String              acMode          "Mode"                                  { channel="intesis:intesisHome:acOffice:mode" }
-String              acFanSpeed      "Fan Speed"             <fan>           { channel="intesis:intesisHome:acOffice:fanSpeed" }
-String              acVanesUpDown   "Vanes Up/Ddown Position"               { channel="intesis:intesisHome:acOffice:vanesUpDown" }
-String              acVanesLeftRight "Vanes Left/Right Position"            { channel="intesis:intesisHome:acOffice:vanesLeftRight" }
-Number:Temperature  acSetPoint      "Target Temperature"    <heating>       { channel="intesis:intesisHome:acOffice:targetTemperature" }
-Number:Temperature  acAmbientTemp   "Ambient Temperature"   <temperature>   { channel="intesis:intesisHome:acOffice:ambientTemperature" }
-Number:Temperature  acOutdoorTemp   "Outdoor Temperature"   <temperature>   { channel="intesis:intesisHome:acOffice:outdoorTemperature" }
+Switch              ac               "Power"                                        { channel="intesis:intesisHome:acOffice:power" }
+String              acMode           "Mode"                                         { channel="intesis:intesisHome:acOffice:mode" }
+String              acFanSpeed       "Fan Speed"             <fan>                  { channel="intesis:intesisHome:acOffice:fanSpeed" }
+String              acVanesUpDown    "Vanes Up/Ddown Position"                      { channel="intesis:intesisHome:acOffice:vanesUpDown" }
+String              acVanesLeftRight "Vanes Left/Right Position"                    { channel="intesis:intesisHome:acOffice:vanesLeftRight" }
+Number:Temperature  acSetPoint       "Target Temperature"    <heating>              { channel="intesis:intesisHome:acOffice:targetTemperature" }
+Number:Temperature  acAmbientTemp    "Ambient Temperature"   <temperature>          { channel="intesis:intesisHome:acOffice:ambientTemperature" }
+Number:Temperature  acOutdoorTemp    "Outdoor Temperature"   <temperature>          { channel="intesis:intesisHome:acOffice:outdoorTemperature" }
+String              acErrorStatus    "Errorstatus"                                  { channel="intesis:intesisBox:acOffice:errorStatus" }
+String              acErrorCode      "Errorcode"                                    { channel="intesis:intesisBox:acOffice:errorCode" }
+String              acWifiSignal     "Wifi Signal Quality"   <qualityofservice>     { channel="intesis:intesisBox:acOffice:wifiSignal" }
 ```
 
 **Sitemap**
@@ -85,13 +88,17 @@ sitemap intesishome label="My AC control" {
 
     Frame label="Climate" {
           Switch item=ac
-          Switch item=acMode        icon="heating"          mappings=[AUTO="Auto", HEAT="Heat", DRY="Dry", FAN="Fan", COOL="Cool"]
-          Switch item=acFanSpeed    icon="qualityofservice" mappings=[AUTO="Auto", 1="Low", 2="Med", 3="MedHigh", 4="High"]
-          Switch item=acVanesUpDown icon="movecontrol"      mappings=[AUTO="Stop", 1="1", 2="2", 3="3", 4="4", 5="5", SWING="Swing"]
-          Switch item=acVanesLeftRight icon="movecontrol"   mappings=[AUTO="Stop", 1="1", 2="2", 3="3", 4="4", 5="5", SWING="Swing"]
-          Setpoint item=acSetPoint  icon="temperature"      minValue=16 maxValue=28 step=1
-          Text item=acAmbientTemp   icon="temperature" 
-          Text item=acOutdoorTemp   icon="temperature" 
+          Switch item=acMode           icon="heating"          mappings=[AUTO="Auto", HEAT="Heat", DRY="Dry", FAN="Fan", COOL="Cool"]
+          Switch item=acFanSpeed       icon="qualityofservice" mappings=[AUTO="Auto", 1="Low", 2="Med", 3="MedHigh", 4="High"]
+          Switch item=acVanesUpDown    icon="movecontrol"      mappings=[AUTO="Stop", 1="1", 2="2", 3="3", 4="4", 5="5", SWING="Swing"]
+          Switch item=acVanesLeftRight icon="movecontrol"      mappings=[AUTO="Stop", 1="1", 2="2", 3="3", 4="4", 5="5", SWING="Swing"]
+          Setpoint item=acSetPoint     icon="temperature"      minValue=16 maxValue=28 step=1
+          Text item=acAmbientTemp      icon="temperature" 
+          Text item=acOutdoorTemp      icon="temperature"
+          Text item=acErrorStatus
+          Text item=acErrorCode
+          Text item=acWifiSignal       icon="qualityofservice"
+           
     }
 }
 ```

--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisBoxHandler.java
@@ -263,12 +263,10 @@ public class IntesisBoxHandler extends BaseThingHandler implements IntesisBoxCha
                 updateState(CHANNEL_TYPE_VANESLR, new StringType(value));
                 break;
             case "ERRCODE":
-                properties.put("errorCode", value);
-                updateProperties(properties);
+                updateState(CHANNEL_TYPE_ERRORCODE, new StringType(value));
                 break;
             case "ERRSTATUS":
-                properties.put("errorStatus", value);
-                updateProperties(properties);
+                updateState(CHANNEL_TYPE_ERRORSTATUS, new StringType(value));
                 if ("ERR".equals(value)) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "device reported an error");

--- a/bundles/org.openhab.binding.intesis/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.intesis/src/main/resources/OH-INF/thing/thing-types.xml
@@ -59,12 +59,14 @@
 		<item-type>String</item-type>
 		<label>@text/channel-type.intesis.errorCode.label</label>
 		<description>@text/channel-type.intesis.errorCode.description</description>
+		<state readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="errorStatus">
 		<item-type>String</item-type>
 		<label>@text/channel-type.intesis.errorStatus.label</label>
 		<description>@text/channel-type.intesis.errorStatus.description</description>
+		<state readOnly="true"></state>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
Signed-off-by: Hans-Jörg Merk <github@hmerk.de>

The newly introduced channels "errorStatus" and errorCode" did not receive updates, as the had still been populated as properties.
The "readOnly" pattern was also missing and has been added.
Missing examples have been added to the readme as well.