### PR TITLE
[rrd4j] Return QuantityTypes for number items with dimension

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jItem.java
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jItem.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.persistence.rrd4j.internal;
 
-import java.text.DateFormat;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.types.State;
@@ -53,6 +55,8 @@ public class RRD4jItem implements HistoricItem {
 
     @Override
     public String toString() {
-        return DateFormat.getDateTimeInstance().format(timestamp) + ": " + name + " -> " + state.toString();
+        return timestamp
+                .format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).withLocale(Locale.getDefault())) + ": "
+                + name + " -> " + state.toString();
     }
 }


### PR DESCRIPTION
The call of `getUnit()` on a NumberItem is very expensive as it scans all StateDescriptionProviders.
With this PR, this call is only done once and not for every record in the query result set.

This builds on top of the work in https://github.com/openhab/openhab-addons/pull/8929 and completes it without introducing the regression of #8809.

Fixes #8928

Signed-off-by: Kai Kreuzer <kai@openhab.org>