### PR TITLE
[deconz] fix lastSeenPolling and compile warnings

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -81,7 +81,7 @@ Auto-discovered things do not need to be configured.
 All sensor-things have an additional `lastSeenPolling` parameter.
 Due to limitations in the API of deCONZ, the `lastSeen` channel (available some sensors) is only available when using polling.
 Allowed values are all positive integers, the unit is minutes.
-The default-value is `0`, which means "no polling at all".
+The default-value is `1440`, which means "once a day".
 
 `dimmablelight`, `extendedcolorlight`, `colorlight` and `colortemperaturelight` have an additional optional parameter `transitiontime`.
 The transition time is the time to move between two states and is configured in seconds.

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -163,11 +163,11 @@ public class ThingDiscoveryService extends AbstractDiscoveryService implements D
         properties.put(Thing.PROPERTY_VENDOR, light.manufacturername);
         properties.put(Thing.PROPERTY_MODEL_ID, light.modelid);
 
-        if (light.ctmax != null && light.ctmin != null) {
-            properties.put(PROPERTY_CT_MAX,
-                    Integer.toString(Util.constrainToRange(light.ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
-            properties.put(PROPERTY_CT_MIN,
-                    Integer.toString(Util.constrainToRange(light.ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
+        Integer ctmax = light.ctmax;
+        Integer ctmin = light.ctmin;
+        if (ctmax != null && ctmin != null) {
+            properties.put(PROPERTY_CT_MAX, Integer.toString(Util.constrainToRange(ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
+            properties.put(PROPERTY_CT_MIN, Integer.toString(Util.constrainToRange(ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
         }
 
         switch (lightType) {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
@@ -91,8 +91,9 @@ public class GroupThingHandler extends DeconzBaseThingHandler<GroupMessage> {
             case CHANNEL_COLOR:
                 if (command instanceof HSBType) {
                     HSBType hsbCommand = (HSBType) command;
-                    newGroupAction.bri = Util.fromPercentType(hsbCommand.getBrightness());
-                    if (newGroupAction.bri > 0) {
+                    Integer bri = Util.fromPercentType(hsbCommand.getBrightness());
+                    newGroupAction.bri = bri;
+                    if (bri > 0) {
                         newGroupAction.hue = (int) (hsbCommand.getHue().doubleValue() * HUE_FACTOR);
                         newGroupAction.sat = Util.fromPercentType(hsbCommand.getSaturation());
                     }
@@ -118,7 +119,8 @@ public class GroupThingHandler extends DeconzBaseThingHandler<GroupMessage> {
                 return;
         }
 
-        if (newGroupAction.bri != null && newGroupAction.bri > 0) {
+        Integer bri = newGroupAction.bri;
+        if (bri != null && bri > 0) {
             newGroupAction.on = true;
         }
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -221,16 +221,17 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
                 return;
         }
 
-        if (newLightState.on != null && !newLightState.on) {
+        Boolean newOn = newLightState.on;
+        if (newOn != null && !newOn) {
             // if light shall be off, no other commands are allowed, so reset the new light state
             newLightState.clear();
             newLightState.on = false;
         }
 
         sendCommand(newLightState, command, channelUID, () -> {
+            Integer transitionTime = newLightState.transitiontime;
             lastCommandExpireTimestamp = System.currentTimeMillis()
-                    + (newLightState.transitiontime != null ? newLightState.transitiontime
-                            : DEFAULT_COMMAND_EXPIRY_TIME);
+                    + (transitionTime != null ? transitionTime : DEFAULT_COMMAND_EXPIRY_TIME);
             lastCommand = newLightState;
         });
     }
@@ -241,16 +242,18 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
             return null;
         } else if (r.getResponseCode() == 200) {
             LightMessage lightMessage = gson.fromJson(r.getBody(), LightMessage.class);
-            if (lightMessage != null && needsPropertyUpdate) {
+            if (needsPropertyUpdate) {
                 // if we did not receive an ctmin/ctmax, then we probably don't need it
                 needsPropertyUpdate = false;
 
-                if (lightMessage.ctmin != null && lightMessage.ctmax != null) {
+                Integer ctmax = lightMessage.ctmax;
+                Integer ctmin = lightMessage.ctmin;
+                if (ctmin != null && ctmax != null) {
                     Map<String, String> properties = new HashMap<>(thing.getProperties());
                     properties.put(PROPERTY_CT_MAX,
-                            Integer.toString(Util.constrainToRange(lightMessage.ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
+                            Integer.toString(Util.constrainToRange(ctmax, ZCL_CT_MIN, ZCL_CT_MAX)));
                     properties.put(PROPERTY_CT_MIN,
-                            Integer.toString(Util.constrainToRange(lightMessage.ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
+                            Integer.toString(Util.constrainToRange(ctmin, ZCL_CT_MIN, ZCL_CT_MAX)));
                     updateProperties(properties);
                 }
             }
@@ -271,6 +274,8 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
 
     private void valueUpdated(String channelId, LightState newState) {
         Integer bri = newState.bri;
+        Integer hue = newState.hue;
+        Integer sat = newState.sat;
         Boolean on = newState.on;
 
         switch (channelId) {
@@ -285,15 +290,13 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
             case CHANNEL_COLOR:
                 if (on != null && on == false) {
                     updateState(channelId, OnOffType.OFF);
-                } else if (bri != null && newState.colormode != null && newState.colormode.equals("xy")) {
+                } else if (bri != null && "xy".equals(newState.colormode)) {
                     final double @Nullable [] xy = newState.xy;
                     if (xy != null && xy.length == 2) {
                         HSBType color = HSBType.fromXY((float) xy[0], (float) xy[1]);
                         updateState(channelId, new HSBType(color.getHue(), color.getSaturation(), toPercentType(bri)));
                     }
-                } else if (bri != null && newState.hue != null && newState.sat != null) {
-                    final Integer hue = newState.hue;
-                    final Integer sat = newState.sat;
+                } else if (bri != null && hue != null && sat != null) {
                     updateState(channelId,
                             new HSBType(new DecimalType(hue / HUE_FACTOR), toPercentType(sat), toPercentType(bri)));
                 }
@@ -333,7 +336,7 @@ public class LightThingHandler extends DeconzBaseThingHandler<LightMessage> {
                     return;
                 }
                 lightStateCache = lightState;
-                if (lightState.reachable != null && lightState.reachable) {
+                if (Boolean.TRUE.equals(lightState.reachable)) {
                     updateStatus(ThingStatus.ONLINE);
                     thing.getChannels().stream().map(c -> c.getUID().getId()).forEach(c -> valueUpdated(c, lightState));
                 } else {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
@@ -34,8 +34,6 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
@@ -64,8 +62,6 @@ public class SensorThingHandler extends SensorBaseThingHandler {
 
     private static final List<String> CONFIG_CHANNELS = Arrays.asList(CHANNEL_BATTERY_LEVEL, CHANNEL_BATTERY_LOW,
             CHANNEL_TEMPERATURE);
-
-    private final Logger logger = LoggerFactory.getLogger(SensorThingHandler.class);
 
     public SensorThingHandler(Thing thing, Gson gson) {
         super(thing, gson);

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
@@ -23,6 +23,6 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ThingConfig {
     public String id = "";
-    public int lastSeenPolling = 0;
+    public int lastSeenPolling = 1440;
     public @Nullable Double transitiontime;
 }

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
@@ -42,8 +42,8 @@
 		<parameter name="lastSeenPolling" type="integer" min="0" unit="min">
 			<label>LastSeen Poll Interval</label>
 			<description>Interval to poll the deCONZ Gateway for this sensor's "lastSeen" channel. Polling is disabled when set
-				to 0.</description>
-			<default>0</default>
+				to 1440 (once per day).</description>
+			<default>1440</default>
 		</parameter>
 	</config-description>
 


### PR DESCRIPTION
Finally fixes the lastSeenPolling feature (used to update the thing on each poll cycle). Also fixes compiler warnings.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
