### PR TITLE
[lgwebos] Fix Volume Subscription on newer LGWebOS TVs which report volumeStatus.

### DIFF
--- a/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
+++ b/bundles/org.openhab.binding.lgwebos/src/main/java/org/openhab/binding/lgwebos/internal/handler/LGWebOSTVSocket.java
@@ -519,20 +519,22 @@ public class LGWebOSTVSocket {
         return request;
     }
 
+    private Float volumeFromResponse(JsonObject jsonObj) {
+        final String VOLUME_STATUS = "volumeStatus";
+        final String VOLUME = "volume";
+        JsonObject parent = jsonObj.has(VOLUME_STATUS) ? jsonObj.getAsJsonObject(VOLUME_STATUS) : jsonObj;
+        return parent.get(VOLUME).getAsInt() >= 0 ? (float) (parent.get(VOLUME).getAsInt() / 100.0) : Float.NaN;
+    }
+
     public ServiceSubscription<Float> subscribeVolume(ResponseListener<Float> listener) {
-        ServiceSubscription<Float> request = new ServiceSubscription<>(VOLUME, null,
-                jsonObj -> jsonObj.get("volume").getAsInt() >= 0 ? (float) (jsonObj.get("volume").getAsInt() / 100.0)
-                        : Float.NaN,
+        ServiceSubscription<Float> request = new ServiceSubscription<>(VOLUME, null, this::volumeFromResponse,
                 listener);
         sendCommand(request);
         return request;
     }
 
     public ServiceCommand<Float> getVolume(ResponseListener<Float> listener) {
-        ServiceCommand<Float> request = new ServiceCommand<>(VOLUME, null,
-                jsonObj -> jsonObj.get("volume").getAsInt() >= 0 ? (float) (jsonObj.get("volume").getAsInt() / 100.0)
-                        : Float.NaN,
-                listener);
+        ServiceCommand<Float> request = new ServiceCommand<>(VOLUME, null, this::volumeFromResponse, listener);
         sendCommand(request);
         return request;
     }


### PR DESCRIPTION
This fix addresses issue: #9000
Volume Change response in API on newer LGWebOS TVs has changed.
It can be encapsulated in volumeStatus element in JSON response. See description on issue.

@shmilgan has successfully validated the fix on new OS.  
I have validated legacy api still works with this fix. 