### PR TITLE
[fronius] fix thing definition

### DIFF
--- a/bundles/org.openhab.binding.fronius/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.fronius/src/main/resources/OH-INF/thing/bridge.xml
@@ -8,7 +8,7 @@
 		<label>Fronius Bridge</label>
 		<description>A bridge to connect Fronius devices</description>
 		<config-description>
-			<parameter name="hostname" type="text" required="true" groupName="network">
+			<parameter name="hostname" type="text" required="true">
 				<context>network-address</context>
 				<label>Hostname</label>
 				<description>The hostname or IP address of the Fronius gateway/device</description>


### PR DESCRIPTION
`hostname`  can't be configured with `groupName` set (probably due to missing parameter group definition). There is no benefit in adding parameter groups anyway if there is only one paramaeter.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
