### PR TITLE
[avmfritz] Avoid a hidden NPE when getIdentifier() of an uninitialized ThingHandler is called

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -269,7 +269,6 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                 .collect(Collectors.toMap(it -> it.getIdentifier(), Function.identity()));
         getThing().getThings().forEach(childThing -> {
             final AVMFritzBaseThingHandler childHandler = (AVMFritzBaseThingHandler) childThing.getHandler();
-            // if (childHandler != null && ThingHandlerHelper.isHandlerInitialized(childHandler)) {
             if (childHandler != null) {
                 final AVMFritzBaseModel device = deviceIdentifierMap.get(childHandler.getIdentifier());
                 if (device != null) {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -270,11 +269,10 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
                 .collect(Collectors.toMap(it -> it.getIdentifier(), Function.identity()));
         getThing().getThings().forEach(childThing -> {
             final AVMFritzBaseThingHandler childHandler = (AVMFritzBaseThingHandler) childThing.getHandler();
+            // if (childHandler != null && ThingHandlerHelper.isHandlerInitialized(childHandler)) {
             if (childHandler != null) {
-                final Optional<AVMFritzBaseModel> optionalDevice = Optional
-                        .ofNullable(deviceIdentifierMap.get(childHandler.getIdentifier()));
-                if (optionalDevice.isPresent()) {
-                    final AVMFritzBaseModel device = optionalDevice.get();
+                final AVMFritzBaseModel device = deviceIdentifierMap.get(childHandler.getIdentifier());
+                if (device != null) {
                     deviceList.remove(device);
                     listeners.forEach(listener -> listener.onDeviceUpdated(childThing.getUID(), device));
                 } else {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseBridgeHandler.java
@@ -125,7 +125,7 @@ public abstract class AVMFritzBaseBridgeHandler extends BaseBridgeHandler {
         AVMFritzBoxConfiguration config = getConfigAs(AVMFritzBoxConfiguration.class);
 
         String localIpAddress = config.ipAddress;
-        if (localIpAddress == null || localIpAddress.trim().isEmpty()) {
+        if (localIpAddress == null || localIpAddress.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "The 'ipAddress' parameter must be configured.");
             configValid = false;

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -82,7 +82,7 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
      * keeps track of the current state for handling of increase/decrease
      */
     private @Nullable AVMFritzBaseModel state;
-    private @NonNullByDefault({}) AVMFritzDeviceConfiguration config;
+    private @Nullable String identifier;
 
     /**
      * Constructor
@@ -95,13 +95,13 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
 
     @Override
     public void initialize() {
-        config = getConfigAs(AVMFritzDeviceConfiguration.class);
-
-        String newIdentifier = config.ain;
-        if (newIdentifier == null || newIdentifier.trim().isEmpty()) {
+        final AVMFritzDeviceConfiguration config = getConfigAs(AVMFritzDeviceConfiguration.class);
+        final String newIdentifier = config.ain;
+        if (newIdentifier == null || newIdentifier.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "The 'ain' parameter must be configured.");
         } else {
+            this.identifier = newIdentifier;
             updateStatus(ThingStatus.UNKNOWN);
         }
     }
@@ -472,6 +472,6 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
      * @return the AIN
      */
     public @Nullable String getIdentifier() {
-        return config.ain;
+        return identifier;
     }
 }

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/Powerline546EHandler.java
@@ -31,7 +31,6 @@ import org.openhab.binding.avmfritz.internal.dto.PowerMeterModel;
 import org.openhab.binding.avmfritz.internal.dto.SwitchModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaStatusListener;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
-import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
@@ -91,30 +90,21 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler implements F
             this.identifier = newIdentifier;
         }
 
-        registerStatusListener(this);
-
         super.initialize();
-    }
-
-    @Override
-    public void dispose() {
-        unregisterStatusListener(this);
-
-        super.dispose();
     }
 
     @SuppressWarnings({ "null", "unused" })
     @Override
     public void onDeviceListAdded(List<AVMFritzBaseModel> devicelist) {
-        final String identifier = getIdentifier();
-        final Predicate<AVMFritzBaseModel> predicate = identifier == null ? it -> thing.getUID().equals(getThingUID(it))
-                : it -> identifier.equals(it.getIdentifier());
+        final String ain = getIdentifier();
+        final Predicate<AVMFritzBaseModel> predicate = ain == null ? it -> thing.getUID().equals(getThingUID(it))
+                : it -> ain.equals(it.getIdentifier());
         final AVMFritzBaseModel device = devicelist.stream().filter(predicate).findFirst().orElse(null);
         if (device != null) {
             devicelist.remove(device);
-            listeners.stream().forEach(listener -> listener.onDeviceUpdated(thing.getUID(), device));
+            onDeviceUpdated(thing.getUID(), device);
         } else {
-            listeners.stream().forEach(listener -> listener.onDeviceGone(thing.getUID()));
+            onDeviceGone(thing.getUID());
         }
         super.onDeviceListAdded(devicelist);
     }
@@ -128,7 +118,9 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler implements F
     public void onDeviceUpdated(ThingUID thingUID, AVMFritzBaseModel device) {
         if (thing.getUID().equals(thingUID)) {
             // save AIN to config for FRITZ!Powerline 546E stand-alone
-            updateConfiguration(device);
+            if (this.identifier == null) {
+                this.identifier = device.getIdentifier();
+            }
 
             logger.debug("Update self '{}' with device model: {}", thingUID, device);
             if (device.getPresent() == 1) {
@@ -184,17 +176,6 @@ public class Powerline546EHandler extends AVMFritzBaseBridgeHandler implements F
         Map<String, String> editProperties = editProperties();
         editProperties.put(Thing.PROPERTY_FIRMWARE_VERSION, device.getFirmwareVersion());
         updateProperties(editProperties);
-    }
-
-    /**
-     * Updates thing configuration.
-     *
-     * @param device the {@link AVMFritzBaseModel}
-     */
-    private void updateConfiguration(AVMFritzBaseModel device) {
-        Configuration editConfig = editConfiguration();
-        editConfig.put(CONFIG_AIN, device.getIdentifier());
-        updateConfiguration(editConfig);
     }
 
     /**


### PR DESCRIPTION
- Avoid a hidden NPE when `getIdentifier()` of an uninitialized `ThingHandler` is called

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
