### PR TITLE
[bluetooth.bluegiga] Fix broken device discovery

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -127,6 +127,10 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
         updateLastSeenTime();
     }
 
+    public void setAddressType(BluetoothAddressType addressType) {
+        this.addressType = addressType;
+    }
+
     @Override
     public boolean connect() {
         if (connection != -1) {

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
@@ -143,7 +143,6 @@ public class BlueGigaBridgeHandler extends AbstractBluetoothBridgeHandler<BlueGi
 
     // Map of Bluetooth devices known to this bridge.
     // This is all devices we have heard on the network - not just things bound to the bridge
-    private final Map<BluetoothAddress, BlueGigaBluetoothDevice> devices = new ConcurrentHashMap<>();
 
     // Map of open connections
     private final Map<Integer, BluetoothAddress> connections = new ConcurrentHashMap<>();
@@ -707,14 +706,9 @@ public class BlueGigaBridgeHandler extends AbstractBluetoothBridgeHandler<BlueGi
                 // We use the scan event to add any devices we hear to the devices list
                 // The device gets created, and then manages itself for discovery etc.
                 BluetoothAddress sender = new BluetoothAddress(scanEvent.getSender());
-                if (!devices.containsKey(sender)) {
-                    BlueGigaBluetoothDevice device;
-                    logger.debug("BlueGiga adding new device to adaptor {}: {}", address, sender);
-                    device = new BlueGigaBluetoothDevice(this, new BluetoothAddress(scanEvent.getSender()),
-                            scanEvent.getAddressType());
-                    devices.put(sender, device);
-                    deviceDiscovered(device);
-                }
+                BlueGigaBluetoothDevice device = getDevice(sender);
+                device.setAddressType(scanEvent.getAddressType());
+                deviceDiscovered(device);
             } else {
                 logger.trace("Ignore BlueGigaScanResponseEvent as initialization is not complete");
             }

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/handler/BlueGigaBridgeHandler.java
@@ -141,9 +141,6 @@ public class BlueGigaBridgeHandler extends AbstractBluetoothBridgeHandler<BlueGi
     // Our BT address
     private @Nullable BluetoothAddress address;
 
-    // Map of Bluetooth devices known to this bridge.
-    // This is all devices we have heard on the network - not just things bound to the bridge
-
     // Map of open connections
     private final Map<Integer, BluetoothAddress> connections = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
During testing I noticed that I couldn't get any bluetooth devices to appear in the inbox during a manual scan through my BlueGiga dongle. Turns out the bluegiga bridge wasn't using the AbstractBluetoothBridgeHandler's device cache.

Signed-off-by: Connor Petty <mistercpp2000+gitsignoff@gmail.com>