### PR TITLE
Revert "[modbus] Disable failing test"

### DIFF
--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
@@ -33,7 +33,6 @@ import java.util.function.Function;
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openhab.binding.modbus.handler.EndpointNotInitializedException;
@@ -561,7 +560,6 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
     }
 
     @Test
-    @Disabled("See: https://github.com/openhab/openhab-addons/issues/8880")
     public void testOnRegistersNaNFloatInRegisters() throws InvalidSyntaxException {
         ModbusDataThingHandler dataHandler = testReadHandlingGeneric(ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS,
                 "0", "default", ModbusConstants.ValueType.FLOAT32, null, new ModbusRegisterArray(


### PR DESCRIPTION
Reverts openhab/openhab-addons#8884

Closes #8880 (see https://github.com/openhab/openhab-core/pull/1774)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>