### PR TITLE
[hueemulation] Changes to fix pairing and device discovery with Alexa

### DIFF
--- a/bundles/org.openhab.io.hueemulation/README.md
+++ b/bundles/org.openhab.io.hueemulation/README.md
@@ -167,6 +167,15 @@ You must either
   ```
 * or let openHAB run on port 80 (the entire java process requires elevated privileges).
 
+* For Amazon Echo the pairing process may fail due to a 302 response from openHAB, this can be resolved by using a reverse proxy to change the request url from `/api` to `/api/`, for example nginx with the following configuration:
+```
+  server {
+    listen 80;
+    location /api {
+      proxy_pass http://localhost:8080/api/;
+    }
+  }
+  ```
 Please open port 80 tcp and port 1900 udp in your firewall installation.
 
 You can test if the hue emulation does its job by enabling pairing mode including the option "Amazon Echo device discovery fix".

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationService.java
@@ -126,7 +126,7 @@ public class HueEmulationService implements EventHandler {
         @Override
         public Set<Object> getSingletons() {
             return Set.of(userManagement, configurationAccess, lightItems, sensors, scenes, schedules, rules,
-                    statusResource, accessInterceptor);
+                    statusResource, accessInterceptor, requestCleaner);
         }
 
         Dictionary<String, String> serviceProperties() {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/HueEmulationConfigWithRuntime.java
@@ -95,8 +95,7 @@ class HueEmulationConfigWithRuntime extends Thread implements Runnable {
         }
     }
 
-    public synchronized CompletableFuture<@Nullable HueEmulationConfigWithRuntime> startNow(
-            @Nullable HueEmulationConfigWithRuntime ignored) {
+    public synchronized CompletableFuture<@Nullable HueEmulationConfigWithRuntime> startNow() {
         if (hasAlreadyBeenStarted) {
             logger.debug("Cannot restart thread");
             return future;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/upnp/UpnpServer.java
@@ -349,8 +349,9 @@ public class UpnpServer extends HttpServlet implements Consumer<HueEmulationConf
         }
         configChangeFuture = root.thenApply(this::createConfiguration)
                 .thenApplyAsync(this::performAddressTest, executor).thenApply(this::applyConfiguration)
-                .thenCompose(config::startNow)
-                .whenComplete((HueEmulationConfigWithRuntime config, @Nullable Throwable e) -> {
+                .thenCompose(c -> {
+                    return c.startNow();
+                }).whenComplete((HueEmulationConfigWithRuntime config, @Nullable Throwable e) -> {
                     if (e != null) {
                         logger.warn("Upnp server: Address test failed", e);
                     }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
@@ -88,7 +88,7 @@ public class ItemUIDtoHueIDMappingTests {
         itemRegistry.add(item);
 
         String hueID = cs.mapItemUIDtoHueID(item);
-        assertThat(hueID, CoreMatchers.is("2"));
+        assertThat(hueID, CoreMatchers.is("02"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
         assertThat(device.item, is(item));
@@ -108,7 +108,7 @@ public class ItemUIDtoHueIDMappingTests {
         itemRegistry.add(item);
 
         String hueID = cs.mapItemUIDtoHueID(item);
-        assertThat(hueID, CoreMatchers.is("10"));
+        assertThat(hueID, CoreMatchers.is("0A"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
         assertThat(device.item, is(item));

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/upnp/UpnpTests.java
@@ -123,7 +123,7 @@ public class UpnpTests {
         }
 
         // UDP thread started?
-        r.startNow(r).get(5, TimeUnit.SECONDS);
+        r.startNow().get(5, TimeUnit.SECONDS);
         assertThat(subject.upnpAnnouncementThreadRunning(), is(true));
 
         // Send M-SEARCH UPNP "packet" and check if the result contains our bridge ID


### PR DESCRIPTION
Fixes #9147

Enabling pairing would stop the UPNP server until paring was automatically disabled, Alexa would refuse to talk to OH without the UPNP server running and would not start the pairing process.

Alexa requests an API key using the `/api` URL, OH needs to receive `/api/` or else it responds with a 302. Updated the documentation to use a reverse proxy to workaround this.

Alexa no longer seems to like the large `uniqueid` which was previously generated and would fail to discover any devices, this has now been changed to follow the Hue API example.

Tested with Alexa, Logitech Harmony and Hue Control Android app.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>

