### PR TITLE
[espmilighthub] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -164,6 +164,7 @@
 /bundles/org.openhab.binding.monopriceaudio/ @mlobstein
 /bundles/org.openhab.binding.mpd/ @stefanroellin
 /bundles/org.openhab.binding.mqtt/ @davidgraeff
+/bundles/org.openhab.binding.mqtt.espmilighthub/ @Skinah
 /bundles/org.openhab.binding.mqtt.generic/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.homeassistant/ @davidgraeff
 /bundles/org.openhab.binding.mqtt.homie/ @davidgraeff

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -808,6 +808,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.mqtt.espmilighthub</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.mqtt.generic</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/NOTICE
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -1,0 +1,156 @@
+# EspMilightHub Binding
+
+This binding allows an open source esp8266 based bridge to automatically find and add Milight globes.
+The hubs can be built from 2 ready made boards and connecting them with 7 wires, they can be very easy to build with no soldering needed. 
+
+Advantages to using this DIY bridge over the OEM bridge:
+
++ Almost unlimited groups so you can have individual control over an entire house of Milight globes without multiple bridges.
++ If using the Milight remotes to control the globes with this binding can update the openHAB controls the moment a key is pressed on the remote.
++ Supports auto discovery.
+
+## Setup the hardware
+
+In depth details on how to build and what the bridge is can be found here: <http://blog.christophermullins.com/2017/02/11/milight-wifi-gateway-emulator-on-an-esp8266>
+
+A quick overview of the steps to get the hardware going are:
+
++ Connect a nodemcu/D1 mini/esp8266 to your computer via a USB cable.
++ Download the latest BIN file from here <https://github.com/sidoh/esp8266_milight_hub/releases>
++ Download esp8266flasher if you are on windows <https://github.com/nodemcu/nodemcu-flasher>
++ Check the blog above on more info for Mac or Linux.
++ Open the flasher tool and make sure the flash size is 4mb or whatever your esp8266 board has.
++ Flash the bin and press the reset button on the board when it completes.
++ Connect to the wifi access point of the esp directly with your phone/tablet and setup wifi details.
++ Login by using the IP address of the esp8266 in a web browser and the control panel will show up.
++ Connect 7 wires between the two ready made PCBs as shown in the blog.
++ Setup a MQTT broker as this method uses the faster and lightweight MQTT protocol and not UDP.
+
+## Setup the Firmware
+
+Enter the control panel for the ESP8266 by using any browser and enter the IP address. 
+The following options need to be changed in the firmware for the binding to work.
+Click on SETTINGS>MQTT>:
+
+**mqtt_topic_pattern:**
+`milight/commands/:device_id/:device_type/:group_id`
+
+**mqtt_update_topic_pattern:**
+Leave this blank.
+
+**mqtt_state_topic_pattern:**
+`milight/states/:device_id/:device_type/:group_id`
+
+**group_state_fields:** 
+IMPORTANT: Make sure only the following are ticked:
+
++ state
++ level
++ hue
++ saturation
++ mode
++ color_temp
++ bulb_mode
+
+Fill in the MQTT broker fields with the correct details so the hub can connect and then click **save**.
+Now when you use any Milight remote control, you will see MQTT topics being created that should include `level` and `hsb` in the messages.
+If you see `brightness` and not `level`, then go back and follow the above setup steps.
+
+You can use this linux command to watch all MQTT topics from milight:
+
+```
+mosquitto_sub -u usernamehere -P passwordhere -p 1883 -v -t 'milight/#'
+```
+
+You can also use the mosquitto_pub command to send your own commands and watch the bulbs respond all without the binding being setup.
+Everything this binding does goes in and out via MQTT and can be watched with the above command.
+Once you have setup and test the hub you can move onto using the binding.
+
+## Supported Things
+
+This binding is best thought of as a remote control emulator, so the things are really the type of remote that you own and not the globes. The Milight protocol is 1 way only so there is no way to find actual globes.
+
+| Thing Type ID | Description |
+|-|-|
+| `rgb_cct` | Remote that has 4 channels and controls globes with full colour, and both cool and warm whites. |
+| `fut089` | Remote is the newer 8 channel type called FUT089 and your globes are the rgb_cct. |
+| `cct` | Remote is 4 channels and the globes have no colours with only cool and warm white controls. |
+| `fut091` | Remote is the newer 8 group model called a fut091 and your globes are cct. |
+| `rgbw` | Remote is 4 channels and the globes have RGB and a fixed white. |
+| `rgb` | Remote is 4 channels and the globes have full RGB with no white. |
+
+## Discovery
+
+First install the MQTT binding and setup a `broker` and make sure it is ONLINE, as this binding uses the MQTT binding to talk to your broker and hence that binding must be setup first.
+Next make sure you have moved a control on either a physical remote, or used a virtual control inside the esp8266 control panel web page to create a MQTT message.
+This binding should then detect the new device the moment the control is moved and a new entry should appear in your INBOX.
+
+To remove a saved state from your MQTT broker that causes an entry in your INBOX you can use this command or use the ignore feature of openHAB.
+
+```
+mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' -n -r
+```
+
+## Thing Configuration
+
+| Parameter | Description | Required | Default |
+|-|-|-|-|
+| `defaultCommand` | When the send command button is pressed, if no selection is made from the command channel then use this. | Y | night_mode |
+| `whiteHue` | When both the `whiteHue` and `whiteSat` values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 0 for Alexa, or 36 for Google Home. | Y | 35 |
+| `whiteSat` | When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 100 for Alexa or 32 for Google Home. | Y | 32 |
+| `favouriteWhite` | When one of the shortcuts triggers white mode, use this for the colour white instead of the default colour. | Y |200 |
+| `dimmedCT` | Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable. | N | blank |
+| `oneTriggersNightMode` | `Night Mode` is a much lower level of light and this feature allows it to be auto selected when your fader/slider moves to 1%. NOTE: Night mode locks out some controls of a physical remote so this is disabled by default. | Y | false |
+| `powerFailsToMinimum` | If lights loose power from the power switch OR a power outage, they will default to using the lowest brightness if the light was turned off before the power failure occurred. | Y | true |
+| `whiteThreshold` | RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that if the saturation drops below, it will trigger the white mode. -1 will disable this feature. | Y | 12 |
+
+## Channels
+
+| Channel | Type | Description |
+|-|-|-|
+| level | Dimmer | Level changes the brightness of the globe. |
+| colourTemperature | Dimmer | Change from cool to warm white with this control. |
+| colour | Color | Allows you to change the colour, brightness and saturation of the globe. |
+| discoMode | String | Switch to a Disco mode directly from a drop down list. |
+| bulbMode | String (read only) | Displays the mode the bulb is currently in so that rules can determine if the globe is white, a color, disco modes or night mode are selected. |
+| command | String | Choose the command from this list to send to the globe, then press the `sendCommand` button to send it as many times as you wish. |
+| sendCommand | Switch | Sends the selected command. |
+
+## Note Regarding Transmission Delays
+
+If you have lots of globes and openHAB turns them all on, you may notice a delay that causes the globes to turn on one by one and the delay can add up when a lot of globes are installed in your house.
+This is caused by the time it takes to transmit the desired setting to the globe * by how many times the hub repeats transmitting the setting.
+Since it takes around 2.8ms for a setting to be transmitted, if the firmware is set to repeat the packets 50 times it would then take 2.8*50 = 140ms before the next globe starts to have its new state transmitted by the hub.
+You can reduce the packet repeats to speed up the response of this binding and the hub, but a few settings can be tweaked.
+
+Settings for the radio tab found in the esp control panel using your browser, mine are:
+
+Packet repeats = 12 (if you only turn 1 globe on or off it uses this value)
+Packet repeat throttle threshold= 200
+Packet repeat throttle sensitivity = 0
+Packet repeat minimum = 8 (When turning multiple globes on and off it will use this value as it throttles the repeats back to reduce latency/delay between each globe)
+
+## Important for Textual Configuration
+
+The binding requires things to have a specific format for the unique ID, the auto discovery does this for you.
+
+```
+espmilighthub:ThingType:broker:ThingUID
+```
+
+You need to add the Device ID and Group ID together to create the things unique ID.
+The DeviceID is different for each remotes.
+The GroupID can be 0 (all channels on the remote), or 1 to 8 for each of the individual channels on the remote).
+If you do not understand this please use auto discovery to do it for you. 
+
+The formula is
+DeviceID + GroupID = ThingUID
+
+For example:
+
+| Device ID | Group ID |ThingUID  | 
+|-----------|----------|----------|
+| 0xC210    | 1        | 0xC2101  | 
+| 0xB4CA    | 4        | 0xB4CA4  | 
+| 0xB4CA    | 8        | 0xB4CA8  |
+| 0xB4CA    | 0        | 0xB4CA0  |

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -171,7 +171,8 @@ Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xE6C4:level"}
 Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xE6C4:colourTemperature"}
 Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xE6C4:colour"}
 String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xE6C4:discoMode"}
-Switch Hallway_Command "Send Command" {channel="mqtt:rgb_cct:0xE6C4:command"}
+String Hallway_BulbCommand "Send Command" {channel="mqtt:rgb_cct:0xE6C4:command"}
+String Hallway_BulbMode "Bulb Mode" {channel="mqtt:rgb_cct:0xE6C4:bulbMode"}
 
 ```
 
@@ -185,6 +186,7 @@ Switch Hallway_Command "Send Command" {channel="mqtt:rgb_cct:0xE6C4:command"}
             Slider      item=Hallway_ColourTemperature
             Colorpicker item=Hallway_Colour
             Selection   item=Hallway_DiscoMode
-            Switch      item=Hallway_Command     
+            Text        item=Hallway_BulbMode
+            Switch item=Hallway_BulbCommand mappings=[next_mode='Mode +', previous_mode='Mode -', mode_speed_up='Speed +', mode_speed_down='Speed -', set_white='White', night_mode='Night' ]   
         }
 ```

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -56,7 +56,7 @@ Fill in the MQTT broker fields with the correct details so the hub can connect a
 Now when you use any Milight remote control, you will see MQTT topics being created that should include `level` and `hsb` in the messages.
 If you see `brightness` and not `level`, then go back and follow the above setup steps.
 
-You can use this linux command to watch all MQTT topics from milight:
+You can use this linux command to watch all MQTT topics from Milight:
 
 ```
 mosquitto_sub -u usernamehere -P passwordhere -p 1883 -v -t 'milight/#'
@@ -108,15 +108,12 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 
 | Channel | Type | Description |
 |-|-|-|
-| level | Dimmer | Level changes the brightness of the globe. |
-| colourTemperature | Dimmer | Change from cool to warm white with this control. |
-| colour | Color | Allows you to change the colour, brightness and saturation of the globe. |
-| discoMode | String | Switch to a Disco mode directly from a drop down list. |
-| bulbMode | String (read only) | Displays the mode the bulb is currently in so that rules can determine if the globe is white, a color, disco modes or night mode are selected. |
-| speedUp | Switch | Send the command to speed up the disco mode. |
-| slowDown | Switch | Send the command to slow down the disco mode. |
-| setWhite | Switch | Change the light to use white LEDs. |
-| nightMode | Switch | Send the command to use night mode which uses a very dim level of light and locks out some features of the remote controls. |
+| `level` | Dimmer | Level changes the brightness of the globe. |
+| `colourTemperature` | Dimmer | Change from cool to warm white with this control. |
+| `colour` | Color | Allows you to change the colour, brightness and saturation of the globe. |
+| `discoMode` | String | Switch to a Disco mode directly from a drop down list. |
+| `bulbMode` | String (read only) | Displays the mode the bulb is currently in so that rules can determine if the globe is white, a color, disco modes or night mode are selected. |
+| `command` | String | Sends the raw commands that the buttons on a remote send. |
 
 ## Note Regarding Transmission Delays
 
@@ -175,8 +172,7 @@ Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xC2101:Level"}
 Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xC2101:colourTemperature"}
 Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xC2101:colour"}
 String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xC2101:discoMode"}
-String Hallway_Command "Command to Send" {channel="mqtt:rgb_cct:0xC2101:command"}
-Switch Hallway_SendCommand "Send Command" {channel="mqtt:rgb_cct:0xC2101:sendCommand"}
+Switch Hallway_Command "Send Command" {channel="mqtt:rgb_cct:0xC2101:command"}
 
 ```
 
