### PR TITLE
[remoteopenhab] Deprecated tag "required" for configuration parameter

### DIFF
--- a/bundles/org.openhab.binding.remoteopenhab/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.remoteopenhab/src/main/resources/OH-INF/thing/thing-types.xml
@@ -11,26 +11,23 @@
 		<representation-property>host</representation-property>
 
 		<config-description>
-			<parameter name="host" type="text">
+			<parameter name="host" type="text" required="true">
 				<context>network-address</context>
 				<label>Server Address</label>
 				<description>The host name or IP address of the remote openHAB server.</description>
-				<required>true</required>
 			</parameter>
 
 			<parameter name="useHttps" type="boolean">
 				<label>Use HTTPS</label>
 				<description>Set it to true in case you want to use HTTPS to communicate with the remote openHAB server. Default is
 					false.</description>
-				<required>false</required>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="port" type="integer">
+			<parameter name="port" type="integer" required="true">
 				<label>Server HTTP Port</label>
 				<description>The HTTP port to use to communicate with the remote openHAB server.</description>
-				<required>true</required>
 				<default>8080</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -39,15 +36,13 @@
 				<label>Trust SSL Certificate</label>
 				<description>Set it to true in case you want to use HTTPS even without a valid SSL certificate provided by your
 					remote server.</description>
-				<required>false</required>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="restPath" type="text">
+			<parameter name="restPath" type="text" required="true">
 				<label>REST API Path</label>
 				<description>The subpath of the REST API on the remote openHAB server.</description>
-				<required>true</required>
 				<default>/rest</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -56,7 +51,6 @@
 				<context>password</context>
 				<label>Token</label>
 				<description>The token to use when the remote openHAB server is setup to require authorization to run its REST API.</description>
-				<required>false</required>
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
@@ -73,17 +67,15 @@
 		<representation-property>thingUID</representation-property>
 
 		<config-description>
-			<parameter name="thingUID" type="text">
+			<parameter name="thingUID" type="text" required="true">
 				<label>Remote Thing UID</label>
 				<description>The thing UID in the remote openHAB server.</description>
-				<required>true</required>
 			</parameter>
 
 			<parameter name="buildTriggerChannels" type="boolean">
 				<label>Automatic Trigger Channels Building</label>
 				<description>If set to true, a trigger channel will be automatically created and linked to each trigger channel from
 					the remote thing.</description>
-				<required>false</required>
 				<default>true</default>
 				<advanced>true</advanced>
 			</parameter>


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>