### PR TITLE
[squeezebox] Match the name of the binding with the name it has in the UI

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -1,4 +1,4 @@
-# Logitech Squeezebox Binding
+# Squeezebox Binding
 
 This binding integrates the [Logitech Media Server](https://www.mysqueezebox.com) and compatible Squeeze players.
 


### PR DESCRIPTION
I kept searching for "Logitech" in PaperUI but couldn't find it. Until I saw that it's actually called "Squeezebox Binding"

<!--
Aim: to prevent people from going insane
-->

