### PR TITLE
[rrd4j] Correctly identify Number items with dimensions and persist them in the defined unit

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -220,7 +220,6 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
                 logger.debug("Error closing rrd4j database: {}", e.getMessage());
             }
         }
-
     }
 
     @Override


### PR DESCRIPTION
The persistence service will now use the defined unit of Number items with dimensions (which is derived from the unit given in its state description or - if not set - from the defaults of the used measurement system) for both writing and reading values from the database.

Fixes #8809
Fixes #8856

Signed-off-by: Kai Kreuzer <kai@openhab.org>
