### PR TITLE
[bluetooth] Fix duplicate channel bug

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
@@ -102,11 +102,17 @@ public class BeaconBluetoothHandler extends BaseThingHandler implements Bluetoot
         }
 
         ThingBuilder builder = editThing();
+        boolean changed = false;
         for (Channel channel : createDynamicChannels()) {
             // we only want to add each channel, not replace all of them
-            builder.withChannel(channel);
+            if (getThing().getChannel(channel.getUID()) == null) {
+                builder.withChannel(channel);
+                changed = true;
+            }
         }
-        updateThing(builder.build());
+        if (changed) {
+            updateThing(builder.build());
+        }
 
         updateStatus(ThingStatus.UNKNOWN);
     }


### PR DESCRIPTION
This fixes a major bug in the current bluetooth binding that prevents the initialization of bluetooth handlers for existing bluetooth things.

Signed-off-by: Connor Petty <mistercpp2000+gitsignoff@gmail.com>
