### PR TITLE
[squeezebox] Clarify the process of adding/discovering the server

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -25,7 +25,8 @@ Squeeze players may be official Logitech products or other players like [Squeeze
 ## Discovery
 
 A Squeeze Server is discovered through UPnP in the local network.
-Once it is added as a Thing the Squeeze Server bridge will discover Squeeze Players automatically. If your Squeeze Server is not discovered automatically, you can add it manually by creating a .thing file containing something like this (more example [below](https://www.openhab.org/addons/bindings/squeezebox/#thing-configuration)):
+Once it is added as a Thing the Squeeze Server bridge will discover Squeeze Players automatically.
+If your Squeeze Server is not discovered automatically, you can add it manually by creating a .thing file containing something like this (more example [below](https://www.openhab.org/addons/bindings/squeezebox/#thing-configuration)):
 ```
 Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090 ]
 ````

--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -25,7 +25,10 @@ Squeeze players may be official Logitech products or other players like [Squeeze
 ## Discovery
 
 A Squeeze Server is discovered through UPnP in the local network.
-Once it is added as a Thing the Squeeze Server bridge will discover Squeeze Players automatically.
+Once it is added as a Thing the Squeeze Server bridge will discover Squeeze Players automatically. If your Squeeze Server is not discovered automatically, you can add it manually by creating a .thing file containing something like this (more example [below](https://www.openhab.org/addons/bindings/squeezebox/#thing-configuration)):
+```
+Bridge squeezebox:squeezeboxserver:myServer [ ipAddress="192.168.1.10", webport=9000, cliport=9090 ]
+````
 
 ## Binding Configuration
 


### PR DESCRIPTION
<!--
Under some circumstances, the LMS server may not be discovered (maybe when openHAB is dockerized?). In those cases, the server may be added manually. It took me a while to figure that out so I clarified this option in the text.
-->

