### PR TITLE
[bluetooth.bluez] Fix the unpairing of all devices on binding disposal

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -118,20 +118,14 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
      */
     @Override
     public void dispose() {
-        logger.debug("###.00 BlueZBluetoothDevice.dispose()");
         BluetoothDevice dev = device;
         if (dev != null) {
-            logger.debug("###.01 dev is not null");
             if (Boolean.TRUE.equals(dev.isPaired())) {
-                logger.debug("###.02 dev is paired");
                 return;
             }
 
-            logger.debug("###.03 dev is NOT paired");
-
             try {
                 dev.getAdapter().removeDevice(dev.getRawDevice());
-                logger.debug("###.04 dev has been removed");
             } catch (DBusException ex) {
                 if (ex.getMessage().contains("Does Not Exist")) {
                     // this happens when the underlying device has already been removed

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -118,25 +118,6 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
      */
     @Override
     public void dispose() {
-        BluetoothDevice dev = device;
-        if (dev != null) {
-            try {
-                dev.getAdapter().removeDevice(dev.getRawDevice());
-            } catch (DBusException ex) {
-                if (ex.getMessage().contains("Does Not Exist")) {
-                    // this happens when the underlying device has already been removed
-                    // but we don't have a way to check if that is the case beforehand so
-                    // we will just eat the error here.
-                } else {
-                    logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
-                            ex.getMessage());
-                }
-            } catch (RuntimeException ex) {
-                // try to catch any other exceptions
-                logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
-                        ex.getMessage());
-            }
-        }
     }
 
     private void setConnectionState(ConnectionState state) {

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -118,6 +118,35 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
      */
     @Override
     public void dispose() {
+        logger.debug("###.00 BlueZBluetoothDevice.dispose()");
+        BluetoothDevice dev = device;
+        if (dev != null) {
+            logger.debug("###.01 dev is not null");
+            if (Boolean.TRUE.equals(dev.isPaired())) {
+                logger.debug("###.02 dev is paired");
+                return;
+            }
+
+            logger.debug("###.03 dev is NOT paired");
+
+            try {
+                dev.getAdapter().removeDevice(dev.getRawDevice());
+                logger.debug("###.04 dev has been removed");
+            } catch (DBusException ex) {
+                if (ex.getMessage().contains("Does Not Exist")) {
+                    // this happens when the underlying device has already been removed
+                    // but we don't have a way to check if that is the case beforehand so
+                    // we will just eat the error here.
+                } else {
+                    logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
+                            ex.getMessage());
+                }
+            } catch (RuntimeException ex) {
+                // try to catch any other exceptions
+                logger.debug("Exception occurred when trying to remove inactive device '{}': {}", address,
+                        ex.getMessage());
+            }
+        }
     }
 
     private void setConnectionState(ConnectionState state) {

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -369,8 +369,10 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
         }
         BluetoothCharacteristic c = getCharacteristic(UUID.fromString(characteristic.getUuid()));
         if (c != null) {
-            c.setValue(event.getData());
-            notifyListeners(BluetoothEventType.CHARACTERISTIC_UPDATED, c, BluetoothCompletionStatus.SUCCESS);
+            synchronized (c) {
+                c.setValue(event.getData());
+                notifyListeners(BluetoothEventType.CHARACTERISTIC_UPDATED, c, BluetoothCompletionStatus.SUCCESS);
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/ConnectedBluetoothHandler.java
@@ -67,9 +67,14 @@ public class ConnectedBluetoothHandler extends BeaconBluetoothHandler {
         super.initialize();
 
         connectionJob = scheduler.scheduleWithFixedDelay(() -> {
-            if (device.getConnectionState() != ConnectionState.CONNECTED) {
-                device.connect();
-                // we do not set the Thing status here, because we will anyhow receive a call to onConnectionStateChange
+            if (device == null) {
+                logger.debug("initialize(): device is null ({})", super.thing);
+            } else {
+                if (device.getConnectionState() != ConnectionState.CONNECTED) {
+                    device.connect();
+                    // we do not set the Thing status here, because we will anyhow receive a call to
+                    // onConnectionStateChange
+                }
             }
             updateRSSI();
         }, 0, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
The block removed was causing the unpairing of all devices when the binding was disposed (shutdown, reload...).

Signed-off-by: Benjamin Lafois <benjamin.lafois@gmail.com>
