### PR TITLE
[ipcamera] Improve ONVIF discovery and bug fixes.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
@@ -56,7 +56,7 @@ public class AmcrestHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
@@ -68,9 +68,7 @@ public class AmcrestHandler extends ChannelDuplexHandler {
                 content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
             }
             if (msg instanceof LastHttpContent) {
-                if (!content.isEmpty()) {
-                    ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
-                }
+                ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
                 if (content.contains("Error: No Events")) {
                     if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=VideoMotion".equals(requestUrl)) {
                         ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/AmcrestHandler.java
@@ -31,9 +31,6 @@ import org.openhab.core.types.UnDefType;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -46,7 +43,6 @@ import io.netty.util.ReferenceCountUtil;
 @NonNullByDefault
 public class AmcrestHandler extends ChannelDuplexHandler {
     private String requestUrl = "Empty";
-    private String content = "";
     private IpCameraHandler ipCameraHandler;
 
     public AmcrestHandler(ThingHandler handler) {
@@ -60,55 +56,48 @@ public class AmcrestHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null) {
+        if (msg == null || ctx == null || msg.toString().isEmpty()) {
             return;
         }
         try {
-            if (msg instanceof HttpContent) {
-                content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
+            String content = msg.toString();
+            ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
+            if (content.contains("Error: No Events")) {
+                if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=VideoMotion".equals(requestUrl)) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);
+                } else if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=AudioMutation".equals(requestUrl)) {
+                    ipCameraHandler.noAudioDetected();
+                }
+            } else if (content.contains("channels[0]=0")) {
+                if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=VideoMotion".equals(requestUrl)) {
+                    ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                } else if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=AudioMutation".equals(requestUrl)) {
+                    ipCameraHandler.audioDetected();
+                }
             }
-            if (msg instanceof LastHttpContent) {
-                ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
-                if (content.contains("Error: No Events")) {
-                    if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=VideoMotion".equals(requestUrl)) {
-                        ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);
-                    } else if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=AudioMutation"
-                            .equals(requestUrl)) {
-                        ipCameraHandler.noAudioDetected();
-                    }
-                } else if (content.contains("channels[0]=0")) {
-                    if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=VideoMotion".equals(requestUrl)) {
-                        ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
-                    } else if ("/cgi-bin/eventManager.cgi?action=getEventIndexes&code=AudioMutation"
-                            .equals(requestUrl)) {
-                        ipCameraHandler.audioDetected();
-                    }
-                }
 
