### PR TITLE
[amazonechocontrol] improve documentation

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -76,7 +76,7 @@ The configuration of your amazon account must be done in the 'Amazon Account' de
 1) Create an 'Amazon Account' thing
 2) open the url YOUR_OPENHAB/amazonechocontrol in your browser (e.g. http://openhab:8080/amazonechocontrol/), click the link for your account thing and login.
 3) You should see now a message that the login was successful
-
+4) If you encounter redirect/page refresh issues, enable two-factor authentication (2FA) on your Amazon account.
 ## Discovery
 
 After configuration of the account thing with the login data, the echo devices registered in the Amazon account, get discovered.

--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -77,6 +77,7 @@ The configuration of your amazon account must be done in the 'Amazon Account' de
 2) open the url YOUR_OPENHAB/amazonechocontrol in your browser (e.g. http://openhab:8080/amazonechocontrol/), click the link for your account thing and login.
 3) You should see now a message that the login was successful
 4) If you encounter redirect/page refresh issues, enable two-factor authentication (2FA) on your Amazon account.
+
 ## Discovery
 
 After configuration of the account thing with the login data, the echo devices registered in the Amazon account, get discovered.


### PR DESCRIPTION
Fixes #8590 

State in the documentation that redirect/refresh issues during login are solved by enabling 2FA.