### PR TITLE
[digitalstrom] remove unnecessary call to bridgeStatusChanged

### DIFF
--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/BridgeHandler.java
@@ -64,7 +64,6 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.openhab.core.thing.binding.ThingHandler;
-import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -367,14 +366,8 @@ public class BridgeHandler extends BaseBridgeHandler
 
     @Override
     public void handleRemoval() {
-        for (Thing thing : getThing().getThings()) {
-            // Inform Thing-Child's about removed bridge.
-            final ThingHandler thingHandler = thing.getHandler();
-            if (thingHandler != null) {
-                thingHandler.bridgeStatusChanged(ThingStatusInfoBuilder.create(ThingStatus.REMOVED).build());
-            }
-        }
-        if (StringUtils.isNotBlank((String) super.getConfig().get(APPLICATION_TOKEN))) {
+        String applicationToken = (String) super.getConfig().get(APPLICATION_TOKEN);
+        if (applicationToken != null && !applicationToken.isEmpty()) {
             if (connMan == null) {
                 Config config = loadAndCheckConnectionData(this.getConfig());
                 if (config != null) {

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/CircuitHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/CircuitHandler.java
@@ -151,9 +151,6 @@ public class CircuitHandler extends BaseThingHandler implements DeviceStatusList
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.OFFLINE)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
-        if (bridgeStatusInfo.getStatus().equals(ThingStatus.REMOVED)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Bridge has been removed.");
-        }
         logger.debug("Set status to {}", getThing().getStatusInfo());
     }
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
@@ -176,9 +176,6 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.OFFLINE)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
-        if (bridgeStatusInfo.getStatus().equals(ThingStatus.REMOVED)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Bridge has been removed.");
-        }
         logger.debug("Set status to {}", getThing().getStatusInfo());
     }
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/SceneHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/SceneHandler.java
@@ -171,9 +171,6 @@ public class SceneHandler extends BaseThingHandler implements SceneStatusListene
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.OFFLINE)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
-        if (bridgeStatusInfo.getStatus().equals(ThingStatus.REMOVED)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Bridge has been removed.");
-        }
         logger.debug("Set status to {}", getThing().getStatusInfo());
     }
 

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/ZoneTemperatureControlHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/ZoneTemperatureControlHandler.java
@@ -186,9 +186,6 @@ public class ZoneTemperatureControlHandler extends BaseThingHandler implements T
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.OFFLINE)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
         }
-        if (bridgeStatusInfo.getStatus().equals(ThingStatus.REMOVED)) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "Bridge has been removed.");
-        }
         logger.debug("Set status to {}", getThing().getStatusInfo());
     }
 


### PR DESCRIPTION
Fixes #7704

The bridge handler is disposed before the thing is removed. Before disposing the bridge handler all of it's child handlers are diposed, so it's wrong to set the child's thing status to offline on removal of the bridge handler.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
