### PR TITLE
Remove Map null annotation workarounds

### DIFF
--- a/bundles/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/discovery/AirQualityDiscoveryService.java
+++ b/bundles/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/discovery/AirQualityDiscoveryService.java
@@ -63,13 +63,13 @@ public class AirQualityDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 
     @Override
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/json/AirQualityJsonData.java
+++ b/bundles/org.openhab.binding.airquality/src/main/java/org/openhab/binding/airquality/internal/json/AirQualityJsonData.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link AirQualityJsonData} is responsible for storing
@@ -36,7 +35,7 @@ public class AirQualityJsonData {
     private @NonNullByDefault({}) AirQualityJsonTime time;
     private @NonNullByDefault({}) AirQualityJsonCity city;
     private List<Attribute> attributions = new ArrayList<>();
-    private Map<String, @Nullable AirQualityValue> iaqi = new HashMap<>();
+    private Map<String, AirQualityValue> iaqi = new HashMap<>();
     private String dominentpol = "";
 
     /**

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderHandlerFactory.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderHandlerFactory.java
@@ -76,7 +76,7 @@ public class AlarmDecoderHandlerFactory extends BaseThingHandlerFactory {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegMap = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegMap = new HashMap<>();
     // Marked as Nullable only to fix incorrect redundant null check complaints from null annotations
 
     @Override

--- a/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADMsgType.java
+++ b/bundles/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/protocol/ADMsgType.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.alarmdecoder.internal.protocol;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -34,7 +35,7 @@ public enum ADMsgType {
     INVALID; // invalid message
 
     /** hash map from protocol message heading to type */
-    private static HashMap<String, @Nullable ADMsgType> startToMsgType = new HashMap<>();
+    private static Map<String, ADMsgType> startToMsgType = new HashMap<>();
 
     static {
         startToMsgType.put("!REL", ADMsgType.REL);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountServlet.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AccountServlet.java
@@ -499,8 +499,7 @@ public class AccountServlet extends HttpServlet {
         html.append("<table><tr><th align='left'>Name</th><th align='left'>Value</th></tr>");
         List<JsonMusicProvider> musicProviders = connection.getMusicProviders();
         for (JsonMusicProvider musicProvider : musicProviders) {
-            @Nullable
-            List<@Nullable String> properties = musicProvider.supportedProperties;
+            List<String> properties = musicProvider.supportedProperties;
             String providerId = musicProvider.id;
             String displayName = musicProvider.displayName;
             if (properties != null && properties.contains("Alexa.Music.PlaySearchPhrase")
@@ -557,7 +556,7 @@ public class AccountServlet extends HttpServlet {
         }
 
         if (playLists != null) {
-            Map<String, @Nullable PlayList @Nullable []> playlistMap = playLists.playlists;
+            Map<String, PlayList @Nullable []> playlistMap = playLists.playlists;
             if (playlistMap != null && !playlistMap.isEmpty()) {
                 html.append("<table><tr><th align='left'>Name</th><th align='left'>Value</th></tr>");
 

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlHandlerFactory.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoControlHandlerFactory.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.amazonechocontrol.internal;
 
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.SUPPORTED_ECHO_THING_TYPES_UIDS;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.SUPPORTED_SMART_HOME_THING_TYPES_UIDS;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_ACCOUNT;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_FLASH_BRIEFING_PROFILE;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,7 +63,7 @@ import com.google.gson.Gson;
 @NonNullByDefault
 public class AmazonEchoControlHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(AmazonEchoControlHandlerFactory.class);
-    private final Map<ThingUID, @Nullable List<ServiceRegistration<?>>> discoveryServiceRegistrations = new HashMap<>();
+    private final Map<ThingUID, List<ServiceRegistration<?>>> discoveryServiceRegistrations = new HashMap<>();
 
     private final Set<AccountHandler> accountHandlers = new HashSet<>();
     private final HttpService httpService;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/AmazonEchoDynamicStateDescriptionProvider.java
@@ -12,14 +12,7 @@
  */
 package org.openhab.binding.amazonechocontrol.internal;
 
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.BINDING_ID;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_AMAZON_MUSIC_PLAY_LIST_ID;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_BLUETHOOTH_MAC;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_CHANNEL_PLAY_ON_DEVICE;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_MUSIC_PROVIDER_ID;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_PLAY_ALARM_SOUND;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.CHANNEL_TYPE_START_COMMAND;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.FLASH_BRIEFING_COMMAND_PREFIX;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,7 +112,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             options.add(new StateOption("", ""));
             for (PairedDevice device : pairedDeviceList) {
                 if (device == null) {
@@ -144,10 +137,9 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             options.add(new StateOption("", ""));
-            @Nullable
-            Map<String, @Nullable PlayList @Nullable []> playlistMap = playLists.playlists;
+            Map<String, PlayList @Nullable []> playlistMap = playLists.playlists;
             if (playlistMap != null) {
                 for (PlayList[] innerLists : playlistMap.values()) {
                     if (innerLists != null && innerLists.length > 0) {
@@ -174,7 +166,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             options.add(new StateOption("", ""));
 
             for (JsonNotificationSound notificationSound : notificationSounds) {
@@ -202,7 +194,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             options.add(new StateOption("", ""));
             for (Device device : devices) {
                 final String value = device.serialNumber;
@@ -223,10 +215,9 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             for (JsonMusicProvider musicProvider : musicProviders) {
-                @Nullable
-                List<@Nullable String> properties = musicProvider.supportedProperties;
+                List<String> properties = musicProvider.supportedProperties;
                 String providerId = musicProvider.id;
                 String displayName = musicProvider.displayName;
                 if (properties != null && properties.contains("Alexa.Music.PlaySearchPhrase")
@@ -252,7 +243,7 @@ public class AmazonEchoDynamicStateDescriptionProvider implements DynamicStateDe
                 return null;
             }
 
-            ArrayList<StateOption> options = new ArrayList<>();
+            List<StateOption> options = new ArrayList<>();
             options.addAll(originalStateDescription.getOptions());
 
             for (FlashBriefingProfileHandler flashBriefing : flashbriefings) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -1490,7 +1490,7 @@ public class Connection {
             JsonArray ttsVolumeNodesToExecute = new JsonArray();
             for (int i = 0; i < devices.length; i++) {
                 if (ttsVolumes[i] != null && (standardVolumes == null || !ttsVolumes[i].equals(standardVolumes[i]))) {
-                    Map<String, @Nullable Object> volumeParameters = new HashMap<>();
+                    Map<String, Object> volumeParameters = new HashMap<>();
                     volumeParameters.put("value", ttsVolumes[i]);
                     ttsVolumeNodesToExecute
                             .add(createExecutionNode(devices[i], "Alexa.DeviceControls.Volume", volumeParameters));

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/AmazonEchoDiscovery.java
@@ -122,7 +122,7 @@ public class AmazonEchoDiscovery extends AbstractDiscoveryService {
 
     @Override
     @Activate
-    public void activate(@Nullable Map<String, @Nullable Object> config) {
+    public void activate(@Nullable Map<String, Object> config) {
         super.activate(config);
         if (config != null) {
             modified(config);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/SmartHomeDevicesDiscovery.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/discovery/SmartHomeDevicesDiscovery.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.binding.amazonechocontrol.internal.discovery;
 
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.DEVICE_PROPERTY_ID;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.SUPPORTED_SMART_HOME_THING_TYPES_UIDS;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_SMART_HOME_DEVICE;
-import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.THING_TYPE_SMART_HOME_DEVICE_GROUP;
+import static org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants.*;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -63,7 +60,7 @@ public class SmartHomeDevicesDiscovery extends AbstractDiscoveryService {
     }
 
     public void activate() {
-        activate(new Hashtable<String, @Nullable Object>());
+        activate(new Hashtable<String, Object>());
     }
 
     @Override
@@ -123,7 +120,7 @@ public class SmartHomeDevicesDiscovery extends AbstractDiscoveryService {
 
     @Override
     @Activate
-    public void activate(@Nullable Map<String, @Nullable Object> config) {
+    public void activate(@Nullable Map<String, Object> config) {
         super.activate(config);
         if (config != null) {
             modified(config);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
@@ -70,8 +70,8 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
 
     private @Nullable SmartHomeBaseDevice smartHomeBaseDevice;
     private final Gson gson;
-    private final Map<String, @Nullable HandlerBase> handlers = new HashMap<>();
-    private final Map<String, @Nullable JsonArray> lastStates = new HashMap<>();
+    private final Map<String, HandlerBase> handlers = new HashMap<>();
+    private final Map<String, JsonArray> lastStates = new HashMap<>();
 
     public SmartHomeDeviceHandler(Thing thing, Gson gson) {
         super(thing);

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAutomation.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonAutomation.java
@@ -27,7 +27,7 @@ public class JsonAutomation {
     public @Nullable String automationId;
     public @Nullable String name;
     public @Nullable Trigger @Nullable [] triggers;
-    public @Nullable TreeMap<String, @Nullable Object> sequence;
+    public @Nullable TreeMap<String, Object> sequence;
     public @Nullable String status;
     public long creationTimeEpochMillis;
     public long lastUpdatedTimeEpochMillis;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonMusicProvider.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonMusicProvider.java
@@ -25,9 +25,9 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class JsonMusicProvider {
     public @Nullable String displayName;
-    public @Nullable List<@Nullable Object> @Nullable [] supportedTriggers;
+    public @Nullable List<Object> @Nullable [] supportedTriggers;
     public @Nullable String icon;
-    public @Nullable List<@Nullable String> supportedProperties;
+    public @Nullable List<String> supportedProperties;
     public @Nullable String id;
     public @Nullable String availability;
     public @Nullable String description;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonPlaylists.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class JsonPlaylists {
 
-    public @Nullable Map<String, @Nullable PlayList @Nullable []> playlists;
+    public @Nullable Map<String, PlayList @Nullable []> playlists;
 
     public static class PlayList {
         public @Nullable String playlistId;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/Constants.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/Constants.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.amazonechocontrol.internal.AmazonEchoControlBindingConstants;
 import org.openhab.core.thing.type.ChannelTypeUID;
 
@@ -27,7 +26,7 @@ import org.openhab.core.thing.type.ChannelTypeUID;
  */
 @NonNullByDefault
 public class Constants {
-    public static final Map<String, @Nullable Supplier<HandlerBase>> HANDLER_FACTORY = new HashMap<>();
+    public static final Map<String, Supplier<HandlerBase>> HANDLER_FACTORY = new HashMap<>();
 
     static {
         HANDLER_FACTORY.put(HandlerPowerController.INTERFACE, HandlerPowerController::new);

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/discovery/AstroDiscoveryService.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/discovery/AstroDiscoveryService.java
@@ -64,7 +64,7 @@ public class AstroDiscoveryService extends AbstractDiscoveryService {
     @Activate
     public AstroDiscoveryService(final @Reference LocationProvider locationProvider,
             final @Reference LocaleProvider localeProvider, final @Reference TranslationProvider i18nProvider,
-            @Nullable Map<String, @Nullable Object> configProperties) {
+            @Nullable Map<String, Object> configProperties) {
         super(new HashSet<>(Arrays.asList(new ThingTypeUID(BINDING_ID, "-"))), DISCOVER_TIMEOUT_SECONDS, true);
         this.locationProvider = locationProvider;
         this.localeProvider = localeProvider;

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
@@ -48,7 +48,7 @@ public class BlueZHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .singleton(BlueZAdapterConstants.THING_TYPE_BLUEZ);
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> serviceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> serviceRegs = new HashMap<>();
 
     private final DeviceManagerFactory deviceManagerFactory;
 

--- a/bundles/org.openhab.binding.bluetooth.roaming/src/main/java/org/openhab/binding/bluetooth/roaming/internal/RoamingHandlerFactory.java
+++ b/bundles/org.openhab.binding.bluetooth.roaming/src/main/java/org/openhab/binding/bluetooth/roaming/internal/RoamingHandlerFactory.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(configurationPid = "binding.roaming", service = ThingHandlerFactory.class)
 public class RoamingHandlerFactory extends BaseThingHandlerFactory {
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> serviceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> serviceRegs = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
@@ -75,14 +75,14 @@ public class BluetoothDiscoveryService extends AbstractDiscoveryService implemen
 
     @Override
     @Activate
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         logger.debug("Activating Bluetooth discovery service");
         super.activate(configProperties);
     }
 
     @Override
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 
@@ -170,7 +170,7 @@ public class BluetoothDiscoveryService extends AbstractDiscoveryService implemen
     private class DiscoveryCache {
 
         private final Map<BluetoothAdapter, SnapshotFuture> discoveryFutures = new HashMap<>();
-        private final Map<BluetoothAdapter, @Nullable Set<DiscoveryResult>> discoveryResults = new ConcurrentHashMap<>();
+        private final Map<BluetoothAdapter, Set<DiscoveryResult>> discoveryResults = new ConcurrentHashMap<>();
 
         private @Nullable BluetoothDeviceSnapshot latestSnapshot;
 

--- a/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/discovery/SmartherModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/discovery/SmartherModuleDiscoveryService.java
@@ -73,7 +73,7 @@ public class SmartherModuleDiscoveryService extends AbstractDiscoveryService
     @Override
     public void activate() {
         logger.debug("Bridge[{}] Activating chronothermostat discovery service", this.bridgeUID);
-        Map<String, @Nullable Object> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY, Boolean.TRUE);
         super.activate(properties);
     }

--- a/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
+++ b/bundles/org.openhab.binding.cbus/src/main/java/org/openhab/binding/cbus/internal/CBusThreadPool.java
@@ -28,28 +28,22 @@ import com.daveoxley.cbus.CGateThreadPoolExecutor;
  *
  * @author John Harvey - Initial contribution
  */
-
 @NonNullByDefault
 public class CBusThreadPool extends CGateThreadPool {
 
-    private final Map<String, @Nullable CGateThreadPoolExecutor> executorMap = new HashMap<>();
+    private final Map<String, CGateThreadPoolExecutor> executorMap = new HashMap<>();
 
     @Override
     protected synchronized CGateThreadPoolExecutor CreateExecutor(@Nullable String name) {
-        if (name == null || name.isEmpty()) {
-            name = "_default";
+        String nullSafeName = name == null || name.isEmpty() ? "_default" : name;
+        CGateThreadPoolExecutor executor = executorMap.get(nullSafeName);
+        if (executor == null) {
+            executor = new CBusThreadPoolExecutor(nullSafeName);
+            executorMap.put(nullSafeName, executor);
         }
-        @Nullable
-        CGateThreadPoolExecutor executor = executorMap.get(name);
-        if (executor != null) {
-            return executor;
-        }
-        CGateThreadPoolExecutor newExecutor = new CBusThreadPoolExecutor(name);
-        executorMap.put(name, newExecutor);
-        return newExecutor;
+        return executor;
     }
 
-    @NonNullByDefault
     public class CBusThreadPoolExecutor extends CGateThreadPoolExecutor {
         private final ThreadPoolExecutor threadPool;
 

--- a/bundles/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/handler/HVACHandler.java
+++ b/bundles/org.openhab.binding.coolmasternet/src/main/java/org/openhab/binding/coolmasternet/internal/handler/HVACHandler.java
@@ -53,14 +53,14 @@ public class HVACHandler extends BaseThingHandler {
      * speed, but the protocol's fan command (and matching binding command) use
      * single-letter abbreviations.
      */
-    private static final Map<String, @Nullable String> FAN_NUM_TO_STR;
+    private static final Map<String, String> FAN_NUM_TO_STR;
 
     /**
      * The CoolMasterNet query command returns numbers 0-5 for operation modes,
      * but these don't map to any mode you can set on the device, so we use this
      * lookup table.
      */
-    private static final Map<String, @Nullable String> MODE_NUM_TO_STR;
+    private static final Map<String, String> MODE_NUM_TO_STR;
 
     static {
         FAN_NUM_TO_STR = new HashMap<>();

--- a/bundles/org.openhab.binding.darksky/src/main/java/org/openhab/binding/darksky/internal/discovery/DarkSkyDiscoveryService.java
+++ b/bundles/org.openhab.binding.darksky/src/main/java/org/openhab/binding/darksky/internal/discovery/DarkSkyDiscoveryService.java
@@ -66,7 +66,7 @@ public class DarkSkyDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Client.java
+++ b/bundles/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Client.java
@@ -39,7 +39,7 @@ import org.xml.sax.SAXException;
 
 /**
  * The {@link Enigma2Client} class is responsible for communicating with the Enigma2 device.
- * 
+ *
  * @see <a href=
  *      "https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/wiki/OpenWebif-API-documentation">OpenWebif-API-documentation</a>
  *
@@ -65,7 +65,7 @@ public class Enigma2Client {
     static final int TYPE_INFO = 1;
     static final int TYPE_WARNING = 2;
     static final int TYPE_ERROR = 3;
-    private final Map<String, @Nullable String> channels = new ConcurrentHashMap<>();
+    private final Map<String, String> channels = new ConcurrentHashMap<>();
     private final String host;
     private boolean power;
     private String channel = "";
@@ -342,7 +342,7 @@ public class Enigma2Client {
 
     /**
      * Getter for Test-Injection
-     * 
+     *
      * @return HttpGet.
      */
     Enigma2HttpClient getEnigma2HttpClient() {

--- a/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/EvohomeHandlerFactory.java
+++ b/bundles/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/EvohomeHandlerFactory.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class EvohomeHandlerFactory extends BaseThingHandlerFactory {
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     private final HttpClient httpClient;
 

--- a/bundles/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/discovery/FreeboxDiscoveryService.java
+++ b/bundles/org.openhab.binding.freebox/src/main/java/org/openhab/binding/freebox/internal/discovery/FreeboxDiscoveryService.java
@@ -16,8 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.freebox.internal.FreeboxBindingConstants;
 import org.openhab.binding.freebox.internal.FreeboxDataListener;
 import org.openhab.binding.freebox.internal.api.FreeboxException;
@@ -73,7 +71,7 @@ public class FreeboxDiscoveryService extends AbstractDiscoveryService implements
     }
 
     @Override
-    public void activate(@Nullable Map<@NonNull String, @Nullable Object> configProperties) {
+    public void activate(Map<String, Object> configProperties) {
         super.activate(configProperties);
         applyConfig(configProperties);
         bridgeHandler.registerDataListener(this);

--- a/bundles/org.openhab.binding.gce/src/main/java/org/openhab/binding/gce/internal/handler/Ipx800v3Handler.java
+++ b/bundles/org.openhab.binding.gce/src/main/java/org/openhab/binding/gce/internal/handler/Ipx800v3Handler.java
@@ -83,7 +83,7 @@ public class Ipx800v3Handler extends BaseThingHandler implements Ipx800EventList
     private @NonNullByDefault({}) StatusFileInterpreter statusFile;
     private @Nullable ScheduledFuture<?> refreshJob;
 
-    private final Map<String, @Nullable PortData> portDatas = new HashMap<>();
+    private final Map<String, PortData> portDatas = new HashMap<>();
 
     private class LongPressEvaluator implements Runnable {
         private final ZonedDateTime referenceTime;
@@ -147,9 +147,7 @@ public class Ipx800v3Handler extends BaseThingHandler implements Ipx800EventList
         parser = null;
 
         portDatas.values().stream().forEach(portData -> {
-            if (portData != null) {
-                portData.destroy();
-            }
+            portData.destroy();
         });
         super.dispose();
     }

--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/discovery/TrackerDiscoveryService.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/discovery/TrackerDiscoveryService.java
@@ -104,13 +104,13 @@ public class TrackerDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     @Activate
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 
     @Override
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
+++ b/bundles/org.openhab.binding.gree/src/main/java/org/openhab/binding/gree/internal/discovery/GreeDiscoveryService.java
@@ -58,8 +58,7 @@ public class GreeDiscoveryService extends AbstractDiscoveryService {
     @Activate
     public GreeDiscoveryService(@Reference GreeDeviceFinder deviceFinder,
             @Reference NetworkAddressService networkAddressService,
-            @Reference GreeTranslationProvider translationProvider,
-            @Nullable Map<String, @Nullable Object> configProperties) {
+            @Reference GreeTranslationProvider translationProvider, @Nullable Map<String, Object> configProperties) {
         super(SUPPORTED_THING_TYPES_UIDS, TIMEOUT_SEC);
         this.messages = translationProvider;
         this.deviceFinder = deviceFinder;
@@ -70,7 +69,7 @@ public class GreeDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusHandlerFactory.java
+++ b/bundles/org.openhab.binding.groheondus/src/main/java/org/openhab/binding/groheondus/internal/handler/GroheOndusHandlerFactory.java
@@ -48,7 +48,7 @@ import org.osgi.service.http.HttpService;
 @Component(configurationPid = "binding.groheondus", service = ThingHandlerFactory.class)
 public class GroheOndusHandlerFactory extends BaseThingHandlerFactory {
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     private HttpService httpService;
     private StorageService storageService;

--- a/bundles/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
+++ b/bundles/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubHandlerFactory.java
@@ -68,7 +68,7 @@ public class HarmonyHubHandlerFactory extends BaseThingHandlerFactory
                     HarmonyDeviceHandler.SUPPORTED_THING_TYPES_UIDS.stream())
             .collect(Collectors.toSet());
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
     private final HttpClient httpClient;
 
     private final List<ChannelType> channelTypes = new CopyOnWriteArrayList<>();

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueDeviceDiscoveryService.java
@@ -79,7 +79,7 @@ public class HueDeviceDiscoveryService extends AbstractDiscoveryService
             .flatMap(i -> i).collect(Collectors.toSet()));
 
     // @formatter:off
-    private static final Map<String, @Nullable String> TYPE_TO_ZIGBEE_ID_MAP = Map.ofEntries(
+    private static final Map<String, String> TYPE_TO_ZIGBEE_ID_MAP = Map.ofEntries(
             new SimpleEntry<>("on_off_light", "0000"),
             new SimpleEntry<>("on_off_plug_in_unit", "0010"),
             new SimpleEntry<>("dimmable_light", "0100"),

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -99,14 +99,14 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     private final Logger logger = LoggerFactory.getLogger(HueBridgeHandler.class);
     private final HueStateDescriptionOptionProvider stateDescriptionOptionProvider;
 
-    private final Map<String, @Nullable FullLight> lastLightStates = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable FullSensor> lastSensorStates = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable FullGroup> lastGroupStates = new ConcurrentHashMap<>();
+    private final Map<String, FullLight> lastLightStates = new ConcurrentHashMap<>();
+    private final Map<String, FullSensor> lastSensorStates = new ConcurrentHashMap<>();
+    private final Map<String, FullGroup> lastGroupStates = new ConcurrentHashMap<>();
 
     private @Nullable HueDeviceDiscoveryService discoveryService;
-    private final Map<String, @Nullable LightStatusListener> lightStatusListeners = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable SensorStatusListener> sensorStatusListeners = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable GroupStatusListener> groupStatusListeners = new ConcurrentHashMap<>();
+    private final Map<String, LightStatusListener> lightStatusListeners = new ConcurrentHashMap<>();
+    private final Map<String, SensorStatusListener> sensorStatusListeners = new ConcurrentHashMap<>();
+    private final Map<String, GroupStatusListener> groupStatusListeners = new ConcurrentHashMap<>();
 
     final ReentrantLock pollingLock = new ReentrantLock();
 
@@ -182,7 +182,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     private final Runnable sensorPollingRunnable = new PollingRunnable() {
         @Override
         protected void doConnectedRun() throws IOException, ApiException {
-            Map<String, @Nullable FullSensor> lastSensorStateCopy = new HashMap<>(lastSensorStates);
+            Map<String, FullSensor> lastSensorStateCopy = new HashMap<>(lastSensorStates);
 
             final HueDeviceDiscoveryService discovery = discoveryService;
 
@@ -231,7 +231,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         }
 
         private void updateLights() throws IOException, ApiException {
-            Map<String, @Nullable FullLight> lastLightStateCopy = new HashMap<>(lastLightStates);
+            Map<String, FullLight> lastLightStateCopy = new HashMap<>(lastLightStates);
 
             List<FullLight> lights;
             if (ApiVersionUtils.supportsFullLights(hueBridge.getVersion())) {
@@ -279,7 +279,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         }
 
         private void updateGroups() throws IOException, ApiException {
-            Map<String, @Nullable FullGroup> lastGroupStateCopy = new HashMap<>(lastGroupStates);
+            Map<String, FullGroup> lastGroupStateCopy = new HashMap<>(lastGroupStates);
 
             List<FullGroup> groups = hueBridge.getGroups();
 
@@ -379,7 +379,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             notifyGroupSceneUpdate(scenes);
         }
 
-        private void setBridgeSceneChannelStateOptions(List<Scene> scenes, Map<String, @Nullable FullGroup> groups) {
+        private void setBridgeSceneChannelStateOptions(List<Scene> scenes, Map<String, FullGroup> groups) {
             Map<String, String> groupNames = groups.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getName()));
             List<StateOption> stateOptions = scenes.stream().map(scene -> scene.toStateOption(groupNames))

--- a/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudHandlerFactory.java
+++ b/bundles/org.openhab.binding.icloud/src/main/java/org/openhab/binding/icloud/internal/ICloudHandlerFactory.java
@@ -44,7 +44,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.icloud")
 public class ICloudHandlerFactory extends BaseThingHandlerFactory {
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
     private LocaleProvider localeProvider;
     private TranslationProvider i18nProvider;
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBinding.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonBinding.java
@@ -249,8 +249,7 @@ public class InsteonBinding {
         handler.updateState(channelUID, state);
     }
 
-    public InsteonDevice makeNewDevice(InsteonAddress addr, String productKey,
-            Map<String, @Nullable Object> deviceConfigMap) {
+    public InsteonDevice makeNewDevice(InsteonAddress addr, String productKey, Map<String, Object> deviceConfigMap) {
         DeviceType dt = DeviceTypeLoader.instance().getDeviceType(productKey);
         InsteonDevice dev = InsteonDevice.makeDevice(dt);
         dev.setAddress(addr);
@@ -296,7 +295,7 @@ public class InsteonBinding {
     private int checkIfInModemDatabase(InsteonDevice dev) {
         try {
             InsteonAddress addr = dev.getAddress();
-            Map<InsteonAddress, @Nullable ModemDBEntry> dbes = driver.lockModemDBEntries();
+            Map<InsteonAddress, ModemDBEntry> dbes = driver.lockModemDBEntries();
             if (dbes.containsKey(addr)) {
                 if (!dev.hasModemDBEntry()) {
                     logger.debug("device {} found in the modem database and {}.", addr, getLinkInfo(dbes, addr, true));
@@ -316,7 +315,7 @@ public class InsteonBinding {
     public Map<String, String> getDatabaseInfo() {
         try {
             Map<String, String> databaseInfo = new HashMap<>();
-            Map<InsteonAddress, @Nullable ModemDBEntry> dbes = driver.lockModemDBEntries();
+            Map<InsteonAddress, ModemDBEntry> dbes = driver.lockModemDBEntries();
             for (InsteonAddress addr : dbes.keySet()) {
                 String a = addr.toString();
                 databaseInfo.put(a, a + ": " + getLinkInfo(dbes, addr, false));
@@ -360,7 +359,7 @@ public class InsteonBinding {
         return (dev);
     }
 
-    private String getLinkInfo(Map<InsteonAddress, @Nullable ModemDBEntry> dbes, InsteonAddress a, boolean prefix) {
+    private String getLinkInfo(Map<InsteonAddress, ModemDBEntry> dbes, InsteonAddress a, boolean prefix) {
         ModemDBEntry dbe = dbes.get(a);
         List<Byte> controls = dbe.getControls();
         List<Byte> responds = dbe.getRespondsTo();
@@ -454,7 +453,7 @@ public class InsteonBinding {
         public void driverCompletelyInitialized() {
             List<String> missing = new ArrayList<>();
             try {
-                Map<InsteonAddress, @Nullable ModemDBEntry> dbes = driver.lockModemDBEntries();
+                Map<InsteonAddress, ModemDBEntry> dbes = driver.lockModemDBEntries();
                 logger.debug("modem database has {} entries!", dbes.size());
                 if (dbes.isEmpty()) {
                     logger.warn("the modem link database is empty!");

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonHandlerFactory.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/InsteonHandlerFactory.java
@@ -53,8 +53,8 @@ public class InsteonHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(Stream.of(DEVICE_THING_TYPE, NETWORK_THING_TYPE).collect(Collectors.toSet()));
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> serviceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> serviceRegs = new HashMap<>();
 
     private @Nullable SerialPortManager serialPortManager;
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/config/InsteonChannelConfiguration.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/config/InsteonChannelConfiguration.java
@@ -15,7 +15,6 @@ package org.openhab.binding.insteon.internal.config;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.insteon.internal.device.InsteonAddress;
 import org.openhab.core.thing.ChannelUID;
 
@@ -33,10 +32,10 @@ public class InsteonChannelConfiguration {
     private final InsteonAddress address;
     private final String feature;
     private final String productKey;
-    private final Map<String, @Nullable String> parameters;
+    private final Map<String, String> parameters;
 
     public InsteonChannelConfiguration(ChannelUID channelUID, String feature, InsteonAddress address, String productKey,
-            Map<String, @Nullable String> parameters) {
+            Map<String, String> parameters) {
         this.channelUID = channelUID;
         this.feature = feature;
         this.address = address;
@@ -66,7 +65,7 @@ public class InsteonChannelConfiguration {
         return productKey;
     }
 
-    public Map<String, @Nullable String> getParameters() {
+    public Map<String, String> getParameters() {
         return parameters;
     }
 }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/CommandHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/CommandHandler.java
@@ -49,7 +49,7 @@ public abstract class CommandHandler {
     private static final Logger logger = LoggerFactory.getLogger(CommandHandler.class);
     DeviceFeature feature; // related DeviceFeature
     @Nullable
-    Map<String, @Nullable String> parameters = new HashMap<>();
+    Map<String, String> parameters = new HashMap<>();
 
     /**
      * Constructor
@@ -113,7 +113,7 @@ public abstract class CommandHandler {
     }
 
     protected int getMaxLightLevel(InsteonChannelConfiguration conf, int defaultLevel) {
-        Map<String, @Nullable String> params = conf.getParameters();
+        Map<String, String> params = conf.getParameters();
         if (conf.getFeature().contains("dimmer") && params.containsKey("dimmermax")) {
             String item = conf.getChannelName();
             String dimmerMax = params.get("dimmermax");
@@ -136,7 +136,7 @@ public abstract class CommandHandler {
         return defaultLevel;
     }
 
-    void setParameters(Map<String, @Nullable String> map) {
+    void setParameters(Map<String, String> map) {
         parameters = map;
     }
 
@@ -597,7 +597,7 @@ public abstract class CommandHandler {
         }
 
         @Override
-        void setParameters(Map<String, @Nullable String> params) {
+        void setParameters(Map<String, String> params) {
             super.setParameters(params);
             onCmd = (byte) getIntParameter("on", 0x2E);
             offCmd = (byte) getIntParameter("off", 0x2F);
@@ -877,8 +877,7 @@ public abstract class CommandHandler {
      * @return the handler which was created
      */
     @Nullable
-    public static <T extends CommandHandler> T makeHandler(String name, Map<String, @Nullable String> params,
-            DeviceFeature f) {
+    public static <T extends CommandHandler> T makeHandler(String name, Map<String, String> params, DeviceFeature f) {
         String cname = CommandHandler.class.getName() + "$" + name;
         try {
             Class<?> c = Class.forName(cname);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeatureListener.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/DeviceFeatureListener.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.insteon.internal.InsteonBinding;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -46,8 +45,8 @@ public class DeviceFeatureListener {
 
     private String itemName;
     private ChannelUID channelUID;
-    private Map<String, @Nullable String> parameters = new HashMap<>();
-    private Map<Class<?>, @Nullable State> state = new HashMap<>();
+    private Map<String, String> parameters = new HashMap<>();
+    private Map<Class<?>, State> state = new HashMap<>();
     private List<InsteonAddress> relatedDevices = new ArrayList<>();
     private InsteonBinding binding;
     private static final int TIME_DELAY_POLL_RELATED_MSEC = 5000;
@@ -91,7 +90,7 @@ public class DeviceFeatureListener {
      *
      * @param p the parameters to set
      */
-    public void setParameters(Map<String, @Nullable String> p) {
+    public void setParameters(Map<String, String> p) {
         parameters = p;
         updateRelatedDevices();
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/FeatureTemplateLoader.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/FeatureTemplateLoader.java
@@ -24,7 +24,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.insteon.internal.utils.Utils;
 import org.openhab.binding.insteon.internal.utils.Utils.ParsingException;
 import org.openhab.core.library.types.DecimalType;
@@ -111,7 +110,7 @@ public class FeatureTemplateLoader {
         }
 
         NamedNodeMap attributes = e.getAttributes();
-        Map<String, @Nullable String> params = new HashMap<>();
+        Map<String, String> params = new HashMap<>();
         for (int i = 0; i < attributes.getLength(); i++) {
             Node n = attributes.item(i);
             params.put(n.getNodeName(), n.getNodeValue());

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/HandlerEntry.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/HandlerEntry.java
@@ -15,7 +15,6 @@ package org.openhab.binding.insteon.internal.device;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Ugly little helper class to facilitate late instantiation of handlers
@@ -25,15 +24,15 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 @NonNullByDefault
 public class HandlerEntry {
-    Map<String, @Nullable String> params;
+    Map<String, String> params;
     String name;
 
-    HandlerEntry(String name, Map<String, @Nullable String> params) {
+    HandlerEntry(String name, Map<String, String> params) {
         this.name = name;
         this.params = params;
     }
 
-    Map<String, @Nullable String> getParams() {
+    Map<String, String> getParams() {
         return params;
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/InsteonDevice.java
@@ -63,7 +63,7 @@ public class InsteonDevice {
     private InsteonAddress address = new InsteonAddress();
     private long pollInterval = -1L; // in milliseconds
     private @Nullable Driver driver = null;
-    private HashMap<String, @Nullable DeviceFeature> features = new HashMap<>();
+    private Map<String, DeviceFeature> features = new HashMap<>();
     private @Nullable String productKey = null;
     private volatile long lastTimePolled = 0L;
     private volatile long lastMsgReceived = 0L;
@@ -73,8 +73,8 @@ public class InsteonDevice {
     private long lastQueryTime = 0L;
     private boolean hasModemDBEntry = false;
     private DeviceStatus status = DeviceStatus.INITIALIZED;
-    private Map<Integer, @Nullable GroupMessageStateMachine> groupState = new HashMap<>();
-    private Map<String, @Nullable Object> deviceConfigMap = new HashMap<String, @Nullable Object>();
+    private Map<Integer, GroupMessageStateMachine> groupState = new HashMap<>();
+    private Map<String, Object> deviceConfigMap = new HashMap<String, Object>();
 
     /**
      * Constructor
@@ -121,7 +121,7 @@ public class InsteonDevice {
         return features.get(f);
     }
 
-    public HashMap<String, @Nullable DeviceFeature> getFeatures() {
+    public Map<String, DeviceFeature> getFeatures() {
         return features;
     }
 
@@ -194,11 +194,11 @@ public class InsteonDevice {
         }
     }
 
-    public void setDeviceConfigMap(Map<String, @Nullable Object> deviceConfigMap) {
+    public void setDeviceConfigMap(Map<String, Object> deviceConfigMap) {
         this.deviceConfigMap = deviceConfigMap;
     }
 
-    public Map<String, @Nullable Object> getDeviceConfigMap() {
+    public Map<String, Object> getDeviceConfigMap() {
         return deviceConfigMap;
     }
 
@@ -217,7 +217,7 @@ public class InsteonDevice {
     public boolean removeFeatureListener(String aItemName) {
         boolean removedListener = false;
         synchronized (features) {
-            for (Iterator<Entry<String, @Nullable DeviceFeature>> it = features.entrySet().iterator(); it.hasNext();) {
+            for (Iterator<Entry<String, DeviceFeature>> it = features.entrySet().iterator(); it.hasNext();) {
                 DeviceFeature f = it.next().getValue();
                 if (f.removeListener(aItemName)) {
                     removedListener = true;
@@ -584,7 +584,7 @@ public class InsteonDevice {
     @Override
     public String toString() {
         String s = address.toString();
-        for (Entry<String, @Nullable DeviceFeature> f : features.entrySet()) {
+        for (Entry<String, DeviceFeature> f : features.entrySet()) {
             s += "|" + f.getKey() + "->" + f.getValue().toString();
         }
         return s;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/MessageDispatcher.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/MessageDispatcher.java
@@ -37,7 +37,7 @@ public abstract class MessageDispatcher {
 
     DeviceFeature feature;
     @Nullable
-    Map<String, @Nullable String> parameters = new HashMap<>();
+    Map<String, String> parameters = new HashMap<>();
 
     /**
      * Constructor
@@ -48,7 +48,7 @@ public abstract class MessageDispatcher {
         feature = f;
     }
 
-    public void setParameters(@Nullable Map<String, @Nullable String> map) {
+    public void setParameters(@Nullable Map<String, String> map) {
         parameters = map;
     }
 
@@ -397,8 +397,8 @@ public abstract class MessageDispatcher {
      * @return the handler which was created
      */
     @Nullable
-    public static <T extends MessageDispatcher> T makeHandler(String name,
-            @Nullable Map<String, @Nullable String> params, DeviceFeature f) {
+    public static <T extends MessageDispatcher> T makeHandler(String name, @Nullable Map<String, String> params,
+            DeviceFeature f) {
         String cname = MessageDispatcher.class.getName() + "$" + name;
         try {
             Class<?> c = Class.forName(cname);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/MessageHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/MessageHandler.java
@@ -55,7 +55,7 @@ public abstract class MessageHandler {
     private static final Logger logger = LoggerFactory.getLogger(MessageHandler.class);
 
     protected DeviceFeature feature;
-    protected Map<String, @Nullable String> parameters = new HashMap<>();
+    protected Map<String, String> parameters = new HashMap<>();
 
     /**
      * Constructor
@@ -324,7 +324,7 @@ public abstract class MessageHandler {
      *
      * @param map the parameter map for this message handler
      */
-    public void setParameters(Map<String, @Nullable String> map) {
+    public void setParameters(Map<String, String> map) {
         parameters = map;
     }
 
@@ -457,7 +457,7 @@ public abstract class MessageHandler {
         }
 
         @Override
-        public void setParameters(Map<String, @Nullable String> params) {
+        public void setParameters(Map<String, String> params) {
             super.setParameters(params);
             onCmd = getIntParameter("on", 0x2E);
             offCmd = getIntParameter("off", 0x2F);
@@ -1342,7 +1342,7 @@ public abstract class MessageHandler {
      * @param f the feature for which to create the handler
      * @return the handler which was created
      */
-    public static @Nullable <T extends MessageHandler> T makeHandler(String name, Map<String, @Nullable String> params,
+    public static @Nullable <T extends MessageHandler> T makeHandler(String name, Map<String, String> params,
             DeviceFeature f) {
         String cname = MessageHandler.class.getName() + "$" + name;
         try {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/ModemDBBuilder.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/ModemDBBuilder.java
@@ -151,8 +151,8 @@ public class ModemDBBuilder implements MsgListener {
     private void logModemDB() {
         try {
             logger.debug("MDB ------- start of modem link records ------------------");
-            Map<InsteonAddress, @Nullable ModemDBEntry> dbes = port.getDriver().lockModemDBEntries();
-            for (Entry<InsteonAddress, @Nullable ModemDBEntry> db : dbes.entrySet()) {
+            Map<InsteonAddress, ModemDBEntry> dbes = port.getDriver().lockModemDBEntries();
+            for (Entry<InsteonAddress, ModemDBEntry> db : dbes.entrySet()) {
                 List<Msg> lrs = db.getValue().getLinkRecords();
                 for (Msg m : lrs) {
                     int recordFlags = m.getByte("RecordFlags") & 0xff;
@@ -177,7 +177,7 @@ public class ModemDBBuilder implements MsgListener {
 
     public void updateModemDB(InsteonAddress linkAddr, Port port, @Nullable Msg m, boolean isModem) {
         try {
-            Map<InsteonAddress, @Nullable ModemDBEntry> dbes = port.getDriver().lockModemDBEntries();
+            Map<InsteonAddress, ModemDBEntry> dbes = port.getDriver().lockModemDBEntries();
             ModemDBEntry dbe = dbes.get(linkAddr);
             if (dbe == null) {
                 dbe = new ModemDBEntry(linkAddr, isModem);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/PollHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/PollHandler.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public abstract class PollHandler {
     private static final Logger logger = LoggerFactory.getLogger(PollHandler.class);
     DeviceFeature feature;
-    Map<String, @Nullable String> parameters = new HashMap<>();
+    Map<String, String> parameters = new HashMap<>();
 
     /**
      * Constructor
@@ -57,7 +57,7 @@ public abstract class PollHandler {
      */
     public abstract @Nullable Msg makeMsg(InsteonDevice device);
 
-    public void setParameters(Map<String, @Nullable String> hm) {
+    public void setParameters(Map<String, String> hm) {
         parameters = hm;
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestQueueManager.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/RequestQueueManager.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.insteon.internal.device;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.PriorityQueue;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -41,7 +42,7 @@ public class RequestQueueManager {
     private final Logger logger = LoggerFactory.getLogger(RequestQueueManager.class);
     private @Nullable Thread queueThread = null;
     private PriorityQueue<RequestQueue> requestQueues = new PriorityQueue<>();
-    private HashMap<InsteonDevice, @Nullable RequestQueue> requestQueueHash = new HashMap<>();
+    private Map<InsteonDevice, RequestQueue> requestQueueHash = new HashMap<>();
     private boolean keepRunning = true;
 
     private RequestQueueManager() {

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/X10.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/device/X10.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.insteon.internal.device;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -139,7 +140,7 @@ public class X10 {
         return 0xf;
     }
 
-    private static @Nullable <T, E> T findKey(HashMap<T, E> map, E value) {
+    private static @Nullable <T, E> T findKey(Map<T, E> map, E value) {
         for (Entry<T, E> entry : map.entrySet()) {
             if (value.equals(entry.getValue())) {
                 return entry.getKey();
@@ -151,11 +152,11 @@ public class X10 {
     /**
      * Map between 4-bit X10 code and the house code.
      */
-    private static HashMap<Integer, @Nullable String> houseCodeToString = new HashMap<>();
+    private static Map<Integer, String> houseCodeToString = new HashMap<>();
     /**
      * Map between 4-bit X10 code and the unit code.
      */
-    private static HashMap<Integer, @Nullable Integer> unitCodeToInt = new HashMap<>();
+    private static Map<Integer, Integer> unitCodeToInt = new HashMap<>();
 
     static {
         houseCodeToString.put(0x6, "A");

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/driver/Driver.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/driver/Driver.java
@@ -36,7 +36,7 @@ public class Driver {
     private Port port;
     private String portName;
     private DriverListener listener;
-    private Map<InsteonAddress, @Nullable ModemDBEntry> modemDBEntries = new HashMap<>();
+    private Map<InsteonAddress, ModemDBEntry> modemDBEntries = new HashMap<>();
     private ReentrantLock modemDBEntriesLock = new ReentrantLock();
 
     public Driver(String portName, DriverListener listener, @Nullable SerialPortManager serialPortManager,
@@ -51,7 +51,7 @@ public class Driver {
         return port.isRunning();
     }
 
-    public Map<InsteonAddress, @Nullable ModemDBEntry> lockModemDBEntries() {
+    public Map<InsteonAddress, ModemDBEntry> lockModemDBEntries() {
         modemDBEntriesLock.lock();
         return modemDBEntries;
     }

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/driver/Port.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/driver/Port.java
@@ -152,7 +152,7 @@ public class Port {
      */
     public void clearModemDB() {
         logger.debug("clearing modem db!");
-        Map<InsteonAddress, @Nullable ModemDBEntry> dbes = getDriver().lockModemDBEntries();
+        Map<InsteonAddress, ModemDBEntry> dbes = getDriver().lockModemDBEntries();
         for (InsteonAddress addr : dbes.keySet()) {
             if (!dbes.get(addr).isModem()) {
                 dbes.remove(addr);

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonDeviceHandler.java
@@ -162,7 +162,7 @@ public class InsteonDeviceHandler extends BaseThingHandler {
             }
 
             String deviceConfig = config.getDeviceConfig();
-            Map<String, @Nullable Object> deviceConfigMap;
+            Map<String, Object> deviceConfigMap;
             if (deviceConfig != null) {
                 Type mapType = new TypeToken<Map<String, Object>>() {
                 }.getType();
@@ -368,7 +368,7 @@ public class InsteonDeviceHandler extends BaseThingHandler {
             return;
         }
 
-        Map<String, @Nullable String> params = new HashMap<>();
+        Map<String, String> params = new HashMap<>();
         Channel channel = getThing().getChannel(channelUID.getId());
 
         Map<String, Object> channelProperties = channel.getConfiguration().getProperties();

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/Msg.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/Msg.java
@@ -74,11 +74,11 @@ public class Msg {
     }
 
     // has the structure of all known messages
-    private static final Map<String, @Nullable Msg> MSG_MAP = new HashMap<>();
+    private static final Map<String, Msg> MSG_MAP = new HashMap<>();
     // maps between command number and the length of the header
-    private static final Map<Integer, @Nullable Integer> HEADER_MAP = new HashMap<>();
+    private static final Map<Integer, Integer> HEADER_MAP = new HashMap<>();
     // has templates for all message from modem to host
-    private static final Map<Integer, @Nullable Msg> REPLY_MAP = new HashMap<>();
+    private static final Map<Integer, Msg> REPLY_MAP = new HashMap<>();
 
     private int headerLength = -1;
     private byte @Nullable [] data = null;

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/MsgDefinition.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/MsgDefinition.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.insteon.internal.message;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -28,7 +29,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 @SuppressWarnings("null")
 public class MsgDefinition {
-    private HashMap<String, @Nullable Field> fields = new HashMap<>();
+    private Map<String, Field> fields = new HashMap<>();
 
     MsgDefinition() {
     }
@@ -42,7 +43,7 @@ public class MsgDefinition {
         fields = new HashMap<>(m.fields);
     }
 
-    public HashMap<String, @Nullable Field> getFields() {
+    public Map<String, Field> getFields() {
         return fields;
     }
 

--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/MsgType.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/message/MsgType.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.insteon.internal.message;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Represents insteon message type flags
@@ -47,7 +47,7 @@ public enum MsgType {
     ALL_LINK_CLEANUP_NACK(0xe0),
     INVALID(0xff); // should never happen
 
-    private static HashMap<Integer, @Nullable MsgType> hash = new HashMap<>();
+    private static Map<Integer, MsgType> hash = new HashMap<>();
 
     private byte byteValue = 0;
 
@@ -73,7 +73,6 @@ public enum MsgType {
 
     public static MsgType fromValue(byte b) throws IllegalArgumentException {
         int i = b & 0xe0;
-        @Nullable
         MsgType mt = hash.get(i);
         if (mt == null) {
             throw new IllegalArgumentException("msg type of byte value " + i + " not found");

--- a/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/handler/DeviceThingHandler.java
@@ -72,8 +72,8 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
     private final Set<GroupAddress> groupAddresses = new HashSet<>();
     private final Set<GroupAddress> groupAddressesWriteBlockedOnce = new HashSet<>();
     private final Set<OutboundSpec> groupAddressesRespondingSpec = new HashSet<>();
-    private final Map<GroupAddress, @Nullable ScheduledFuture<?>> readFutures = new HashMap<>();
-    private final Map<ChannelUID, @Nullable ScheduledFuture<?>> channelFutures = new HashMap<>();
+    private final Map<GroupAddress, ScheduledFuture<?>> readFutures = new HashMap<>();
+    private final Map<ChannelUID, ScheduledFuture<?>> channelFutures = new HashMap<>();
     private int readInterval;
 
     public DeviceThingHandler(Thing thing) {

--- a/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiHandlerFactory.java
+++ b/bundles/org.openhab.binding.kodi/src/main/java/org/openhab/binding/kodi/internal/KodiHandlerFactory.java
@@ -60,7 +60,7 @@ public class KodiHandlerFactory extends BaseThingHandlerFactory {
     private final KodiDynamicStateDescriptionProvider stateDescriptionProvider;
     private final WebSocketClient webSocketClient;
 
-    private final Map<String, @Nullable ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
 
     // url (scheme+server+port) to use for playing notification sounds
     private @Nullable String callbackUrl;

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleHandler.java
@@ -71,9 +71,9 @@ public class LcnModuleHandler extends BaseThingHandler {
     private static final Map<String, Converter> VALUE_CONVERTERS = new HashMap<>();
     private static final InversionConverter INVERSION_CONVERTER = new InversionConverter();
     private @Nullable LcnAddrMod moduleAddress;
-    private final Map<LcnChannelGroup, @Nullable AbstractLcnModuleSubHandler> subHandlers = new HashMap<>();
+    private final Map<LcnChannelGroup, AbstractLcnModuleSubHandler> subHandlers = new HashMap<>();
     private final List<AbstractLcnModuleSubHandler> metadataSubHandlers = new ArrayList<>();
-    private final Map<ChannelUID, @Nullable Converter> converters = new HashMap<>();
+    private final Map<ChannelUID, Converter> converters = new HashMap<>();
 
     static {
         VALUE_CONVERTERS.put("temperature", Converters.TEMPERATURE);
@@ -123,8 +123,9 @@ public class LcnModuleHandler extends BaseThingHandler {
                             converters.put(channel.getUID(), new S0Converter(parameterObject));
                             break;
                         default:
-                            if (VALUE_CONVERTERS.containsKey(unitObject)) {
-                                converters.put(channel.getUID(), VALUE_CONVERTERS.get(unitObject));
+                            Converter converter = VALUE_CONVERTERS.get(unitObject);
+                            if (converter != null) {
+                                converters.put(channel.getUID(), converter);
                             }
                             break;
                     }

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/connection/ModInfo.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/connection/ModInfo.java
@@ -82,7 +82,7 @@ public class ModInfo {
      * Variables request status.
      * Lazy initialization: Will be filled once the firmware version is known.
      */
-    private final Map<Variable, @Nullable RequestStatus> requestStatusVars = new HashMap<>();
+    private final Map<Variable, RequestStatus> requestStatusVars = new HashMap<>();
 
     /**
      * Caches the values of the variables, needed for changing the values.
@@ -291,9 +291,9 @@ public class ModInfo {
                     }
                 }
                 // Variables
-                for (Map.Entry<Variable, @Nullable RequestStatus> kv : this.requestStatusVars.entrySet()) {
+                for (Map.Entry<Variable, RequestStatus> kv : this.requestStatusVars.entrySet()) {
                     RequestStatus requestStatus = kv.getValue();
-                    if (requestStatus != null && requestStatus.shouldSendNextRequest(timeoutMSec, currTime)) {
+                    if (requestStatus.shouldSendNextRequest(timeoutMSec, currTime)) {
                         // Detect if we can send immediately or if we have to wait for a "typeless" request first
                         boolean hasTypeInResponse = kv.getKey().hasTypeInResponse(this.firmwareVersion);
                         if (hasTypeInResponse || this.lastRequestedVarWithoutTypeInResponse == Variable.UNKNOWN) {
@@ -351,9 +351,7 @@ public class ModInfo {
         // increase poll interval, if the LCN module sends status updates of a variable event-based
         requestStatusVars.entrySet().stream().filter(e -> e.getKey().isEventBased(firmwareVersion)).forEach(e -> {
             RequestStatus value = e.getValue();
-            if (value != null) {
-                value.setMaxAgeMSec(MAX_STATUS_EVENTBASED_VALUEAGE_MSEC);
-            }
+            value.setMaxAgeMSec(MAX_STATUS_EVENTBASED_VALUEAGE_MSEC);
         });
     }
 

--- a/bundles/org.openhab.binding.leapmotion/src/main/java/org/openhab/binding/leapmotion/internal/discovery/LeapMotionDiscoveryService.java
+++ b/bundles/org.openhab.binding.leapmotion/src/main/java/org/openhab/binding/leapmotion/internal/discovery/LeapMotionDiscoveryService.java
@@ -46,7 +46,7 @@ public class LeapMotionDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         leapController = new Controller();
         listener = new Listener() {
             @Override

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LauncherApplication.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/LauncherApplication.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class LauncherApplication extends BaseChannelHandler<AppInfo> {
     private final Logger logger = LoggerFactory.getLogger(LauncherApplication.class);
-    private final Map<ThingUID, @Nullable List<AppInfo>> applicationListCache = new HashMap<>();
+    private final Map<ThingUID, List<AppInfo>> applicationListCache = new HashMap<>();
     private final ResponseListener<LaunchSession> launchSessionResponseListener = createResponseListener();
 
     @Override

--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/TVControlChannel.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/TVControlChannel.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class TVControlChannel extends BaseChannelHandler<ChannelInfo> {
     private final Logger logger = LoggerFactory.getLogger(TVControlChannel.class);
-    private final Map<ThingUID, @Nullable List<ChannelInfo>> channelListCache = new HashMap<>();
+    private final Map<ThingUID, List<ChannelInfo>> channelListCache = new HashMap<>();
     private final ResponseListener<CommandConfirmation> objResponseListener = createResponseListener();
 
     @Override

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightDiscovery.java
@@ -69,7 +69,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(LifxLightDiscovery.class);
 
-    private final Map<MACAddress, @Nullable DiscoveredLight> discoveredLights = new HashMap<>();
+    private final Map<MACAddress, DiscoveredLight> discoveredLights = new HashMap<>();
     private final long sourceId = randomSourceId();
     private final Supplier<Integer> sequenceNumberSupplier = new LifxSequenceNumberSupplier();
 
@@ -121,13 +121,13 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
     @Activate
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 
     @Modified
     @Override
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 
@@ -248,9 +248,6 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         // Iterate through the discovered lights that have to be set up, and the packets that have to be sent
         // Workaround to avoid a ConcurrentModifictionException on the selector.SelectedKeys() Set
         for (DiscoveredLight light : discoveredLights.values()) {
-            if (light == null) {
-                continue;
-            }
             boolean waitingForLightResponse = System.currentTimeMillis() - light.lastRequestTimeMillis < 200;
 
             if (light.supportedProduct && !light.isDataComplete() && !waitingForLightResponse) {

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightStateChanger.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxLightStateChanger.java
@@ -85,7 +85,7 @@ public class LifxLightStateChanger implements LifxLightStateListener {
 
     private @Nullable ScheduledFuture<?> sendJob;
 
-    private Map<Integer, @Nullable List<PendingPacket>> pendingPacketsMap = new ConcurrentHashMap<>();
+    private Map<Integer, List<PendingPacket>> pendingPacketsMap = new ConcurrentHashMap<>();
 
     private class PendingPacket {
 
@@ -230,12 +230,10 @@ public class LifxLightStateChanger implements LifxLightStateListener {
     private @Nullable PendingPacket findPacketToSend() {
         PendingPacket result = null;
         for (List<PendingPacket> pendingPackets : pendingPacketsMap.values()) {
-            if (pendingPackets != null) {
-                for (PendingPacket pendingPacket : pendingPackets) {
-                    if (pendingPacket.hasAcknowledgeIntervalElapsed()
-                            && (result == null || pendingPacket.lastSend < result.lastSend)) {
-                        result = pendingPacket;
-                    }
+            for (PendingPacket pendingPacket : pendingPackets) {
+                if (pendingPacket.hasAcknowledgeIntervalElapsed()
+                        && (result == null || pendingPacket.lastSend < result.lastSend)) {
+                    result = pendingPacket;
                 }
             }
         }
@@ -254,15 +252,13 @@ public class LifxLightStateChanger implements LifxLightStateListener {
 
     private void removeFailedPackets() {
         for (List<PendingPacket> pendingPackets : pendingPacketsMap.values()) {
-            if (pendingPackets != null) {
-                Iterator<PendingPacket> it = pendingPackets.iterator();
-                while (it.hasNext()) {
-                    PendingPacket pendingPacket = it.next();
-                    if (pendingPacket.sendCount > MAX_RETRIES && pendingPacket.hasAcknowledgeIntervalElapsed()) {
-                        logger.warn("{} failed (unacknowledged {} times to light {})",
-                                pendingPacket.packet.getClass().getSimpleName(), pendingPacket.sendCount, logId);
-                        it.remove();
-                    }
+            Iterator<PendingPacket> it = pendingPackets.iterator();
+            while (it.hasNext()) {
+                PendingPacket pendingPacket = it.next();
+                if (pendingPacket.sendCount > MAX_RETRIES && pendingPacket.hasAcknowledgeIntervalElapsed()) {
+                    logger.warn("{} failed (unacknowledged {} times to light {})",
+                            pendingPacket.packet.getClass().getSimpleName(), pendingPacket.sendCount, logId);
+                    it.remove();
                 }
             }
         }
@@ -270,14 +266,12 @@ public class LifxLightStateChanger implements LifxLightStateListener {
 
     private @Nullable PendingPacket removeAcknowledgedPacket(int sequenceNumber) {
         for (List<PendingPacket> pendingPackets : pendingPacketsMap.values()) {
-            if (pendingPackets != null) {
-                Iterator<PendingPacket> it = pendingPackets.iterator();
-                while (it.hasNext()) {
-                    PendingPacket pendingPacket = it.next();
-                    if (pendingPacket.packet.getSequence() == sequenceNumber) {
-                        it.remove();
-                        return pendingPacket;
-                    }
+            Iterator<PendingPacket> it = pendingPackets.iterator();
+            while (it.hasNext()) {
+                PendingPacket pendingPacket = it.next();
+                if (pendingPacket.packet.getSequence() == sequenceNumber) {
+                    it.remove();
+                    return pendingPacket;
                 }
             }
         }

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxThrottlingUtil.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxThrottlingUtil.java
@@ -79,7 +79,7 @@ public final class LifxThrottlingUtil {
      */
     private static List<LifxLightCommunicationTracker> trackers = new CopyOnWriteArrayList<>();
 
-    private static Map<MACAddress, @Nullable LifxLightCommunicationTracker> macTrackerMapping = new ConcurrentHashMap<>();
+    private static Map<MACAddress, LifxLightCommunicationTracker> macTrackerMapping = new ConcurrentHashMap<>();
 
     public static void lock(@Nullable MACAddress mac) {
         if (mac != null) {

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/LutronHandlerFactory.java
@@ -131,7 +131,7 @@ public class LutronHandlerFactory extends BaseThingHandlerFactory {
                 || HW_DISCOVERABLE_DEVICE_TYPES_UIDS.contains(thingTypeUID);
     }
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegMap = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegMap = new HashMap<>();
     // Marked as Nullable only to fix incorrect redundant null check complaints after adding null annotations
 
     @Override

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/discovery/LutronMcastBridgeDiscoveryService.java
@@ -171,7 +171,7 @@ public class LutronMcastBridgeDiscoveryService extends AbstractDiscoveryService 
                     StandardCharsets.US_ASCII);
 
             Matcher matcher = BRIDGE_PROP_PATTERN.matcher(data);
-            Map<String, @Nullable String> bridgeProperties = new HashMap<>();
+            Map<String, String> bridgeProperties = new HashMap<>();
 
             while (matcher.find()) {
                 bridgeProperties.put(matcher.group(1), matcher.group(2));

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfig.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/keypadconfig/KeypadConfig.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public abstract class KeypadConfig {
     private final Logger logger = LoggerFactory.getLogger(KeypadConfig.class);
 
-    protected final HashMap<String, @Nullable List<KeypadComponent>> modelData = new HashMap<>();
+    protected final Map<String, List<KeypadComponent>> modelData = new HashMap<>();
 
     public abstract boolean isCCI(int id);
 

--- a/bundles/org.openhab.binding.melcloud/src/main/java/org/openhab/binding/melcloud/internal/discovery/MelCloudDiscoveryService.java
+++ b/bundles/org.openhab.binding.melcloud/src/main/java/org/openhab/binding/melcloud/internal/discovery/MelCloudDiscoveryService.java
@@ -61,7 +61,7 @@ public class MelCloudDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    protected void activate(Map<String, @Nullable Object> configProperties) {
+    protected void activate(Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 
@@ -72,7 +72,7 @@ public class MelCloudDiscoveryService extends AbstractDiscoveryService
 
     @Override
     @Modified
-    protected void modified(Map<String, @Nullable Object> configProperties) {
+    protected void modified(Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/handler/MPDHandler.java
+++ b/bundles/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/handler/MPDHandler.java
@@ -60,7 +60,7 @@ public class MPDHandler extends BaseThingHandler implements MPDEventListener {
 
     private final Logger logger = LoggerFactory.getLogger(MPDHandler.class);
 
-    private Map<String, @Nullable State> stateMap = Collections.synchronizedMap(new HashMap<String, @Nullable State>());
+    private Map<String, State> stateMap = Collections.synchronizedMap(new HashMap<>());
 
     private final MPDConnection connection;
     private int volume = 0;

--- a/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
+++ b/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestHandlerFactory.java
@@ -60,7 +60,7 @@ public class NestHandlerFactory extends BaseThingHandlerFactory {
 
     private final ClientBuilder clientBuilder;
     private final SseEventSourceFactory eventSourceFactory;
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryService = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryService = new HashMap<>();
 
     @Activate
     public NestHandlerFactory(@Reference ClientBuilder clientBuilder,

--- a/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/update/NestCompositeUpdateHandler.java
+++ b/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/update/NestCompositeUpdateHandler.java
@@ -35,7 +35,7 @@ import org.openhab.binding.nest.internal.listener.NestThingDataListener;
 public class NestCompositeUpdateHandler {
 
     private final Supplier<Set<String>> presentNestIdsSupplier;
-    private final Map<Class<?>, @Nullable NestUpdateHandler<?>> updateHandlersMap = new ConcurrentHashMap<>();
+    private final Map<Class<?>, NestUpdateHandler<?>> updateHandlersMap = new ConcurrentHashMap<>();
 
     public NestCompositeUpdateHandler(Supplier<Set<String>> presentNestIdsSupplier) {
         this.presentNestIdsSupplier = presentNestIdsSupplier;
@@ -104,9 +104,7 @@ public class NestCompositeUpdateHandler {
         Set<String> missingNestIds = findMissingNestIds(updates);
         if (!missingNestIds.isEmpty()) {
             updateHandlersMap.values().forEach(handler -> {
-                if (handler != null) {
-                    handler.handleMissingNestIds(missingNestIds);
-                }
+                handler.handleMissingNestIds(missingNestIds);
             });
         }
     }
@@ -121,9 +119,7 @@ public class NestCompositeUpdateHandler {
 
     public void resendLastUpdates() {
         updateHandlersMap.values().forEach(handler -> {
-            if (handler != null) {
-                handler.resendLastUpdates();
-            }
+            handler.resendLastUpdates();
         });
     }
 }

--- a/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/update/NestUpdateHandler.java
+++ b/bundles/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/update/NestUpdateHandler.java
@@ -39,8 +39,8 @@ public class NestUpdateHandler<T> {
      */
     private static final String ANY_ID = "*";
 
-    private final Map<String, @Nullable T> lastUpdates = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable Set<NestThingDataListener<T>>> listenersMap = new ConcurrentHashMap<>();
+    private final Map<String, T> lastUpdates = new ConcurrentHashMap<>();
+    private final Map<String, Set<NestThingDataListener<T>>> listenersMap = new ConcurrentHashMap<>();
 
     public boolean addListener(NestThingDataListener<T> listener) {
         return addListener(ANY_ID, listener);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoHandlerFactory.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoHandlerFactory.java
@@ -68,8 +68,8 @@ import org.slf4j.LoggerFactory;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.netatmo")
 public class NetatmoHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(NetatmoHandlerFactory.class);
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> webHookServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> webHookServiceRegs = new HashMap<>();
     private final HttpService httpService;
     private final NATherm1StateDescriptionProvider stateDescriptionProvider;
     private final TimeZoneProvider timeZoneProvider;
@@ -158,7 +158,7 @@ public class NetatmoHandlerFactory extends BaseThingHandlerFactory {
         if (bundleContext != null) {
             NetatmoModuleDiscoveryService discoveryService = new NetatmoModuleDiscoveryService(netatmoBridgeHandler,
                     localeProvider, translationProvider);
-            Map<String, @Nullable Object> configProperties = new HashMap<>();
+            Map<String, Object> configProperties = new HashMap<>();
             configProperties.put(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY,
                     Boolean.valueOf(backgroundDiscovery));
             discoveryService.activate(configProperties);

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryService.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/discovery/NetatmoModuleDiscoveryService.java
@@ -58,7 +58,7 @@ public class NetatmoModuleDiscoveryService extends AbstractDiscoveryService impl
     }
 
     @Override
-    public void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    public void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
         netatmoBridgeHandler.registerDataListener(this);
     }

--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/discovery/NetworkDiscoveryService.java
@@ -79,14 +79,14 @@ public class NetworkDiscoveryService extends AbstractDiscoveryService implements
 
     @Override
     @Activate
-    public void activate(@Nullable Map<String, @Nullable Object> config) {
+    public void activate(@Nullable Map<String, Object> config) {
         super.activate(config);
         modified(config);
     }
 
     @Override
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> config) {
+    protected void modified(@Nullable Map<String, Object> config) {
         super.modified(config);
         // We update instead of replace the configuration object, so that if the user updates the
         // configuration, the values are automatically available in all handlers. Because they all

--- a/bundles/org.openhab.binding.networkupstools/src/main/java/org/openhab/binding/networkupstools/internal/NUTHandler.java
+++ b/bundles/org.openhab.binding.networkupstools/src/main/java/org/openhab/binding/networkupstools/internal/NUTHandler.java
@@ -64,7 +64,7 @@ public class NUTHandler extends BaseThingHandler {
      * Map to cache user configured channels with their configuration. Channels are dynamically created at
      * initialization phase of the thing.
      */
-    private final Map<ChannelUID, @Nullable NUTDynamicChannelConfiguration> userChannelToNutMap = new HashMap<>();
+    private final Map<ChannelUID, NUTDynamicChannelConfiguration> userChannelToNutMap = new HashMap<>();
     /**
      * Cache of the UPS status. When expired makes a call to the NUT server is done to get the actual status. Expires at
      * the

--- a/bundles/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/handler/UplinkBaseHandler.java
+++ b/bundles/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/handler/UplinkBaseHandler.java
@@ -169,7 +169,7 @@ public abstract class UplinkBaseHandler extends BaseThingHandler implements Nibe
      * @param values map containing the data updates
      */
     @Override
-    public void updateChannelStatus(Map<Channel, @Nullable State> values) {
+    public void updateChannelStatus(Map<Channel, State> values) {
         logger.debug("Handling channel update. ({} Channels)", values.size());
 
         for (Channel channel : values.keySet()) {

--- a/bundles/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/GenericDataResponse.java
+++ b/bundles/org.openhab.binding.nibeuplink/src/main/java/org/openhab/binding/nibeuplink/internal/model/GenericDataResponse.java
@@ -33,7 +33,6 @@ import com.google.gson.annotations.SerializedName;
 public class GenericDataResponse implements DataResponse {
     private final Logger logger = LoggerFactory.getLogger(GenericDataResponse.class);
 
-    @NonNullByDefault
     public static class Value {
         @SerializedName("VariableId")
         private @Nullable String variableId;

--- a/bundles/org.openhab.binding.ntp/src/main/java/org/openhab/binding/ntp/internal/discovery/NtpDiscovery.java
+++ b/bundles/org.openhab.binding.ntp/src/main/java/org/openhab/binding/ntp/internal/discovery/NtpDiscovery.java
@@ -48,7 +48,7 @@ public class NtpDiscovery extends AbstractDiscoveryService {
     @Activate
     public NtpDiscovery(final @Reference LocaleProvider localeProvider,
             final @Reference TranslationProvider i18nProvider, final @Reference TimeZoneProvider timeZoneProvider,
-            @Nullable Map<String, @Nullable Object> configProperties) throws IllegalArgumentException {
+            @Nullable Map<String, Object> configProperties) throws IllegalArgumentException {
         super(SUPPORTED_THING_TYPES_UIDS, 2);
         this.localeProvider = localeProvider;
         this.i18nProvider = i18nProvider;

--- a/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwHandlerFactory.java
+++ b/bundles/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OwHandlerFactory.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.onewire")
 public class OwHandlerFactory extends BaseThingHandlerFactory {
     Logger logger = LoggerFactory.getLogger(OwHandlerFactory.class);
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     @NonNullByDefault({})
     private OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider;

--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoStateDescriptionProvider.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoStateDescriptionProvider.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = { DynamicStateDescriptionProvider.class, OnkyoStateDescriptionProvider.class })
 @NonNullByDefault
 public class OnkyoStateDescriptionProvider implements DynamicStateDescriptionProvider {
-    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+    private final Map<ChannelUID, List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
 
     public void setStateOptions(ChannelUID channelUID, List<StateOption> options) {
         channelOptionsMap.put(channelUID, options);

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/GatewayCommand.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/GatewayCommand.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 /**
  * The {@link GatewayCommand} is used to validate and match commands send through the binding
  * to the OpenTherm gateway device.
- * 
+ *
  * @author Arjen Korevaar - Initial contribution
  */
 @NonNullByDefault

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/discovery/OpenWeatherMapDiscoveryService.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/discovery/OpenWeatherMapDiscoveryService.java
@@ -66,7 +66,7 @@ public class OpenWeatherMapDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/factory/OpenWeatherMapHandlerFactory.java
+++ b/bundles/org.openhab.binding.openweathermap/src/main/java/org/openhab/binding/openweathermap/internal/factory/OpenWeatherMapHandlerFactory.java
@@ -61,7 +61,7 @@ public class OpenWeatherMapHandlerFactory extends BaseThingHandlerFactory {
             .unmodifiableSet(Stream.concat(OpenWeatherMapAPIHandler.SUPPORTED_THING_TYPES.stream(),
                     AbstractOpenWeatherMapHandler.SUPPORTED_THING_TYPES.stream()).collect(Collectors.toSet()));
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
     private final HttpClient httpClient;
     private final LocaleProvider localeProvider;
     private final LocationProvider locationProvider;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetBridgeHandler.java
@@ -70,7 +70,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
 
     // ConcurrentHashMap of devices registered to this BridgeHandler
     // association is: ownId (String) -> OpenWebNetThingHandler, with ownId = WHO.WHERE
-    private Map<String, @Nullable OpenWebNetThingHandler> registeredDevices = new ConcurrentHashMap<>();
+    private Map<String, OpenWebNetThingHandler> registeredDevices = new ConcurrentHashMap<>();
 
     protected @Nullable OpenGateway gateway;
     private boolean isBusGateway = false;

--- a/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/handlers/ParadoxAlarmHandlerFactory.java
+++ b/bundles/org.openhab.binding.paradoxalarm/src/main/java/org/openhab/binding/paradoxalarm/internal/handlers/ParadoxAlarmHandlerFactory.java
@@ -46,7 +46,7 @@ public class ParadoxAlarmHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(ParadoxAlarmHandlerFactory.class);
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/PLCLogoBindingConstants.java
+++ b/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/PLCLogoBindingConstants.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**
@@ -82,7 +81,7 @@ public class PLCLogoBindingConstants {
     public static final String NI_ANALOG = "NAI"; // Network analog input
     public static final String NQ_ANALOG = "NAQ"; // Network analog output
 
-    private static final Map<Integer, @Nullable String> LOGO_STATES_0BA7;
+    private static final Map<Integer, String> LOGO_STATES_0BA7;
     static {
         Map<Integer, String> buffer = new HashMap<>();
         // buffer.put(???, "Network access error"); // Netzwerkzugriffsfehler
@@ -92,7 +91,7 @@ public class PLCLogoBindingConstants {
         LOGO_STATES_0BA7 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<Integer, @Nullable String> LOGO_STATES_0BA8;
+    private static final Map<Integer, String> LOGO_STATES_0BA8;
     static {
         Map<Integer, String> buffer = new HashMap<>();
         buffer.put(1, "Ethernet link error"); // Netzwerk Verbindungsfehler
@@ -104,9 +103,9 @@ public class PLCLogoBindingConstants {
         LOGO_STATES_0BA8 = Collections.unmodifiableMap(buffer);
     }
 
-    public static final Map<String, @Nullable Map<Integer, @Nullable String>> LOGO_STATES;
+    public static final Map<String, Map<Integer, String>> LOGO_STATES;
     static {
-        Map<String, @Nullable Map<Integer, @Nullable String>> buffer = new HashMap<>();
+        Map<String, Map<Integer, String>> buffer = new HashMap<>();
         buffer.put(LOGO_0BA7, LOGO_STATES_0BA7);
         buffer.put(LOGO_0BA8, LOGO_STATES_0BA8);
         LOGO_STATES = Collections.unmodifiableMap(buffer);
@@ -122,18 +121,18 @@ public class PLCLogoBindingConstants {
         }
     }
 
-    public static final Map<String, @Nullable Layout> LOGO_CHANNELS;
+    public static final Map<String, Layout> LOGO_CHANNELS;
     static {
-        Map<String, @Nullable Layout> buffer = new HashMap<>();
+        Map<String, Layout> buffer = new HashMap<>();
         buffer.put(DAIGNOSTICS_CHANNEL, new Layout(984, 1)); // Diagnostics starts at 984 for 1 byte
         buffer.put(RTC_CHANNEL, new Layout(985, 6)); // RTC starts at 985 for 6 bytes: year month day hour minute second
         buffer.put(DAY_OF_WEEK_CHANNEL, new Layout(998, 1)); // Diagnostics starts at 998 for 1 byte
         LOGO_CHANNELS = Collections.unmodifiableMap(buffer);
     }
 
-    public static final Map<Integer, @Nullable String> DAY_OF_WEEK;
+    public static final Map<Integer, String> DAY_OF_WEEK;
     static {
-        Map<Integer, @Nullable String> buffer = new HashMap<>();
+        Map<Integer, String> buffer = new HashMap<>();
         buffer.put(1, "SUNDAY");
         buffer.put(2, "MONDAY");
         buffer.put(3, "TUEsDAY");
@@ -144,9 +143,9 @@ public class PLCLogoBindingConstants {
         DAY_OF_WEEK = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Layout> LOGO_MEMORY_0BA7;
+    private static final Map<String, Layout> LOGO_MEMORY_0BA7;
     static {
-        Map<String, @Nullable Layout> buffer = new HashMap<>();
+        Map<String, Layout> buffer = new HashMap<>();
         buffer.put(MEMORY_BYTE, new Layout(0, 850));
         buffer.put(MEMORY_DWORD, new Layout(0, 850));
         buffer.put(MEMORY_WORD, new Layout(0, 850));
@@ -160,9 +159,9 @@ public class PLCLogoBindingConstants {
         LOGO_MEMORY_0BA7 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Layout> LOGO_MEMORY_0BA8;
+    private static final Map<String, Layout> LOGO_MEMORY_0BA8;
     static {
-        Map<String, @Nullable Layout> buffer = new HashMap<>();
+        Map<String, Layout> buffer = new HashMap<>();
         buffer.put(MEMORY_BYTE, new Layout(0, 850));
         buffer.put(MEMORY_DWORD, new Layout(0, 850));
         buffer.put(MEMORY_WORD, new Layout(0, 850));
@@ -180,9 +179,9 @@ public class PLCLogoBindingConstants {
         LOGO_MEMORY_0BA8 = Collections.unmodifiableMap(buffer);
     }
 
-    public static final Map<String, @Nullable Map<String, @Nullable Layout>> LOGO_MEMORY_BLOCK;
+    public static final Map<String, Map<String, Layout>> LOGO_MEMORY_BLOCK;
     static {
-        Map<String, @Nullable Map<String, @Nullable Layout>> buffer = new HashMap<>();
+        Map<String, Map<String, Layout>> buffer = new HashMap<>();
         buffer.put(LOGO_0BA7, LOGO_MEMORY_0BA7);
         buffer.put(LOGO_0BA8, LOGO_MEMORY_0BA8);
         LOGO_MEMORY_BLOCK = Collections.unmodifiableMap(buffer);

--- a/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCAnalogHandler.java
+++ b/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCAnalogHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.plclogo.internal.PLCLogoClient;
 import org.openhab.binding.plclogo.internal.config.PLCAnalogConfiguration;
 import org.openhab.core.config.core.Configuration;
@@ -59,18 +58,18 @@ public class PLCAnalogHandler extends PLCCommonHandler {
     private final Logger logger = LoggerFactory.getLogger(PLCAnalogHandler.class);
     private AtomicReference<PLCAnalogConfiguration> config = new AtomicReference<>();
 
-    private static final Map<String, @Nullable Integer> LOGO_BLOCKS_0BA7;
+    private static final Map<String, Integer> LOGO_BLOCKS_0BA7;
     static {
-        Map<String, @Nullable Integer> buffer = new HashMap<>();
+        Map<String, Integer> buffer = new HashMap<>();
         buffer.put(I_ANALOG, 8); // 8 analog inputs
         buffer.put(Q_ANALOG, 2); // 2 analog outputs
         buffer.put(M_ANALOG, 16); // 16 analog markers
         LOGO_BLOCKS_0BA7 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Integer> LOGO_BLOCKS_0BA8;
+    private static final Map<String, Integer> LOGO_BLOCKS_0BA8;
     static {
-        Map<String, @Nullable Integer> buffer = new HashMap<>();
+        Map<String, Integer> buffer = new HashMap<>();
         buffer.put(I_ANALOG, 8); // 8 analog inputs
         buffer.put(Q_ANALOG, 8); // 8 analog outputs
         buffer.put(M_ANALOG, 64); // 64 analog markers
@@ -79,9 +78,9 @@ public class PLCAnalogHandler extends PLCCommonHandler {
         LOGO_BLOCKS_0BA8 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Map<String, @Nullable Integer>> LOGO_BLOCK_NUMBER;
+    private static final Map<String, Map<String, Integer>> LOGO_BLOCK_NUMBER;
     static {
-        Map<String, @Nullable Map<String, @Nullable Integer>> buffer = new HashMap<>();
+        Map<String, Map<String, Integer>> buffer = new HashMap<>();
         buffer.put(LOGO_0BA7, LOGO_BLOCKS_0BA7);
         buffer.put(LOGO_0BA8, LOGO_BLOCKS_0BA8);
         LOGO_BLOCK_NUMBER = Collections.unmodifiableMap(buffer);
@@ -217,7 +216,7 @@ public class PLCAnalogHandler extends PLCCommonHandler {
         String family = getLogoFamily();
         logger.debug("Get block number of {} LOGO! for {} blocks.", family, kind);
 
-        Map<?, @Nullable Integer> blocks = LOGO_BLOCK_NUMBER.get(family);
+        Map<?, Integer> blocks = LOGO_BLOCK_NUMBER.get(family);
         Integer number = (blocks != null) ? blocks.get(kind) : null;
         return (number != null) ? number.intValue() : 0;
     }

--- a/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCBridgeHandler.java
+++ b/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCBridgeHandler.java
@@ -64,7 +64,7 @@ public class PLCBridgeHandler extends BaseBridgeHandler {
 
     private final Logger logger = LoggerFactory.getLogger(PLCBridgeHandler.class);
 
-    private Map<ChannelUID, @Nullable String> oldValues = new HashMap<>();
+    private Map<ChannelUID, String> oldValues = new HashMap<>();
 
     @Nullable
     private volatile PLCLogoClient client; // S7 client used for communication with Logo!
@@ -94,7 +94,7 @@ public class PLCBridgeHandler extends BaseBridgeHandler {
         @Override
         public void run() {
             PLCLogoClient localClient = client;
-            Map<?, @Nullable Layout> memory = LOGO_MEMORY_BLOCK.get(getLogoFamily());
+            Map<?, Layout> memory = LOGO_MEMORY_BLOCK.get(getLogoFamily());
             Layout layout = (memory != null) ? memory.get(MEMORY_SIZE) : null;
             if ((layout != null) && (localClient != null)) {
                 try {
@@ -172,7 +172,7 @@ public class PLCBridgeHandler extends BaseBridgeHandler {
                     rtc.set(clock);
                     updateState(channelUID, new DateTimeType(clock));
                 } else if (DAIGNOSTICS_CHANNEL.equals(channelId)) {
-                    Map<Integer, @Nullable String> states = LOGO_STATES.get(getLogoFamily());
+                    Map<Integer, String> states = LOGO_STATES.get(getLogoFamily());
                     if (states != null) {
                         for (Integer key : states.keySet()) {
                             String message = states.get(buffer[0] & key.intValue());

--- a/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCCommonHandler.java
+++ b/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCCommonHandler.java
@@ -96,7 +96,7 @@ public abstract class PLCCommonHandler extends BaseThingHandler {
         String family = getLogoFamily();
         logger.debug("Get start address of {} LOGO! for {} blocks.", family, kind);
 
-        Map<?, @Nullable Layout> memory = LOGO_MEMORY_BLOCK.get(family);
+        Map<?, Layout> memory = LOGO_MEMORY_BLOCK.get(family);
         Layout layout = (memory != null) ? memory.get(kind) : null;
         return layout != null ? layout.address : INVALID;
     }
@@ -111,7 +111,7 @@ public abstract class PLCCommonHandler extends BaseThingHandler {
         String family = getLogoFamily();
         logger.debug("Get data buffer length of {} LOGO! for {} blocks.", family, kind);
 
-        Map<?, @Nullable Layout> memory = LOGO_MEMORY_BLOCK.get(family);
+        Map<?, Layout> memory = LOGO_MEMORY_BLOCK.get(family);
         Layout layout = (memory != null) ? memory.get(kind) : null;
         return layout != null ? layout.length : 0;
     }
@@ -186,7 +186,7 @@ public abstract class PLCCommonHandler extends BaseThingHandler {
         logger.debug("Get base address of {} LOGO! for block {} .", family, name);
 
         String block = name.split("\\.")[0];
-        Map<?, @Nullable Layout> memory = LOGO_MEMORY_BLOCK.get(family);
+        Map<?, Layout> memory = LOGO_MEMORY_BLOCK.get(family);
         if (isValid(name) && !block.isEmpty() && (memory != null)) {
             if (Character.isDigit(block.charAt(1))) {
                 layout = memory.get(block.substring(0, 1));

--- a/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCDigitalHandler.java
+++ b/bundles/org.openhab.binding.plclogo/src/main/java/org/openhab/binding/plclogo/internal/handler/PLCDigitalHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.plclogo.internal.PLCLogoClient;
 import org.openhab.binding.plclogo.internal.config.PLCDigitalConfiguration;
 import org.openhab.core.config.core.Configuration;
@@ -61,18 +60,18 @@ public class PLCDigitalHandler extends PLCCommonHandler {
     private final Logger logger = LoggerFactory.getLogger(PLCDigitalHandler.class);
     private AtomicReference<PLCDigitalConfiguration> config = new AtomicReference<>();
 
-    private static final Map<String, @Nullable Integer> LOGO_BLOCKS_0BA7;
+    private static final Map<String, Integer> LOGO_BLOCKS_0BA7;
     static {
-        Map<String, @Nullable Integer> buffer = new HashMap<>();
+        Map<String, Integer> buffer = new HashMap<>();
         buffer.put(I_DIGITAL, 24); // 24 digital inputs
         buffer.put(Q_DIGITAL, 16); // 16 digital outputs
         buffer.put(M_DIGITAL, 27); // 27 digital markers
         LOGO_BLOCKS_0BA7 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Integer> LOGO_BLOCKS_0BA8;
+    private static final Map<String, Integer> LOGO_BLOCKS_0BA8;
     static {
-        Map<String, @Nullable Integer> buffer = new HashMap<>();
+        Map<String, Integer> buffer = new HashMap<>();
         buffer.put(I_DIGITAL, 24); // 24 digital inputs
         buffer.put(Q_DIGITAL, 20); // 20 digital outputs
         buffer.put(M_DIGITAL, 64); // 64 digital markers
@@ -81,9 +80,9 @@ public class PLCDigitalHandler extends PLCCommonHandler {
         LOGO_BLOCKS_0BA8 = Collections.unmodifiableMap(buffer);
     }
 
-    private static final Map<String, @Nullable Map<String, @Nullable Integer>> LOGO_BLOCK_NUMBER;
+    private static final Map<String, Map<String, Integer>> LOGO_BLOCK_NUMBER;
     static {
-        Map<String, @Nullable Map<String, @Nullable Integer>> buffer = new HashMap<>();
+        Map<String, Map<String, Integer>> buffer = new HashMap<>();
         buffer.put(LOGO_0BA7, LOGO_BLOCKS_0BA7);
         buffer.put(LOGO_0BA8, LOGO_BLOCKS_0BA8);
         LOGO_BLOCK_NUMBER = Collections.unmodifiableMap(buffer);
@@ -227,7 +226,7 @@ public class PLCDigitalHandler extends PLCCommonHandler {
         String family = getLogoFamily();
         logger.debug("Get block number of {} LOGO! for {} blocks.", family, kind);
 
-        Map<?, @Nullable Integer> blocks = LOGO_BLOCK_NUMBER.get(family);
+        Map<?, Integer> blocks = LOGO_BLOCK_NUMBER.get(family);
         Integer number = (blocks != null) ? blocks.get(kind) : null;
         return (number != null) ? number.intValue() : 0;
     }

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseHandlerFactory.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.plugwise")
 public class PlugwiseHandlerFactory extends BaseThingHandlerFactory {
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegistrations = new HashMap<>();
 
     private final SerialPortManager serialPortManager;
 

--- a/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseThingDiscoveryService.java
@@ -102,7 +102,7 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
     private @Nullable ScheduledFuture<?> watchJob;
     private CurrentRoleCall currentRoleCall = new CurrentRoleCall();
 
-    private final Map<MACAddress, @Nullable DiscoveredNode> discoveredNodes = new ConcurrentHashMap<>();
+    private final Map<MACAddress, DiscoveredNode> discoveredNodes = new ConcurrentHashMap<>();
 
     public PlugwiseThingDiscoveryService(PlugwiseStickHandler stickHandler) throws IllegalArgumentException {
         super(DISCOVERED_THING_TYPES_UIDS, 1, true);
@@ -309,16 +309,16 @@ public class PlugwiseThingDiscoveryService extends AbstractDiscoveryService
                 }
             }
 
-            Iterator<Entry<MACAddress, @Nullable DiscoveredNode>> it = discoveredNodes.entrySet().iterator();
+            Iterator<Entry<MACAddress, DiscoveredNode>> it = discoveredNodes.entrySet().iterator();
             while (it.hasNext()) {
-                Entry<MACAddress, @Nullable DiscoveredNode> entry = it.next();
+                Entry<MACAddress, DiscoveredNode> entry = it.next();
                 DiscoveredNode node = entry.getValue();
-                if (node != null && (System.currentTimeMillis() - node.lastRequestMillis) > (MESSAGE_TIMEOUT * 1000)
+                if (System.currentTimeMillis() - node.lastRequestMillis > (MESSAGE_TIMEOUT * 1000)
                         && node.attempts < MESSAGE_RETRY_ATTEMPTS) {
                     logger.debug("Resending timed out information request message to node ({})", node.macAddress);
                     updateInformation(node.macAddress);
                     node.attempts++;
-                } else if (node != null && node.attempts >= MESSAGE_RETRY_ATTEMPTS) {
+                } else if (node.attempts >= MESSAGE_RETRY_ATTEMPTS) {
                     logger.debug("Giving up on information request for node ({})", node.macAddress);
                     it.remove();
                 }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowermaxHandlerFactory.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowermaxHandlerFactory.java
@@ -49,7 +49,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.powermax")
 public class PowermaxHandlerFactory extends BaseThingHandlerFactory {
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     private final SerialPortManager serialPortManager;
     private final TimeZoneProvider timeZoneProvider;

--- a/bundles/org.openhab.binding.sagercaster/src/main/java/org/openhab/binding/sagercaster/internal/discovery/SagerCasterDiscoveryService.java
+++ b/bundles/org.openhab.binding.sagercaster/src/main/java/org/openhab/binding/sagercaster/internal/discovery/SagerCasterDiscoveryService.java
@@ -60,12 +60,12 @@ public class SagerCasterDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 
     @Override
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/EventDispatcher.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/EventDispatcher.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +37,7 @@ public class EventDispatcher {
     private final Set<SatelEventListener> eventListeners = new CopyOnWriteArraySet<>();
 
     @SuppressWarnings("unchecked")
-    private final Map<Class<? extends SatelEvent>, @Nullable Method> eventHandlers = Stream
+    private final Map<Class<? extends SatelEvent>, Method> eventHandlers = Stream
             .of(SatelEventListener.class.getDeclaredMethods())
             .filter(m -> m.getParameterCount() == 1 && SatelEvent.class.isAssignableFrom(m.getParameterTypes()[0]))
             .collect(Collectors.toMap(m -> (Class<SatelEvent>) m.getParameterTypes()[0], m -> m));

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
@@ -70,7 +70,7 @@ public class RdsDataPoints {
      * the Map, and b) by pointClass (which we do indirectly "double dereferenced"
      * via this index
      */
-    private final Map<String, @Nullable String> indexClassToId = new HashMap<>();
+    private final Map<String, String> indexClassToId = new HashMap<>();
 
     @SerializedName("totalCount")
     private @Nullable String totalCount;
@@ -323,11 +323,11 @@ public class RdsDataPoints {
                         throw new RdsCloudException("existing vs. new point class mismatch");
                     }
 
-                    myPoint.refreshValueFrom((BasePoint) newPoint);
+                    myPoint.refreshValueFrom(newPoint);
 
                     if (logger.isDebugEnabled()) {
                         logger.debug("refresh {}.{}: {} << {}", getDescription(), myPoint.getPointClass(),
-                                myPoint.getState(), ((BasePoint) newPoint).getState());
+                                myPoint.getState(), newPoint.getState());
                     }
                 }
             }
@@ -349,9 +349,7 @@ public class RdsDataPoints {
         if (points != null) {
             indexClassToId.clear();
             for (Entry<String, @Nullable BasePoint> entry : points.entrySet()) {
-                @Nullable
                 String pointKey = entry.getKey();
-                @Nullable
                 BasePoint pointValue = entry.getValue();
                 if (pointValue != null) {
                     indexClassToId.put(pointValue.getPointClass(), pointKey);

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDebouncer.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDebouncer.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link RdsDebouncer} determines if change events should be forwarded to a
@@ -30,10 +29,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class RdsDebouncer {
 
-    private final Map<String, @Nullable DebounceDelay> channels = new HashMap<>();
+    private final Map<String, DebounceDelay> channels = new HashMap<>();
 
-    @SuppressWarnings("null")
-    @NonNullByDefault
     static class DebounceDelay {
 
         private long expireTime;
@@ -58,10 +55,9 @@ public class RdsDebouncer {
 
     public Boolean timeExpired(String channelId) {
         if (channels.containsKey(channelId)) {
-            @Nullable
             DebounceDelay debounceDelay = channels.get(channelId);
             if (debounceDelay != null) {
-                return ((DebounceDelay) debounceDelay).timeExpired();
+                return debounceDelay.timeExpired();
             }
         }
         return true;

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandlerFactory.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsHandlerFactory.java
@@ -47,7 +47,7 @@ public class RdsHandlerFactory extends BaseThingHandlerFactory {
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(THING_TYPE_CLOUD, THING_TYPE_RDS)));
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discos = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discos = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/Forecast.java
+++ b/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/Forecast.java
@@ -28,9 +28,9 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class Forecast implements Comparable<Forecast> {
     private final ZonedDateTime validTime;
-    private final Map<String, @Nullable BigDecimal> parameters;
+    private final Map<String, BigDecimal> parameters;
 
-    public Forecast(ZonedDateTime validTime, Map<String, @Nullable BigDecimal> parameters) {
+    public Forecast(ZonedDateTime validTime, Map<String, BigDecimal> parameters) {
         this.validTime = validTime;
         this.parameters = parameters;
     }
@@ -39,7 +39,7 @@ public class Forecast implements Comparable<Forecast> {
         return validTime;
     }
 
-    public Map<String, @Nullable BigDecimal> getParameters() {
+    public Map<String, BigDecimal> getParameters() {
         return parameters;
     }
 

--- a/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/Parser.java
+++ b/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/Parser.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -80,7 +79,7 @@ public class Parser {
      */
     private static Forecast parseForecast(JsonObject object) {
         ZonedDateTime validTime = ZonedDateTime.parse(object.get("validTime").getAsString());
-        Map<String, @Nullable BigDecimal> parameters = new HashMap<>();
+        Map<String, BigDecimal> parameters = new HashMap<>();
 
         JsonArray parameterArray = object.get("parameters").getAsJsonArray();
 

--- a/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/handler/SolarEdgeBaseHandler.java
+++ b/bundles/org.openhab.binding.solaredge/src/main/java/org/openhab/binding/solaredge/internal/handler/SolarEdgeBaseHandler.java
@@ -123,7 +123,7 @@ public abstract class SolarEdgeBaseHandler extends BaseThingHandler implements S
      * will update all channels provided in the map
      */
     @Override
-    public void updateChannelStatus(Map<Channel, @Nullable State> values) {
+    public void updateChannelStatus(Map<Channel, State> values) {
         logger.debug("Handling channel update.");
 
         for (Channel channel : values.keySet()) {

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosHandlerFactory.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosHandlerFactory.java
@@ -64,7 +64,7 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
     private final NetworkAddressService networkAddressService;
     private final SonosStateDescriptionOptionProvider stateDescriptionProvider;
 
-    private final Map<String, @Nullable ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
 
     // optional OPML URL that can be configured through configuration admin
     private @Nullable String opmlUrl;

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosXMLParser.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosXMLParser.java
@@ -185,7 +185,7 @@ public class SonosXMLParser {
         return handler.getTextFields();
     }
 
-    public static Map<String, @Nullable String> getRenderingControlFromXML(String xml) {
+    public static Map<String, String> getRenderingControlFromXML(String xml) {
         RenderingControlEventHandler handler = new RenderingControlEventHandler();
         try {
             XMLReader reader = XMLReaderFactory.createXMLReader();
@@ -200,7 +200,7 @@ public class SonosXMLParser {
         return handler.getChanges();
     }
 
-    public static Map<String, @Nullable String> getAVTransportFromXML(String xml) {
+    public static Map<String, String> getAVTransportFromXML(String xml) {
         AVTransportEventHandler handler = new AVTransportEventHandler();
         try {
             XMLReader reader = XMLReaderFactory.createXMLReader();
@@ -712,7 +712,7 @@ public class SonosXMLParser {
          * </Event>
          */
 
-        private final Map<String, @Nullable String> changes = new HashMap<>();
+        private final Map<String, String> changes = new HashMap<>();
 
         @Override
         public void startElement(@Nullable String uri, @Nullable String localName, @Nullable String qName,
@@ -732,7 +732,7 @@ public class SonosXMLParser {
             }
         }
 
-        public Map<String, @Nullable String> getChanges() {
+        public Map<String, String> getChanges() {
             return changes;
         }
     }
@@ -842,7 +842,7 @@ public class SonosXMLParser {
 
     private static class RenderingControlEventHandler extends DefaultHandler {
 
-        private final Map<String, @Nullable String> changes = new HashMap<>();
+        private final Map<String, String> changes = new HashMap<>();
 
         private boolean getPresetName = false;
         private @Nullable String presetName;
@@ -900,7 +900,7 @@ public class SonosXMLParser {
             }
         }
 
-        public Map<String, @Nullable String> getChanges() {
+        public Map<String, String> getChanges() {
             return changes;
         }
     }

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -128,12 +128,12 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     private final Object stateLock = new Object();
     private final Object jobLock = new Object();
 
-    private final Map<String, @Nullable String> stateMap = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, String> stateMap = Collections.synchronizedMap(new HashMap<>());
 
     private @Nullable ScheduledFuture<?> pollingJob;
     private @Nullable SonosZonePlayerState savedState;
 
-    private Map<String, @Nullable Boolean> subscriptionState = new HashMap<>();
+    private Map<String, Boolean> subscriptionState = new HashMap<>();
 
     /**
      * Thing handler instance of the coordinator speaker used for control delegation
@@ -405,7 +405,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
             // pre-process some variables, eg XML processing
             if (service.equals("AVTransport") && variable.equals("LastChange")) {
-                Map<String, @Nullable String> parsedValues = SonosXMLParser.getAVTransportFromXML(value);
+                Map<String, String> parsedValues = SonosXMLParser.getAVTransportFromXML(value);
                 for (String parsedValue : parsedValues.keySet()) {
                     // Update the transport state after the update of the media information
                     // to not break the notification mechanism
@@ -427,7 +427,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
             }
 
             if (service.equals("RenderingControl") && variable.equals("LastChange")) {
-                Map<String, @Nullable String> parsedValues = SonosXMLParser.getRenderingControlFromXML(value);
+                Map<String, String> parsedValues = SonosXMLParser.getRenderingControlFromXML(value);
                 for (String parsedValue : parsedValues.keySet()) {
                     onValueReceived(parsedValue, parsedValues.get(parsedValue), "RenderingControl");
                 }
@@ -957,8 +957,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     protected void updateRunningAlarmProperties() {
-        Map<String, @Nullable String> result = service.invokeAction(this, "AVTransport", "GetRunningAlarmProperties",
-                null);
+        Map<String, String> result = service.invokeAction(this, "AVTransport", "GetRunningAlarmProperties", null);
 
         String alarmID = result.get("AlarmID");
         String loggedStartTime = result.get("LoggedStartTime");
@@ -1327,7 +1326,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         inputs.put("RequestedCount", Integer.toString(200));
         inputs.put("SortCriteria", "");
 
-        Map<String, @Nullable String> result = service.invokeAction(this, "ContentDirectory", "Browse", inputs);
+        Map<String, String> result = service.invokeAction(this, "ContentDirectory", "Browse", inputs);
 
         String initialResult = result.get("Result");
         if (initialResult == null) {
@@ -1369,7 +1368,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         inputs.put("RequestedCount", "1");
         inputs.put("SortCriteria", "");
 
-        Map<String, @Nullable String> result = service.invokeAction(this, "ContentDirectory", "Browse", inputs);
+        Map<String, String> result = service.invokeAction(this, "ContentDirectory", "Browse", inputs);
 
         return getResultEntry(result, "TotalMatches", type, "dc:title");
     }
@@ -1384,7 +1383,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
      *
      * @return 0 as long or the value corresponding to the requiredKey if found
      */
-    private Long getResultEntry(Map<String, @Nullable String> resultInput, String requestedKey, String entriesType,
+    private Long getResultEntry(Map<String, String> resultInput, String requestedKey, String entriesType,
             String entriesFilter) {
         long result = 0;
 
@@ -2090,7 +2089,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     public List<SonosAlarm> getCurrentAlarmList() {
-        Map<String, @Nullable String> result = service.invokeAction(this, "AlarmClock", "ListAlarms", null);
+        Map<String, String> result = service.invokeAction(this, "AlarmClock", "ListAlarms", null);
 
         for (String variable : result.keySet()) {
             this.onValueReceived(variable, result.get(variable), "AlarmClock");
@@ -2822,8 +2821,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     private @Nullable List<SonosMusicService> getAvailableMusicServices() {
         if (musicServices == null) {
-            Map<String, @Nullable String> result = service.invokeAction(this, "MusicServices", "ListAvailableServices",
-                    null);
+            Map<String, String> result = service.invokeAction(this, "MusicServices", "ListAvailableServices", null);
 
             String serviceList = result.get("AvailableServiceDescriptorList");
             if (serviceList != null) {

--- a/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.spotify/src/main/java/org/openhab/binding/spotify/internal/discovery/SpotifyDeviceDiscoveryService.java
@@ -74,7 +74,7 @@ public class SpotifyDeviceDiscoveryService extends AbstractDiscoveryService
 
     @Override
     public void activate() {
-        Map<String, @Nullable Object> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY, Boolean.TRUE);
         super.activate(properties);
     }

--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/coe/TACmiHandler.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/coe/TACmiHandler.java
@@ -57,8 +57,8 @@ public class TACmiHandler extends BaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(TACmiHandler.class);
 
-    private final Map<@Nullable PodIdentifier, @Nullable PodData> podDatas = new HashMap<>();
-    private final Map<@Nullable ChannelUID, @Nullable TACmiChannelConfiguration> channelConfigByUID = new HashMap<>();
+    private final Map<PodIdentifier, PodData> podDatas = new HashMap<>();
+    private final Map<ChannelUID, TACmiChannelConfiguration> channelConfigByUID = new HashMap<>();
 
     private @Nullable TACmiCoEBridgeHandler bridge;
     private long lastMessageRecvTS; // last received message timestamp
@@ -368,7 +368,7 @@ public class TACmiHandler extends BaseThingHandler {
                     "No update from C.M.I. for 15 min");
         }
         for (final PodData pd : this.podDatas.values()) {
-            if (pd == null || !(pd instanceof PodDataOutgoing)) {
+            if (!(pd instanceof PodDataOutgoing)) {
                 continue;
             }
             PodDataOutgoing podDataOutgoing = (PodDataOutgoing) pd;

--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/ApiPageParser.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/ApiPageParser.java
@@ -88,11 +88,11 @@ public class ApiPageParser extends AbstractSimpleMarkupHandler {
     private @Nullable String address;
     private @Nullable StringBuilder value;
     private ButtonValue buttonValue = ButtonValue.UNKNOWN;
-    private Map<String, @Nullable ApiPageEntry> entries;
+    private Map<String, ApiPageEntry> entries;
     private Set<String> seenNames = new HashSet<>();
     private List<Channel> channels = new ArrayList<>();
 
-    public ApiPageParser(TACmiSchemaHandler taCmiSchemaHandler, Map<String, @Nullable ApiPageEntry> entries,
+    public ApiPageParser(TACmiSchemaHandler taCmiSchemaHandler, Map<String, ApiPageEntry> entries,
             TACmiChannelTypeProvider channelTypeProvider) {
         super();
         this.taCmiSchemaHandler = taCmiSchemaHandler;

--- a/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
+++ b/bundles/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/schema/TACmiSchemaHandler.java
@@ -66,7 +66,7 @@ public class TACmiSchemaHandler extends BaseThingHandler {
 
     private final HttpClient httpClient;
     private final TACmiChannelTypeProvider channelTypeProvider;
-    private final Map<String, @Nullable ApiPageEntry> entries = new HashMap<>();
+    private final Map<String, ApiPageEntry> entries = new HashMap<>();
     private boolean online;
     private @Nullable String serverBase;
     private @Nullable URI schemaApiPage;

--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/discovery/TeslaAccountDiscoveryService.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/discovery/TeslaAccountDiscoveryService.java
@@ -14,7 +14,7 @@ package org.openhab.binding.tesla.internal.discovery;
 
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.tesla.internal.TeslaHandlerFactory;
 import org.openhab.binding.tesla.internal.command.TeslaCommandExtension;
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Component;
  *
  */
 @Component(service = { TeslaAccountDiscoveryService.class, DiscoveryService.class })
+@NonNullByDefault
 public class TeslaAccountDiscoveryService extends AbstractDiscoveryService {
 
     public TeslaAccountDiscoveryService() throws IllegalArgumentException {
@@ -42,7 +43,7 @@ public class TeslaAccountDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    public void activate(@Nullable Map<@NonNull String, @Nullable Object> configProperties) {
+    public void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/discovery/TeslaVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/discovery/TeslaVehicleDiscoveryService.java
@@ -14,8 +14,6 @@ package org.openhab.binding.tesla.internal.discovery;
 
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.tesla.internal.TeslaBindingConstants;
 import org.openhab.binding.tesla.internal.TeslaHandlerFactory;
 import org.openhab.binding.tesla.internal.handler.TeslaAccountHandler;
@@ -69,7 +67,7 @@ public class TeslaVehicleDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void activate(@Nullable Map<@NonNull String, @Nullable Object> configProperties) {
+    public void activate(Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.touchwand/src/main/java/org/openhab/binding/touchwand/internal/discovery/TouchWandControllerDiscoveryService.java
+++ b/bundles/org.openhab.binding.touchwand/src/main/java/org/openhab/binding/touchwand/internal/discovery/TouchWandControllerDiscoveryService.java
@@ -70,7 +70,7 @@ public class TouchWandControllerDiscoveryService extends AbstractDiscoveryServic
     }
 
     @Override
-    public void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    public void activate(@Nullable Map<String, Object> configProperties) {
         removeOlderResults(getTimestampOfLastScan());
         super.activate(configProperties);
     }

--- a/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/discovery/VolvoVehicleDiscoveryService.java
+++ b/bundles/org.openhab.binding.volvooncall/src/main/java/org/openhab/binding/volvooncall/internal/discovery/VolvoVehicleDiscoveryService.java
@@ -63,7 +63,7 @@ public class VolvoVehicleDiscoveryService extends AbstractDiscoveryService imple
     }
 
     @Override
-    public void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    public void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/discovery/WeatherCompanyDiscoveryService.java
+++ b/bundles/org.openhab.binding.weathercompany/src/main/java/org/openhab/binding/weathercompany/internal/discovery/WeatherCompanyDiscoveryService.java
@@ -67,7 +67,7 @@ public class WeatherCompanyDiscoveryService extends AbstractDiscoveryService {
     }
 
     @Override
-    public void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    public void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
         logger.debug("Discovery: Activating discovery service for {}", bridgeHandler.getThing().getUID());
     }

--- a/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/WeatherUndergroundHandlerFactory.java
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/WeatherUndergroundHandlerFactory.java
@@ -59,7 +59,7 @@ public class WeatherUndergroundHandlerFactory extends BaseThingHandlerFactory {
             .of(BRIDGE_THING_TYPES_UIDS, WeatherUndergroundBindingConstants.SUPPORTED_THING_TYPES_UIDS)
             .flatMap(x -> x.stream()).collect(Collectors.toSet());
 
-    private final Map<ThingUID, @Nullable ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     private final LocaleProvider localeProvider;
     private final LocationProvider locationProvider;

--- a/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.weatherunderground.internal.handler.WeatherUndergroundHandler;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
@@ -73,7 +71,7 @@ public class WeatherUndergroundDiscoveryService extends AbstractDiscoveryService
 
     /* We override this method to allow a call from the thing handler factory */
     @Override
-    public void activate(@Nullable Map<@NonNull String, @Nullable Object> configProperties) {
+    public void activate(Map<String, Object> configProperties) {
         super.activate(configProperties);
     }
 

--- a/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/handler/WeatherUndergroundHandler.java
+++ b/bundles/org.openhab.binding.weatherunderground/src/main/java/org/openhab/binding/weatherunderground/internal/handler/WeatherUndergroundHandler.java
@@ -87,7 +87,7 @@ public class WeatherUndergroundHandler extends BaseThingHandler {
     private static final Set<String> USUAL_FEATURES = Stream.of(FEATURE_CONDITIONS, FEATURE_FORECAST10DAY)
             .collect(Collectors.toSet());
 
-    private static final Map<String, @Nullable String> LANG_ISO_TO_WU_CODES = new HashMap<>();
+    private static final Map<String, String> LANG_ISO_TO_WU_CODES = new HashMap<>();
     // Codes from https://www.wunderground.com/weather/api/d/docs?d=language-support
     static {
         LANG_ISO_TO_WU_CODES.put("AF", "AF");
@@ -171,7 +171,7 @@ public class WeatherUndergroundHandler extends BaseThingHandler {
         // Yiddish - transliterated => JI
         LANG_ISO_TO_WU_CODES.put("YI", "YI");
     }
-    private static final Map<String, @Nullable String> LANG_COUNTRY_TO_WU_CODES = new HashMap<>();
+    private static final Map<String, String> LANG_COUNTRY_TO_WU_CODES = new HashMap<>();
     static {
         LANG_COUNTRY_TO_WU_CODES.put("en-GB", "LI"); // British English
         LANG_COUNTRY_TO_WU_CODES.put("fr-CA", "FC"); // French Canadian

--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoDeviceKeys.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoDeviceKeys.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.http.HttpStatus;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.io.neeo.internal.models.NeeoThingUID;
@@ -48,7 +47,7 @@ public class NeeoDeviceKeys {
     private final Logger logger = LoggerFactory.getLogger(NeeoDeviceKeys.class);
 
     /** The mapping between ThingUID to brain keys */
-    private final ConcurrentHashMap<NeeoThingUID, @Nullable Set<String>> uidToKey = new ConcurrentHashMap<>();
+    private final Map<NeeoThingUID, Set<String>> uidToKey = new ConcurrentHashMap<>();
 
     /** The brain's url */
     private final String brainUrl;
@@ -163,7 +162,7 @@ public class NeeoDeviceKeys {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder(200);
-        for (Entry<NeeoThingUID, @Nullable Set<String>> entry : uidToKey.entrySet()) {
+        for (Entry<NeeoThingUID, Set<String>> entry : uidToKey.entrySet()) {
             final Set<String> entries = entry.getValue();
             if (entries == null) {
                 continue;

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/InfluxDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/InfluxDBPersistenceService.java
@@ -103,7 +103,7 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
      * Connect to database when service is activated
      */
     @Activate
-    public void activate(final @Nullable Map<String, @Nullable Object> config) {
+    public void activate(final @Nullable Map<String, Object> config) {
         logger.debug("InfluxDB persistence service is being activated");
 
         if (loadConfiguration(config)) {
@@ -141,7 +141,7 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
      * Rerun deactivation/activation code each time configuration is changed
      */
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> config) {
+    protected void modified(@Nullable Map<String, Object> config) {
         if (config != null) {
             logger.debug("Config has been modified will deactivate/activate with new config");
 
@@ -152,7 +152,7 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
         }
     }
 
-    private boolean loadConfiguration(@Nullable Map<String, @Nullable Object> config) {
+    private boolean loadConfiguration(@Nullable Map<String, Object> config) {
         boolean configurationIsValid;
         if (config != null) {
             configuration = new InfluxDBConfiguration(config);

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConfiguration.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConfiguration.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.StringJoiner;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
@@ -55,13 +54,13 @@ public class InfluxDBConfiguration {
     private final boolean addTypeTag;
     private final boolean addLabelTag;
 
-    public InfluxDBConfiguration(Map<String, @Nullable Object> config) {
-        url = (@NonNull String) config.getOrDefault(URL_PARAM, "http://127.0.0.1:8086");
-        user = (@NonNull String) config.getOrDefault(USER_PARAM, "openhab");
-        password = (@NonNull String) config.getOrDefault(PASSWORD_PARAM, "");
-        token = (@NonNull String) config.getOrDefault(TOKEN_PARAM, "");
-        databaseName = (@NonNull String) config.getOrDefault(DATABASE_PARAM, "openhab");
-        retentionPolicy = (@NonNull String) config.getOrDefault(RETENTION_POLICY_PARAM, "autogen");
+    public InfluxDBConfiguration(Map<String, Object> config) {
+        url = (String) config.getOrDefault(URL_PARAM, "http://127.0.0.1:8086");
+        user = (String) config.getOrDefault(USER_PARAM, "openhab");
+        password = (String) config.getOrDefault(PASSWORD_PARAM, "");
+        token = (String) config.getOrDefault(TOKEN_PARAM, "");
+        databaseName = (String) config.getOrDefault(DATABASE_PARAM, "openhab");
+        retentionPolicy = (String) config.getOrDefault(RETENTION_POLICY_PARAM, "autogen");
         version = parseInfluxVersion(config.getOrDefault(VERSION_PARAM, InfluxDBVersion.V1.name()));
 
         replaceUnderscore = getConfigBooleanValue(config, REPLACE_UNDERSCORE_PARAM, false);
@@ -70,8 +69,7 @@ public class InfluxDBConfiguration {
         addTypeTag = getConfigBooleanValue(config, ADD_TYPE_TAG_PARAM, false);
     }
 
-    private static boolean getConfigBooleanValue(Map<String, @Nullable Object> config, String key,
-            boolean defaultValue) {
+    private static boolean getConfigBooleanValue(Map<String, Object> config, String key, boolean defaultValue) {
         Object object = config.get(key);
         if (object instanceof Boolean) {
             return (Boolean) object;

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ConfigurationTestHelper.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/ConfigurationTestHelper.java
@@ -12,17 +12,12 @@
  */
 package org.openhab.persistence.influxdb.internal;
 
-import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.DATABASE_PARAM;
-import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.RETENTION_POLICY_PARAM;
-import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.TOKEN_PARAM;
-import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.URL_PARAM;
-import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.VERSION_PARAM;
+import static org.openhab.persistence.influxdb.internal.InfluxDBConfiguration.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Joan Pujol Espinar - Initial contribution
@@ -30,8 +25,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ConfigurationTestHelper {
 
-    public static Map<String, @Nullable Object> createValidConfigurationParameters() {
-        Map<String, @Nullable Object> config = new HashMap<>();
+    public static Map<String, Object> createValidConfigurationParameters() {
+        Map<String, Object> config = new HashMap<>();
         config.put(URL_PARAM, "http://localhost:8086");
         config.put(VERSION_PARAM, InfluxDBVersion.V2.name());
         config.put(TOKEN_PARAM, "sampletoken");
@@ -44,8 +39,8 @@ public class ConfigurationTestHelper {
         return new InfluxDBConfiguration(createValidConfigurationParameters());
     }
 
-    public static Map<String, @Nullable Object> createInvalidConfigurationParameters() {
-        Map<String, @Nullable Object> config = createValidConfigurationParameters();
+    public static Map<String, Object> createInvalidConfigurationParameters() {
+        Map<String, Object> config = createValidConfigurationParameters();
         config.remove(TOKEN_PARAM);
         return config;
     }

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceServiceTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceServiceTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.DefaultLocation;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,8 +39,8 @@ public class InfluxDBPersistenceServiceTest {
 
     private @Mock InfluxDBRepository influxDBRepository;
 
-    private Map<String, @Nullable Object> validConfig;
-    private Map<String, @Nullable Object> invalidConfig;
+    private Map<String, Object> validConfig;
+    private Map<String, Object> invalidConfig;
 
     @BeforeEach
     public void before() {

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.persistence.jdbc.db.JdbcBaseDAO;
 import org.openhab.persistence.jdbc.utils.MovingAverage;
 import org.openhab.persistence.jdbc.utils.StringUtilsExt;
@@ -74,7 +73,7 @@ public class JdbcConfiguration {
         valid = updateConfig(configuration);
     }
 
-    private boolean updateConfig(Map<Object, @Nullable Object> config) {
+    private boolean updateConfig(Map<Object, Object> config) {
         configuration = config;
 
         logger.debug("JDBC::updateConfig: configuration size = {}", configuration.size());

--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jPersistenceService.java
@@ -102,7 +102,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3,
             new NamedThreadFactory("RRD4j"));
 
-    private final Map<String, @Nullable RrdDefConfig> rrdDefs = new ConcurrentHashMap<>();
+    private final Map<String, RrdDefConfig> rrdDefs = new ConcurrentHashMap<>();
 
     private static final String DATASOURCE_STATE = "state";
 
@@ -110,7 +110,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
 
     private final Logger logger = LoggerFactory.getLogger(RRD4jPersistenceService.class);
 
-    private final Map<String, @Nullable ScheduledFuture<?>> scheduledJobs = new HashMap<>();
+    private final Map<String, ScheduledFuture<?>> scheduledJobs = new HashMap<>();
 
     protected final ItemRegistry itemRegistry;
 
@@ -329,7 +329,7 @@ public class RRD4jPersistenceService implements QueryablePersistenceService {
 
     private @Nullable RrdDefConfig getRrdDefConfig(String itemName) {
         RrdDefConfig useRdc = null;
-        for (Map.Entry<String, @Nullable RrdDefConfig> e : rrdDefs.entrySet()) {
+        for (Map.Entry<String, RrdDefConfig> e : rrdDefs.entrySet()) {
             // try to find special config
             RrdDefConfig rdc = e.getValue();
             if (rdc != null && rdc.appliesTo(itemName)) {


### PR DESCRIPTION
These workarounds to prevent false positives can be removed now the EEAs allow for proper null analysis.

Depends on https://github.com/openhab/openhab-core/pull/1780