### PR TITLE
[rrd4j] Support Colour item and Group item with a state

### DIFF
--- a/bundles/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/org.openhab.persistence.rrd4j/README.md
@@ -12,7 +12,7 @@ This service cannot be directly queried, because of its data compression, which 
 
 NOTE: rrd4j is for storing numerical data only.
 It cannot store complex data types.
-The supported item types are therefore only `Switch` (internally mapped to 0/1), `Dimmer`, `Number`, `Contact` (internally mapped to 0/1) and `Rollershutter`.
+The supported item types are therefore only `Switch` (internally mapped to 0/1), `Dimmer`, `Number`, `Contact` (internally mapped to 0/1), `Rollershutter` and `Color` (only brightness component stored).
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #9013

Add support for storing the brightness component of a Color item which used to work with OH 2.5.

Also add support for storing the state of a Group item.
