### PR TITLE
[miio] Update channels only if they are linked

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -319,7 +319,7 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         JsonArray getPropString = new JsonArray();
         for (MiIoBasicChannel miChannel : refreshList) {
             if (!isLinked(miChannel.getChannel())) {
-                logger.info("Skip refresh of channel {} for {} as it is not linked", miChannel.getChannel(),
+                logger.debug("Skip refresh of channel {} for {} as it is not linked", miChannel.getChannel(),
                         getThing().getUID());
                 continue;
             }

--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -318,6 +318,11 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         int maxProperties = device.getDevice().getMaxProperties();
         JsonArray getPropString = new JsonArray();
         for (MiIoBasicChannel miChannel : refreshList) {
+            if (!isLinked(miChannel.getChannel())) {
+                logger.info("Skip refresh of channel {} for {} as it is not linked", miChannel.getChannel(),
+                        getThing().getUID());
+                continue;
+            }
             JsonElement property;
             if (miChannel.isMiOt()) {
                 JsonObject json = new JsonObject();


### PR DESCRIPTION
With introduction of miot devices with enormous amount of channels
refreshes can become slow. With this change only relevant updates are
done.

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>

