### PR TITLE
Use core unit classes

### DIFF
--- a/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/api/dto/Measure.java
+++ b/bundles/org.openhab.binding.bticinosmarther/src/main/java/org/openhab/binding/bticinosmarther/internal/api/dto/Measure.java
@@ -24,12 +24,11 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
 import com.google.gson.annotations.SerializedName;
-
-import tec.uom.se.unit.Units;
 
 /**
  * The {@code Measure} class defines the dto for Smarther API measure object.
@@ -101,7 +100,8 @@ public class Measure {
                         .orElse(UnDefType.UNDEF);
                 break;
             case PERCENTAGE:
-                state = optValue.<State> map(t -> new QuantityType<Dimensionless>(new DecimalType(t), Units.PERCENT))
+                state = optValue
+                        .<State> map(t -> new QuantityType<Dimensionless>(new DecimalType(t), SmartHomeUnits.PERCENT))
                         .orElse(UnDefType.UNDEF);
                 break;
             case DIMENSIONLESS:

--- a/bundles/org.openhab.binding.coronastats/src/main/java/org/openhab/binding/coronastats/internal/dto/CoronaStatsCases.java
+++ b/bundles/org.openhab.binding.coronastats/src/main/java/org/openhab/binding/coronastats/internal/dto/CoronaStatsCases.java
@@ -21,10 +21,9 @@ import javax.measure.quantity.Dimensionless;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
-
-import tec.uom.se.AbstractUnit;
 
 /**
  * The {@link CoronaStatsCountry} class holds the internal data representation of each Country
@@ -59,7 +58,7 @@ public class CoronaStatsCases {
         if (count == -1) {
             return UnDefType.NULL;
         } else {
-            return new QuantityType<Dimensionless>(count, AbstractUnit.ONE);
+            return new QuantityType<Dimensionless>(count, SmartHomeUnits.ONE);
         }
     }
 }

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/NumberValue.java
@@ -23,13 +23,12 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.UpDownType;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import tec.uom.se.AbstractUnit;
 
 /**
  * Implements a number value.
@@ -111,7 +110,7 @@ public class NumberValue extends Value {
         } else if (command instanceof QuantityType<?>) {
             QuantityType<?> qType = (QuantityType<?>) command;
 
-            if (qType.getUnit().isCompatible(AbstractUnit.ONE)) {
+            if (qType.getUnit().isCompatible(SmartHomeUnits.ONE)) {
                 newValue = qType.toBigDecimal();
             } else {
                 qType = qType.toUnit(unit);

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/values/PercentageValue.java
@@ -27,11 +27,10 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.types.UpDownType;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.UnDefType;
-
-import tec.uom.se.unit.Units;
 
 /**
  * Implements a percentage value. Minimum and maximum are definable.
@@ -88,7 +87,7 @@ public class PercentageValue extends Value {
         } else //
                // A quantity type need to be converted according to the current min/max values
         if (command instanceof QuantityType) {
-            QuantityType<?> qty = ((QuantityType<?>) command).toUnit(Units.PERCENT);
+            QuantityType<?> qty = ((QuantityType<?>) command).toUnit(SmartHomeUnits.PERCENT);
             if (qty != null) {
                 BigDecimal v = qty.toBigDecimal();
                 v = v.subtract(min).multiply(HUNDRED).divide(max.subtract(min), MathContext.DECIMAL128);

--- a/bundles/org.openhab.binding.neohub/src/main/java/org/openhab/binding/neohub/internal/NeoHubHandler.java
+++ b/bundles/org.openhab.binding.neohub/src/main/java/org/openhab/binding/neohub/internal/NeoHubHandler.java
@@ -29,8 +29,10 @@ import javax.measure.Unit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.neohub.internal.NeoHubAbstractDeviceData.AbstractRecord;
+import org.openhab.binding.neohub.internal.NeoHubBindingConstants.NeoHubReturnResult;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -45,8 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonSyntaxException;
-
-import tec.uom.se.unit.Units;
 
 /**
  * The {@link NeoHubHandler} is the openHAB Handler for NeoHub devices
@@ -212,7 +212,7 @@ public class NeoHubHandler extends BaseBridgeHandler {
 
     /**
      * sends a JSON request to the NeoHub to read the device data
-     * 
+     *
      * @return a class that contains the full status of all devices
      */
     protected @Nullable NeoHubAbstractDeviceData fromNeoHubGetDeviceData() {
@@ -259,7 +259,7 @@ public class NeoHubHandler extends BaseBridgeHandler {
                 if (deviceData instanceof NeoHubLiveDeviceData) {
                     /*
                      * note: time-stamps are measured in seconds from 1970-01-01T00:00:00Z
-                     * 
+                     *
                      * new API: discard systemData if its time-stamp is older than the system
                      * time-stamp on the hub
                      */
@@ -269,7 +269,7 @@ public class NeoHubHandler extends BaseBridgeHandler {
                 } else {
                     /*
                      * note: time-stamps are measured in seconds from 1970-01-01T00:00:00Z
-                     * 
+                     *
                      * legacy API: discard systemData if its time-stamp is older than one hour
                      */
                     if (systemData.timeStamp < Instant.now().minus(1, ChronoUnit.HOURS).getEpochSecond()) {
@@ -288,7 +288,7 @@ public class NeoHubHandler extends BaseBridgeHandler {
 
     /**
      * sends a JSON request to the NeoHub to read the system data
-     * 
+     *
      * @return a class that contains the status of the system
      */
     protected @Nullable NeoHubReadDcbResponse fromNeoHubReadSystemData() {
@@ -369,7 +369,7 @@ public class NeoHubHandler extends BaseBridgeHandler {
                         onlineDeviceCount++;
                     }
                 }
-                state = new QuantityType<>((100.0 * onlineDeviceCount) / totalDeviceCount, Units.PERCENT);
+                state = new QuantityType<>((100.0 * onlineDeviceCount) / totalDeviceCount, SmartHomeUnits.PERCENT);
             }
             updateState(CHAN_MESH_NETWORK_QOS, state);
         }

--- a/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerStationHandler.java
+++ b/bundles/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/handler/OpenSprinklerStationHandler.java
@@ -27,6 +27,7 @@ import org.openhab.binding.opensprinkler.internal.api.exception.GeneralApiExcept
 import org.openhab.binding.opensprinkler.internal.config.OpenSprinklerStationConfig;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -36,8 +37,6 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import tec.uom.se.unit.Units;
 
 /**
  * @author Florian Schmidt - Refactoring
@@ -91,7 +90,7 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
             return;
         }
         QuantityType<?> quantity = (QuantityType<?>) command;
-        this.nextDurationTime = quantity.toUnit(Units.SECOND).toBigDecimal();
+        this.nextDurationTime = quantity.toUnit(SmartHomeUnits.SECOND).toBigDecimal();
         updateState(channelUID, quantity);
     }
 
@@ -183,7 +182,7 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
                             + " for the OpenSprinkler device. Exception received: " + exp);
         }
 
-        return new QuantityType<>(remainingWaterTime, Units.SECOND);
+        return new QuantityType<>(remainingWaterTime, SmartHomeUnits.SECOND);
     }
 
     @Override
@@ -204,7 +203,7 @@ public class OpenSprinklerStationHandler extends OpenSprinklerBaseHandler {
             case NEXT_DURATION:
                 BigDecimal duration = nextDurationValue();
                 if (duration != null) {
-                    updateState(channel, new QuantityType<>(duration, Units.SECOND));
+                    updateState(channel, new QuantityType<>(duration, SmartHomeUnits.SECOND));
                 }
                 break;
             case STATION_QUEUED:

--- a/bundles/org.openhab.binding.sensibo/src/main/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandler.java
+++ b/bundles/org.openhab.binding.sensibo/src/main/java/org/openhab/binding/sensibo/internal/handler/SensiboSkyHandler.java
@@ -12,14 +12,7 @@
  */
 package org.openhab.binding.sensibo.internal.handler;
 
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_CURRENT_HUMIDITY;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_CURRENT_TEMPERATURE;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_FAN_LEVEL;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_MASTER_SWITCH;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_MODE;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_SWING_MODE;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_TARGET_TEMPERATURE;
-import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.CHANNEL_TIMER;
+import static org.openhab.binding.sensibo.internal.SensiboBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +48,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -74,8 +68,6 @@ import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import tec.uom.se.unit.Units;
 
 /**
  * The {@link SensiboSkyHandler} is responsible for handling commands, which are
@@ -300,7 +292,7 @@ public class SensiboSkyHandler extends SensiboBaseThingHandler implements Channe
 
     private void handleCurrentHumidityCommand(ChannelUID channelUID, Command command, SensiboSky sensiboSky) {
         if (command instanceof RefreshType) {
-            updateState(channelUID, new QuantityType<>(sensiboSky.getHumidity(), Units.PERCENT));
+            updateState(channelUID, new QuantityType<>(sensiboSky.getHumidity(), SmartHomeUnits.PERCENT));
         }
     }
 

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpApi.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/api/ShellyHttpApi.java
@@ -43,13 +43,12 @@ import org.openhab.binding.shelly.internal.api.ShellyApiJsonDTO.ShellyStatusRela
 import org.openhab.binding.shelly.internal.api.ShellyApiJsonDTO.ShellyStatusSensor;
 import org.openhab.binding.shelly.internal.config.ShellyThingConfiguration;
 import org.openhab.core.library.unit.ImperialUnits;
+import org.openhab.core.library.unit.SIUnits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-
-import tec.uom.se.unit.Units;
 
 /**
  * {@link ShellyHttpApi} wraps the Shelly REST API and provides various low level function to access the device api (not
@@ -187,10 +186,10 @@ public class ShellyHttpApi {
         if (profile.isSense) {
             // complete reported data, map C to F or vice versa: C=(F - 32) * 0.5556;
             status.tmp.tC = status.tmp.units.equals(SHELLY_TEMP_CELSIUS) ? status.tmp.value
-                    : ImperialUnits.FAHRENHEIT.getConverterTo(Units.CELSIUS).convert(getDouble(status.tmp.value))
+                    : ImperialUnits.FAHRENHEIT.getConverterTo(SIUnits.CELSIUS).convert(getDouble(status.tmp.value))
                             .doubleValue();
             status.tmp.tF = status.tmp.units.equals(SHELLY_TEMP_FAHRENHEIT) ? status.tmp.value
-                    : Units.CELSIUS.getConverterTo(ImperialUnits.FAHRENHEIT).convert(getDouble(status.tmp.value))
+                    : SIUnits.CELSIUS.getConverterTo(ImperialUnits.FAHRENHEIT).convert(getDouble(status.tmp.value))
                             .doubleValue();
         }
         if ((status.charger == null) && (status.externalPower != null)) {

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoIoTVersion1.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/coap/ShellyCoIoTVersion1.java
@@ -33,8 +33,6 @@ import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import tec.uom.se.unit.Units;
-
 /**
  * The {@link ShellyCoIoTVersion1} implements the parsing for CoIoT version 1
  *
@@ -84,7 +82,7 @@ public class ShellyCoIoTVersion1 extends ShellyCoIoTProtocol implements ShellyCo
                     case "temperature": // Sensor Temp
                         if (getString(getProfile().settings.temperatureUnits)
                                 .equalsIgnoreCase(SHELLY_TEMP_FAHRENHEIT)) {
-                            value = ImperialUnits.FAHRENHEIT.getConverterTo(Units.CELSIUS).convert(getDouble(s.value))
+                            value = ImperialUnits.FAHRENHEIT.getConverterTo(SIUnits.CELSIUS).convert(getDouble(s.value))
                                     .doubleValue();
                         }
                         updateChannel(updates, CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_TEMP,

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/handler/ShellyComponents.java
@@ -31,8 +31,6 @@ import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.SmartHomeUnits;
 
-import tec.uom.se.unit.Units;
-
 /***
  * The{@link ShellyComponents} implements updates for supplemental components
  * Meter will be used by Relay + Light; Sensor is part of H&T, Flood, Door Window, Sense
@@ -276,7 +274,7 @@ public class ShellyComponents {
                         : getDouble(sdata.tmp.tF);
                 if (getString(sdata.tmp.units).toUpperCase().equals(SHELLY_TEMP_FAHRENHEIT)) {
                     // convert Fahrenheit to Celsius
-                    temp = ImperialUnits.FAHRENHEIT.getConverterTo(Units.CELSIUS).convert(temp).doubleValue();
+                    temp = ImperialUnits.FAHRENHEIT.getConverterTo(SIUnits.CELSIUS).convert(temp).doubleValue();
                 }
                 updated |= thingHandler.updateChannel(CHANNEL_GROUP_SENSOR, CHANNEL_SENSOR_TEMP,
                         toQuantityType(temp.doubleValue(), DIGITS_TEMP, SIUnits.CELSIUS));

--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/points/BasePoint.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/points/BasePoint.java
@@ -19,13 +19,11 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
 import com.google.gson.annotations.SerializedName;
-
-import tec.uom.se.AbstractUnit;
-import tec.uom.se.unit.Units;
 
 /**
  * private class: a generic data point
@@ -142,14 +140,14 @@ public abstract class BasePoint {
                     return ImperialUnits.FAHRENHEIT;
                 }
                 case DEGREES_KELVIN: {
-                    return Units.KELVIN;
+                    return SmartHomeUnits.KELVIN;
                 }
                 case PERCENT_RELATIVE_HUMIDITY: {
-                    return Units.PERCENT;
+                    return SmartHomeUnits.PERCENT;
                 }
             }
         }
-        return AbstractUnit.ONE;
+        return SmartHomeUnits.ONE;
     }
 
     /*

--- a/bundles/org.openhab.binding.siemensrds/src/test/java/org/openhab/binding/siemensrds/test/RdsTestData.java
+++ b/bundles/org.openhab.binding.siemensrds/src/test/java/org/openhab/binding/siemensrds/test/RdsTestData.java
@@ -36,9 +36,8 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.State;
-
-import tec.uom.se.unit.Units;
 
 /**
  * test suite
@@ -295,13 +294,13 @@ public class RdsTestData {
 
             state = dataPoints.getPointByClass("'SpTRShft").getState();
             assertTrue(state instanceof QuantityType<?>);
-            QuantityType<?> kelvin = ((QuantityType<?>) state).toUnit(Units.KELVIN);
+            QuantityType<?> kelvin = ((QuantityType<?>) state).toUnit(SmartHomeUnits.KELVIN);
             assertNotNull(kelvin);
             assertEquals(0, kelvin.floatValue(), 0.01);
 
             state = dataPoints.getPointByClass("'RHuRel").getState();
             assertTrue(state instanceof QuantityType<?>);
-            QuantityType<?> relativeHumidity = ((QuantityType<?>) state).toUnit(Units.PERCENT);
+            QuantityType<?> relativeHumidity = ((QuantityType<?>) state).toUnit(SmartHomeUnits.PERCENT);
             assertNotNull(relativeHumidity);
             assertEquals(46.86865, relativeHumidity.floatValue(), 0.1);
 
@@ -321,7 +320,7 @@ public class RdsTestData {
 
             state = dataPoints.getPointByClass("'TRBltnMsvAdj").getState();
             assertTrue(state instanceof QuantityType<?>);
-            kelvin = ((QuantityType<?>) state).toUnit(Units.KELVIN);
+            kelvin = ((QuantityType<?>) state).toUnit(SmartHomeUnits.KELVIN);
             assertNotNull(kelvin);
             assertEquals(35.0, celsius.floatValue(), 0.01);
 
@@ -377,7 +376,7 @@ public class RdsTestData {
                     @Nullable
                     String x = entry.getKey();
                     assertNotNull(x);
-                    String y = ((BasePoint) point).getPointClass();
+                    String y = point.getPointClass();
                     String z = dataPoints.pointClassToId(y);
                     assertEquals(x, z);
                 }
@@ -469,21 +468,21 @@ public class RdsTestData {
             // test temperature units code (C)
             BasePoint tempPoint = dataPoints.getPointByClass("'SpTR");
             assertTrue(tempPoint instanceof BasePoint);
-            assertEquals(SIUnits.CELSIUS, ((BasePoint) tempPoint).getUnit());
+            assertEquals(SIUnits.CELSIUS, tempPoint.getUnit());
 
             // test temperature units code (F)
             tempPoint = dataPoints.getPointByClass("'SpHPcf");
             assertTrue(tempPoint instanceof BasePoint);
-            assertEquals(ImperialUnits.FAHRENHEIT, ((BasePoint) tempPoint).getUnit());
+            assertEquals(ImperialUnits.FAHRENHEIT, tempPoint.getUnit());
 
             // test temperature units code (K)
             tempPoint = dataPoints.getPointByClass("'SpHPcf");
             assertTrue(tempPoint instanceof BasePoint);
-            assertEquals(ImperialUnits.FAHRENHEIT, ((BasePoint) tempPoint).getUnit());
+            assertEquals(ImperialUnits.FAHRENHEIT, tempPoint.getUnit());
 
             tempPoint = dataPoints.getPointByClass("'SpTRShft");
             assertTrue(tempPoint instanceof BasePoint);
-            assertEquals(Units.KELVIN, ((BasePoint) tempPoint).getUnit());
+            assertEquals(SmartHomeUnits.KELVIN, tempPoint.getUnit());
         } catch (RdsCloudException e) {
             fail(e.getMessage());
         }
@@ -503,13 +502,13 @@ public class RdsTestData {
             PlantInfo plant;
             plant = plantList.get(0);
             assertTrue(plant instanceof PlantInfo);
-            assertEquals("Pd1774247-7de7-4896-ac76-b7e0dd943c40", ((PlantInfo) plant).getId());
+            assertEquals("Pd1774247-7de7-4896-ac76-b7e0dd943c40", plant.getId());
             assertTrue(plant.isOnline());
 
             plant = plantList.get(1);
             assertTrue(plant instanceof PlantInfo);
-            assertEquals("Pfaf770c8-abeb-4742-ad65-ead39030d369", ((PlantInfo) plant).getId());
-            assertTrue(((PlantInfo) plant).isOnline());
+            assertEquals("Pfaf770c8-abeb-4742-ad65-ead39030d369", plant.getId());
+            assertTrue(plant.isOnline());
         } catch (RdsCloudException e) {
             fail(e.getMessage());
         }

--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaChannelSelectorProxy.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/TeslaChannelSelectorProxy.java
@@ -28,12 +28,11 @@ import org.openhab.core.library.types.PointType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.ImperialUnits;
+import org.openhab.core.library.unit.MetricPrefix;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
-
-import tec.uom.se.unit.MetricPrefix;
 
 /**
  * The {@link TeslaChannelSelectorProxy} class is a helper class to instantiate

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,5 +1,5 @@
 checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
 checkstyle.headerCheck.values=2010,2020
-checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time
+checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time,tec.uom.se
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.requiredFilesCheck.files=pom.xml


### PR DESCRIPTION
Add-ons should not depend on `tec.uom.se` classes but use core unit classes instead so they are less impacted when this library is replaced or upgraded.

* Fixes many occurences (but not all)
* Adds `tec.uom.se` to the forbidden packages

See : https://github.com/openhab/openhab-core/issues/1589#issuecomment-739491526