### PR TITLE
[fronius] Accept null value as zero for inverterdatachannelpac channel (backported to 2.5.x)

### DIFF
--- a/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
+++ b/bundles/org.openhab.binding.fronius/src/main/java/org/openhab/binding/fronius/internal/handler/FroniusSymoInverterHandler.java
@@ -93,7 +93,12 @@ public class FroniusSymoInverterHandler extends FroniusBaseThingHandler {
                 }
                 return day;
             case FroniusBindingConstants.InverterDataChannelPac:
-                return inverterRealtimeResponse.getBody().getData().getPac();
+                ValueUnit pac = inverterRealtimeResponse.getBody().getData().getPac();
+                if (pac == null) {
+                    pac = new ValueUnit();
+                    pac.setValue(0);
+                }
+                return pac;
             case FroniusBindingConstants.InverterDataChannelTotal:
                 ValueUnit total = inverterRealtimeResponse.getBody().getData().getTotalEnergy();
                 if (total != null) {


### PR DESCRIPTION
Fix https://github.com/openhab/openhab-addons/issues/9053
Backporting PR https://github.com/openhab/openhab-addons/pull/9077 to 2.5.x branch