### PR TITLE
[tr064] Add support for PPP connections

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -99,6 +99,7 @@ This is an optional parameter and multiple values are allowed.
 | `wanAccessType`            | `String`                  |     x    | Access Type                                                    |
 | `wanConnectionStatus`      | `String`                  |          | Connection Status                                              |
 | `wanIpAddress`             | `String`                  |     x    | WAN IP Address                                                 |
+| `wanPppIpAddress`          | `String`                  |     x    | WAN IP Address (if using PPP)                                  |
 | `wanMaxDownstreamRate`     | `Number:DataTransferRate` |     x    | Max. Downstream Rate                                           |
 | `wanMaxUpstreamRate`       | `Number:DataTransferRate` |     x    | Max. Upstream Rate                                             |
 | `wanPhysicalLinkStatus`    | `String`                  |     x    | Link Status                                                    |

--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -98,6 +98,7 @@ This is an optional parameter and multiple values are allowed.
 | `uptime`                   | `Number:Time`             |          | Uptime                                                         |
 | `wanAccessType`            | `String`                  |     x    | Access Type                                                    |
 | `wanConnectionStatus`      | `String`                  |          | Connection Status                                              |
+| `wanPppConnectionStatus`   | `String`                  |          | Connection Status (if using PPP)                               |
 | `wanIpAddress`             | `String`                  |     x    | WAN IP Address                                                 |
 | `wanPppIpAddress`          | `String`                  |     x    | WAN IP Address (if using PPP)                                  |
 | `wanMaxDownstreamRate`     | `Number:DataTransferRate` |     x    | Max. Downstream Rate                                           |

--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -96,6 +96,7 @@ This is an optional parameter and multiple values are allowed.
 | `tamEnable`                | `Switch`                  |          | Enable/Disable the answering machine with the given index.     |
 | `tamNewMessages`           | `Number`                  |          | The number of new messages of the given answering machine.     |
 | `uptime`                   | `Number:Time`             |          | Uptime                                                         |
+| `pppUptime`                | `Number:Time`             |          | Uptime (if using PPP)                                          |
 | `wanAccessType`            | `String`                  |     x    | Access Type                                                    |
 | `wanConnectionStatus`      | `String`                  |          | Connection Status                                              |
 | `wanPppConnectionStatus`   | `String`                  |          | Connection Status (if using PPP)                               |

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -256,6 +256,12 @@
 			serviceId="urn:WANIPConnection-com:serviceId:WANIPConnection1"/>
 		<getAction name="GetInfo" argument="NewConnectionStatus"/>
 	</channel>
+	<channel name="wanPppConnectionStatus" label="Connection Status">
+		<item type="String"/>
+		<service deviceType="urn:dslforum-org:device:WANConnectionDevice:1"
+			serviceId="urn:WANPPPConnection-com:serviceId:WANPPPConnection1"/>
+		<getAction name="GetInfo" argument="NewConnectionStatus"/>
+	</channel>
 	<channel name="uptime" label="Uptime">
 		<item type="Number:Time" unit="s" statePattern="%d s"/>
 		<service deviceType="urn:dslforum-org:device:WANConnectionDevice:1"

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -268,6 +268,10 @@
 			serviceId="urn:WANIPConnection-com:serviceId:WANIPConnection1"/>
 		<getAction name="GetInfo" argument="NewUptime"/>
 	</channel>
-
-
+	<channel name="pppUptime" label="Uptime">
+		<item type="Number:Time" unit="s" statePattern="%d s"/>
+		<service deviceType="urn:dslforum-org:device:WANConnectionDevice:1"
+			serviceId="urn:WANPPPConnection-com:serviceId:WANPPPConnection1"/>
+		<getAction name="GetInfo" argument="NewUptime"/>
+	</channel>
 </channels>

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -244,6 +244,12 @@
 			serviceId="urn:WANIPConnection-com:serviceId:WANIPConnection1"/>
 		<getAction name="GetInfo" argument="NewExternalIPAddress"/>
 	</channel>
+	<channel name="wanPppIpAddress" label="WAN PPP-IP Address">
+		<item type="String"/>
+		<service deviceType="urn:dslforum-org:device:WANConnectionDevice:1"
+			serviceId="urn:WANPPPConnection-com:serviceId:WANPPPConnection1"/>
+		<getAction name="GetInfo" argument="NewExternalIPAddress"/>
+	</channel>
 	<channel name="wanConnectionStatus" label="Connection Status">
 		<item type="String"/>
 		<service deviceType="urn:dslforum-org:device:WANConnectionDevice:1"


### PR DESCRIPTION
Fixes #9173 

DSL Fritzboxes use different service-names on the same device for external ip, uptime and connectionstatus.