### PR TITLE
[miio] Update channels only if they are linked (#9163)

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/handler/MiIoBasicHandler.java
@@ -291,6 +291,11 @@ public class MiIoBasicHandler extends MiIoAbstractHandler {
         int maxProperties = device.getDevice().getMaxProperties();
         JsonArray getPropString = new JsonArray();
         for (MiIoBasicChannel miChannel : refreshList) {
+            if (!isLinked(miChannel.getChannel())) {
+                logger.debug("Skip refresh of channel {} for {} as it is not linked", miChannel.getChannel(),
+                        getThing().getUID());
+                continue;
+            }
             JsonElement property;
             if (miChannel.isMiOt()) {
                 JsonObject json = new JsonObject();


### PR DESCRIPTION
* [miio] Update channels only if they are linked

With introduction of miot devices with enormous amount of channels
refreshes can become slow. With this change only relevant updates are
done.

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>

backport from OH3