### PR TITLE
[miio] Use generic channeltypes if none provided

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.miio.internal.handler;
 
-import static org.openhab.binding.miio.internal.MiIoBindingConstants.CHANNEL_COMMAND;
+import static org.openhab.binding.miio.internal.MiIoBindingConstants.*;
 
 import java.awt.Color;
 import java.io.IOException;
@@ -452,6 +452,7 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
             thingBuilder.withoutChannel(new ChannelUID(getThing().getUID(), channel));
         }
         ChannelBuilder newChannel = ChannelBuilder.create(channelUID, datatype).withLabel(friendlyName);
+        boolean useGenericChannelType = false;
         if (!channelType.isBlank()) {
             ChannelTypeUID channelTypeUID = new ChannelTypeUID(channelType);
             if (channelTypeRegistry.getChannelType(channelTypeUID) != null) {
@@ -459,7 +460,13 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
             } else {
                 logger.debug("ChannelType '{}' is not available. Check the Json file for {}", channelTypeUID,
                         getThing().getUID());
+                useGenericChannelType = true;
             }
+        } else {
+            useGenericChannelType = true;
+        }
+        if (useGenericChannelType) {
+            newChannel = newChannel.withType(new ChannelTypeUID(BINDING_ID, datatype.toLowerCase()));
         }
         thingBuilder.withChannel(newChannel.build());
         return channelUID;

--- a/bundles/org.openhab.binding.miio/src/main/resources/OH-INF/thing/commonChannels.xml
+++ b/bundles/org.openhab.binding.miio/src/main/resources/OH-INF/thing/commonChannels.xml
@@ -14,6 +14,52 @@
 		</channels>
 	</channel-group-type>
 
+	<!-- Generic channels -->
+	<channel-type id="color">
+		<item-type>Color</item-type>
+		<label>Generic Color Channel</label>
+	</channel-type>
+	<channel-type id="contact">
+		<item-type>Contact</item-type>
+		<label>Generic Contact Channel</label>
+	</channel-type>
+	<channel-type id="datetime">
+		<item-type>DateTime</item-type>
+		<label>Generic DateTime Channel</label>
+	</channel-type>
+	<channel-type id="dimmer">
+		<item-type>Dimmer</item-type>
+		<label>Generic Dimmer Channel</label>
+	</channel-type>
+	<channel-type id="image">
+		<item-type>Image</item-type>
+		<label>Generic Image Channel</label>
+	</channel-type>
+	<channel-type id="location">
+		<item-type>Location</item-type>
+		<label>Generic Location Channel</label>
+	</channel-type>
+	<channel-type id="number">
+		<item-type>Number</item-type>
+		<label>Generic Number Channel</label>
+	</channel-type>
+	<channel-type id="player">
+		<item-type>Player</item-type>
+		<label>Generic Player Channel</label>
+	</channel-type>
+	<channel-type id="rollershutter">
+		<item-type>Rollershutter</item-type>
+		<label>Generic Rollershutter Channel</label>
+	</channel-type>
+	<channel-type id="string">
+		<item-type>String</item-type>
+		<label>Generic String Channel</label>
+	</channel-type>
+	<channel-type id="switch">
+		<item-type>Switch</item-type>
+		<label>Generic Switch Channel</label>
+	</channel-type>
+
 	<!-- Network channels -->
 	<channel-type id="ssid" advanced="true">
 		<item-type>String</item-type>


### PR DESCRIPTION
To prevent channels not showing up in OH3 main UI
https://github.com/openhab/openhab-webui/issues/406

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
