### PR TITLE
2.5.x

### DIFF
--- a/bundles/org.openhab.binding.digiplex/README.md
+++ b/bundles/org.openhab.binding.digiplex/README.md
@@ -39,6 +39,16 @@ Baud rate to use for serial port communication
 
 Controls how often area status is refreshed from the alarm system.
 
+#### Area number [areaNo]
+
+The area number used for communication with alarm systems when is configured using text files. This is not needed if area thing is automatically discovered.
+
+### Area configuration
+
+#### Zone number [zoneNo]
+
+The zone number used for communication with alarm systems when is configured using text files. This is not needed if zone thing is automatically discovered.
+
 ## Channels
 
 ### PTR3 Module Channels

--- a/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/DigiplexZoneConfiguration.java
+++ b/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/DigiplexZoneConfiguration.java
@@ -13,13 +13,11 @@
 package org.openhab.binding.digiplex.internal;
 
 /**
- * The {@link DigiplexAreaConfiguration} class contains fields mapping area configuration parameters.
+ * The {@link DigiplexZoneConfiguration} class contains fields mapping zone configuration parameters.
  *
- * @author Robert Michalak - Initial contribution
+ * @author Olivian Daniel Tofan - Add zone configuration to things configured from file
  */
-public class DigiplexAreaConfiguration {
-
-    public int refreshPeriod;
+public class DigiplexZoneConfiguration {
     
-    public int areaNo;
+    public int zoneNo;
 }

--- a/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/handler/DigiplexAreaHandler.java
+++ b/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/handler/DigiplexAreaHandler.java
@@ -163,7 +163,11 @@ public class DigiplexAreaHandler extends BaseThingHandler {
         bridgeHandler = (DigiplexBridgeHandler) bridge.getHandler();
 
         String areaParm = getThing().getProperties().get(DigiplexBindingConstants.PROPERTY_AREA_NO);
-        areaNo = Integer.parseInt(areaParm);
+        if (areaParm != null) {
+            areaNo = Integer.parseInt(areaParm);
+        } else {
+            areaNo = config.areaNo;
+        }
         bridgeHandler.registerMessageHandler(visitor);
 
         updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/handler/DigiplexZoneHandler.java
+++ b/bundles/org.openhab.binding.digiplex/src/main/java/org/openhab/binding/digiplex/internal/handler/DigiplexZoneHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.openhab.binding.digiplex.internal.DigiplexZoneConfiguration;
 import org.openhab.binding.digiplex.internal.DigiplexBindingConstants;
 import org.openhab.binding.digiplex.internal.communication.DigiplexMessageHandler;
 import org.openhab.binding.digiplex.internal.communication.DigiplexRequest;
@@ -51,6 +52,7 @@ import org.openhab.binding.digiplex.internal.communication.events.ZoneStatusEven
 @NonNullByDefault
 public class DigiplexZoneHandler extends BaseThingHandler {
 
+    private @Nullable DigiplexZoneConfiguration config;
     private @Nullable DigiplexBridgeHandler bridgeHandler;
     private DigiplexZoneMessageHandler messageHandler = new DigiplexZoneMessageHandler();
     private int zoneNo;
@@ -113,6 +115,7 @@ public class DigiplexZoneHandler extends BaseThingHandler {
     @SuppressWarnings("null")
     @Override
     public void initialize() {
+        config = getConfigAs(DigiplexZoneConfiguration.class);
         Bridge bridge = getBridge();
         if (bridge == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
@@ -121,7 +124,11 @@ public class DigiplexZoneHandler extends BaseThingHandler {
         this.bridgeHandler = (DigiplexBridgeHandler) bridge.getHandler();
 
         String nodeParm = getThing().getProperties().get(DigiplexBindingConstants.PROPERTY_ZONE_NO);
-        zoneNo = Integer.parseInt(nodeParm);
+        if (nodeParm != null) {
+            zoneNo = Integer.parseInt(nodeParm);
+        } else {
+            zoneNo = config.zoneNo;
+        }
         String areaParm = getThing().getProperties().get(DigiplexBindingConstants.PROPERTY_AREA_NO);
         if (areaParm != null) {
             areaNo = Integer.parseInt(areaParm);

--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
@@ -27,7 +27,7 @@
 				<description>Controls how often area status will be refreshed from the PRT3 module</description>
 				<default>60</default>
 			</parameter>
-            <parameter name="areaNo" type="integer">
+			<parameter name="areaNo" type="integer">
 				<label>Area Number</label>
 				<description>The area number</description>
 				<default>0</default>

--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/area.xml
@@ -27,6 +27,11 @@
 				<description>Controls how often area status will be refreshed from the PRT3 module</description>
 				<default>60</default>
 			</parameter>
+            <parameter name="areaNo" type="integer">
+				<label>Area Number</label>
+				<description>The area number</description>
+				<default>0</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/zone.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/zone.xml
@@ -19,6 +19,13 @@
 			<channel typeId="low_battery" id="low_battery"/>
 			<channel typeId="last_triggered" id="last_triggered"/>
 		</channels>
+        <config-description>
+            <parameter name="zoneNo" type="integer">
+				<label>Zone Number</label>
+				<description>The zone number</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
 	</thing-type>
 
 	<channel-type id="status">

--- a/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/zone.xml
+++ b/bundles/org.openhab.binding.digiplex/src/main/resources/ESH-INF/thing/zone.xml
@@ -19,8 +19,8 @@
 			<channel typeId="low_battery" id="low_battery"/>
 			<channel typeId="last_triggered" id="last_triggered"/>
 		</channels>
-        <config-description>
-            <parameter name="zoneNo" type="integer">
+		<config-description>
+			<parameter name="zoneNo" type="integer">
 				<label>Zone Number</label>
 				<description>The zone number</description>
 				<default>0</default>


### PR DESCRIPTION
<!-- TITLE -->
[digiplex]Read area number and zone number from configuration file

<!-- DESCRIPTION -->
Currently the binding allow defining things only by autodiscovery of areas and zones from alarm, system, If you want to setup the OH via configuration files then defining areas and zones is not possible. This PR adds two configuration to area respectively to zone thing where the user can specify the identification number. 

This PR fulfill the enhancement mentioned in #6927

Using configuration file (eg. paradox.things) things cand be defines as:
```
 Bridge digiplex:bridge:paradox "Paradox PRT3" @ "Paradox" [ port="/dev/ttyOpenHabParadox", baudrate=9600 ] {
    Thing area area1 "Paradox GroundFloor" @ "Paradox" [ areaNo=1, refreshPeriod=60 ]
    Thing zone zone1 "Paradox GroundFloor Hall" @ "Paradox" [ zoneNo = 1]
    Thing zone zone2 "Paradox GroundFloor Kitchen" @ "Paradox" [ zoneNo = 2]
 }
```