### PR TITLE
[deconz] fix brightness factor

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/BindingConstants.java
@@ -131,5 +131,5 @@ public class BindingConstants {
     public static final double HUE_FACTOR = 65535 / 360.0;
     public static final int BRIGHTNESS_MIN = 0;
     public static final int BRIGHTNESS_MAX = 254;
-    public static final double BRIGHTNESS_FACTOR = BRIGHTNESS_MAX / PercentType.HUNDRED.intValue();
+    public static final double BRIGHTNESS_FACTOR = BRIGHTNESS_MAX / PercentType.HUNDRED.doubleValue();
 }


### PR DESCRIPTION
Don't know why this has not been discovered. There is a test that fails if the factor is wrong.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
