### PR TITLE
[telegram] Add event channels and Answer overload

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramBindingConstants.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramBindingConstants.java
@@ -41,4 +41,9 @@ public class TelegramBindingConstants {
     public static final String LASTMESSAGEUSERNAME = "lastMessageUsername";
     public static final String CHATID = "chatId";
     public static final String REPLYID = "replyId";
+    public static final String LONGPOLLINGTIME = "longPollingTime";
+    public static final String MESSAGEEVENT = "messageEvent";
+    public static final String MESSAGERAWEVENT = "messageRawEvent";
+    public static final String CALLBACKEVENT = "callbackEvent";
+    public static final String CALLBACKRAWEVENT = "callbackRawEvent";
 }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -398,8 +398,7 @@ public class TelegramHandler extends BaseThingHandler {
                     JsonObject callbackRaw = json.parse(gson.toJson(callbackQuery)).getAsJsonObject();
                     JsonObject callbackPayload = new JsonObject();
                     callbackPayload.addProperty("message_id", callbackQuery.message().messageId());
-                    callbackPayload.addProperty("from", String.join(" ",
-                            new String[] { callbackQuery.from().firstName(), callbackQuery.from().lastName() }));
+                    callbackPayload.addProperty("from", lastMessageFirstName + " " + lastMessageLastName);
                     callbackPayload.addProperty("chat_id", callbackQuery.message().chat().id());
                     callbackPayload.addProperty("callback_id", callbackQuery.id());
                     callbackPayload.addProperty("reply_id", callbackData[0]);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -81,9 +81,7 @@ import okhttp3.OkHttpClient;
 @NonNullByDefault
 public class TelegramHandler extends BaseThingHandler {
 
-    @NonNullByDefault
     private class ReplyKey {
-
         final Long chatId;
         final String replyId;
 

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -467,7 +467,7 @@ public class TelegramHandler extends BaseThingHandler {
     }
 
     public void triggerEvent(String channelName, String payload) {
-        triggerChannel(new ChannelUID(getThing().getUID(), channelName), payload);
+        triggerChannel(channelName, payload);
     }
 
     @Override

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -257,6 +257,15 @@ public class TelegramHandler extends BaseThingHandler {
         return bot.getFullFilePath(bot.execute(new GetFile(fileId)).file());
     }
 
+    private void addFileUrlsToPayload(JsonObject filePayload) {
+        filePayload.addProperty("file_url",
+                getFullDownloadUrl(filePayload.getAsJsonPrimitive("file_id").getAsString()));
+        if (filePayload.has("thumb")) {
+            filePayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
+                    filePayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
+        }
+    }
+
     private int handleUpdates(List<Update> updates) {
         final TelegramBot localBot = bot;
         if (localBot == null) {
@@ -300,36 +309,16 @@ public class TelegramHandler extends BaseThingHandler {
                     messagePayload.addProperty("text", message.text());
                 }
                 if (messageRaw.has("animation")) {
-                    JsonObject animationPayload = messageRaw.getAsJsonObject("animation");
-                    String animationURL = getFullDownloadUrl(
-                            animationPayload.getAsJsonPrimitive("file_id").getAsString());
-                    animationPayload.addProperty("file_url", animationURL);
-                    messagePayload.addProperty("animation_url", animationURL);
-                    if (animationPayload.has("thumb")) {
-                        animationPayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                animationPayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("animation"));
+                    messagePayload.add("animation_url", messageRaw.getAsJsonObject("animation").get("file_url"));
                 }
                 if (messageRaw.has("audio")) {
-                    JsonObject audioPayload = messageRaw.getAsJsonObject("audio");
-                    String audioURL = getFullDownloadUrl(audioPayload.getAsJsonPrimitive("file_id").getAsString());
-                    audioPayload.addProperty("file_url", audioURL);
-                    messagePayload.addProperty("audio_url", audioURL);
-                    if (audioPayload.has("thumb")) {
-                        audioPayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                audioPayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("audio"));
+                    messagePayload.add("audio_url", messageRaw.getAsJsonObject("audio").get("file_url"));
                 }
                 if (messageRaw.has("document")) {
-                    JsonObject documentPayload = messageRaw.getAsJsonObject("document");
-                    String documentURL = getFullDownloadUrl(
-                            documentPayload.getAsJsonPrimitive("file_id").getAsString());
-                    documentPayload.addProperty("file_url", documentURL);
-                    messagePayload.addProperty("document_url", documentURL);
-                    if (documentPayload.has("thumb")) {
-                        documentPayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                documentPayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("document"));
+                    messagePayload.add("document_url", messageRaw.getAsJsonObject("document").get("file_url"));
                 }
                 if (messageRaw.has("photo")) {
                     JsonArray photoURLArray = new JsonArray();
@@ -343,35 +332,16 @@ public class TelegramHandler extends BaseThingHandler {
                     messagePayload.add("photo_url", photoURLArray);
                 }
                 if (messageRaw.has("sticker")) {
-                    JsonObject stickerPayload = messageRaw.getAsJsonObject("sticker");
-                    String stickerURL = getFullDownloadUrl(stickerPayload.getAsJsonPrimitive("file_id").getAsString());
-                    stickerPayload.addProperty("file_url", stickerURL);
-                    messagePayload.addProperty("sticker_url", stickerURL);
-                    if (stickerPayload.has("thumb")) {
-                        stickerPayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                stickerPayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("sticker"));
+                    messagePayload.add("sticker_url", messageRaw.getAsJsonObject("sticker").get("file_url"));
                 }
                 if (messageRaw.has("video")) {
-                    JsonObject videoPayload = messageRaw.getAsJsonObject("video");
-                    String videoURL = getFullDownloadUrl(videoPayload.getAsJsonPrimitive("file_id").getAsString());
-                    videoPayload.addProperty("file_url", videoURL);
-                    messagePayload.addProperty("video_url", videoURL);
-                    if (videoPayload.has("thumb")) {
-                        videoPayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                videoPayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("video"));
+                    messagePayload.add("video_url", messageRaw.getAsJsonObject("video").get("file_url"));
                 }
                 if (messageRaw.has("video_note")) {
-                    JsonObject videoNotePayload = messageRaw.getAsJsonObject("animation");
-                    String videoNoteURL = getFullDownloadUrl(
-                            videoNotePayload.getAsJsonPrimitive("file_id").getAsString());
-                    videoNotePayload.addProperty("file_url", videoNoteURL);
-                    messagePayload.addProperty("video_note_url", videoNoteURL);
-                    if (videoNotePayload.has("thumb")) {
-                        videoNotePayload.getAsJsonObject("thumb").addProperty("file_url", getFullDownloadUrl(
-                                videoNotePayload.getAsJsonObject("thumb").getAsJsonPrimitive("file_id").getAsString()));
-                    }
+                    addFileUrlsToPayload(messageRaw.getAsJsonObject("video_note"));
+                    messagePayload.add("video_note_url", messageRaw.getAsJsonObject("video_note").get("file_url"));
                 }
                 if (messageRaw.has("voice")) {
                     JsonObject voicePayload = messageRaw.getAsJsonObject("voice");
@@ -432,8 +402,8 @@ public class TelegramHandler extends BaseThingHandler {
                             new String[] { callbackQuery.from().firstName(), callbackQuery.from().lastName() }));
                     callbackPayload.addProperty("chat_id", callbackQuery.message().chat().id());
                     callbackPayload.addProperty("callback_id", callbackQuery.id());
-                    callbackPayload.addProperty("reply_id", callbackQuery.data().split(" ", 2)[0]);
-                    callbackPayload.addProperty("text", callbackQuery.data().split(" ", 2)[1]);
+                    callbackPayload.addProperty("reply_id", callbackData[0]);
+                    callbackPayload.addProperty("text", callbackData[1]);
                     triggerEvent(CALLBACKEVENT, callbackPayload.toString());
                     triggerEvent(CALLBACKRAWEVENT, callbackRaw.toString());
 

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -114,11 +114,8 @@ public class TelegramHandler extends BaseThingHandler {
     }
 
     private static Gson gson = new Gson();
-    private static JsonParser json = new JsonParser();
-
     private final List<Long> authorizedSenderChatId = new ArrayList<>();
     private final List<Long> receiverChatId = new ArrayList<>();
-
     private final Logger logger = LoggerFactory.getLogger(TelegramHandler.class);
     private @Nullable ScheduledFuture<?> thingOnlineStatusJob;
 
@@ -299,7 +296,7 @@ public class TelegramHandler extends BaseThingHandler {
                 }
 
                 // build and publish messageEvent trigger channel payload
-                JsonObject messageRaw = json.parse(gson.toJson(message)).getAsJsonObject();
+                JsonObject messageRaw = JsonParser.parseString(gson.toJson(message)).getAsJsonObject();
                 JsonObject messagePayload = new JsonObject();
                 messagePayload.addProperty("message_id", message.messageId());
                 messagePayload.addProperty("from",
@@ -395,7 +392,7 @@ public class TelegramHandler extends BaseThingHandler {
                     replyIdToCallbackId.put(new ReplyKey(chatId, replyId), callbackQuery.id());
 
                     // build and publish callbackEvent trigger channel payload
-                    JsonObject callbackRaw = json.parse(gson.toJson(callbackQuery)).getAsJsonObject();
+                    JsonObject callbackRaw = JsonParser.parseString(gson.toJson(callbackQuery)).getAsJsonObject();
                     JsonObject callbackPayload = new JsonObject();
                     callbackPayload.addProperty("message_id", callbackQuery.message().messageId());
                     callbackPayload.addProperty("from", lastMessageFirstName + " " + lastMessageLastName);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -107,6 +107,43 @@ public class TelegramActions implements ThingActions {
 
     @RuleAction(label = "send an answer", description = "Send a Telegram answer using the Telegram API.")
     public boolean sendTelegramAnswer(@ActionInput(name = "chatId") @Nullable Long chatId,
+            @ActionInput(name = "callbackId") @Nullable String callbackId,
+            @ActionInput(name = "messageId") @Nullable Long messageId,
+            @ActionInput(name = "message") @Nullable String message) {
+        if (chatId == null) {
+            logger.warn("chatId not defined; action skipped.");
+            return false;
+        }
+        if (messageId == null) {
+            logger.warn("messageId not defined; action skipped.");
+            return false;
+        }
+        TelegramHandler localHandler = handler;
+        if (localHandler != null) {
+            if (callbackId != null) {
+                AnswerCallbackQuery answerCallbackQuery = new AnswerCallbackQuery(callbackId);
+                // we could directly set the text here, but this
+                // doesn't result in a real message only in a
+                // little popup or in an alert, so the only purpose
+                // is to stop the progress bar on client side
+                logger.debug("Answering query with callbackId '{}'", callbackId);
+                if (!evaluateResponse(localHandler.execute(answerCallbackQuery))) {
+                    return false;
+                }
+            }
+            EditMessageReplyMarkup editReplyMarkup = new EditMessageReplyMarkup(chatId, messageId.intValue())
+                    .replyMarkup(new InlineKeyboardMarkup(new InlineKeyboardButton[0]));// remove reply markup from
+                                                                                        // old message
+            if (!evaluateResponse(localHandler.execute(editReplyMarkup))) {
+                return false;
+            }
+            return message != null ? sendTelegram(chatId, message) : true;
+        }
+        return false;
+    }
+
+    @RuleAction(label = "send an answer", description = "Send a Telegram answer using the Telegram API.")
+    public boolean sendTelegramAnswer(@ActionInput(name = "chatId") @Nullable Long chatId,
             @ActionInput(name = "replyId") @Nullable String replyId,
             @ActionInput(name = "message") @Nullable String message) {
         if (replyId == null) {
@@ -121,32 +158,13 @@ public class TelegramActions implements ThingActions {
         if (localHandler != null) {
             String callbackId = localHandler.getCallbackId(chatId, replyId);
             if (callbackId != null) {
-                AnswerCallbackQuery answerCallbackQuery = new AnswerCallbackQuery(
-                        localHandler.getCallbackId(chatId, replyId));
                 logger.debug("AnswerCallbackQuery for chatId {} and replyId {} is the callbackId {}", chatId, replyId,
-                        localHandler.getCallbackId(chatId, replyId));
-                // we could directly set the text here, but this
-                // doesn't result in a real message only in a
-                // little popup or in an alert, so the only purpose
-                // is to stop the progress bar on client side
-                if (!evaluateResponse(localHandler.execute(answerCallbackQuery))) {
-                    return false;
-                }
+                        callbackId);
             }
             Integer messageId = localHandler.removeMessageId(chatId, replyId);
-            if (messageId == null) {
-                logger.warn("messageId could not be found for chatId {} and replyId {}", chatId, replyId);
-                return false;
-            }
             logger.debug("remove messageId {} for chatId {} and replyId {}", messageId, chatId, replyId);
 
-            EditMessageReplyMarkup editReplyMarkup = new EditMessageReplyMarkup(chatId, messageId.intValue())
-                    .replyMarkup(new InlineKeyboardMarkup(new InlineKeyboardButton[0]));// remove reply markup from
-                                                                                        // old message
-            if (!evaluateResponse(localHandler.execute(editReplyMarkup))) {
-                return false;
-            }
-            return message != null ? sendTelegram(chatId, message) : true;
+            return sendTelegramAnswer(chatId, callbackId, messageId != null ? Long.valueOf(messageId) : null, message);
         }
         return false;
     }
@@ -647,6 +665,24 @@ public class TelegramActions implements ThingActions {
                 return false;
             }
             return ((TelegramActions) actions).sendTelegramAnswer(Long.valueOf(chatId), replyId, message);
+        } else {
+            throw new IllegalArgumentException("Actions is not an instance of TelegramActions");
+        }
+    }
+
+    public static boolean sendTelegramAnswer(ThingActions actions, @Nullable Long chatId, @Nullable String callbackId,
+            @Nullable Long messageId, @Nullable String message) {
+        return ((TelegramActions) actions).sendTelegramAnswer(chatId, callbackId, messageId, message);
+    }
+
+    public static boolean sendTelegramAnswer(ThingActions actions, @Nullable String chatId, @Nullable String callbackId,
+            @Nullable String messageId, @Nullable String message) {
+        if (actions instanceof TelegramActions) {
+            if (chatId == null) {
+                return false;
+            }
+            return ((TelegramActions) actions).sendTelegramAnswer(Long.valueOf(chatId), callbackId,
+                    messageId != null ? Long.parseLong(messageId) : null, message);
         } else {
             throw new IllegalArgumentException("Actions is not an instance of TelegramActions");
         }

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -173,7 +173,7 @@
 
 	<channel-type id="callbackRawEvent">
 		<kind>trigger</kind>
-		<label>Callback Query Received Event</label>
+		<label>Raw Callback Query Received</label>
 		<description>Raw Callback Query response from the Telegram library encoded as JSON.</description>
 		<event></event>
 	</channel-type>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -151,7 +151,7 @@
 		<event></event>
 	</channel-type>
 
-	<channel-type id="callbackEvent">
+	<channel-type id="callbackEvent" advanced="true">
 		<kind>trigger</kind>
 		<label>Query Callback Received</label>
 		<description>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -146,7 +146,7 @@
 
 	<channel-type id="messageRawEvent">
 		<kind>trigger</kind>
-		<label>Message Received Event</label>
+		<label>Raw Message Received</label>
 		<description>Raw Message from the Telegram library as JSON.</description>
 		<event></event>
 	</channel-type>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -144,7 +144,7 @@
 		<event></event>
 	</channel-type>
 
-	<channel-type id="messageRawEvent">
+	<channel-type id="messageRawEvent" advanced="true">
 		<kind>trigger</kind>
 		<label>Raw Message Received</label>
 		<description>Raw Message from the Telegram library as JSON.</description>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,6 +16,10 @@
 			<channel id="lastMessageUsername" typeId="lastMessageUsername"/>
 			<channel id="chatId" typeId="chatId"/>
 			<channel id="replyId" typeId="replyId"/>
+			<channel id="messageEvent" typeId="messageEvent"/>
+			<channel id="messageRawEvent" typeId="messageRawEvent"/>
+			<channel id="callbackEvent" typeId="callbackEvent"/>
+			<channel id="callbackRawEvent" typeId="callbackRawEvent"/>
 		</channels>
 
 		<config-description>
@@ -112,6 +116,66 @@
 		<description>Contains the id of the reply which was passed to sendTelegram() as replyId. This id can be used to have
 			an unambiguous assignment of the user reply to the message which was sent by the bot.</description>
 		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="messageEvent">
+		<kind>trigger</kind>
+		<label>Message Received Event</label>
+		<description>
+			<![CDATA[
+			Message encoded as JSON.<br />
+			Event payload could contain the following, but `null` values will not be present:
+			<ul>
+				<li>Long `message_id` - Unique message ID in this chat</li>
+				<li>String `from` - First and/or last name of sender</li>
+				<li>Long `chat_id` - Unique chat ID</li>
+				<li>String `text` - Message text</li>
+				<li>String `animation_url` - URL to download animation from</li>
+				<li>String `audio_url` - URL to download audio from</li>
+				<li>String `document_url` - URL to download file from</li>
+				<li>Array `photo_url` - Array of URLs to download photos from</li>
+				<li>String `sticker_url` - URL to download sticker from</li>
+				<li>String `video_url` - URL to download video from</li>
+				<li>String `video_note_url` - URL to download video note from</li>
+				<li>String `voice_url` - URL to download voice clip from</li>
+			</ul>
+			]]>
+		</description>
+		<event></event>
+	</channel-type>
+
+	<channel-type id="messageRawEvent">
+		<kind>trigger</kind>
+		<label>Message Received Event</label>
+		<description>Raw Message from the Telegram library as JSON.</description>
+		<event></event>
+	</channel-type>
+
+	<channel-type id="callbackEvent">
+		<kind>trigger</kind>
+		<label>Query Callback Received Event</label>
+		<description>
+			<![CDATA[
+			Callback Query response encoded as JSON.<br />
+			Event payload could contain the following, but `null` values will not be present:
+			<ul>
+				<li>Long `message_id` - Unique message ID of the original Query message</li>
+				<li>String `from` - First and/or last name of sender</li>
+				<li>Long `chat_id` - Unique chat ID</li>
+				<li>String `callback_id` - Unique callback ID to send receipt confirmation to</li>
+				<li>String `reply_id` - Plain text name of original Query</li>
+				<li>String `text` - Selected response text from options give in original Query</li>
+			</ul>
+			]]>
+		</description>
+		<event></event>
+	</channel-type>
+
+	<channel-type id="callbackRawEvent">
+		<kind>trigger</kind>
+		<label>Callback Query Received Event</label>
+		<description>Raw Callback Query response from the Telegram library encoded as JSON.</description>
+		<event></event>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -118,7 +118,7 @@
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="messageEvent">
+	<channel-type id="messageEvent" advanced="true">
 		<kind>trigger</kind>
 		<label>Message Received</label>
 		<description>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -171,7 +171,7 @@
 		<event></event>
 	</channel-type>
 
-	<channel-type id="callbackRawEvent">
+	<channel-type id="callbackRawEvent" advanced="true">
 		<kind>trigger</kind>
 		<label>Raw Callback Query Received</label>
 		<description>Raw Callback Query response from the Telegram library encoded as JSON.</description>

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -120,7 +120,7 @@
 
 	<channel-type id="messageEvent">
 		<kind>trigger</kind>
-		<label>Message Received Event</label>
+		<label>Message Received</label>
 		<description>
 			<![CDATA[
 			Message encoded as JSON.<br />

--- a/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.telegram/src/main/resources/OH-INF/thing/thing-types.xml
@@ -153,7 +153,7 @@
 
 	<channel-type id="callbackEvent">
 		<kind>trigger</kind>
-		<label>Query Callback Received Event</label>
+		<label>Query Callback Received</label>
 		<description>
 			<![CDATA[
 			Callback Query response encoded as JSON.<br />


### PR DESCRIPTION
This adds 4 event trigger channels that fire when messages or query callbacks are received, presenting the entire message as the payload for easier use in rules.

* `messageEvent` provides simplified message properties
* `messageRawEvent` provides the entire message object from the Telegram library
* `callbackEvent` provides simplified callback query properties
* `callbackRawEvent` provides the entire callback query object from the Telegram library

Additionally, a new overload to the `sendTelegramAnswer` action was added that allows you to provide the `callbackId` and `messageId` that would normally be retrieved by a lookup in the handler. This can be used to answer queries that were sent before openHAB restarted by saving the `callbackId` and `messageId` outside the binding, or to answer queries directly instead of via `replyId`. `callbackId` and `messageId` are provided in both callback events.

I have tested all changes locally using rules.

This is my first time building anything Java and there is one thing that was/is not working in the build that I was not able to figure out. Both `OH-INF/binding/binding.xml` and `OH-INF/thing/thing-types.xml` are empty in the built JARs, regardless of which build process I run. Is this normal for local builds? I will be checking the automated build to see if the results are the same. Any insight would be much appreciated.

---

Another question I had is about how many things should go into one PR. I am working on other changes that will add a new action ~~and modify the return values for actions to provide data that the new action would use. It won't be a breaking change, as the return values will still be falsy if the action failed and true-ish if it succeeds.~~ Seems the concept of falsy doesn't exist in a strictly typed language like Java, so changing the return type of the actions with be a breaking change.
Should I include those commits in this PR for consiceness, or make a separate PR for them?