@@ -190,7 +186,6 @@ Switch Hallway_SendCommand "Send Command" {channel="mqtt:rgb_cct:0xC2101:sendCom
             Slider      item=Hallway_ColourTemperature
             Colorpicker item=Hallway_Colour
             Selection   item=Hallway_DiscoMode
-            Selection   item=Hallway_Command
-            Switch      item=Hallway_SendCommand mappings=[ON="Send"]        
+            Switch      item=Hallway_Command     
         }
 ```

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -96,7 +96,7 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 | Parameter | Description | Required | Default |
 |-|-|-|-|
 | `defaultCommand` | When the send command button is pressed, if no selection is made from the command channel then use this. | Y | night_mode |
-| `whiteHue` | When both the `whiteHue` and `whiteSat` values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 0 for Alexa, or 36 for Google Home. | Y | 35 |
+| `whiteHue` | When both the `whiteHue` and `whiteSat` values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 0 for Alexa, or 35 for Google Home. | Y | 35 |
 | `whiteSat` | When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 100 for Alexa or 32 for Google Home. | Y | 32 |
 | `favouriteWhite` | When one of the shortcuts triggers white mode, use this for the colour white instead of the default colour. | Y |200 |
 | `dimmedCT` | Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable. | N | blank |
@@ -125,10 +125,10 @@ You can reduce the packet repeats to speed up the response of this binding and t
 
 Settings for the radio tab found in the esp control panel using your browser, mine are:
 
-Packet repeats = 12 (if you only turn 1 globe on or off it uses this value)
-Packet repeat throttle threshold= 200
-Packet repeat throttle sensitivity = 0
-Packet repeat minimum = 8 (When turning multiple globes on and off it will use this value as it throttles the repeats back to reduce latency/delay between each globe)
++ Packet repeats = 12 (if you only turn 1 globe on or off it uses this value)
++ Packet repeat throttle threshold = 200
++ Packet repeat throttle sensitivity = 0
++ Packet repeat minimum = 8 (When turning multiple globes on and off it will use this value as it throttles the repeats back to reduce latency/delay between each globe)
 
 ## Important for Textual Configuration
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -1,7 +1,7 @@
 # EspMilightHub Binding
 
 This binding allows an open source esp8266 based bridge to automatically find and add Milight globes.
-The hubs can be built from 2 ready made boards and  only need connecting with 7 wires. 
+The hubs can be built from 2 ready made boards and only need connecting with 7 wires. 
 They can be very easy to build with no soldering needed. 
 
 Advantages to using this DIY bridge over the OEM bridge:

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -123,7 +123,8 @@ This is caused by the time it takes to transmit the desired setting to the globe
 Since it takes around 2.8ms for a setting to be transmitted, if the firmware is set to repeat the packets 50 times it would then take 2.8*50 = 140ms before the next globe starts to have its new state transmitted by the hub.
 You can reduce the packet repeats to speed up the response of this binding and the hub, but a few settings can be tweaked.
 
-Settings for the radio tab found in the esp control panel using your browser, mine are:
+Settings can be found on the radio tab in the esp control panel using your browser.
+Suggested settings are as follows:
 
 + Packet repeats = 12 (if you only turn 1 globe on or off it uses this value)
 + Packet repeat throttle threshold = 200

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -154,7 +154,7 @@ For example:
 
 ## Full Example
 
-To use these examples for textual configuration, you must have already have a configured a MQTT `broker` thing and know its unique ID.
+To use these examples for textual configuration, you must already have a configured a MQTT `broker` thing and know its unique ID.
 This UID will be used in the things file and will replace the text `myBroker`.
 The first line in the things file will create a `broker` thing and this can be removed if you have already setup a broker in another file or via the UI already.
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -121,7 +121,7 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 If you have lots of globes and openHAB turns them all on, you may notice a delay that causes the globes to turn on one by one and the delay can add up when a lot of globes are installed in your house.
 This is caused by the time it takes to transmit the desired setting to the globe multiplied by how many times the hub repeats transmitting the setting.
 Since it takes around 2.8ms for a setting to be transmitted, if the firmware is set to repeat the packets 50 times it would then take 2.8*50 = 140ms before the next globe starts to have its new state transmitted by the hub.
-You can reduce the packet repeats to speed up the response of this binding and the hub, but a few settings can be tweaked.
+You can reduce the packet repeats to speed up the response of this binding and the hub by tweaking a few settings.
 
 Settings can be found on the radio tab in the esp control panel using your browser.
 Suggested settings are as follows:

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -1,12 +1,13 @@
 # EspMilightHub Binding
 
 This binding allows an open source esp8266 based bridge to automatically find and add Milight globes.
-The hubs can be built from 2 ready made boards and connecting them with 7 wires, they can be very easy to build with no soldering needed. 
+The hubs can be built from 2 ready made boards and  only need connecting with 7 wires. 
+They can be very easy to build with no soldering needed. 
 
 Advantages to using this DIY bridge over the OEM bridge:
 
-+ Almost unlimited groups so you can have individual control over an entire house of Milight globes without multiple bridges.
-+ If using the Milight remotes to control the globes with this binding can update the openHAB controls the moment a key is pressed on the remote.
++ Almost unlimited groups to give individual control over an entire house of Milight globes without needing multiple bridges.
++ If using the Milight remotes to control the globes, this binding can update the openHAB controls the moment a key is pressed on the physical remotes.
 + Supports auto discovery.
 
 ## Setup the hardware
@@ -56,7 +57,7 @@ Fill in the MQTT broker fields with the correct details so the hub can connect a
 Now when you use any Milight remote control, you will see MQTT topics being created that should include `level` and `hsb` in the messages.
 If you see `brightness` and not `level`, then go back and follow the above setup steps.
 
-You can use this linux command to watch all MQTT topics from Milight:
+You can use this Linux command to watch all MQTT topics from Milight:
 
 ```
 mosquitto_sub -u usernamehere -P passwordhere -p 1883 -v -t 'milight/#'
@@ -68,7 +69,8 @@ Once you have setup and test the hub you can move onto using the binding.
 
 ## Supported Things
 
-This binding is best thought of as a remote control emulator, so the things are really the type of remote that you own and not the globes. The Milight protocol is 1 way only so there is no way to find actual globes.
+This binding is best thought of as a remote control emulator, so the things are really the type of remote that you own and not the globes.
+The Milight protocol is 1 way only so there is no way to find actual globes.
 
 | Thing Type ID | Description |
 |-|-|
@@ -81,8 +83,8 @@ This binding is best thought of as a remote control emulator, so the things are 
 
 ## Discovery
 
-First install the MQTT binding and setup a `broker` and make sure it is ONLINE, as this binding uses the MQTT binding to talk to your broker and hence that binding must be setup first.
-Next make sure you have moved a control on either a physical remote, or used a virtual control inside the esp8266 control panel web page to create a MQTT message.
+First install the MQTT binding and setup a `broker` thing and make sure it is ONLINE, as this binding uses the MQTT binding to talk to your broker and hence that binding must be setup first.
+Next, move a control on either a physical remote, or used a virtual control inside the esp8266 control panel web page which cause a MQTT message to be sent.
 This binding should then detect the new device the moment the control is moved and a new entry should appear in your INBOX.
 
 To remove a saved state from your MQTT broker that causes an entry in your INBOX you can use this command or use the ignore feature of openHAB.
@@ -95,12 +97,11 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 
 | Parameter | Description | Required | Default |
 |-|-|-|-|
-| `defaultCommand` | When the send command button is pressed, if no selection is made from the command channel then use this. | Y | night_mode |
 | `whiteHue` | When both the `whiteHue` and `whiteSat` values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 0 for Alexa, or 35 for Google Home. | Y | 35 |
 | `whiteSat` | When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set to -1 to disable, 100 for Alexa or 32 for Google Home. | Y | 32 |
 | `favouriteWhite` | When one of the shortcuts triggers white mode, use this for the colour white instead of the default colour. | Y |200 |
 | `dimmedCT` | Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable. | N | blank |
-| `oneTriggersNightMode` | `Night Mode` is a much lower level of light and this feature allows it to be auto selected when your fader/slider moves to 1%. NOTE: Night mode locks out some controls of a physical remote so this is disabled by default. | Y | false |
+| `oneTriggersNightMode` | Night mode is a much lower level of light and this feature allows it to be auto selected when your fader/slider moves to 1%. NOTE: Night mode by design locks out some controls of a physical remote, so this feature is disabled by default. | Y | false |
 | `powerFailsToMinimum` | If lights loose power from the power switch OR a power outage, they will default to using the lowest brightness if the light was turned off before the power failure occurred. | Y | true |
 | `whiteThreshold` | RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that if the saturation drops below, it will trigger the white mode. -1 will disable this feature. | Y | 12 |
 
@@ -131,14 +132,10 @@ Settings for the radio tab found in the esp control panel using your browser, mi
 
 ## Important for Textual Configuration
 
-The binding requires things to have a specific format for the unique ID, the auto discovery does this for you.
+This binding requires things to have a specific format for the unique ID, the auto discovery does this for you.
 
-```
-espmilighthub:ThingType:broker:ThingUID
-```
-
-You need to add the Device ID and Group ID together to create the things unique ID.
-The DeviceID is different for each remotes.
+If doing textual configuration you need to add the Device ID and Group ID together to create the things unique ID.
+The DeviceID is different for each remote.
 The GroupID can be 0 (all channels on the remote), or 1 to 8 for each of the individual channels on the remote).
 If you do not understand this please use auto discovery to do it for you. 
 
@@ -149,30 +146,32 @@ For example:
 
 | Device ID | Group ID |ThingUID  | 
 |-----------|----------|----------|
-| 0xC210    | 1        | 0xC2101  | 
+| 0xE6C     | 4        | 0xE6C4   | 
 | 0xB4CA    | 4        | 0xB4CA4  | 
 | 0xB4CA    | 8        | 0xB4CA8  |
 | 0xB4CA    | 0        | 0xB4CA0  |
 
 ## Full Example
 
-To use these examples for textual configuration, you must have already configured a MQTT broker thing and know its unique ID.
-This UID will be used in the things file and will replace the text `brokerUID`.
+To use these examples for textual configuration, you must have already have a configured a MQTT `broker` thing and know its unique ID.
+This UID will be used in the things file and will replace the text `myBroker`.
+The first line in the things file will create a `broker` thing and this can be removed if you have already setup a broker in another file or via the UI already.
 
 *.things
 
 ```
-Thing mqtt:rgb_cct:0xC2101 "Hallway" (mqtt:broker:brokerUID) @ "MQTT"
+Bridge mqtt:broker:myBroker [ host="localhost", secure=false, password="*******", qos=1, username="user"]
+Thing mqtt:rgb_cct:0xE6C4 "Hallway" (mqtt:broker:myBroker) @ "MQTT"
 ```
 
 *.items
 
 ```
-Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xC2101:Level"}
-Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xC2101:colourTemperature"}
-Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xC2101:colour"}
-String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xC2101:discoMode"}
-Switch Hallway_Command "Send Command" {channel="mqtt:rgb_cct:0xC2101:command"}
+Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xE6C4:level"}
+Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xE6C4:colourTemperature"}
+Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xE6C4:colour"}
+String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xE6C4:discoMode"}
+Switch Hallway_Command "Send Command" {channel="mqtt:rgb_cct:0xE6C4:command"}
 
 ```
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -113,8 +113,10 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 | colour | Color | Allows you to change the colour, brightness and saturation of the globe. |
 | discoMode | String | Switch to a Disco mode directly from a drop down list. |
 | bulbMode | String (read only) | Displays the mode the bulb is currently in so that rules can determine if the globe is white, a color, disco modes or night mode are selected. |
-| command | String | Choose the command from this list to send to the globe, then press the `sendCommand` button to send it as many times as you wish. |
-| sendCommand | Switch | Sends the selected command. |
+| speedUp | Switch | Send the command to speed up the disco mode. |
+| slowDown | Switch | Send the command to slow down the disco mode. |
+| setWhite | Switch | Change the light to use white LEDs. |
+| nightMode | Switch | Send the command to use night mode which uses a very dim level of light and locks out some features of the remote controls. |
 
 ## Note Regarding Transmission Delays
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -119,7 +119,7 @@ mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' 
 ## Note Regarding Transmission Delays
 
 If you have lots of globes and openHAB turns them all on, you may notice a delay that causes the globes to turn on one by one and the delay can add up when a lot of globes are installed in your house.
-This is caused by the time it takes to transmit the desired setting to the globe * by how many times the hub repeats transmitting the setting.
+This is caused by the time it takes to transmit the desired setting to the globe multiplied by how many times the hub repeats transmitting the setting.
 Since it takes around 2.8ms for a setting to be transmitted, if the firmware is set to repeat the packets 50 times it would then take 2.8*50 = 140ms before the next globe starts to have its new state transmitted by the hub.
 You can reduce the packet repeats to speed up the response of this binding and the hub, but a few settings can be tweaked.
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -154,3 +154,41 @@ For example:
 | 0xB4CA    | 4        | 0xB4CA4  | 
 | 0xB4CA    | 8        | 0xB4CA8  |
 | 0xB4CA    | 0        | 0xB4CA0  |
