### PR TITLE
[miele] Fixed declaration of representation property

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
@@ -83,7 +83,8 @@ public class MieleMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 }
 
                 return DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withRepresentationProperty(uid.getId()).withLabel("Miele XGW3000 Gateway").build();
+                        .withRepresentationProperty(MieleBindingConstants.HOST).withLabel("Miele XGW3000 Gateway")
+                        .build();
             }
         }
         return null;


### PR DESCRIPTION
This fixes the warning in the log:

```
17:12:56.365 [WARN ] [nfig.discovery.DiscoveryResultBuilder] - Representation property 'Miele_XGW3000' of discovery result for thing 'miele:xgw3000:Miele_XGW3000' is missing in properties map. It has to be fixed by the bindings developer.
```

Signed-off-by: Kai Kreuzer <kai@openhab.org>