### PR TITLE
[miio] send miot actions parameter as jsonObject (#9056)

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -200,7 +200,13 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
                             parameters.add(value);
                         }
                     }
-                    cmd = cmd + parameters.toString();
+                    if (action.isMiOtAction() && parameters.size() > 0 && parameters.get(0).isJsonObject()) {
+                        // hack as unlike any other commands miot actions parameters appear to be send as a json object
+                        // instead of a json array
+                        cmd = cmd + parameters.get(0).getAsJsonObject().toString();
+                    } else {
+                        cmd = cmd + parameters.toString();
+                    }
                     if (value != null) {
                         logger.debug("Sending command {}", cmd);
                         sendCommand(cmd);


### PR DESCRIPTION
* [miio] send miot actions parameter as jsonObject
* [miio] avoid maven error

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>

Backport - cherryp icked from OH3