+
+## Full Example
+
+To use these examples for textual configuration, you must have already configured a MQTT broker thing and know its unique ID.
+This UID will be used in the things file and will replace the text `brokerUID`.
+
+*.things
+
+```
+Thing mqtt:rgb_cct:0xC2101 "Hallway" (mqtt:broker:brokerUID) @ "MQTT"
+```
+
+*.items
+
+```
+Dimmer Hallway_Level "Front Hall" {channel="mqtt:rgb_cct:0xC2101:Level"}
+Dimmer Hallway_ColourTemperature "White Color Temp" {channel="mqtt:rgb_cct:0xC2101:colourTemperature"}
+Color  Hallway_Colour "Front Hall" ["Lighting"] {channel="mqtt:rgb_cct:0xC2101:colour"}
+String Hallway_DiscoMode "Disco Mode" {channel="mqtt:rgb_cct:0xC2101:discoMode"}
+String Hallway_Command "Command to Send" {channel="mqtt:rgb_cct:0xC2101:command"}
+Switch Hallway_SendCommand "Send Command" {channel="mqtt:rgb_cct:0xC2101:sendCommand"}
+
+```
+
+*.sitemap
+
+```
+        Text label="Hallway" icon="light" 
+        {
+            Switch      item=Hallway_Level
+            Slider      item=Hallway_Level
+            Slider      item=Hallway_ColourTemperature
+            Colorpicker item=Hallway_Colour
+            Selection   item=Hallway_DiscoMode
+            Selection   item=Hallway_Command
+            Switch      item=Hallway_SendCommand mappings=[ON="Send"]        
+        }
+```

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.openhab.binding.mqtt.espmilighthub</artifactId>
+  <name>openHAB Add-ons :: Bundles :: MQTT EspMilightHub Convention</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.mqtt</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
@@ -3,16 +3,16 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
     <version>3.0.0-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>org.openhab.binding.mqtt.espmilighthub</artifactId>
   <name>openHAB Add-ons :: Bundles :: MQTT EspMilightHub</name>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
@@ -3,13 +3,16 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
     <version>3.0.0-SNAPSHOT</version>
   </parent>
+  
   <artifactId>org.openhab.binding.mqtt.espmilighthub</artifactId>
-  <name>openHAB Add-ons :: Bundles :: MQTT EspMilightHub Convention</name>
+  <name>openHAB Add-ons :: Bundles :: MQTT EspMilightHub</name>
+  
   <dependencies>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.mqtt.espmilighthub</artifactId>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/feature/feature.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.mqtt.espmilighthub-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-mqtt-espmilighthub" description="MQTT Binding EspMilightHub" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-mqtt</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
