### PR TITLE
[icalendar] Fix race condition while initialization of EventFilterHandler

### DIFF
--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/EventFilterHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/EventFilterHandler.java
@@ -256,6 +256,7 @@ public class EventFilterHandler extends BaseThingHandler implements CalendarUpda
     private void updateStates() {
         if (!initFinished) {
             logger.debug("Ignoring call for updating states as this instance is not initialized yet.");
+            return;
         }
         final Bridge iCalendarBridge = getBridge();
         if (iCalendarBridge == null) {

--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/EventFilterHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/EventFilterHandler.java
@@ -95,9 +95,7 @@ public class EventFilterHandler extends BaseThingHandler implements CalendarUpda
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
-            if (initFinished) {
-                updateStates();
-            }
+            updateStates();
         }
     }
 
@@ -121,14 +119,13 @@ public class EventFilterHandler extends BaseThingHandler implements CalendarUpda
         }
         configuration = config;
 
+        updateChannelSet(config);
+        initFinished = true;
         if (iCalendarBridge.getStatus() != ThingStatus.ONLINE) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
             return;
-        } else {
-            updateChannelSet(config);
-            updateStates();
         }
-        initFinished = true;
+        updateStates();
     }
 
     @Override
@@ -257,6 +254,9 @@ public class EventFilterHandler extends BaseThingHandler implements CalendarUpda
      * Updates all states and channels. Reschedules an update if no error occurs.
      */
     private void updateStates() {
+        if (!initFinished) {
+            logger.debug("Ignoring call for updating states as this instance is not initialized yet.");
+        }
         final Bridge iCalendarBridge = getBridge();
         if (iCalendarBridge == null) {
             logger.debug("Bridge not instantiated!");

--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
@@ -183,6 +183,7 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
                 ThingHandler handler = childThing.getHandler();
                 if (handler instanceof CalendarUpdateListener) {
                     try {
+                        logger.trace("Notifying {} about fresh calendar.", handler.getThing().getUID().getAsString());
                         ((CalendarUpdateListener) handler).onCalendarUpdated();
                     } catch (Exception e) {
                         logger.trace("The update of a child handler failed. Ignoring.", e);

--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
@@ -183,7 +183,7 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
                 ThingHandler handler = childThing.getHandler();
                 if (handler instanceof CalendarUpdateListener) {
                     try {
-                        logger.trace("Notifying {} about fresh calendar.", handler.getThing().getUID().getAsString());
+                        logger.trace("Notifying {} about fresh calendar.", handler.getThing().getUID());
                         ((CalendarUpdateListener) handler).onCalendarUpdated();
                     } catch (Exception e) {
                         logger.trace("The update of a child handler failed. Ignoring.", e);


### PR DESCRIPTION
Should fix #9029. The channels do not get updated as the known channels by the binding where only updated if Bridge was already online while initializing EventFilterHandler. Even if it does not fix the issue, the race condition is is fixed.

Also added a bit more output.

Signed-off-by: Michael Wodniok <michi@noorganization.org>
