### PR TITLE
[mqtt.generic] Fix re-subscribing on new connection

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -290,7 +290,7 @@ public class ChannelState implements MqttMessageSubscriber {
             int timeout) {
         synchronized (futureLock) {
             // if the connection is still the same, the subscription is still present, otherwise we need to renew
-            if (hasSubscribed || !future.isDone() && connection.equals(this.connection)) {
+            if ((hasSubscribed || !future.isDone()) && connection.equals(this.connection)) {
                 return future;
             }
             hasSubscribed = false;


### PR DESCRIPTION
Generic things would not resubscribe to a a new connection.

see https://github.com/openhab/openhab-addons/issues/6243#issuecomment-719887436

I still see a problem as the changed stateTopic is not seen in the thing. It subscribes to the old value again :-( 