-                if (content.contains("table.MotionDetect[0].Enable=false")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
-                } else if (content.contains("table.MotionDetect[0].Enable=true")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
-                }
-                // determine if the audio alarm is turned on or off.
-                if (content.contains("table.AudioDetect[0].MutationDetect=true")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
-                } else if (content.contains("table.AudioDetect[0].MutationDetect=false")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
-                }
-                // Handle AudioMutationThreshold alarm
-                if (content.contains("table.AudioDetect[0].MutationThreold=")) {
-                    String value = ipCameraHandler.returnValueFromString(content,
-                            "table.AudioDetect[0].MutationThreold=");
-                    ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM, PercentType.valueOf(value));
-                }
-                // Privacy Mode on/off
-                if (content.contains("Code=LensMaskOpen;") || content.contains("table.LeLensMask[0].Enable=true")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.ON);
-                } else if (content.contains("Code=LensMaskClose;")
-                        || content.contains("table.LeLensMask[0].Enable=false")) {
-                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.OFF);
-                }
+            if (content.contains("table.MotionDetect[0].Enable=false")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
+            } else if (content.contains("table.MotionDetect[0].Enable=true")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
+            }
+            // determine if the audio alarm is turned on or off.
+            if (content.contains("table.AudioDetect[0].MutationDetect=true")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
+            } else if (content.contains("table.AudioDetect[0].MutationDetect=false")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
+            }
+            // Handle AudioMutationThreshold alarm
+            if (content.contains("table.AudioDetect[0].MutationThreold=")) {
+                String value = ipCameraHandler.returnValueFromString(content, "table.AudioDetect[0].MutationThreold=");
+                ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM, PercentType.valueOf(value));
+            }
+            // Privacy Mode on/off
+            if (content.contains("Code=LensMaskOpen;") || content.contains("table.LeLensMask[0].Enable=true")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.ON);
+            } else if (content.contains("Code=LensMaskClose;")
+                    || content.contains("table.LeLensMask[0].Enable=false")) {
+                ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.OFF);
             }
         } finally {
             ReferenceCountUtil.release(msg);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
@@ -52,7 +52,7 @@ public class DahuaHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
@@ -64,9 +64,7 @@ public class DahuaHandler extends ChannelDuplexHandler {
                 content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
             }
             if (msg instanceof LastHttpContent) {
-                if (!content.isEmpty()) {
-                    ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
-                }
+                ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
                 // determine if the motion detection is turned on or off.
                 if (content.contains("table.MotionDetect[0].Enable=true")) {
                     ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DahuaHandler.java
@@ -30,6 +30,9 @@ import org.openhab.core.types.UnDefType;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -42,6 +45,7 @@ import io.netty.util.ReferenceCountUtil;
 @NonNullByDefault
 public class DahuaHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
+    private String content = "";
     private int nvrChannel;
 
     public DahuaHandler(IpCameraHandler handler, int nvrChannel) {
@@ -55,100 +59,105 @@ public class DahuaHandler extends ChannelDuplexHandler {
         if (msg == null || ctx == null) {
             return;
         }
-        String content = msg.toString();
         try {
-            if (!content.isEmpty()) {
-                ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
+            if (msg instanceof HttpContent) {
+                content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
             }
-            // determine if the motion detection is turned on or off.
-            if (content.contains("table.MotionDetect[0].Enable=true")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
-            } else if (content.contains("table.MotionDetect[" + nvrChannel + "].Enable=false")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
-            }
-            // Handle motion alarm
-            if (content.contains("Code=VideoMotion;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
-            } else if (content.contains("Code=VideoMotion;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);
-            }
-            // Handle item taken alarm
-            if (content.contains("Code=TakenAwayDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_ITEM_TAKEN);
-            } else if (content.contains("Code=TakenAwayDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_ITEM_TAKEN);
-            }
-            // Handle item left alarm
-            if (content.contains("Code=LeftDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_ITEM_LEFT);
-            } else if (content.contains("Code=LeftDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_ITEM_LEFT);
-            }
-            // Handle CrossLineDetection alarm
-            if (content.contains("Code=CrossLineDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_LINE_CROSSING_ALARM);
-            } else if (content.contains("Code=CrossLineDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_LINE_CROSSING_ALARM);
-            }
-            // determine if the audio alarm is turned on or off.
-            if (content.contains("table.AudioDetect[0].MutationDetect=true")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
-            } else if (content.contains("table.AudioDetect[0].MutationDetect=false")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
-            }
-            // Handle AudioMutation alarm
-            if (content.contains("Code=AudioMutation;action=Start;index=0")) {
-                ipCameraHandler.audioDetected();
-            } else if (content.contains("Code=AudioMutation;action=Stop;index=0")) {
-                ipCameraHandler.noAudioDetected();
-            }
-            // Handle AudioMutationThreshold alarm
-            if (content.contains("table.AudioDetect[0].MutationThreold=")) {
-                String value = ipCameraHandler.returnValueFromString(content, "table.AudioDetect[0].MutationThreold=");
-                ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM, PercentType.valueOf(value));
-            }
-            // Handle FaceDetection alarm
-            if (content.contains("Code=FaceDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_FACE_DETECTED);
-            } else if (content.contains("Code=FaceDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_FACE_DETECTED);
-            }
-            // Handle ParkingDetection alarm
-            if (content.contains("Code=ParkingDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_PARKING_ALARM);
-            } else if (content.contains("Code=ParkingDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_PARKING_ALARM);
-            }
-            // Handle CrossRegionDetection alarm
-            if (content.contains("Code=CrossRegionDetection;action=Start;index=0")) {
-                ipCameraHandler.motionDetected(CHANNEL_FIELD_DETECTION_ALARM);
-            } else if (content.contains("Code=CrossRegionDetection;action=Stop;index=0")) {
-                ipCameraHandler.noMotionDetected(CHANNEL_FIELD_DETECTION_ALARM);
-            }
-            // Handle External Input alarm
-            if (content.contains("Code=AlarmLocal;action=Start;index=0")) {
-                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.ON);
-            } else if (content.contains("Code=AlarmLocal;action=Stop;index=0")) {
-                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
-            }
-            // Handle External Input alarm2
-            if (content.contains("Code=AlarmLocal;action=Start;index=1")) {
-                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT2, OnOffType.ON);
-            } else if (content.contains("Code=AlarmLocal;action=Stop;index=1")) {
-                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT2, OnOffType.OFF);
-            }
-            // CrossLineDetection alarm on/off
-            if (content.contains("table.VideoAnalyseRule[0][1].Enable=true")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.ON);
-            } else if (content.contains("table.VideoAnalyseRule[0][1].Enable=false")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.OFF);
-            }
-            // Privacy Mode on/off
-            if (content.contains("Code=LensMaskOpen;") || content.contains("table.LeLensMask[0].Enable=true")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.ON);
-            } else if (content.contains("Code=LensMaskClose;")
-                    || content.contains("table.LeLensMask[0].Enable=false")) {
-                ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.OFF);
+            if (msg instanceof LastHttpContent) {
+                if (!content.isEmpty()) {
+                    ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
+                }
+                // determine if the motion detection is turned on or off.
+                if (content.contains("table.MotionDetect[0].Enable=true")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
+                } else if (content.contains("table.MotionDetect[" + nvrChannel + "].Enable=false")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
+                }
+                // Handle motion alarm
+                if (content.contains("Code=VideoMotion;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                } else if (content.contains("Code=VideoMotion;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_MOTION_ALARM);
+                }
+                // Handle item taken alarm
+                if (content.contains("Code=TakenAwayDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_ITEM_TAKEN);
+                } else if (content.contains("Code=TakenAwayDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_ITEM_TAKEN);
+                }
+                // Handle item left alarm
+                if (content.contains("Code=LeftDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_ITEM_LEFT);
+                } else if (content.contains("Code=LeftDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_ITEM_LEFT);
+                }
+                // Handle CrossLineDetection alarm
+                if (content.contains("Code=CrossLineDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_LINE_CROSSING_ALARM);
+                } else if (content.contains("Code=CrossLineDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_LINE_CROSSING_ALARM);
+                }
+                // determine if the audio alarm is turned on or off.
+                if (content.contains("table.AudioDetect[0].MutationDetect=true")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
+                } else if (content.contains("table.AudioDetect[0].MutationDetect=false")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
+                }
+                // Handle AudioMutation alarm
+                if (content.contains("Code=AudioMutation;action=Start;index=0")) {
+                    ipCameraHandler.audioDetected();
+                } else if (content.contains("Code=AudioMutation;action=Stop;index=0")) {
+                    ipCameraHandler.noAudioDetected();
+                }
+                // Handle AudioMutationThreshold alarm
+                if (content.contains("table.AudioDetect[0].MutationThreold=")) {
+                    String value = ipCameraHandler.returnValueFromString(content,
+                            "table.AudioDetect[0].MutationThreold=");
+                    ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM, PercentType.valueOf(value));
+                }
+                // Handle FaceDetection alarm
+                if (content.contains("Code=FaceDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_FACE_DETECTED);
+                } else if (content.contains("Code=FaceDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_FACE_DETECTED);
+                }
+                // Handle ParkingDetection alarm
+                if (content.contains("Code=ParkingDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_PARKING_ALARM);
+                } else if (content.contains("Code=ParkingDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_PARKING_ALARM);
+                }
+                // Handle CrossRegionDetection alarm
+                if (content.contains("Code=CrossRegionDetection;action=Start;index=0")) {
+                    ipCameraHandler.motionDetected(CHANNEL_FIELD_DETECTION_ALARM);
+                } else if (content.contains("Code=CrossRegionDetection;action=Stop;index=0")) {
+                    ipCameraHandler.noMotionDetected(CHANNEL_FIELD_DETECTION_ALARM);
+                }
+                // Handle External Input alarm
+                if (content.contains("Code=AlarmLocal;action=Start;index=0")) {
+                    ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.ON);
+                } else if (content.contains("Code=AlarmLocal;action=Stop;index=0")) {
+                    ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
+                }
+                // Handle External Input alarm2
+                if (content.contains("Code=AlarmLocal;action=Start;index=1")) {
+                    ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT2, OnOffType.ON);
+                } else if (content.contains("Code=AlarmLocal;action=Stop;index=1")) {
+                    ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT2, OnOffType.OFF);
+                }
+                // CrossLineDetection alarm on/off
+                if (content.contains("table.VideoAnalyseRule[0][1].Enable=true")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.ON);
+                } else if (content.contains("table.VideoAnalyseRule[0][1].Enable=false")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.OFF);
+                }
+                // Privacy Mode on/off
+                if (content.contains("Code=LensMaskOpen;") || content.contains("table.LeLensMask[0].Enable=true")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.ON);
+                } else if (content.contains("Code=LensMaskClose;")
+                        || content.contains("table.LeLensMask[0].Enable=false")) {
+                    ipCameraHandler.setChannelState(CHANNEL_ENABLE_PRIVACY_MODE, OnOffType.OFF);
+                }
             }
         } finally {
             ReferenceCountUtil.release(msg);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DoorBirdHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DoorBirdHandler.java
@@ -48,7 +48,7 @@ public class DoorBirdHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DoorBirdHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/DoorBirdHandler.java
@@ -40,7 +40,6 @@ import io.netty.util.ReferenceCountUtil;
 @NonNullByDefault
 public class DoorBirdHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
-    private String content = "";
 
     public DoorBirdHandler(ThingHandler handler) {
         ipCameraHandler = (IpCameraHandler) handler;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
@@ -171,8 +171,7 @@ public class Ffmpeg {
     public void startConverting() {
         if (!ipCameraFfmpegThread.isAlive()) {
             ipCameraFfmpegThread = new IpCameraFfmpegThread();
-            logger.debug("Starting ffmpeg with this command now:{}",
-                    ffmpegCommand.replaceAll(password, "********"));
+            logger.debug("Starting ffmpeg with this command now:{}", ffmpegCommand.replaceAll(password, "********"));
             ipCameraFfmpegThread.start();
             running = true;
             if (format.equals(FFmpegFormat.HLS)) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
@@ -53,10 +53,12 @@ public class Ffmpeg {
     private IpCameraFfmpegThread ipCameraFfmpegThread = new IpCameraFfmpegThread();
     private int keepAlive = 8;
     private boolean running = false;
+    private String password;
 
     public Ffmpeg(IpCameraHandler handle, FFmpegFormat format, String ffmpegLocation, String inputArguments,
             String input, String outArguments, String output, String username, String password) {
         this.format = format;
+        this.password = password;
         ipCameraHandler = handle;
         String altInput = input;
         // Input can be snapshots not just rtsp or http
@@ -169,7 +171,8 @@ public class Ffmpeg {
     public void startConverting() {
         if (!ipCameraFfmpegThread.isAlive()) {
             ipCameraFfmpegThread = new IpCameraFfmpegThread();
-            logger.debug("Starting ffmpeg with this command now:{}", ffmpegCommand);
+            logger.debug("Starting ffmpeg with this command now:{}",
+                    ffmpegCommand.replaceAll(password, "passwordRemoved"));
             ipCameraFfmpegThread.start();
             running = true;
             if (format.equals(FFmpegFormat.HLS)) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/Ffmpeg.java
@@ -172,7 +172,7 @@ public class Ffmpeg {
         if (!ipCameraFfmpegThread.isAlive()) {
             ipCameraFfmpegThread = new IpCameraFfmpegThread();
             logger.debug("Starting ffmpeg with this command now:{}",
-                    ffmpegCommand.replaceAll(password, "passwordRemoved"));
+                    ffmpegCommand.replaceAll(password, "********"));
             ipCameraFfmpegThread.start();
             running = true;
             if (format.equals(FFmpegFormat.HLS)) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
@@ -44,7 +44,6 @@ import io.netty.util.ReferenceCountUtil;
 public class FoscamHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
     private String password, username;
-    private String content = "";
 
     public FoscamHandler(ThingHandler handler, String username, String password) {
         ipCameraHandler = (IpCameraHandler) handler;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/FoscamHandler.java
@@ -54,7 +54,7 @@ public class FoscamHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -36,10 +36,13 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -55,6 +58,7 @@ public class HikvisionHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
     private int nvrChannel;
     private int lineCount, vmdCount, leftCount, takenCount, faceCount, pirCount, fieldCount;
+    private String content = "";
 
     public HikvisionHandler(ThingHandler handler, int nvrChannel) {
         ipCameraHandler = (IpCameraHandler) handler;
@@ -67,158 +71,161 @@ public class HikvisionHandler extends ChannelDuplexHandler {
         if (msg == null || ctx == null) {
             return;
         }
-        String content = "";
-        int debounce = 3;
         try {
-            content = msg.toString();
-            if (content.isEmpty()) {
-                return;
+            if (msg instanceof HttpContent) {
+                content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
             }
-            logger.trace("HTTP Result back from camera is \t:{}:", content);
-
-            if (content.contains("--boundary")) {// Alarm checking goes in here//
-                if (content.contains("<EventNotificationAlert version=\"")) {
-                    if (content.contains("hannelID>" + nvrChannel + "</")) {// some camera use c or <dynChannelID>
-                        if (content.contains("<eventType>linedetection</eventType>")) {
-                            ipCameraHandler.motionDetected(CHANNEL_LINE_CROSSING_ALARM);
-                            lineCount = debounce;
-                        }
-                        if (content.contains("<eventType>fielddetection</eventType>")) {
-                            ipCameraHandler.motionDetected(CHANNEL_FIELD_DETECTION_ALARM);
-                            fieldCount = debounce;
-                        }
-                        if (content.contains("<eventType>VMD</eventType>")) {
-                            ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
-                            vmdCount = debounce;
-                        }
-                        if (content.contains("<eventType>facedetection</eventType>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_FACE_DETECTED, OnOffType.ON);
-                            faceCount = debounce;
-                        }
-                        if (content.contains("<eventType>unattendedBaggage</eventType>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ITEM_LEFT, OnOffType.ON);
-                            leftCount = debounce;
-                        }
-                        if (content.contains("<eventType>attendedBaggage</eventType>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ITEM_TAKEN, OnOffType.ON);
-                            takenCount = debounce;
-                        }
-                        if (content.contains("<eventType>PIR</eventType>")) {
-                            ipCameraHandler.motionDetected(CHANNEL_PIR_ALARM);
-                            pirCount = debounce;
-                        }
-                        if (content.contains("<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
-                            if (vmdCount > 1) {
-                                vmdCount = 1;
+            if (msg instanceof LastHttpContent) {
+                logger.trace("HTTP Result back from camera is \t:{}:", content);
+                int debounce = 3;
+                if (content.contains("--boundary")) {// Alarm checking goes in here//
+                    if (content.contains("<EventNotificationAlert version=\"")) {
+                        if (content.contains("hannelID>" + nvrChannel + "</")) {// some camera use c or <dynChannelID>
+                            if (content.contains("<eventType>linedetection</eventType>")) {
+                                ipCameraHandler.motionDetected(CHANNEL_LINE_CROSSING_ALARM);
+                                lineCount = debounce;
                             }
-                            countDown();
-                            countDown();
-                        }
-                    } else if (content.contains("<channelID>0</channelID>")) {// NVR uses channel 0 to say all channels
-                        if (content.contains("<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
-                            if (vmdCount > 1) {
-                                vmdCount = 1;
+                            if (content.contains("<eventType>fielddetection</eventType>")) {
+                                ipCameraHandler.motionDetected(CHANNEL_FIELD_DETECTION_ALARM);
+                                fieldCount = debounce;
                             }
-                            countDown();
-                            countDown();
-                        }
-                    }
-                    countDown();
-                }
-            } else {
-                String replyElement = Helper.fetchXML(content, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<");
-                switch (replyElement) {
-                    case "MotionDetection version=":
-                        ipCameraHandler.storeHttpReply(
-                                "/ISAPI/System/Video/inputs/channels/" + nvrChannel + "01/motionDetection", content);
-                        if (content.contains("<enabled>true</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
-                        } else if (content.contains("<enabled>false</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "IOInputPort version=":
-                        ipCameraHandler.storeHttpReply("/ISAPI/System/IO/inputs/" + nvrChannel, content);
-                        if (content.contains("<enabled>true</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.ON);
-                        } else if (content.contains("<enabled>false</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
-                        }
-                        if (content.contains("<triggering>low</triggering>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_TRIGGER_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
-                        } else if (content.contains("<triggering>high</triggering>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_TRIGGER_EXTERNAL_ALARM_INPUT, OnOffType.ON);
-                        }
-                        break;
-                    case "LineDetection":
-                        ipCameraHandler.storeHttpReply("/ISAPI/Smart/LineDetection/" + nvrChannel + "01", content);
-                        if (content.contains("<enabled>true</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.ON);
-                        } else if (content.contains("<enabled>false</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "TextOverlay version=":
-                        ipCameraHandler.storeHttpReply(
-                                "/ISAPI/System/Video/inputs/channels/" + nvrChannel + "/overlays/text/1", content);
-                        String text = Helper.fetchXML(content, "<enabled>true</enabled>", "<displayText>");
-                        ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.valueOf(text));
-                        break;
-                    case "AudioDetection version=":
-                        ipCameraHandler.storeHttpReply("/ISAPI/Smart/AudioDetection/channels/" + nvrChannel + "01",
-                                content);
-                        if (content.contains("<enabled>true</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
-                        } else if (content.contains("<enabled>false</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "IOPortStatus version=":
-                        if (content.contains("<ioState>active</ioState>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.ON);
-                        } else if (content.contains("<ioState>inactive</ioState>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
-                        }
-                        break;
-                    case "FieldDetection version=":
-                        ipCameraHandler.storeHttpReply("/ISAPI/Smart/FieldDetection/" + nvrChannel + "01", content);
-                        if (content.contains("<enabled>true</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_FIELD_DETECTION_ALARM, OnOffType.ON);
-                        } else if (content.contains("<enabled>false</enabled>")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_FIELD_DETECTION_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "ResponseStatus version=":
-                        ////////////////// External Alarm Input ///////////////
-                        if (content.contains(
-                                "<requestURL>/ISAPI/System/IO/inputs/" + nvrChannel + "/status</requestURL>")) {
-                            // Stops checking the external alarm if camera does not have feature.
-                            if (content.contains("<statusString>Invalid Operation</statusString>")) {
-                                ipCameraHandler.lowPriorityRequests.remove(0);
-                                ipCameraHandler.logger.debug(
-                                        "Stopping checks for alarm inputs as camera appears to be missing this feature.");
+                            if (content.contains("<eventType>VMD</eventType>")) {
+                                ipCameraHandler.motionDetected(CHANNEL_MOTION_ALARM);
+                                vmdCount = debounce;
                             }
-                        }
-                        break;
-                    default:
-                        if (content.contains("<EventNotificationAlert")) {
-                            if (content.contains("hannelID>" + nvrChannel + "</")
-                                    || content.contains("<channelID>0</channelID>")) {// some camera use c or
-                                                                                      // <dynChannelID>
-                                if (content.contains(
-                                        "<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
-                                    if (vmdCount > 1) {
-                                        vmdCount = 1;
-                                    }
-                                    countDown();
-                                    countDown();
+                            if (content.contains("<eventType>facedetection</eventType>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_FACE_DETECTED, OnOffType.ON);
+                                faceCount = debounce;
+                            }
+                            if (content.contains("<eventType>unattendedBaggage</eventType>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ITEM_LEFT, OnOffType.ON);
+                                leftCount = debounce;
+                            }
+                            if (content.contains("<eventType>attendedBaggage</eventType>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ITEM_TAKEN, OnOffType.ON);
+                                takenCount = debounce;
+                            }
+                            if (content.contains("<eventType>PIR</eventType>")) {
+                                ipCameraHandler.motionDetected(CHANNEL_PIR_ALARM);
+                                pirCount = debounce;
+                            }
+                            if (content.contains(
+                                    "<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
+                                if (vmdCount > 1) {
+                                    vmdCount = 1;
                                 }
                                 countDown();
+                                countDown();
                             }
-                        } else {
-                            logger.debug("Unhandled reply-{}.", content);
+                        } else if (content.contains("<channelID>0</channelID>")) {// NVR uses channel 0 to say all
+                                                                                  // channels
+                            if (content.contains(
+                                    "<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
+                                if (vmdCount > 1) {
+                                    vmdCount = 1;
+                                }
+                                countDown();
+                                countDown();
+                            }
                         }
-                        break;
+                        countDown();
+                    }
+                } else {
+                    String replyElement = Helper.fetchXML(content, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<");
+                    switch (replyElement) {
+                        case "MotionDetection version=":
+                            ipCameraHandler.storeHttpReply(
+                                    "/ISAPI/System/Video/inputs/channels/" + nvrChannel + "01/motionDetection",
+                                    content);
+                            if (content.contains("<enabled>true</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
+                            } else if (content.contains("<enabled>false</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
+                            }
+                            break;
+                        case "IOInputPort version=":
+                            ipCameraHandler.storeHttpReply("/ISAPI/System/IO/inputs/" + nvrChannel, content);
+                            if (content.contains("<enabled>true</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.ON);
+                            } else if (content.contains("<enabled>false</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
+                            }
+                            if (content.contains("<triggering>low</triggering>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_TRIGGER_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
+                            } else if (content.contains("<triggering>high</triggering>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_TRIGGER_EXTERNAL_ALARM_INPUT, OnOffType.ON);
+                            }
+                            break;
+                        case "LineDetection":
+                            ipCameraHandler.storeHttpReply("/ISAPI/Smart/LineDetection/" + nvrChannel + "01", content);
+                            if (content.contains("<enabled>true</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.ON);
+                            } else if (content.contains("<enabled>false</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_LINE_CROSSING_ALARM, OnOffType.OFF);
+                            }
+                            break;
+                        case "TextOverlay version=":
+                            ipCameraHandler.storeHttpReply(
+                                    "/ISAPI/System/Video/inputs/channels/" + nvrChannel + "/overlays/text/1", content);
+                            String text = Helper.fetchXML(content, "<enabled>true</enabled>", "<displayText>");
+                            ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.valueOf(text));
+                            break;
+                        case "AudioDetection version=":
+                            ipCameraHandler.storeHttpReply("/ISAPI/Smart/AudioDetection/channels/" + nvrChannel + "01",
+                                    content);
+                            if (content.contains("<enabled>true</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
+                            } else if (content.contains("<enabled>false</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
+                            }
+                            break;
+                        case "IOPortStatus version=":
+                            if (content.contains("<ioState>active</ioState>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.ON);
+                            } else if (content.contains("<ioState>inactive</ioState>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
+                            }
+                            break;
+                        case "FieldDetection version=":
+                            ipCameraHandler.storeHttpReply("/ISAPI/Smart/FieldDetection/" + nvrChannel + "01", content);
+                            if (content.contains("<enabled>true</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_FIELD_DETECTION_ALARM, OnOffType.ON);
+                            } else if (content.contains("<enabled>false</enabled>")) {
+                                ipCameraHandler.setChannelState(CHANNEL_ENABLE_FIELD_DETECTION_ALARM, OnOffType.OFF);
+                            }
+                            break;
+                        case "ResponseStatus version=":
+                            ////////////////// External Alarm Input ///////////////
+                            if (content.contains(
+                                    "<requestURL>/ISAPI/System/IO/inputs/" + nvrChannel + "/status</requestURL>")) {
+                                // Stops checking the external alarm if camera does not have feature.
+                                if (content.contains("<statusString>Invalid Operation</statusString>")) {
+                                    ipCameraHandler.lowPriorityRequests.remove(0);
+                                    ipCameraHandler.logger.debug(
+                                            "Stopping checks for alarm inputs as camera appears to be missing this feature.");
+                                }
+                            }
+                            break;
+                        default:
+                            if (content.contains("<EventNotificationAlert")) {
+                                if (content.contains("hannelID>" + nvrChannel + "</")
+                                        || content.contains("<channelID>0</channelID>")) {// some camera use c or
+                                                                                          // <dynChannelID>
+                                    if (content.contains(
+                                            "<eventType>videoloss</eventType>\r\n<eventState>inactive</eventState>")) {
+                                        if (vmdCount > 1) {
+                                            vmdCount = 1;
+                                        }
+                                        countDown();
+                                        countDown();
+                                    }
+                                    countDown();
+                                }
+                            } else {
+                                logger.debug("Unhandled reply-{}.", content);
+                            }
+                            break;
+                    }
                 }
             }
         } finally {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -64,7 +64,7 @@ public class HikvisionHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/HikvisionHandler.java
@@ -55,7 +55,6 @@ public class HikvisionHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
     private int nvrChannel;
     private int lineCount, vmdCount, leftCount, takenCount, faceCount, pirCount, fieldCount;
-    private String content = "";
 
     public HikvisionHandler(ThingHandler handler, int nvrChannel) {
         ipCameraHandler = (IpCameraHandler) handler;
@@ -70,7 +69,7 @@ public class HikvisionHandler extends ChannelDuplexHandler {
         }
         try {
             int debounce = 3;
-            content = msg.toString();
+            String content = msg.toString();
             logger.trace("HTTP Result back from camera is \t:{}:", content);
             if (content.contains("--boundary")) {// Alarm checking goes in here//
                 if (content.contains("<EventNotificationAlert version=\"")) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -43,7 +43,6 @@ import io.netty.util.ReferenceCountUtil;
 public class InstarHandler extends ChannelDuplexHandler {
     private IpCameraHandler ipCameraHandler;
     private String requestUrl = "Empty";
-    private String content = "";
 
     public InstarHandler(ThingHandler thingHandler) {
         ipCameraHandler = (IpCameraHandler) thingHandler;

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -30,9 +30,6 @@ import org.openhab.core.types.RefreshType;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
 /**
@@ -63,67 +60,62 @@ public class InstarHandler extends ChannelDuplexHandler {
             return;
         }
         try {
-            if (msg instanceof HttpContent) {
-                content += ((HttpContent) msg).content().toString(CharsetUtil.UTF_8);
-            }
-            if (msg instanceof LastHttpContent) {
-                String value1 = "";
-                ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
-                switch (requestUrl) {
-                    case "/param.cgi?cmd=getinfrared":
-                        if (content.contains("var infraredstat=\"auto")) {
-                            ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.ON);
-                        } else {
-                            ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.OFF);
+            String value1 = "";
+            String content = msg.toString();
+            ipCameraHandler.logger.trace("HTTP Result back from camera is \t:{}:", content);
+            switch (requestUrl) {
+                case "/param.cgi?cmd=getinfrared":
+                    if (content.contains("var infraredstat=\"auto")) {
+                        ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.ON);
+                    } else {
+                        ipCameraHandler.setChannelState(CHANNEL_AUTO_LED, OnOffType.OFF);
+                    }
+                    break;
+                case "/param.cgi?cmd=getoverlayattr&-region=1":// Text Overlays
+                    if (content.contains("var show_1=\"0\"")) {
+                        ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.EMPTY);
+                    } else {
+                        value1 = Helper.searchString(content, "var name_1=\"");
+                        if (!value1.isEmpty()) {
+                            ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.valueOf(value1));
                         }
-                        break;
-                    case "/param.cgi?cmd=getoverlayattr&-region=1":// Text Overlays
-                        if (content.contains("var show_1=\"0\"")) {
-                            ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.EMPTY);
-                        } else {
-                            value1 = Helper.searchString(content, "var name_1=\"");
-                            if (!value1.isEmpty()) {
-                                ipCameraHandler.setChannelState(CHANNEL_TEXT_OVERLAY, StringType.valueOf(value1));
-                            }
+                    }
+                    break;
+                case "/cgi-bin/hi3510/param.cgi?cmd=getmdattr":// Motion Alarm
+                    // Motion Alarm
+                    if (content.contains("var m1_enable=\"1\"")) {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
+                    } else {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
+                    }
+                    break;
+                case "/cgi-bin/hi3510/param.cgi?cmd=getaudioalarmattr":// Audio Alarm
+                    if (content.contains("var aa_enable=\"1\"")) {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
+                        value1 = Helper.searchString(content, "var aa_value=\"");
+                        if (!value1.isEmpty()) {
+                            ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM, PercentType.valueOf(value1));
                         }
-                        break;
-                    case "/cgi-bin/hi3510/param.cgi?cmd=getmdattr":// Motion Alarm
-                        // Motion Alarm
-                        if (content.contains("var m1_enable=\"1\"")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.ON);
-                        } else {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_MOTION_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "/cgi-bin/hi3510/param.cgi?cmd=getaudioalarmattr":// Audio Alarm
-                        if (content.contains("var aa_enable=\"1\"")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.ON);
-                            value1 = Helper.searchString(content, "var aa_value=\"");
-                            if (!value1.isEmpty()) {
-                                ipCameraHandler.setChannelState(CHANNEL_THRESHOLD_AUDIO_ALARM,
-                                        PercentType.valueOf(value1));
-                            }
-                        } else {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
-                        }
-                        break;
-                    case "param.cgi?cmd=getpirattr":// PIR Alarm
-                        if (content.contains("var pir_enable=\"1\"")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_PIR_ALARM, OnOffType.ON);
-                        } else {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_PIR_ALARM, OnOffType.OFF);
-                        }
-                        // Reset the Alarm, need to find better place to put this.
-                        ipCameraHandler.noMotionDetected(CHANNEL_PIR_ALARM);
-                        break;
-                    case "/param.cgi?cmd=getioattr":// External Alarm Input
-                        if (content.contains("var io_enable=\"1\"")) {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.ON);
-                        } else {
-                            ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
-                        }
-                        break;
-                }
+                    } else {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_AUDIO_ALARM, OnOffType.OFF);
+                    }
+                    break;
+                case "param.cgi?cmd=getpirattr":// PIR Alarm
+                    if (content.contains("var pir_enable=\"1\"")) {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_PIR_ALARM, OnOffType.ON);
+                    } else {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_PIR_ALARM, OnOffType.OFF);
+                    }
+                    // Reset the Alarm, need to find better place to put this.
+                    ipCameraHandler.noMotionDetected(CHANNEL_PIR_ALARM);
+                    break;
+                case "/param.cgi?cmd=getioattr":// External Alarm Input
+                    if (content.contains("var io_enable=\"1\"")) {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.ON);
+                    } else {
+                        ipCameraHandler.setChannelState(CHANNEL_ENABLE_EXTERNAL_ALARM_INPUT, OnOffType.OFF);
+                    }
+                    break;
             }
         } finally {
             ReferenceCountUtil.release(msg);

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -59,7 +59,7 @@ public class InstarHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null) {
+        if (msg == null || ctx == null || msg.toString().isEmpty()) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/InstarHandler.java
@@ -55,7 +55,7 @@ public class InstarHandler extends ChannelDuplexHandler {
     // This handles the incoming http replies back from the camera.
     @Override
     public void channelRead(@Nullable ChannelHandlerContext ctx, @Nullable Object msg) throws Exception {
-        if (msg == null || ctx == null || msg.toString().isEmpty()) {
+        if (msg == null || ctx == null) {
             return;
         }
         try {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraDiscoveryService.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/IpCameraDiscoveryService.java
@@ -68,7 +68,7 @@ public class IpCameraDiscoveryService extends AbstractDiscoveryService {
         removeOlderResults(getTimestampOfLastScan());
         OnvifDiscovery onvifDiscovery = new OnvifDiscovery(this);
         try {
-            onvifDiscovery.discoverCameras(3702);// WS discovery
+            onvifDiscovery.discoverCameras();
         } catch (UnknownHostException | InterruptedException e) {
             logger.warn(
                     "IpCamera Discovery has an issue discovering the network settings to find cameras with. Try setting up the camera manually.");

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifDiscovery.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -42,19 +43,21 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFactory;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.GlobalEventExecutor;
 
 /**
- * The {@link OnvifDiscovery} is responsible for finding cameras that are Onvif using UDP multicast.
+ * The {@link OnvifDiscovery} is responsible for finding cameras that are ONVIF using UDP multicast.
  *
  * @author Matthew Skinner - Initial contribution
  */
@@ -69,7 +72,8 @@ public class OnvifDiscovery {
         this.ipCameraDiscoveryService = ipCameraDiscoveryService;
     }
 
-    public @Nullable NetworkInterface getLocalNIF() {
+    public @Nullable List<NetworkInterface> getLocalNICs() {
+        List<NetworkInterface> results = new ArrayList<>(2);
         try {
             for (Enumeration<NetworkInterface> enumNetworks = NetworkInterface.getNetworkInterfaces(); enumNetworks
                     .hasMoreElements();) {
@@ -79,13 +83,13 @@ public class OnvifDiscovery {
                     InetAddress inetAddress = enumIpAddr.nextElement();
                     if (!inetAddress.isLoopbackAddress() && inetAddress.getHostAddress().toString().length() < 18
                             && inetAddress.isSiteLocalAddress()) {
-                        return networkInterface;
+                        results.add(networkInterface);
                     }
                 }
             }
         } catch (SocketException ex) {
         }
-        return null;
+        return results;
     }
 
     void searchReply(String url, String xml) {
@@ -180,23 +184,21 @@ public class OnvifDiscovery {
         return brand;
     }
 
-    public void discoverCameras(int port) throws UnknownHostException, InterruptedException {
-        String uuid = UUID.randomUUID().toString();
-        String xml = "";
-
-        if (port == 3702) {
-            xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><e:Envelope xmlns:e=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:w=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" xmlns:dn=\"http://www.onvif.org/ver10/network/wsdl\"><e:Header><w:MessageID>uuid:"
-                    + uuid
-                    + "</w:MessageID><w:To e:mustUnderstand=\"true\">urn:schemas-xmlsoap-org:ws:2005:04:discovery</w:To><w:Action a:mustUnderstand=\"true\">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action></e:Header><e:Body><d:Probe><d:Types xmlns:dp0=\"http://www.onvif.org/ver10/network/wsdl\">dp0:NetworkVideoTransmitter</d:Types></d:Probe></e:Body></e:Envelope>";
-        }
+    private DatagramPacket wsDiscovery() throws UnknownHostException {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><e:Envelope xmlns:e=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:w=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" xmlns:dn=\"http://www.onvif.org/ver10/network/wsdl\"><e:Header><w:MessageID>uuid:"
+                + UUID.randomUUID()
+                + "</w:MessageID><w:To e:mustUnderstand=\"true\">urn:schemas-xmlsoap-org:ws:2005:04:discovery</w:To><w:Action a:mustUnderstand=\"true\">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action></e:Header><e:Body><d:Probe><d:Types xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" xmlns:dp0=\"http://www.onvif.org/ver10/network/wsdl\">dp0:NetworkVideoTransmitter</d:Types></d:Probe></e:Body></e:Envelope>";
         ByteBuf discoveryProbeMessage = Unpooled.copiedBuffer(xml, 0, xml.length(), StandardCharsets.UTF_8);
-        InetSocketAddress localNetworkAddress = new InetSocketAddress(0);// Listen for replies on all connections.
-        InetSocketAddress multiCastAddress = new InetSocketAddress(InetAddress.getByName("239.255.255.250"), port);
-        DatagramPacket datagramPacket = new DatagramPacket(discoveryProbeMessage, multiCastAddress,
-                localNetworkAddress);
-        NetworkInterface networkInterface = getLocalNIF();
-        DatagramChannel datagramChannel;
+        return new DatagramPacket(discoveryProbeMessage,
+                new InetSocketAddress(InetAddress.getByName("239.255.255.250"), 3702), new InetSocketAddress(0));
+    }
 
+    public void discoverCameras() throws UnknownHostException, InterruptedException {
+        List<NetworkInterface> nics = getLocalNICs();
+        if (nics == null || nics.isEmpty()) {
+            return;
+        }
+        NetworkInterface networkInterface = nics.get(0);
         Bootstrap bootstrap = new Bootstrap().group(new NioEventLoopGroup())
                 .channelFactory(new ChannelFactory<NioDatagramChannel>() {
                     @Override
@@ -213,26 +215,21 @@ public class OnvifDiscovery {
                 }).option(ChannelOption.SO_BROADCAST, true).option(ChannelOption.SO_REUSEADDR, true)
                 .option(ChannelOption.IP_MULTICAST_LOOP_DISABLED, false).option(ChannelOption.SO_RCVBUF, 2048)
                 .option(ChannelOption.IP_MULTICAST_TTL, 255).option(ChannelOption.IP_MULTICAST_IF, networkInterface);
-
-        datagramChannel = (DatagramChannel) bootstrap.bind(localNetworkAddress).sync().channel();
-        datagramChannel.joinGroup(multiCastAddress, networkInterface).sync();
-        ChannelFuture chFuture;
-        if (port == 1900) {
-            String ssdp = "M-SEARCH * HTTP/1.1\n" + "HOST: 239.255.255.250:1900\n" + "MAN: \"ssdp:discover\"\n"
-                    + "MX: 1\n" + "ST: urn:dial-multiscreen-org:service:dial:1\n"
-                    + "USER-AGENT: Microsoft Edge/83.0.478.61 Windows\n" + "\n" + "";
-            ByteBuf ssdpProbeMessage = Unpooled.copiedBuffer(ssdp, 0, ssdp.length(), StandardCharsets.UTF_8);
-            datagramPacket = new DatagramPacket(ssdpProbeMessage, multiCastAddress, localNetworkAddress);
-            chFuture = datagramChannel.writeAndFlush(datagramPacket);
-        } else {
-            chFuture = datagramChannel.writeAndFlush(datagramPacket);
+        ChannelGroup openChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        for (NetworkInterface nic : nics) {
+            DatagramChannel datagramChannel = (DatagramChannel) bootstrap.option(ChannelOption.IP_MULTICAST_IF, nic)
+                    .bind(new InetSocketAddress(0)).sync().channel();
+            datagramChannel
+                    .joinGroup(new InetSocketAddress(InetAddress.getByName("239.255.255.250"), 3702), networkInterface)
+                    .sync();
+            openChannels.add(datagramChannel);
         }
-        chFuture.awaitUninterruptibly(2000);
-        chFuture = datagramChannel.closeFuture();
-        TimeUnit.SECONDS.sleep(5);
-        datagramChannel.close();
-        chFuture.awaitUninterruptibly(6000);
-        processCameraReplys();
-        bootstrap.config().group().shutdownGracefully();
+        if (!openChannels.isEmpty()) {
+            openChannels.writeAndFlush(wsDiscovery());
+            TimeUnit.SECONDS.sleep(6);
+            openChannels.close();
+            processCameraReplys();
+            bootstrap.config().group().shutdownGracefully();
+        }
     }
 }

--- a/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.ipcamera/src/main/resources/OH-INF/thing/thing-types.xml
@@ -2665,7 +2665,7 @@
 		<category>Light</category>
 	</channel-type>
 
-	<channel-type id="enablePrivacyMode">
+	<channel-type id="enablePrivacyMode" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Enable Privacy Mode</label>
 		<description>Turn the Privacy Mode on and off.</description>


### PR DESCRIPTION
Closed #9167
Closed #9023
Closed #9022

This PR changes the following:

- Fix Offline detection. Would not detect the camera was offline when not polling a snapshot.
- Improve ONVIF discovery. Now scans on all NICs instead of only the first interface the binding would find.
- Fix motion alarm FFmpeg options. Config was not working correctly if the user supplied options was '-vf xxxxxx' due to binding already providing this argument already.
- Improve log by removing password from logged FFmpeg commands.
- Refactor some code to make it slightly faster and consistent between similar classes.
