### PR TITLE
Fixed typo in class name TrustAllTrustMananger

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzTlsTrustManagerProvider.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzTlsTrustManagerProvider.java
@@ -16,7 +16,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.net.http.TlsTrustManagerProvider;
-import org.openhab.core.io.net.http.TrustAllTrustMananger;
+import org.openhab.core.io.net.http.TrustAllTrustManager;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -35,6 +35,6 @@ public class AVMFritzTlsTrustManagerProvider implements TlsTrustManagerProvider 
 
     @Override
     public X509ExtendedTrustManager getTrustManager() {
-        return TrustAllTrustMananger.getInstance();
+        return TrustAllTrustManager.getInstance();
     }
 }

--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/SamsungTvTlsTrustManagerProvider.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/SamsungTvTlsTrustManagerProvider.java
@@ -16,7 +16,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.net.http.TlsTrustManagerProvider;
-import org.openhab.core.io.net.http.TrustAllTrustMananger;
+import org.openhab.core.io.net.http.TrustAllTrustManager;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -35,6 +35,6 @@ public class SamsungTvTlsTrustManagerProvider implements TlsTrustManagerProvider
 
     @Override
     public X509ExtendedTrustManager getTrustManager() {
-        return TrustAllTrustMananger.getInstance();
+        return TrustAllTrustManager.getInstance();
     }
 }


### PR DESCRIPTION
Changed references from TrustAllTrustMananger to TrustAllTrustManager to reflect openhab-core PR 1773