### PR TITLE
[digitalstrom] fixes StringIndexOutOfBoundsException

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
@@ -216,7 +216,7 @@ public class DiscoveryServiceManager
                 }
             }
         } catch (RuntimeException ex) {
-            logger.warn("Unable to add devices {}: {}", device, ex.getMessage());
+            logger.warn("Unable to add devices {}", device, ex);
         }
     }
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
@@ -40,6 +40,8 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.type.ThingType;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link DiscoveryServiceManager} manages the different scene and device discovery services and informs them about
@@ -50,6 +52,8 @@ import org.osgi.framework.ServiceRegistration;
  */
 public class DiscoveryServiceManager
         implements SceneStatusListener, DeviceStatusListener, TemperatureControlStatusListener {
+
+    private final Logger logger = LoggerFactory.getLogger(DiscoveryServiceManager.class);
 
     private final Map<String, AbstractDiscoveryService> discoveryServices;
     private final Map<String, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
@@ -194,20 +198,25 @@ public class DiscoveryServiceManager
 
     @Override
     public void onDeviceAdded(GeneralDeviceInformation device) {
-        if (device instanceof Device) {
-            String id = ((Device) device).getHWinfo().substring(0, 2);
-            if (((Device) device).isSensorDevice()) {
-                id = ((Device) device).getHWinfo();
+        try {
+            if (device instanceof Device) {
+                String id = ((Device) device).getHWinfo().substring(0, 2);
+                if (((Device) device).isSensorDevice()) {
+                    id = ((Device) device).getHWinfo();
+                }
+                if (discoveryServices.get(id) != null) {
+                    ((DeviceDiscoveryService) discoveryServices.get(id)).onDeviceAdded(device);
+                }
             }
-            if (discoveryServices.get(id) != null) {
-                ((DeviceDiscoveryService) discoveryServices.get(id)).onDeviceAdded(device);
+            if (device instanceof Circuit) {
+                if (discoveryServices.get(DsDeviceThingTypeProvider.SupportedThingTypes.circuit.toString()) != null) {
+                    ((DeviceDiscoveryService) discoveryServices
+                            .get(DsDeviceThingTypeProvider.SupportedThingTypes.circuit.toString()))
+                                    .onDeviceAdded(device);
+                }
             }
-        }
-        if (device instanceof Circuit) {
-            if (discoveryServices.get(DsDeviceThingTypeProvider.SupportedThingTypes.circuit.toString()) != null) {
-                ((DeviceDiscoveryService) discoveryServices
-                        .get(DsDeviceThingTypeProvider.SupportedThingTypes.circuit.toString())).onDeviceAdded(device);
-            }
+        } catch (Exception ex) {
+            logger.error("Unable to add devices {}", device);
         }
     }
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
@@ -215,8 +215,8 @@ public class DiscoveryServiceManager
                                     .onDeviceAdded(device);
                 }
             }
-        } catch (Exception ex) {
-            logger.error("Unable to add devices {}", device);
+        } catch (RuntimeException ex) {
+            logger.warn("Unable to add devices {}: {}", device, ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Related to #9048 

This Bugfix catches any exception that could occurs when a device is added. 

I hesitate with specifically checking for the string length and silently ignore if the hardware info is not here, but I think it's best to log an error when something is wrong on digitalstrom side. This log could help us identify the root cause.

This try and catch will also avoid that the module crashes on open hab side.

