### PR TITLE
[homematic] Docs on channel types: UPPERCASE and typo

### DIFF
--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -256,15 +256,15 @@ The disadvantage is of course, that all events for this channel are delayed.
 ```java
   Thing HM-LC-Dim1T-Pl-2    JEQ0999999 "Name"  @  "Location" {
       Channels:
-          Type HM-LC-Dim1T-Pl-2_1_level : 1#LEVEL [
+          Type HM-LC-Dim1T-Pl-2_1_LEVEL : 1#LEVEL [
               delay = 0,
               receiveDelay = 4
           ]
   }
 ```
 
-The `Type` is the device type, channel number and lowercase channel name separated with an underscore.
-Note that, for Homegear devices, in contrast to the specification of the Rhing above no `HG-` prefix is needed for the specification of the Type of the Channel.
+The `Type` is the device type, channel number and UPPERCASE channel name separated with an underscore.
+Note that, for Homegear devices, in contrast to the specification of the Thing above no `HG-` prefix is needed for the specification of the Type of the Channel.
 
 The channel configs are optional.
 


### PR DESCRIPTION
https://community.openhab.org/t/solved-homematic-channel-type-couldn-t-be-resolved/47950/6 shows the solution with UPPERCASE channel name and fixing a typo in this paragraph.

Signed-off-by: Philip Reimann <github@qimp.org>
