### PR TITLE
[comfoair] Update README.md to refelect recent change.

### DIFF
--- a/bundles/org.openhab.binding.comfoair/README.md
+++ b/bundles/org.openhab.binding.comfoair/README.md
@@ -228,7 +228,7 @@ Switch	comfoairFreezeMode			"Freeze [MAP(comfoair_freeze.map):%s]"		<climate>	(C
 sitemap comfoair label="ComfoAir" {
 	Frame label="Main" {
 		Text item=comfoairError labelcolor=[!="No Errors"="red"] valuecolor=[!="No Errors"="red"]
-		Switch item=comfoairControl mappings=[0="CCEase", 1="Computer"]
+		Switch item=comfoairControl mappings=[OFF="CCEase", ON="Computer"]
 		Switch item=comfoairErrorReset mappings=[1="Reset"]
 		Switch item=comfoairFilterReset mappings=[1="Reset"]
 	}


### PR DESCRIPTION
As the ComfoairControl item changed from Number to Switch in the new binding also the sitemap mapping should OFF=CC and ON=APP instead of 0 and 1. I found this out today when running some tests together with Hans Boehm.
Refer to: https://community.openhab.org/t/comfoair-new-comfoair-binding/92891/81