### PR TITLE
[exec] improve logging and documentation

### DIFF
--- a/bundles/org.openhab.binding.exec/README.md
+++ b/bundles/org.openhab.binding.exec/README.md
@@ -67,7 +67,7 @@ All Things support the following channels:
 | run             | Switch    | Send ON to execute the command, the current state tells whether it is running or not |
 | lastexecution   | DateTime  | Time/Date the command was last executed, in yyyy-MM-dd'T'HH:mm:ss.SSSZ format        |
 
-**Attention:** Linking `input` to any other item type than `String` will result in errorneous behaviour.
+**Attention:** Linking `input` to any other item type than `String` will result in erroneous behavior.
 If needed, please use a rule to convert your item's state to a string.
 Also note that only commands (e.g. `sendCommand`) to the `input` channel are recognized, updating the item's state will not work (e.g. `postUpdate`).
 

--- a/bundles/org.openhab.binding.exec/README.md
+++ b/bundles/org.openhab.binding.exec/README.md
@@ -68,7 +68,7 @@ All Things support the following channels:
 | lastexecution   | DateTime  | Time/Date the command was last executed, in yyyy-MM-dd'T'HH:mm:ss.SSSZ format        |
 
 **Attention:** Linking `input` to any other item type than `String` will result in errorneous behaviour.
-If needed, please use rule to convert your item state to a string.
+If needed, please use a rule to convert your item's state to a string.
 Also note that only commands (e.g. `sendCommand`) to the `input` channel are recognized, updating the item's state will not work (e.g. `postUpdate`).
 
 ## Minimal Example

--- a/bundles/org.openhab.binding.exec/README.md
+++ b/bundles/org.openhab.binding.exec/README.md
@@ -67,6 +67,9 @@ All Things support the following channels:
 | run             | Switch    | Send ON to execute the command, the current state tells whether it is running or not |
 | lastexecution   | DateTime  | Time/Date the command was last executed, in yyyy-MM-dd'T'HH:mm:ss.SSSZ format        |
 
+**Attention:** Linking `input` to any other item type than `String` will result in errorneous behaviour.
+If needed, please use rule to convert your item state to a string.
+Also note that only commands (e.g. `sendCommand`) to the `input` channel are recognized, updating the item's state will not work (e.g. `postUpdate`).
 
 ## Minimal Example
 

--- a/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/handler/ExecHandler.java
+++ b/bundles/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/handler/ExecHandler.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.IllegalFormatException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -168,16 +169,17 @@ public class ExecHandler extends BaseThingHandler {
             // problem for external commands that generate a lot of output, but this will be dependent on the limits
             // of the underlying operating system.
 
+            Date date = Calendar.getInstance().getTime();
             try {
                 if (lastInput != null) {
-                    commandLine = String.format(commandLine, Calendar.getInstance().getTime(), lastInput);
+                    commandLine = String.format(commandLine, date, lastInput);
                 } else {
-                    commandLine = String.format(commandLine, Calendar.getInstance().getTime());
+                    commandLine = String.format(commandLine, date);
                 }
             } catch (IllegalFormatException e) {
                 logger.warn(
-                        "An exception occurred while formatting the command line with the current time and input values : '{}'",
-                        e.getMessage());
+                        "An exception occurred while formatting the command line '{}' with the current time '{}' and input value '{}': {}",
+                        commandLine, date, lastInput, e.getMessage());
                 updateState(RUN, OnOffType.OFF);
                 updateState(OUTPUT, new StringType(e.getMessage()));
                 return;


### PR DESCRIPTION
After investigating all available information it seems that all issues arise from the fact that

- a non `StringType` command is sent ad this is ignore. (rant:This is an issue of textual configuration, linking an incompatible item type is not possible in UI).
- the item's state is updated instead of sending a command

This PR makes it more clear in the documentation what needs to be done and improves the logging to make the error more obvious.
 
Closes #2605