### PR TITLE
[lcn] add workaround for dynamic text firmware bug

### DIFF
--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleActions.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnModuleActions.java
@@ -125,6 +125,11 @@ public class LcnModuleActions implements ThingActions {
                 text = new String();
             }
 
+            // some LCN-GTxD don't display the text if it fits exactly in one chunk. Observed with GT10D 8.0.
+            if (text.getBytes(LcnDefs.LCN_ENCODING).length % DYN_TEXT_CHUNK_LENGTH == 0) {
+                text += " ";
+            }
+
             // convert String to bytes to split the data every 12 bytes, because a unicode character can take more than
             // one byte
             ByteBuffer bb = ByteBuffer.wrap(text.getBytes(LcnDefs.LCN_ENCODING));

--- a/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/ModuleActionsTest.java
+++ b/bundles/org.openhab.binding.lcn/src/test/java/org/openhab/binding/lcn/internal/ModuleActionsTest.java
@@ -63,7 +63,10 @@ public class ModuleActionsTest {
     public void testSendDynamicText1ChunkRow1() throws LcnException {
         a.sendDynamicText(1, "abcdfghijklm");
 
-        verify(handler).sendPck(stringToByteBuffer("GTDT11abcdfghijklm"));
+        verify(handler, times(2)).sendPck(byteBufferCaptor.capture());
+
+        assertThat(byteBufferCaptor.getAllValues(), contains(stringToByteBuffer("GTDT11abcdfghijklm"),
+                stringToByteBuffer("GTDT12 \0\0\0\0\0\0\0\0\0\0\0")));
     }
 
     @Test


### PR DESCRIPTION
Some LCN-GTxD don't display the text if it fits exactly in one chunk (12 bytes). Observed with GT10D 8.0.

Closes #9208

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>