+		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.espmilighthub/${project.version}</bundle>
+	</feature>
+
+</features>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.espmilighthub.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ConfigOptions} Holds the config for the settings.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigOptions {
+    public int whiteThreshold = -1;
+    public int whiteSat = 32;
+    public int whiteHue = 35;
+    public int favouriteWhite = 200;
+    public String defaultCommand = "night_mode";
+    public boolean oneTriggersNightMode = false;
+    public boolean powerFailsToMinimum = false;
+    public int dimmedCT = -1;
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/ConfigOptions.java
@@ -25,7 +25,6 @@ public class ConfigOptions {
     public int whiteSat = 32;
     public int whiteHue = 35;
     public int favouriteWhite = 200;
-    public String defaultCommand = "night_mode";
     public boolean oneTriggersNightMode = false;
     public boolean powerFailsToMinimum = false;
     public int dimmedCT = -1;

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -13,6 +13,7 @@
 
 package org.openhab.binding.mqtt.espmilighthub.internal;
 
+import java.math.BigDecimal;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -29,7 +30,7 @@ public class EspMilightHubBindingConstants {
     public static final String BINDING_ID = "mqtt";
     public static final String STATES_BASE_TOPIC = "milight/states/";
     public static final String COMMANDS_BASE_TOPIC = "milight/commands/";
-
+    public static final BigDecimal BIG_DECIMAL_100 = new BigDecimal(100);
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_RGB_CCT = new ThingTypeUID(BINDING_ID, "rgb_cct");
     public static final ThingTypeUID THING_TYPE_CCT = new ThingTypeUID(BINDING_ID, "cct");

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.mqtt.espmilighthub.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link EspMilightHubBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class EspMilightHubBindingConstants {
+    public static final String BINDING_ID = "mqtt";
+    public static final String STATES_BASE_TOPIC = "milight/states/";
+    public static final String COMMANDS_BASE_TOPIC = "milight/commands/";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_RGB_CCT = new ThingTypeUID(BINDING_ID, "rgb_cct");
+    public static final ThingTypeUID THING_TYPE_CCT = new ThingTypeUID(BINDING_ID, "cct");
+    public static final ThingTypeUID THING_TYPE_RGBW = new ThingTypeUID(BINDING_ID, "rgbw");
+    public static final ThingTypeUID THING_TYPE_RGB = new ThingTypeUID(BINDING_ID, "rgb");
+    public static final ThingTypeUID THING_TYPE_FUT089 = new ThingTypeUID(BINDING_ID, "fut089");
+    public static final ThingTypeUID THING_TYPE_FUT091 = new ThingTypeUID(BINDING_ID, "fut091");
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>(Arrays.asList(
+            THING_TYPE_RGBW, THING_TYPE_RGB_CCT, THING_TYPE_FUT089, THING_TYPE_FUT091, THING_TYPE_CCT, THING_TYPE_RGB));
+
+    // Channels
+    public static final String CHANNEL_LEVEL = "level";
+    public static final String CHANNEL_COLOUR = "colour";
+    public static final String CHANNEL_COLOURTEMP = "colourTemperature";
+    public static final String CHANNEL_DISCO_MODE = "discoMode";
+    public static final String CHANNEL_BULB_MODE = "bulbMode";
+    public static final String CHANNEL_COMMAND = "command";
+    public static final String CHANNEL_SEND_COMMAND = "sendCommand";
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -47,8 +47,5 @@ public class EspMilightHubBindingConstants {
     public static final String CHANNEL_COLOURTEMP = "colourTemperature";
     public static final String CHANNEL_DISCO_MODE = "discoMode";
     public static final String CHANNEL_BULB_MODE = "bulbMode";
-    public static final String CHANNEL_NIGHT_MODE = "nightMode";
-    public static final String CHANNEL_SET_WHITE = "setWhite";
-    public static final String CHANNEL_SPEED_UP = "speedUp";
-    public static final String CHANNEL_SLOW_DOWN = "slowDown";
+    public static final String CHANNEL_COMMAND = "command";
 }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -13,6 +13,8 @@
 
 package org.openhab.binding.mqtt.espmilighthub.internal;
 
+import static org.openhab.binding.mqtt.MqttBindingConstants.BINDING_ID;
+
 import java.math.BigDecimal;
 import java.util.Set;
 
@@ -27,7 +29,6 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class EspMilightHubBindingConstants {
-    public static final String BINDING_ID = "mqtt";
     public static final String STATES_BASE_TOPIC = "milight/states/";
     public static final String COMMANDS_BASE_TOPIC = "milight/commands/";
     public static final BigDecimal BIG_DECIMAL_100 = new BigDecimal(100);

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -47,6 +47,8 @@ public class EspMilightHubBindingConstants {
     public static final String CHANNEL_COLOURTEMP = "colourTemperature";
     public static final String CHANNEL_DISCO_MODE = "discoMode";
     public static final String CHANNEL_BULB_MODE = "bulbMode";
-    public static final String CHANNEL_COMMAND = "command";
-    public static final String CHANNEL_SEND_COMMAND = "sendCommand";
+    public static final String CHANNEL_NIGHT_MODE = "nightMode";
+    public static final String CHANNEL_SET_WHITE = "setWhite";
+    public static final String CHANNEL_SPEED_UP = "speedUp";
+    public static final String CHANNEL_SLOW_DOWN = "slowDown";
 }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -13,8 +13,6 @@
 
 package org.openhab.binding.mqtt.espmilighthub.internal;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -40,8 +38,8 @@ public class EspMilightHubBindingConstants {
     public static final ThingTypeUID THING_TYPE_FUT089 = new ThingTypeUID(BINDING_ID, "fut089");
     public static final ThingTypeUID THING_TYPE_FUT091 = new ThingTypeUID(BINDING_ID, "fut091");
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(
-            THING_TYPE_RGBW, THING_TYPE_RGB_CCT, THING_TYPE_FUT089, THING_TYPE_FUT091, THING_TYPE_CCT, THING_TYPE_RGB);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(THING_TYPE_RGBW, THING_TYPE_RGB_CCT,
+            THING_TYPE_FUT089, THING_TYPE_FUT091, THING_TYPE_CCT, THING_TYPE_RGB);
 
     // Channels
     public static final String CHANNEL_LEVEL = "level";

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubBindingConstants.java
@@ -40,8 +40,8 @@ public class EspMilightHubBindingConstants {
     public static final ThingTypeUID THING_TYPE_FUT089 = new ThingTypeUID(BINDING_ID, "fut089");
     public static final ThingTypeUID THING_TYPE_FUT091 = new ThingTypeUID(BINDING_ID, "fut091");
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>(Arrays.asList(
-            THING_TYPE_RGBW, THING_TYPE_RGB_CCT, THING_TYPE_FUT089, THING_TYPE_FUT091, THING_TYPE_CCT, THING_TYPE_RGB));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Set.of(
+            THING_TYPE_RGBW, THING_TYPE_RGB_CCT, THING_TYPE_FUT089, THING_TYPE_FUT091, THING_TYPE_CCT, THING_TYPE_RGB);
 
     // Channels
     public static final String CHANNEL_LEVEL = "level";

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.mqtt.espmilighthub.internal;
+
+import static org.openhab.binding.mqtt.espmilighthub.internal.EspMilightHubBindingConstants.SUPPORTED_THING_TYPES;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.espmilighthub.internal.handler.EspMilightHubHandler;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link EspMilightHubHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@Component(service = ThingHandlerFactory.class)
+@NonNullByDefault
+public class EspMilightHubHandlerFactory extends BaseThingHandlerFactory {
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public EspMilightHubHandlerFactory(final @Reference ThingRegistry thingRegistry) {
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES.contains(thingTypeUID);
+    }
+
+    @Activate
+    @Override
+    protected void activate(ComponentContext componentContext) {
+        super.activate(componentContext);
+    }
+
+    @Deactivate
+    @Override
+    protected void deactivate(ComponentContext componentContext) {
+        super.deactivate(componentContext);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        if (SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
+            return new EspMilightHubHandler(thing, thingRegistry);
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/EspMilightHubHandlerFactory.java
@@ -24,10 +24,8 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -49,18 +47,6 @@ public class EspMilightHubHandlerFactory extends BaseThingHandlerFactory {
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES.contains(thingTypeUID);
-    }
-
-    @Activate
-    @Override
-    protected void activate(ComponentContext componentContext) {
-        super.activate(componentContext);
-    }
-
-    @Deactivate
-    @Override
-    protected void deactivate(ComponentContext componentContext) {
-        super.deactivate(componentContext);
     }
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/Helper.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/Helper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/Helper.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/Helper.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mqtt.espmilighthub.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link Helper} Removes the need for any external JSON libs
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class Helper {
+    /**
+     * resolveJSON will return a value from any key/path that you give and the string can be terminated by any ,}"
+     * characters.
+     *
+     */
+    public static String resolveJSON(String messageJSON, String jsonPath, int resultMaxLength) {
+        String result = "";
+        int index = 0;
+        index = messageJSON.indexOf(jsonPath);
+        if (index != -1) {
+            if ((index + jsonPath.length() + resultMaxLength) > messageJSON.length()) {
+                result = (messageJSON.substring(index + jsonPath.length(), messageJSON.length()));
+            } else {
+                result = (messageJSON.substring(index + jsonPath.length(),
+                        index + jsonPath.length() + resultMaxLength));
+            }
+            index = result.indexOf(',');
+            if (index == -1) {
+                index = result.indexOf('"');
+                if (index == -1) {
+                    index = result.indexOf('}');
+                    if (index == -1) {
+                        return result;
+                    } else {
+                        return result.substring(0, index);
+                    }
+                } else {
+                    return result.substring(0, index);
+                }
+            } else {
+                result = result.substring(0, index);
+                index = result.indexOf('"');
+                if (index == -1) {
+                    return result;
+                } else {
+                    return result.substring(0, index);
+                }
+            }
+        }
+        return "";
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -13,6 +13,7 @@
 
 package org.openhab.binding.mqtt.espmilighthub.internal.discovery;
 
+import static org.openhab.binding.mqtt.MqttBindingConstants.BINDING_ID;
 import static org.openhab.binding.mqtt.espmilighthub.internal.EspMilightHubBindingConstants.*;
 
 import java.util.HashMap;

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -67,7 +67,7 @@ public class EspMilightHubDiscoveryService extends AbstractMQTTDiscovery {
                 index = cutTopic.indexOf("/");
                 if (index != -1) {
                     String globeType = (cutTopic.substring(0, index));
-                    String remoteGroupID = (cutTopic.substring(index+1, index+2));
+                    String remoteGroupID = (cutTopic.substring(index + 1, index + 2));
                     // openHAB's framework has better code for handling groups then the firmware does
                     if (!remoteGroupID.equals("0")) {// Users can manually add group 0 things if they wish
                         publishDevice(connectionBridge, connection, topic, remoteCode, globeType, remoteGroupID);

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.mqtt.espmilighthub.internal.discovery;
+
+import static org.openhab.binding.mqtt.espmilighthub.internal.EspMilightHubBindingConstants.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.mqtt.discovery.AbstractMQTTDiscovery;
+import org.openhab.binding.mqtt.discovery.MQTTTopicDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link EspMilightHubDiscoveryService} is responsible for finding globes
+ * and setting them up for the handlers.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+
+@Component(service = DiscoveryService.class, configurationPid = "discovery.mqttespmilighthub")
+@NonNullByDefault
+public class EspMilightHubDiscoveryService extends AbstractMQTTDiscovery {
+    protected final MQTTTopicDiscoveryService discoveryService;
+
+    @Activate
+    public EspMilightHubDiscoveryService(@Reference MQTTTopicDiscoveryService discoveryService) {
+        super(SUPPORTED_THING_TYPES, 3, true, STATES_BASE_TOPIC + "#");
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    protected MQTTTopicDiscoveryService getDiscoveryService() {
+        return discoveryService;
+    }
+
+    @Override
+    public void receivedMessage(ThingUID connectionBridge, MqttBrokerConnection connection, String topic,
+            byte[] payload) {
+        resetTimeout();
+        if (topic.startsWith(STATES_BASE_TOPIC)) {
+            String cutTopic = topic.replace(STATES_BASE_TOPIC, "");
+            int index = cutTopic.indexOf("/");
+            if (index != -1) // -1 means "not found"
+            {
+                String remoteCode = (cutTopic.substring(0, index)); // Store the remote code for use later
+                cutTopic = topic.replace(STATES_BASE_TOPIC + remoteCode + "/", "");
+                index = cutTopic.indexOf("/");
+                if (index != -1) {
+                    String globeType = (cutTopic.substring(0, index));
+                    String remoteGroupID = (cutTopic.substring(++index, ++index));
+                    // openHAB's framework has better code for handling groups then the firmware does
+                    if (!remoteGroupID.equals("0")) {// Users can manually add group 0 things if they wish
+                        publishDevice(connectionBridge, connection, topic, remoteCode, globeType, remoteGroupID);
+                    }
+                }
+            }
+        }
+    }
+
+    void publishDevice(ThingUID connectionBridge, MqttBrokerConnection connection, String topic, String remoteCode,
+            String globeType, String remoteGroupID) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("deviceid", remoteCode + remoteGroupID);
+        properties.put("basetopic", STATES_BASE_TOPIC + remoteCode + "/" + globeType + "/" + remoteGroupID);
+        thingDiscovered(DiscoveryResultBuilder
+                .create(new ThingUID(new ThingTypeUID(BINDING_ID, globeType), connectionBridge,
+                        remoteCode + remoteGroupID))
+                .withProperties(properties).withRepresentationProperty("deviceid").withBridge(connectionBridge)
+                .withLabel("Milight " + globeType).build());
+    }
+
+    @Override
+    public void topicVanished(ThingUID connectionBridge, MqttBrokerConnection connection, String topic) {
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -67,7 +67,7 @@ public class EspMilightHubDiscoveryService extends AbstractMQTTDiscovery {
                 index = cutTopic.indexOf("/");
                 if (index != -1) {
                     String globeType = (cutTopic.substring(0, index));
-                    String remoteGroupID = (cutTopic.substring(++index, ++index));
+                    String remoteGroupID = (cutTopic.substring(index+1, index+2));
                     // openHAB's framework has better code for handling groups then the firmware does
                     if (!remoteGroupID.equals("0")) {// Users can manually add group 0 things if they wish
                         publishDevice(connectionBridge, connection, topic, remoteCode, globeType, remoteGroupID);

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -13,6 +13,7 @@
 
 package org.openhab.binding.mqtt.espmilighthub.internal.handler;
 
+import static org.openhab.binding.mqtt.MqttBindingConstants.BINDING_ID;
 import static org.openhab.binding.mqtt.espmilighthub.internal.EspMilightHubBindingConstants.*;
 
 import java.math.BigDecimal;

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -283,7 +283,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             maxColourTemp = new BigDecimal(config.favouriteWhite);
             minColourTemp = new BigDecimal(config.dimmedCT);
             if (minColourTemp.intValue() <= maxColourTemp.intValue()) {
-                logger.warn("dimmedCT must be greater than the favourite white value.");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                        "The dimmedCT config value must be greater than the favouriteWhite value.");
             }
         }
         if (getBridge() == null) {

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -1,0 +1,399 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.mqtt.espmilighthub.internal.handler;
+
+import static org.openhab.binding.mqtt.espmilighthub.internal.EspMilightHubBindingConstants.*;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.mqtt.espmilighthub.internal.ConfigOptions;
+import org.openhab.binding.mqtt.espmilighthub.internal.Helper;
+import org.openhab.binding.mqtt.handler.AbstractBrokerHandler;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection;
+import org.openhab.core.io.transport.mqtt.MqttConnectionObserver;
+import org.openhab.core.io.transport.mqtt.MqttConnectionState;
+import org.openhab.core.io.transport.mqtt.MqttMessageSubscriber;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link EspMilightHubHandler} is responsible for handling commands of the globes, which are then
+ * sent to one of the bridges to be sent out by MQTT.
+ *
+ * @author Matthew Skinner - Initial contribution
+ */
+@NonNullByDefault
+public class EspMilightHubHandler extends BaseThingHandler implements MqttConnectionObserver, MqttMessageSubscriber {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private @Nullable MqttBrokerConnection connection;
+    private ThingRegistry thingRegistry;
+    private String globeType = "";
+    private String lastCommand = "";
+    private String bulbMode = "";
+    private String remotesGroupID = "";
+    private String channelPrefix = "";
+    private String fullCommandTopic = "";
+    private String fullStatesTopic = "";
+    private BigDecimal maxColourTemp = BigDecimal.ZERO;
+    private BigDecimal minColourTemp = BigDecimal.ZERO;
+    private BigDecimal savedLevel = new BigDecimal(100);
+    private ConfigOptions config = new ConfigOptions();
+
+    public EspMilightHubHandler(Thing thing, ThingRegistry thingRegistry) {
+        super(thing);
+        this.thingRegistry = thingRegistry;
+    }
+
+    void changeChannel(String channel, State state) {
+        updateState(new ChannelUID(channelPrefix + channel), state);
+        // Remote code of 0 means that all channels need to follow this change.
+        if (remotesGroupID.equals("0")) {
+            switch (globeType) {
+                // These two are 8 channel remotes
+                case "fut091":
+                case "fut089":
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "5:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "6:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "7:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "8:" + channel),
+                            state);
+                default:
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "1:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "2:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "3:" + channel),
+                            state);
+                    updateState(new ChannelUID(channelPrefix.substring(0, channelPrefix.length() - 2) + "4:" + channel),
+                            state);
+            }
+        }
+    }
+
+    private void processIncomingState(String messageJSON) {
+        // Need to handle State and Level at the same time to process level=0 as off//
+        BigDecimal tempBulbLevel = BigDecimal.ZERO;
+        String bulbState = Helper.resolveJSON(messageJSON, "\"state\":\"", 3);
+        String bulbLevel = Helper.resolveJSON(messageJSON, "\"level\":", 3);
+        if (!bulbLevel.isEmpty()) {
+            if (bulbLevel.equals("0") || bulbState.equals("OFF")) {
+                changeChannel(CHANNEL_LEVEL, new PercentType(0));
+                changeChannel(CHANNEL_LEVEL, OnOffType.valueOf("OFF"));
+                tempBulbLevel = BigDecimal.ZERO;
+            } else {
+                tempBulbLevel = new BigDecimal(bulbLevel);
+                changeChannel(CHANNEL_LEVEL, new PercentType(tempBulbLevel));
+            }
+        } else if (bulbState.equals("ON") || bulbState.equals("OFF")) { // NOTE: Level is missing when this runs
+            changeChannel(CHANNEL_LEVEL, OnOffType.valueOf(bulbState));
+        }
+        bulbMode = Helper.resolveJSON(messageJSON, "\"bulb_mode\":\"", 5);
+        switch (bulbMode) {
+            case "white":
+                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                    changeChannel(CHANNEL_BULB_MODE, new StringType("white"));
+                    changeChannel(CHANNEL_COLOUR, new HSBType("0,0," + tempBulbLevel));
+                    changeChannel(CHANNEL_DISCO_MODE, new StringType("None"));
+                }
+                String bulbCTemp = Helper.resolveJSON(messageJSON, "\"color_temp\":", 3);
+                if (!bulbCTemp.isEmpty()) {
+                    int ibulbCTemp = (int) Math.round(((Float.valueOf(bulbCTemp) / 2.17) - 171) * -1);
+                    changeChannel(CHANNEL_COLOURTEMP, new PercentType(ibulbCTemp));
+                }
+                break;
+            case "color":
+                changeChannel(CHANNEL_BULB_MODE, new StringType("color"));
+                changeChannel(CHANNEL_DISCO_MODE, new StringType("None"));
+                String bulbHue = Helper.resolveJSON(messageJSON, "\"hue\":", 3);
+                String bulbSaturation = Helper.resolveJSON(messageJSON, "\"saturation\":", 3);
+                if (bulbHue.isEmpty()) {
+                    logger.warn("Milight MQTT message came in as being a colour mode, but was missing a HUE value.");
+                } else {
+                    if (bulbSaturation.isEmpty()) {
+                        bulbSaturation = "100";
+                    }
+                    changeChannel(CHANNEL_COLOUR, new HSBType(bulbHue + "," + bulbSaturation + "," + tempBulbLevel));
+                }
+                break;
+            case "scene":
+                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                    changeChannel(CHANNEL_BULB_MODE, new StringType("scene"));
+                }
+                String bulbDiscoMode = Helper.resolveJSON(messageJSON, "\"mode\":", 1);
+                if (!bulbDiscoMode.isEmpty()) {
+                    changeChannel(CHANNEL_DISCO_MODE, new StringType(bulbDiscoMode));
+                }
+                break;
+            case "night":
+                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                    changeChannel(CHANNEL_BULB_MODE, new StringType("night"));
+                    if (config.oneTriggersNightMode) {
+                        changeChannel(CHANNEL_LEVEL, new PercentType("1"));
+                    }
+                }
+                break;
+        }
+    }
+
+    /*
+     * Used to calculate the colour temp for a globe if you want the light to get warmer as it is dimmed like a
+     * traditional halogen globe
+     */
+    private int autoColourTemp(int brightness) {
+        return minColourTemp.subtract(
+                minColourTemp.subtract(maxColourTemp).divide(new BigDecimal(100)).multiply(new BigDecimal(brightness)))
+                .intValue();
+    }
+
+    void turnOff() {
+        if (config.powerFailsToMinimum) {
+            sendMQTT("{\"state\":\"OFF\",\"level\":0}");
+        } else {
+            sendMQTT("{\"state\":\"OFF\"}");
+        }
+    }
+
+    void handleLevelColour(Command command) {
+        if (command instanceof OnOffType) {
+            if (OnOffType.ON.equals(command)) {
+                sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel + "}");
+                return;
+            } else {
+                turnOff();
+            }
+        } else if (command instanceof IncreaseDecreaseType) {
+            if (IncreaseDecreaseType.INCREASE.equals(command)) {
+                if (savedLevel.intValue() <= 90) {
+                    savedLevel = savedLevel.add(new BigDecimal(10));
+                }
+            } else {
+                if (savedLevel.intValue() >= 10) {
+                    savedLevel = savedLevel.subtract(new BigDecimal(10));
+                }
+            }
+            sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel.intValue() + "}");
+            return;
+        } else if (command instanceof HSBType) {
+            HSBType hsb = (HSBType) command;
+            // This feature allows google home or Echo to trigger white mode when asked to turn color to white.
+            if (hsb.getHue().intValue() == config.whiteHue && hsb.getSaturation().intValue() == config.whiteSat) {
+                if ("rgb_cct".equals(globeType) || "fut089".equals(globeType)) {
+                    sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
+                } else {// globe must only have 1 type of white
+                    sendMQTT("{\"command\":\"set_white\"}");
+                }
+                return;
+            } else if (hsb.getBrightness() == PercentType.ZERO) {
+                turnOff();
+                return;
+            } else if (config.whiteThreshold != -1 && hsb.getSaturation().intValue() <= config.whiteThreshold
+                    && "rgbw".equals(globeType)) {
+                sendMQTT("{\"command\":\"set_white\"}");
+                return;
+            }
+            sendMQTT("{\"state\":\"ON\",\"level\":" + hsb.getBrightness().intValue() + ",\"hue\":"
+                    + hsb.getHue().intValue() + ",\"saturation\":" + hsb.getSaturation().intValue() + "}");
+            savedLevel = hsb.getBrightness().toBigDecimal();
+            return;
+        } else if (command instanceof PercentType) {
+            if (((PercentType) command).intValue() == 1 && config.oneTriggersNightMode) {
+                sendMQTT("{\"command\":\"night_mode\"}");
+                return;
+            }
+            sendMQTT("{\"state\":\"ON\",\"level\":" + command + "}");
+            savedLevel = ((PercentType) command).toBigDecimal();
+            if (globeType.equals("rgb_cct") || globeType.equals("fut089")) {
+                if (config.dimmedCT > 0 && bulbMode.equals("white")) {
+                    sendMQTT("{\"state\":\"ON\",\"color_temp\":" + autoColourTemp(savedLevel.intValue()) + "}");
+                }
+            }
+            return;
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            return;
+        }
+        switch (channelUID.getId()) {
+            case CHANNEL_LEVEL:
+                handleLevelColour(command);
+                return;
+            case CHANNEL_BULB_MODE:
+                bulbMode = command.toString();
+                break;
+            case CHANNEL_COLOURTEMP:
+                int scaledCommand = (int) Math.round((370 - (2.17 * Float.valueOf(command.toString()))));
+                sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel + ",\"color_temp\":" + scaledCommand + "}");
+                break;
+            case CHANNEL_COMMAND:
+                if (command instanceof StringType) {
+                    lastCommand = command.toString();
+                    if (lastCommand.equals("favourite_white")) {
+                        sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
+                        break;
+                    }
+                    sendMQTT("{\"command\":\"" + command + "\"}");
+                }
+                break;
+            case CHANNEL_SEND_COMMAND:
+                if (lastCommand.isEmpty()) {
+                    lastCommand = config.defaultCommand;
+                    updateState(CHANNEL_COMMAND, new StringType(lastCommand));
+                }
+                if (lastCommand.equals("favourite_white")) {
+                    sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
+                    break;
+                }
+                sendMQTT("{\"command\":\"" + lastCommand + "\"}");
+                break;
+            case CHANNEL_DISCO_MODE:
+                sendMQTT("{\"mode\":\"" + command + "\"}");
+                break;
+            case CHANNEL_COLOUR:
+                handleLevelColour(command);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(ConfigOptions.class);
+        if (config.dimmedCT > 0) {
+            maxColourTemp = new BigDecimal(config.favouriteWhite);
+            minColourTemp = new BigDecimal(config.dimmedCT);
+            if (minColourTemp.intValue() <= maxColourTemp.intValue()) {
+                logger.warn("dimmedCT must be greater than the favourite white value.");
+            }
+        }
+        if (getBridge() == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    "Globe must have a valid bridge selected before it can come online.");
+        } else {
+            globeType = thing.getThingTypeUID().getId();// eg rgb_cct
+            String globeLocation = this.getThing().getUID().getId();// eg 0x014
+            remotesGroupID = globeLocation.substring(globeLocation.length() - 1, globeLocation.length());// eg 4
+            String remotesIDCode = globeLocation.substring(0, globeLocation.length() - 1);// eg 0x01
+            fullCommandTopic = COMMANDS_BASE_TOPIC + remotesIDCode + "/" + globeType + "/" + remotesGroupID;
+            fullStatesTopic = STATES_BASE_TOPIC + remotesIDCode + "/" + globeType + "/" + remotesGroupID;
+            // Need to remove the lowercase x from 0x12AB in case it contains all numbers
+            String caseCheck = globeLocation.substring(2, globeLocation.length() - 1);
+            if (!caseCheck.equals(caseCheck.toUpperCase())) {
+                logger.warn(
+                        "The milight globe {}{} is using lowercase for the remote code when the hub needs UPPERCASE",
+                        remotesIDCode, remotesGroupID);
+            }
+            Bridge localBridge = getBridge();
+            if (localBridge != null) {
+                channelPrefix = BINDING_ID + ":" + globeType + ":" + localBridge.getUID().getId() + ":" + remotesIDCode
+                        + remotesGroupID + ":";
+            }
+            connectMQTT();
+        }
+    }
+
+    private void sendMQTT(String payload) {
+        MqttBrokerConnection localConnection = connection;
+        if (localConnection != null) {
+            localConnection.publish(fullCommandTopic, payload.getBytes(), 1, false);
+        }
+    }
+
+    @Override
+    public void processMessage(String topic, byte[] payload) {
+        String state = new String(payload, StandardCharsets.UTF_8);
+        logger.trace("Recieved the following new Milight state:{}:{}", topic, state);
+        processIncomingState(state);
+    }
+
+    @Override
+    public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
+        logger.debug("MQTT brokers state changed to:{}", state);
+        switch (state) {
+            case CONNECTED:
+                updateStatus(ThingStatus.ONLINE);
+                break;
+            case CONNECTING:
+            case DISCONNECTED:
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "Bridge (broker) is not connected to your MQTT broker.");
+        }
+    }
+
+    public void connectMQTT() {
+        Bridge localBridge = this.getBridge();
+        if (localBridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Bridge is missing or offline, you need to setup a working MQTT broker first.");
+            return;
+        }
+        ThingUID thingUID = new ThingUID(new ThingTypeUID("mqtt", "broker"), localBridge.getUID().getId());
+        Thing thing = thingRegistry.get(thingUID);
+        if (thing == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "Bridge is missing or offline, you need to setup a working MQTT broker first.");
+            return;
+        }
+        ThingHandler handler = thing.getHandler();
+        if (handler instanceof AbstractBrokerHandler) {
+            AbstractBrokerHandler abh = (AbstractBrokerHandler) handler;
+            MqttBrokerConnection localConnection = abh.getConnection();
+            if (localConnection != null) {
+                localConnection.setKeepAliveInterval(20);
+                localConnection.setQos(1);
+                localConnection.setUnsubscribeOnStop(true);
+                localConnection.addConnectionObserver(this);
+                localConnection.start();
+                localConnection.subscribe(fullStatesTopic + "/#", this);
+                connection = localConnection;
+                if (localConnection.connectionState().compareTo(MqttConnectionState.CONNECTED) == 0) {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            }
+        }
+        return;
+    }
+
+    @Override
+    public void dispose() {
+        MqttBrokerConnection localConnection = connection;
+        if (localConnection != null) {
+            localConnection.unsubscribe(fullStatesTopic + "/#", this);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -202,7 +202,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 }
             } else {
                 if (savedLevel.intValue() >= 10) {
-                    savedLevel = savedLevel.subtract(new BigDecimal(10));
+                    savedLevel = savedLevel.subtract(BigDecimal.TEN);
                 }
             }
             sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel.intValue() + "}");

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -67,7 +67,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
     private String fullStatesTopic = "";
     private BigDecimal maxColourTemp = BigDecimal.ZERO;
     private BigDecimal minColourTemp = BigDecimal.ZERO;
-    private BigDecimal savedLevel = new BigDecimal(100);
+    private BigDecimal savedLevel = BIG_DECIMAL_100;
     private ConfigOptions config = new ConfigOptions();
 
     public EspMilightHubHandler(Thing thing, ThingRegistry thingRegistry) {
@@ -175,7 +175,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
      */
     private int autoColourTemp(int brightness) {
         return minColourTemp.subtract(
-                minColourTemp.subtract(maxColourTemp).divide(new BigDecimal(100)).multiply(new BigDecimal(brightness)))
+                minColourTemp.subtract(maxColourTemp).divide(BIG_DECIMAL_100).multiply(new BigDecimal(brightness)))
                 .intValue();
     }
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -230,15 +230,16 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             savedLevel = hsb.getBrightness().toBigDecimal();
             return;
         } else if (command instanceof PercentType) {
-            if (((PercentType) command).intValue() == 0) {
+            PercentType percentType = (PercentType) command;
+            if (percentType.intValue() == 0) {
                 turnOff();
                 return;
-            } else if (((PercentType) command).intValue() == 1 && config.oneTriggersNightMode) {
+            } else if (percentType.intValue() == 1 && config.oneTriggersNightMode) {
                 sendMQTT("{\"command\":\"night_mode\"}");
                 return;
             }
             sendMQTT("{\"state\":\"ON\",\"level\":" + command + "}");
-            savedLevel = ((PercentType) command).toBigDecimal();
+            savedLevel = percentType.toBigDecimal();
             if (globeType.equals("rgb_cct") || globeType.equals("fut089")) {
                 if (config.dimmedCT > 0 && bulbMode.equals("white")) {
                     sendMQTT("{\"state\":\"ON\",\"color_temp\":" + autoColourTemp(savedLevel.intValue()) + "}");

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -217,7 +217,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                     sendMQTT("{\"command\":\"set_white\"}");
                 }
                 return;
-            } else if (hsb.getBrightness() == PercentType.ZERO) {
+            } else if (PercentType.ZERO.equals(hsb.getBrightness())) {
                 turnOff();
                 return;
             } else if (config.whiteThreshold != -1 && hsb.getSaturation().intValue() <= config.whiteThreshold

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -230,7 +230,10 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             savedLevel = hsb.getBrightness().toBigDecimal();
             return;
         } else if (command instanceof PercentType) {
-            if (((PercentType) command).intValue() == 1 && config.oneTriggersNightMode) {
+            if (((PercentType) command).intValue() == 0) {
+                turnOff();
+                return;
+            } else if (((PercentType) command).intValue() == 1 && config.oneTriggersNightMode) {
                 sendMQTT("{\"command\":\"night_mode\"}");
                 return;
             }
@@ -261,29 +264,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 int scaledCommand = (int) Math.round((370 - (2.17 * Float.valueOf(command.toString()))));
                 sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel + ",\"color_temp\":" + scaledCommand + "}");
                 break;
-            case CHANNEL_NIGHT_MODE:
-                if (command.equals(OnOffType.ON)) {
-                    sendMQTT("{\"command\":\"night_mode\"}");
-                }
-                break;
-            case CHANNEL_SPEED_UP:
-                if (command.equals(OnOffType.ON)) {
-                    sendMQTT("{\"command\":\"mode_speed_up\"}");
-                }
-                break;
-            case CHANNEL_SLOW_DOWN:
-                if (command.equals(OnOffType.ON)) {
-                    sendMQTT("{\"command\":\"mode_speed_down\"}");
-                }
-                break;
-            case CHANNEL_SET_WHITE:
-                if (command.equals(OnOffType.ON)) {
-                    if (globeType.equals("rgbw") || globeType.equals("rgb")) {
-                        sendMQTT("{\"command\":\"set_white\"}");
-                        return;
-                    }
-                    sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
-                }
+            case CHANNEL_COMMAND:
+                sendMQTT("{\"command\":\"" + command + "\"}");
                 break;
             case CHANNEL_DISCO_MODE:
                 sendMQTT("{\"mode\":\"" + command + "\"}");

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -60,7 +60,6 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
     private @Nullable MqttBrokerConnection connection;
     private ThingRegistry thingRegistry;
     private String globeType = "";
-    private String lastCommand = "";
     private String bulbMode = "";
     private String remotesGroupID = "";
     private String channelPrefix = "";
@@ -262,26 +261,29 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 int scaledCommand = (int) Math.round((370 - (2.17 * Float.valueOf(command.toString()))));
                 sendMQTT("{\"state\":\"ON\",\"level\":" + savedLevel + ",\"color_temp\":" + scaledCommand + "}");
                 break;
-            case CHANNEL_COMMAND:
-                if (command instanceof StringType) {
-                    lastCommand = command.toString();
-                    if (lastCommand.equals("favourite_white")) {
-                        sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
-                        break;
-                    }
-                    sendMQTT("{\"command\":\"" + command + "\"}");
+            case CHANNEL_NIGHT_MODE:
+                if (command.equals(OnOffType.ON)) {
+                    sendMQTT("{\"command\":\"night_mode\"}");
                 }
                 break;
-            case CHANNEL_SEND_COMMAND:
-                if (lastCommand.isEmpty()) {
-                    lastCommand = config.defaultCommand;
-                    updateState(CHANNEL_COMMAND, new StringType(lastCommand));
+            case CHANNEL_SPEED_UP:
+                if (command.equals(OnOffType.ON)) {
+                    sendMQTT("{\"command\":\"mode_speed_up\"}");
                 }
-                if (lastCommand.equals("favourite_white")) {
+                break;
+            case CHANNEL_SLOW_DOWN:
+                if (command.equals(OnOffType.ON)) {
+                    sendMQTT("{\"command\":\"mode_speed_down\"}");
+                }
+                break;
+            case CHANNEL_SET_WHITE:
+                if (command.equals(OnOffType.ON)) {
+                    if (globeType.equals("rgbw") || globeType.equals("rgb")) {
+                        sendMQTT("{\"command\":\"set_white\"}");
+                        return;
+                    }
                     sendMQTT("{\"state\":\"ON\",\"color_temp\":" + config.favouriteWhite + "}");
-                    break;
                 }
-                sendMQTT("{\"command\":\"" + lastCommand + "\"}");
                 break;
             case CHANNEL_DISCO_MODE:
                 sendMQTT("{\"mode\":\"" + command + "\"}");

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -287,9 +287,11 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                         "The dimmedCT config value must be greater than the favouriteWhite value.");
             }
         }
-        if (getBridge() == null) {
+        Bridge localBridge = getBridge();
+        if (localBridge == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                     "Globe must have a valid bridge selected before it can come online.");
+            return;
         } else {
             globeType = thing.getThingTypeUID().getId();// eg rgb_cct
             String globeLocation = this.getThing().getUID().getId();// eg 0x014
@@ -304,11 +306,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                         "The milight globe {}{} is using lowercase for the remote code when the hub needs UPPERCASE",
                         remotesIDCode, remotesGroupID);
             }
-            Bridge localBridge = getBridge();
-            if (localBridge != null) {
-                channelPrefix = BINDING_ID + ":" + globeType + ":" + localBridge.getUID().getId() + ":" + remotesIDCode
-                        + remotesGroupID + ":";
-            }
+            channelPrefix = BINDING_ID + ":" + globeType + ":" + localBridge.getUID().getId() + ":" + remotesIDCode
+                    + remotesGroupID + ":";
             connectMQTT();
         }
     }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -38,7 +38,6 @@ import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandler;
@@ -347,7 +346,10 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                     "Bridge is missing or offline, you need to setup a working MQTT broker first.");
             return;
         }
-        ThingUID thingUID = new ThingUID(new ThingTypeUID("mqtt", "broker"), localBridge.getUID().getId());
+        ThingUID thingUID = localBridge.getBridgeUID();
+        if (thingUID == null) {
+            return;
+        }
         Thing thing = thingRegistry.get(thingUID);
         if (thing == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -282,8 +282,9 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             maxColourTemp = new BigDecimal(config.favouriteWhite);
             minColourTemp = new BigDecimal(config.dimmedCT);
             if (minColourTemp.intValue() <= maxColourTemp.intValue()) {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
-                        "The dimmedCT config value must be greater than the favouriteWhite value.");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "The dimmedCT config value must be greater than the favourite White value.");
+                return;
             }
         }
         Bridge localBridge = getBridge();

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -198,7 +198,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
         } else if (command instanceof IncreaseDecreaseType) {
             if (IncreaseDecreaseType.INCREASE.equals(command)) {
                 if (savedLevel.intValue() <= 90) {
-                    savedLevel = savedLevel.add(new BigDecimal(10));
+                    savedLevel = savedLevel.add(BigDecimal.TEN);
                 }
             } else {
                 if (savedLevel.intValue() >= 10) {

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -113,7 +113,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
         if (!bulbLevel.isEmpty()) {
             if (bulbLevel.equals("0") || bulbState.equals("OFF")) {
                 changeChannel(CHANNEL_LEVEL, new PercentType(0));
-                changeChannel(CHANNEL_LEVEL, OnOffType.valueOf("OFF"));
+                changeChannel(CHANNEL_LEVEL, OnOffType.OFF);
                 tempBulbLevel = BigDecimal.ZERO;
             } else {
                 tempBulbLevel = new BigDecimal(bulbLevel);

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -111,7 +111,6 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
         String bulbLevel = Helper.resolveJSON(messageJSON, "\"level\":", 3);
         if (!bulbLevel.isEmpty()) {
             if (bulbLevel.equals("0") || bulbState.equals("OFF")) {
-                changeChannel(CHANNEL_LEVEL, new PercentType(0));
                 changeChannel(CHANNEL_LEVEL, OnOffType.OFF);
                 tempBulbLevel = BigDecimal.ZERO;
             } else {

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -12,8 +12,8 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>When globes are off, default to the lowest level of light if the power fails.</label>
-			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
+			<label>Dimmed on Power Fail</label>
+			<description>If lights loose power when soft off, the lights will default back to the minimum brightness.</description>
 			<default>false</default>
 		</parameter>
 	</config-description>
@@ -66,7 +66,7 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>When globes are off, default to the lowest level of light if the power fails.</label>
+			<label>Dimmed on Power Fail</label>
 			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
 			<default>true</default>
 		</parameter>
@@ -94,7 +94,7 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>When globes are off, default to the lowest level of light if the power fails.</label>
+			<label>Dimmed on Power Fail</label>
 			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
 			<default>false</default>
 		</parameter>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -7,18 +7,13 @@
 	<config-description uri="thing-type:mqtt:rgb">
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
 			<label>1% Triggers Night Mode</label>
-			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-			</description>
+			<description>1% on a slider will trigger the Night Mode.</description>
 			<default>false</default>
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
 			<label>When globes are off, default to the lowest level of light if the power fails.</label>
-			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
-				the lowest
-				brightness to prevent waking people.
-			</description>
+			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
 			<default>false</default>
 		</parameter>
 	</config-description>
@@ -32,9 +27,7 @@
 
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
 			<label>1% Triggers Night Mode</label>
-			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-			</description>
+			<description>1% on a slider will trigger the Night Mode.</description>
 			<default>false</default>
 		</parameter>
 	</config-description>
@@ -42,25 +35,21 @@
 	<config-description uri="thing-type:mqtt:rgbandcct">
 		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 			<label>White Hue</label>
-			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-				to -1 to disable, 0 for Alexa, or 35 for Google Home.
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS.
 			</description>
 			<default>35</default>
 		</parameter>
 
 		<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
 			<label>White Saturation</label>
-			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-				to -1 to disable, 100 for Alexa or 32 for Google Home.
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS.
 			</description>
 			<default>32</default>
 		</parameter>
 
 		<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
 			<label>Favourite White</label>
-			<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
-				colour.
-			</description>
+			<description>When a shortcut triggers white mode, use this for the colour white.</description>
 			<default>200</default>
 		</parameter>
 
@@ -72,18 +61,13 @@
 
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
 			<label>1% Triggers Night Mode</label>
-			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-			</description>
+			<description>1% on a slider will trigger the Night Mode.</description>
 			<default>false</default>
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
 			<label>When globes are off, default to the lowest level of light if the power fails.</label>
-			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
-				the lowest
-				brightness to prevent waking people.
-			</description>
+			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
 			<default>true</default>
 		</parameter>
 	</config-description>
@@ -91,42 +75,33 @@
 	<config-description uri="thing-type:mqtt:rgbw">
 		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 			<label>White Hue</label>
-			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-				to -1 to disable, 0 for Alexa, or 35 for Google Home.
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS.
 			</description>
 			<default>35</default>
 		</parameter>
 
 		<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
 			<label>White Saturation</label>
-			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-				to -1 to disable, 100 for Alexa or 32 for Google Home.
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS.
 			</description>
 			<default>32</default>
 		</parameter>
 
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
 			<label>1% Triggers Night Mode</label>
-			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-			</description>
+			<description>1% on a slider will trigger the Night Mode.</description>
 			<default>false</default>
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
 			<label>When globes are off, default to the lowest level of light if the power fails.</label>
-			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
-				the lowest
-				brightness to prevent waking people.
-			</description>
+			<description>If lights loose power, the lights will turn on to the minimum brightness.</description>
 			<default>false</default>
 		</parameter>
 
 		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
 			<label>White Threshold</label>
-			<description>RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that
-				if
-				the saturation drops below, it will trigger the white mode. -1 will disable this feature.
+			<description>RGBW saturation changes, will trigger the white mode. -1 will disable this feature.
 			</description>
 			<default>12</default>
 		</parameter>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -106,7 +106,7 @@
 		</parameter>
 
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
-			<label>1 Triggers Night Mode</label>
+			<label>1% Triggers Night Mode</label>
 			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
 				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
 			</description>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -31,7 +31,7 @@
 		</parameter>
 
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
-			<label>1 Triggers Night Mode</label>
+			<label>1% Triggers Night Mode</label>
 			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
 				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
 			</description>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -5,14 +5,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:mqtt:rgb">
-		<parameter name="defaultCommand" type="text" required="true">
-			<label>Default Command</label>
-			<description>When the send command button is pressed, if no selection is made from the command channel then use this
-				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-			</description>
-			<default>night_mode</default>
-		</parameter>
-
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
 			<label>1 Triggers Night Mode</label>
 			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
@@ -22,9 +14,10 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>Default to the lowest level of light when the power fails.</label>
-			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-				brightness.
+			<label>When globes are off, default to the lowest level of light if the power fails.</label>
+			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
+				the lowest
+				brightness to prevent waking people.
 			</description>
 			<default>true</default>
 		</parameter>
@@ -47,14 +40,6 @@
 	</config-description>
 
 	<config-description uri="thing-type:mqtt:rgbandcct">
-		<parameter name="defaultCommand" type="text" required="true">
-			<label>Default Command</label>
-			<description>When the send command button is pressed, if no selection is made from the command channel then use this
-				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-			</description>
-			<default>night_mode</default>
-		</parameter>
-
 		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 			<label>White Hue</label>
 			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
@@ -94,23 +79,16 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>Default to the lowest level of light when the power fails.</label>
-			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-				brightness.
+			<label>When globes are off, default to the lowest level of light if the power fails.</label>
+			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
+				the lowest
+				brightness to prevent waking people.
 			</description>
 			<default>true</default>
 		</parameter>
 	</config-description>
 
 	<config-description uri="thing-type:mqtt:rgbw">
-		<parameter name="defaultCommand" type="text" required="true">
-			<label>Default Command</label>
-			<description>When the send command button is pressed, if no selection is made from the command channel then use this
-				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-			</description>
-			<default>night_mode</default>
-		</parameter>
-
 		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 			<label>White Hue</label>
 			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
@@ -136,9 +114,10 @@
 		</parameter>
 
 		<parameter name="powerFailsToMinimum" type="boolean" required="true">
-			<label>Default to the lowest level of light when the power fails.</label>
-			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-				brightness.
+			<label>When globes are off, default to the lowest level of light if the power fails.</label>
+			<description>If lights loose power from the power switch being cycled OR a power outage, the lights will default to
+				the lowest
+				brightness to prevent waking people.
 			</description>
 			<default>true</default>
 		</parameter>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -6,7 +6,7 @@
 
 	<config-description uri="thing-type:mqtt:rgb">
 		<parameter name="oneTriggersNightMode" type="boolean" required="true">
-			<label>1 Triggers Night Mode</label>
+			<label>1% Triggers Night Mode</label>
 			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
 				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
 			</description>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:mqtt:rgb">
+		<parameter name="defaultCommand" type="text" required="true">
+			<label>Default Command</label>
+			<description>When the send command button is pressed, if no selection is made from the command channel then use this
+				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+			</description>
+			<default>night_mode</default>
+		</parameter>
+
+		<parameter name="oneTriggersNightMode" type="boolean" required="true">
+			<label>1 Triggers Night Mode</label>
+			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+			</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="powerFailsToMinimum" type="boolean" required="true">
+			<label>Default to the lowest level of light when the power fails.</label>
+			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+				brightness.
+			</description>
+			<default>true</default>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:mqtt:cct">
+		<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+			<label>Dimmed Colour Temp</label>
+			<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+			</description>
+		</parameter>
+
+		<parameter name="oneTriggersNightMode" type="boolean" required="true">
+			<label>1 Triggers Night Mode</label>
+			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+			</description>
+			<default>false</default>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:mqtt:rgbandcct">
+		<parameter name="defaultCommand" type="text" required="true">
+			<label>Default Command</label>
+			<description>When the send command button is pressed, if no selection is made from the command channel then use this
+				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+			</description>
+			<default>night_mode</default>
+		</parameter>
+
+		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
+			<label>White Hue</label>
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+				to -1 to disable, 0 for Alexa, or 35 for Google Home.
+			</description>
+			<default>35</default>
+		</parameter>
+
+		<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
+			<label>White Saturation</label>
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+				to -1 to disable, 100 for Alexa or 32 for Google Home.
+			</description>
+			<default>32</default>
+		</parameter>
+
+		<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
+			<label>Favourite White</label>
+			<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
+				colour.
+			</description>
+			<default>200</default>
+		</parameter>
+
+		<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+			<label>Dimmed Colour Temp</label>
+			<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+			</description>
+		</parameter>
+
+		<parameter name="oneTriggersNightMode" type="boolean" required="true">
+			<label>1% Triggers Night Mode</label>
+			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+			</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="powerFailsToMinimum" type="boolean" required="true">
+			<label>Default to the lowest level of light when the power fails.</label>
+			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+				brightness.
+			</description>
+			<default>true</default>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:mqtt:rgbw">
+		<parameter name="defaultCommand" type="text" required="true">
+			<label>Default Command</label>
+			<description>When the send command button is pressed, if no selection is made from the command channel then use this
+				command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+			</description>
+			<default>night_mode</default>
+		</parameter>
+
+		<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
+			<label>White Hue</label>
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+				to -1 to disable, 0 for Alexa, or 35 for Google Home.
+			</description>
+			<default>35</default>
+		</parameter>
+
+		<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
+			<label>White Saturation</label>
+			<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+				to -1 to disable, 100 for Alexa or 32 for Google Home.
+			</description>
+			<default>32</default>
+		</parameter>
+
+		<parameter name="oneTriggersNightMode" type="boolean" required="true">
+			<label>1 Triggers Night Mode</label>
+			<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+				moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+			</description>
+			<default>false</default>
+		</parameter>
+
+		<parameter name="powerFailsToMinimum" type="boolean" required="true">
+			<label>Default to the lowest level of light when the power fails.</label>
+			<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+				brightness.
+			</description>
+			<default>true</default>
+		</parameter>
+
+		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
+			<label>White Threshold</label>
+			<description>RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that
+				if
+				the saturation drops below, it will trigger the white mode. -1 will disable this feature.
+			</description>
+			<default>12</default>
+		</parameter>
+
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -19,7 +19,7 @@
 				the lowest
 				brightness to prevent waking people.
 			</description>
-			<default>true</default>
+			<default>false</default>
 		</parameter>
 	</config-description>
 
@@ -119,7 +119,7 @@
 				the lowest
 				brightness to prevent waking people.
 			</description>
-			<default>true</default>
+			<default>false</default>
 		</parameter>
 
 		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -367,18 +367,18 @@
 		<state>
 			<options>
 				<option value="next_mode">Next Mode</option>
-				<option value="previous_mode">previous_mode</option>
-				<option value="mode_speed_up">mode_speed_up</option>
-				<option value="mode_speed_down">mode_speed_down</option>
-				<option value="set_white">set_white</option>
-				<option value="pair">pair</option>
-				<option value="unpair">unpair</option>
-				<option value="level_down">level_down</option>
-				<option value="level_up">level_up</option>
-				<option value="temperature_down">temperature_down</option>
-				<option value="temperature_up">temperature_up</option>
-				<option value="night_mode">night_mode</option>
-				<option value="favourite_white">favourite_white</option>
+				<option value="previous_mode">Previous Mode</option>
+				<option value="mode_speed_up">Mode Speed Up</option>
+				<option value="mode_speed_down">Mode Speed Down</option>
+				<option value="set_white">Set White</option>
+				<option value="pair">Pair</option>
+				<option value="unpair">Unpair</option>
+				<option value="level_down">Level Down</option>
+				<option value="level_up">Level Up</option>
+				<option value="temperature_down">Temperature Down</option>
+				<option value="temperature_up">Temperature Up</option>
+				<option value="night_mode">Night Mode</option>
+				<option value="favourite_white">Favourite White</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -62,7 +62,7 @@
 			</parameter>
 
 			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
+				<label>1% Triggers Night Mode</label>
 				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
 					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
 				</description>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -34,7 +34,7 @@
 			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 				<label>White Hue</label>
 				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+					to -1 to disable, 0 for Alexa, or 35 for Google Home.
 				</description>
 				<default>35</default>
 			</parameter>
@@ -110,7 +110,7 @@
 			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 				<label>White Hue</label>
 				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+					to -1 to disable, 0 for Alexa, or 35 for Google Home.
 				</description>
 				<default>35</default>
 			</parameter>
@@ -246,7 +246,7 @@
 			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
 				<label>White Hue</label>
 				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+					to -1 to disable, 0 for Alexa, or 35 for Google Home.
 				</description>
 				<default>35</default>
 			</parameter>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -366,7 +366,7 @@
 			globes support all commands.</description>
 		<state>
 			<options>
-				<option value="next_mode">next_mode</option>
+				<option value="next_mode">Next Mode</option>
 				<option value="previous_mode">previous_mode</option>
 				<option value="mode_speed_up">mode_speed_up</option>
 				<option value="mode_speed_down">mode_speed_down</option>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -18,10 +18,7 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="nightMode" typeId="nightMode"/>
-			<channel id="setWhite" typeId="setWhite"/>
-			<channel id="speedUp" typeId="speedUp"/>
-			<channel id="slowDown" typeId="slowDown"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
@@ -40,10 +37,7 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="nightMode" typeId="nightMode"/>
-			<channel id="setWhite" typeId="setWhite"/>
-			<channel id="speedUp" typeId="speedUp"/>
-			<channel id="slowDown" typeId="slowDown"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
@@ -59,6 +53,7 @@
 		<channels>
 			<channel id="level" typeId="level"/>
 			<channel id="colourTemperature" typeId="colourTemperature"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:cct"/>
 	</thing-type>
@@ -74,6 +69,7 @@
 		<channels>
 			<channel id="level" typeId="level"/>
 			<channel id="colourTemperature" typeId="colourTemperature"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:cct"/>
 	</thing-type>
@@ -91,10 +87,7 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="nightMode" typeId="nightMode"/>
-			<channel id="setWhite" typeId="setWhite"/>
-			<channel id="speedUp" typeId="speedUp"/>
-			<channel id="slowDown" typeId="slowDown"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbw"/>
 	</thing-type>
@@ -112,9 +105,7 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="nightMode" typeId="nightMode"/>
-			<channel id="speedUp" typeId="speedUp"/>
-			<channel id="slowDown" typeId="slowDown"/>
+			<channel id="command" typeId="command"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgb"/>
 	</thing-type>
@@ -143,28 +134,24 @@
 		</tags>
 	</channel-type>
 
-	<channel-type id="nightMode" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Night Mode</label>
-		<description>Send the command to use night mode. </description>
-	</channel-type>
-
-	<channel-type id="speedUp" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Mode Speed Up</label>
-		<description>Send the command to speed up the disco mode</description>
-	</channel-type>
-
-	<channel-type id="slowDown" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Mode Slow Down</label>
-		<description>Send the command to slow down the disco mode</description>
-	</channel-type>
-
-	<channel-type id="setWhite" advanced="true">
-		<item-type>Switch</item-type>
-		<label>Set White</label>
-		<description>Change the light to use white LEDs.</description>
+	<channel-type id="command" advanced="true">
+		<item-type>String</item-type>
+		<label>Command</label>
+		<description>Send a raw command to the globe/s.</description>
+		<state>
+			<options>
+				<option value="next_mode">Next Mode</option>
+				<option value="previous_mode">Previous Mode</option>
+				<option value="mode_speed_up">Mode Speed Up</option>
+				<option value="mode_speed_down">Mode Speed Down</option>
+				<option value="set_white">Set White</option>
+				<option value="level_down">Level Down</option>
+				<option value="level_up">Level Up</option>
+				<option value="temperature_down">Temperature Down</option>
+				<option value="temperature_up">Temperature Up</option>
+				<option value="night_mode">Night Mode</option>
+			</options>
+		</state>
 	</channel-type>
 
 	<channel-type id="bulbMode" advanced="true">

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -18,8 +18,10 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="command" typeId="command"/>
-			<channel id="sendCommand" typeId="sendCommand"/>
+			<channel id="nightMode" typeId="nightMode"/>
+			<channel id="setWhite" typeId="setWhite"/>
+			<channel id="speedUp" typeId="speedUp"/>
+			<channel id="slowDown" typeId="slowDown"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
@@ -38,8 +40,10 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="command" typeId="command"/>
-			<channel id="sendCommand" typeId="sendCommand"/>
+			<channel id="nightMode" typeId="nightMode"/>
+			<channel id="setWhite" typeId="setWhite"/>
+			<channel id="speedUp" typeId="speedUp"/>
+			<channel id="slowDown" typeId="slowDown"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
@@ -87,8 +91,10 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="command" typeId="command"/>
-			<channel id="sendCommand" typeId="sendCommand"/>
+			<channel id="nightMode" typeId="nightMode"/>
+			<channel id="setWhite" typeId="setWhite"/>
+			<channel id="speedUp" typeId="speedUp"/>
+			<channel id="slowDown" typeId="slowDown"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgbw"/>
 	</thing-type>
@@ -106,8 +112,9 @@
 			<channel id="colour" typeId="colour"/>
 			<channel id="discoMode" typeId="discoMode"/>
 			<channel id="bulbMode" typeId="bulbMode"/>
-			<channel id="command" typeId="command"/>
-			<channel id="sendCommand" typeId="sendCommand"/>
+			<channel id="nightMode" typeId="nightMode"/>
+			<channel id="speedUp" typeId="speedUp"/>
+			<channel id="slowDown" typeId="slowDown"/>
 		</channels>
 		<config-description-ref uri="thing-type:mqtt:rgb"/>
 	</thing-type>
@@ -136,34 +143,28 @@
 		</tags>
 	</channel-type>
 
-	<channel-type id="command" advanced="true">
-		<item-type>String</item-type>
-		<label>Bulb Command</label>
-		<description>Choose the command to send to the globe then press the button to send it multiple times. Note: Not all
-			globes support all commands.</description>
-		<state>
-			<options>
-				<option value="next_mode">Next Mode</option>
-				<option value="previous_mode">Previous Mode</option>
-				<option value="mode_speed_up">Mode Speed Up</option>
-				<option value="mode_speed_down">Mode Speed Down</option>
-				<option value="set_white">Set White</option>
-				<option value="pair">Pair</option>
-				<option value="unpair">Unpair</option>
-				<option value="level_down">Level Down</option>
-				<option value="level_up">Level Up</option>
-				<option value="temperature_down">Temperature Down</option>
-				<option value="temperature_up">Temperature Up</option>
-				<option value="night_mode">Night Mode</option>
-				<option value="favourite_white">Favourite White</option>
-			</options>
-		</state>
+	<channel-type id="nightMode" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Night Mode</label>
+		<description>Send the command to use night mode. </description>
 	</channel-type>
 
-	<channel-type id="sendCommand" advanced="true">
+	<channel-type id="speedUp" advanced="true">
 		<item-type>Switch</item-type>
-		<label>Send Bulb Command</label>
-		<description>Send the command selected in the list.</description>
+		<label>Mode Speed Up</label>
+		<description>Send the command to speed up the disco mode</description>
+	</channel-type>
+
+	<channel-type id="slowDown" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Mode Slow Down</label>
+		<description>Send the command to slow down the disco mode</description>
+	</channel-type>
+
+	<channel-type id="setWhite" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Set White</label>
+		<description>Change the light to use white LEDs.</description>
 	</channel-type>
 
 	<channel-type id="bulbMode" advanced="true">

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,425 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="mqtt"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="rgb_cct">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight RGBCCT</label>
+		<description>Led globe with full Colour, and both cool and warm whites.</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colourTemperature" typeId="colourTemperature"/>
+			<channel id="colour" typeId="colour"/>
+			<channel id="discoMode" typeId="discoMode"/>
+			<channel id="bulbMode" typeId="bulbMode"/>
+			<channel id="command" typeId="command"/>
+			<channel id="sendCommand" typeId="sendCommand"/>
+		</channels>
+		<config-description>
+
+			<parameter name="defaultCommand" type="text" required="true">
+				<label>Default Command</label>
+				<description>When the send command button is pressed, if no selection is made from the command channel then use this
+					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+				</description>
+				<default>night_mode</default>
+			</parameter>
+
+			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
+				<label>White Hue</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+				</description>
+				<default>35</default>
+			</parameter>
+
+			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
+				<label>White Saturation</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 100 for Alexa or 32 for Google Home.
+				</description>
+				<default>32</default>
+			</parameter>
+
+			<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
+				<label>Favourite White</label>
+				<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
+					colour.
+				</description>
+				<default>200</default>
+			</parameter>
+
+			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+				<label>Dimmed Colour Temp</label>
+				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+				</description>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+			<parameter name="powerFailsToMinimum" type="boolean" required="true">
+				<label>Default to the lowest level of light when the power fails.</label>
+				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+					brightness.
+				</description>
+				<default>true</default>
+			</parameter>
+
+		</config-description>
+	</thing-type>
+
+	<thing-type id="fut089">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight FUT089</label>
+		<description>Use this when your remote is the newer 8 group type called FUT089 and your globes are rgb_cct</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colourTemperature" typeId="colourTemperature"/>
+			<channel id="colour" typeId="colour"/>
+			<channel id="discoMode" typeId="discoMode"/>
+			<channel id="bulbMode" typeId="bulbMode"/>
+			<channel id="command" typeId="command"/>
+			<channel id="sendCommand" typeId="sendCommand"/>
+		</channels>
+		<config-description>
+
+			<parameter name="defaultCommand" type="text" required="true">
+				<label>Default Command</label>
+				<description>When the send command button is pressed, if no selection is made from the command channel then use this
+					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+				</description>
+				<default>night_mode</default>
+			</parameter>
+
+			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
+				<label>White Hue</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+				</description>
+				<default>35</default>
+			</parameter>
+
+			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
+				<label>White Saturation</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 100 for Alexa or 32 for Google Home.
+				</description>
+				<default>32</default>
+			</parameter>
+
+			<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
+				<label>Favourite White</label>
+				<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
+					colour.
+				</description>
+				<default>200</default>
+			</parameter>
+
+			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+				<label>Dimmed Colour Temp</label>
+				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+				</description>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+			<parameter name="powerFailsToMinimum" type="boolean" required="true">
+				<label>Default to the lowest level of light when the power fails.</label>
+				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+					brightness.
+				</description>
+				<default>true</default>
+			</parameter>
+
+		</config-description>
+	</thing-type>
+
+	<thing-type id="fut091">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight FUT091</label>
+		<description>Use this when your remote is the newer fut091 and your globes are cct</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colourTemperature" typeId="colourTemperature"/>
+		</channels>
+		<config-description>
+
+			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+				<label>Dimmed Colour Temp</label>
+				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+				</description>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+		</config-description>
+	</thing-type>
+
+	<thing-type id="cct">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight CCT</label>
+		<description>Led globe with both cool and warm white controls</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colourTemperature" typeId="colourTemperature"/>
+		</channels>
+		<config-description>
+
+			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
+				<label>Dimmed Colour Temp</label>
+				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
+				</description>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+		</config-description>
+	</thing-type>
+
+	<thing-type id="rgbw">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight RGBW</label>
+		<description>RGB Globe with a fixed white</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colour" typeId="colour"/>
+			<channel id="discoMode" typeId="discoMode"/>
+			<channel id="bulbMode" typeId="bulbMode"/>
+			<channel id="command" typeId="command"/>
+			<channel id="sendCommand" typeId="sendCommand"/>
+		</channels>
+		<config-description>
+			<parameter name="defaultCommand" type="text" required="true">
+				<label>Default Command</label>
+				<description>When the send command button is pressed, if no selection is made from the command channel then use this
+					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+				</description>
+				<default>night_mode</default>
+			</parameter>
+
+			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
+				<label>White Hue</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 0 for Alexa, or 36 for Google Home.
+				</description>
+				<default>35</default>
+			</parameter>
+
+			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
+				<label>White Saturation</label>
+				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
+					to -1 to disable, 100 for Alexa or 32 for Google Home.
+				</description>
+				<default>32</default>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+			<parameter name="powerFailsToMinimum" type="boolean" required="true">
+				<label>Default to the lowest level of light when the power fails.</label>
+				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+					brightness.
+				</description>
+				<default>true</default>
+			</parameter>
+
+			<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
+				<label>White Threshold</label>
+				<description>RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that
+					if the saturation drops below, it will trigger the white mode. -1 will disable this feature.
+				</description>
+				<default>12</default>
+			</parameter>
+
+		</config-description>
+
+	</thing-type>
+
+	<thing-type id="rgb">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="broker"/>
+			<bridge-type-ref id="systemBroker"/>
+		</supported-bridge-type-refs>
+		<label>Milight RGB</label>
+		<description>RGB Globe with no white</description>
+		<category>Lightbulb</category>
+		<channels>
+			<channel id="level" typeId="level"/>
+			<channel id="colour" typeId="colour"/>
+			<channel id="discoMode" typeId="discoMode"/>
+			<channel id="bulbMode" typeId="bulbMode"/>
+			<channel id="command" typeId="command"/>
+			<channel id="sendCommand" typeId="sendCommand"/>
+		</channels>
+		<config-description>
+
+			<parameter name="defaultCommand" type="text" required="true">
+				<label>Default Command</label>
+				<description>When the send command button is pressed, if no selection is made from the command channel then use this
+					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
+				</description>
+				<default>night_mode</default>
+			</parameter>
+
+			<parameter name="oneTriggersNightMode" type="boolean" required="true">
+				<label>1 Triggers Night Mode</label>
+				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
+					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
+				</description>
+				<default>false</default>
+			</parameter>
+
+			<parameter name="powerFailsToMinimum" type="boolean" required="true">
+				<label>Default to the lowest level of light when the power fails.</label>
+				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
+					brightness.
+				</description>
+				<default>true</default>
+			</parameter>
+
+		</config-description>
+	</thing-type>
+
+	<channel-type id="level">
+		<item-type>Dimmer</item-type>
+		<label>Level</label>
+		<description>Level changes the brightness of the globe.</description>
+		<category>DimmableLight</category>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="colourTemperature">
+		<item-type>Dimmer</item-type>
+		<label>Colour Temperature</label>
+		<description>Change from cool to warm white with this control.</description>
+		<category>DimmableCT</category>
+	</channel-type>
+
+	<channel-type id="colour">
+		<item-type>Color</item-type>
+		<label>Colour</label>
+		<description>Allows you to change the colour, brightness and saturation of the globe.</description>
+		<category>ColorLight</category>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
+
+	<channel-type id="command" advanced="true">
+		<item-type>String</item-type>
+		<label>Bulb Command</label>
+		<description>Choose the command to send to the globe then press the button to send it multiple times. Note: Not all
+			globes support all commands.</description>
+		<state>
+			<options>
+				<option value="next_mode">next_mode</option>
+				<option value="previous_mode">previous_mode</option>
+				<option value="mode_speed_up">mode_speed_up</option>
+				<option value="mode_speed_down">mode_speed_down</option>
+				<option value="set_white">set_white</option>
+				<option value="pair">pair</option>
+				<option value="unpair">unpair</option>
+				<option value="level_down">level_down</option>
+				<option value="level_up">level_up</option>
+				<option value="temperature_down">temperature_down</option>
+				<option value="temperature_up">temperature_up</option>
+				<option value="night_mode">night_mode</option>
+				<option value="favourite_white">favourite_white</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="sendCommand" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Send Bulb Command</label>
+		<description>Send the command selected in the list.</description>
+	</channel-type>
+
+	<channel-type id="bulbMode" advanced="true">
+		<item-type>String</item-type>
+		<label>Bulb Mode</label>
+		<description>Displays the mode the bulb is currently in.</description>
+		<state readOnly="true">
+			<options>
+				<option value="white">white</option>
+				<option value="color">color</option>
+				<option value="scene">scene</option>
+				<option value="night">night</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="discoMode" advanced="true">
+		<item-type>String</item-type>
+		<label>Disco Mode</label>
+		<description>Switch to a Disco mode directly.</description>
+		<state>
+			<options>
+				<option value="0">Disco 0</option>
+				<option value="1">Disco 1</option>
+				<option value="2">Disco 2</option>
+				<option value="3">Disco 3</option>
+				<option value="4">Disco 4</option>
+				<option value="5">Disco 5</option>
+				<option value="6">Disco 6</option>
+				<option value="7">Disco 7</option>
+				<option value="8">Disco 8</option>
+			</options>
+		</state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/thing/thing-types.xml
@@ -21,63 +21,7 @@
 			<channel id="command" typeId="command"/>
 			<channel id="sendCommand" typeId="sendCommand"/>
 		</channels>
-		<config-description>
-
-			<parameter name="defaultCommand" type="text" required="true">
-				<label>Default Command</label>
-				<description>When the send command button is pressed, if no selection is made from the command channel then use this
-					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-				</description>
-				<default>night_mode</default>
-			</parameter>
-
-			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
-				<label>White Hue</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 35 for Google Home.
-				</description>
-				<default>35</default>
-			</parameter>
-
-			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
-				<label>White Saturation</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 100 for Alexa or 32 for Google Home.
-				</description>
-				<default>32</default>
-			</parameter>
-
-			<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
-				<label>Favourite White</label>
-				<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
-					colour.
-				</description>
-				<default>200</default>
-			</parameter>
-
-			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
-				<label>Dimmed Colour Temp</label>
-				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
-				</description>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1% Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-			<parameter name="powerFailsToMinimum" type="boolean" required="true">
-				<label>Default to the lowest level of light when the power fails.</label>
-				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-					brightness.
-				</description>
-				<default>true</default>
-			</parameter>
-
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
 
 	<thing-type id="fut089">
@@ -97,63 +41,7 @@
 			<channel id="command" typeId="command"/>
 			<channel id="sendCommand" typeId="sendCommand"/>
 		</channels>
-		<config-description>
-
-			<parameter name="defaultCommand" type="text" required="true">
-				<label>Default Command</label>
-				<description>When the send command button is pressed, if no selection is made from the command channel then use this
-					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-				</description>
-				<default>night_mode</default>
-			</parameter>
-
-			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
-				<label>White Hue</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 35 for Google Home.
-				</description>
-				<default>35</default>
-			</parameter>
-
-			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
-				<label>White Saturation</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 100 for Alexa or 32 for Google Home.
-				</description>
-				<default>32</default>
-			</parameter>
-
-			<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
-				<label>Favourite White</label>
-				<description>When one of the shortcuts triggers white mode, use this for the colour white instead of the default
-					colour.
-				</description>
-				<default>200</default>
-			</parameter>
-
-			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
-				<label>Dimmed Colour Temp</label>
-				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
-				</description>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-			<parameter name="powerFailsToMinimum" type="boolean" required="true">
-				<label>Default to the lowest level of light when the power fails.</label>
-				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-					brightness.
-				</description>
-				<default>true</default>
-			</parameter>
-
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:rgbandcct"/>
 	</thing-type>
 
 	<thing-type id="fut091">
@@ -168,23 +56,7 @@
 			<channel id="level" typeId="level"/>
 			<channel id="colourTemperature" typeId="colourTemperature"/>
 		</channels>
-		<config-description>
-
-			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
-				<label>Dimmed Colour Temp</label>
-				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
-				</description>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:cct"/>
 	</thing-type>
 
 	<thing-type id="cct">
@@ -199,23 +71,7 @@
 			<channel id="level" typeId="level"/>
 			<channel id="colourTemperature" typeId="colourTemperature"/>
 		</channels>
-		<config-description>
-
-			<parameter name="dimmedCT" type="integer" required="false" min="153" max="370">
-				<label>Dimmed Colour Temp</label>
-				<description>Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable.
-				</description>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:cct"/>
 	</thing-type>
 
 	<thing-type id="rgbw">
@@ -234,57 +90,7 @@
 			<channel id="command" typeId="command"/>
 			<channel id="sendCommand" typeId="sendCommand"/>
 		</channels>
-		<config-description>
-			<parameter name="defaultCommand" type="text" required="true">
-				<label>Default Command</label>
-				<description>When the send command button is pressed, if no selection is made from the command channel then use this
-					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-				</description>
-				<default>night_mode</default>
-			</parameter>
-
-			<parameter name="whiteHue" type="integer" required="true" min="-1" max="360">
-				<label>White Hue</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 0 for Alexa, or 35 for Google Home.
-				</description>
-				<default>35</default>
-			</parameter>
-
-			<parameter name="whiteSat" type="integer" required="true" min="-1" max="100">
-				<label>White Saturation</label>
-				<description>When both the whiteHue and whiteSat values are seen by the binding it will trigger the white LEDS. Set
-					to -1 to disable, 100 for Alexa or 32 for Google Home.
-				</description>
-				<default>32</default>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-			<parameter name="powerFailsToMinimum" type="boolean" required="true">
-				<label>Default to the lowest level of light when the power fails.</label>
-				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-					brightness.
-				</description>
-				<default>true</default>
-			</parameter>
-
-			<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
-				<label>White Threshold</label>
-				<description>RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that
-					if the saturation drops below, it will trigger the white mode. -1 will disable this feature.
-				</description>
-				<default>12</default>
-			</parameter>
-
-		</config-description>
-
+		<config-description-ref uri="thing-type:mqtt:rgbw"/>
 	</thing-type>
 
 	<thing-type id="rgb">
@@ -303,50 +109,21 @@
 			<channel id="command" typeId="command"/>
 			<channel id="sendCommand" typeId="sendCommand"/>
 		</channels>
-		<config-description>
-
-			<parameter name="defaultCommand" type="text" required="true">
-				<label>Default Command</label>
-				<description>When the send command button is pressed, if no selection is made from the command channel then use this
-					command by default. TIP: use "set_white" for RGBW globes to set back to white light quickly.
-				</description>
-				<default>night_mode</default>
-			</parameter>
-
-			<parameter name="oneTriggersNightMode" type="boolean" required="true">
-				<label>1 Triggers Night Mode</label>
-				<description>Night Mode is a much lower level of light and this allows it to be auto selected when your fader/slider
-					moves to 1%. NOTE: Night mode locks out some controls of a physical remote.
-				</description>
-				<default>false</default>
-			</parameter>
-
-			<parameter name="powerFailsToMinimum" type="boolean" required="true">
-				<label>Default to the lowest level of light when the power fails.</label>
-				<description>If lights loose power from the power switch OR a power outage, they will default to the lowest
-					brightness.
-				</description>
-				<default>true</default>
-			</parameter>
-
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:rgb"/>
 	</thing-type>
 
 	<channel-type id="level">
 		<item-type>Dimmer</item-type>
 		<label>Level</label>
 		<description>Level changes the brightness of the globe.</description>
-		<category>DimmableLight</category>
-		<tags>
-			<tag>Lighting</tag>
-		</tags>
+		<category>Slider</category>
 	</channel-type>
 
 	<channel-type id="colourTemperature">
 		<item-type>Dimmer</item-type>
 		<label>Colour Temperature</label>
 		<description>Change from cool to warm white with this control.</description>
-		<category>DimmableCT</category>
+		<category>Slider</category>
 	</channel-type>
 
 	<channel-type id="colour">

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/MqttBindingConstants.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/MqttBindingConstants.java
@@ -23,7 +23,7 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class MqttBindingConstants {
-    private static final String BINDING_ID = "mqtt";
+    public static final String BINDING_ID = "mqtt";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID BRIDGE_TYPE_SYSTEMBROKER = new ThingTypeUID(BINDING_ID, "systemBroker");

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -195,6 +195,7 @@
     <module>org.openhab.binding.monopriceaudio</module>
     <module>org.openhab.binding.mpd</module>
     <module>org.openhab.binding.mqtt</module>
+    <module>org.openhab.binding.mqtt.espmilighthub</module>
     <module>org.openhab.binding.mqtt.generic</module>
     <module>org.openhab.binding.mqtt.homeassistant</module>
     <module>org.openhab.binding.mqtt.homie</module>

--- a/features/openhab-addons/src/main/resources/footer.xml
+++ b/features/openhab-addons/src/main/resources/footer.xml
@@ -20,6 +20,7 @@
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-mqtt</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt/${project.version}</bundle>
+		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.espmilighthub/${project.version}</bundle>
 		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.generic/${project.version}</bundle>
 		<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homeassistant/${project.version}</bundle>
 		<bundle start-level="82">mvn:org.openhab.addons.bundles/org.openhab.binding.mqtt.homie/${project.version}</bundle>


### PR DESCRIPTION
A binding that allows an esp8266 based opensource hub to bridge openHAB to Milight globes.

Binding is used by more than 50 users as it has been around since Feb 2018 but I only just updated it to now no longer use the Paho lib and instead use the openHAB MQTT transport. Forum thread on this binding is found here:
https://community.openhab.org/t/espmilighthub-new-binding-for-milight-limitlessled-and-easybulb/39720

The hardware hub has a github project here:
https://github.com/sidoh/esp8266_milight_hub/releases101

A precompiled JAR for V3.0 can be downloaded here:
https://openhab.jfrog.io/artifactory/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.mqtt.espmilighthub/3.1.0-SNAPSHOT/org.openhab.binding.mqtt.espmilighthub-3.1.0-SNAPSHOT.jar

Signed-off-by: Matthew Skinner <matt@pcmus.com>