### PR TITLE
[avmfritz] Properly interrupt monitor thread upon dispose

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/callmonitor/CallMonitor.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/callmonitor/CallMonitor.java
@@ -75,6 +75,7 @@ public class CallMonitor {
      */
     public void dispose() {
         reconnectJob.cancel(true);
+        CallMonitorThread monitorThread = this.monitorThread;
         if (monitorThread != null) {
             monitorThread.interrupt();
         }


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>