### PR TITLE
Remove SmartHome leftovers

### DIFF
--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/config/AstroChannelConfig.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/config/AstroChannelConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Channel configuration from Eclipse SmartHome.
+ * Astro Channel configuration.
  *
  * @author Gerhard Riegler - Initial contribution
  */

--- a/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/config/AstroThingConfig.java
+++ b/bundles/org.openhab.binding.astro/src/main/java/org/openhab/binding/astro/internal/config/AstroThingConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Thing configuration from Eclipse SmartHome.
+ * Astro Thing configuration.
  *
  * @author Gerhard Riegler - Initial contribution
  */

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnit.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/BluetoothUnit.java
@@ -221,7 +221,7 @@ public enum BluetoothUnit {
     }
 
     /**
-     * This class contains the set of units that are not yet defined in SmarthomeUnits.
+     * This class contains the set of units that are not yet defined in Units.
      * Once these units are added to the core then this class will be removed.
      *
      * @author cpetty

--- a/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
+++ b/bundles/org.openhab.binding.boschindego/src/main/java/org/openhab/binding/boschindego/internal/handler/BoschIndegoHandler.java
@@ -111,7 +111,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
             // Query the device state
             DeviceStateInformation state = controller.getState();
             DeviceStatus statusWithMessage = DeviceStatus.decodeStatusCode(state.getState());
-            int eshStatus = getEshStatusFromCommand(statusWithMessage.getAssociatedCommand());
+            int status = getStatusFromCommand(statusWithMessage.getAssociatedCommand());
             int mowed = state.getMowed();
             int error = state.getError();
             int statecode = state.getState();
@@ -136,7 +136,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
                         if (state.getState() != stateTmp.getState()) {
                             state = stateTmp;
                             statusWithMessage = DeviceStatus.decodeStatusCode(state.getState());
-                            eshStatus = getEshStatusFromCommand(statusWithMessage.getAssociatedCommand());
+                            status = getStatusFromCommand(statusWithMessage.getAssociatedCommand());
                             mowed = state.getMowed();
                             error = state.getError();
                             statecode = state.getState();
@@ -156,7 +156,7 @@ public class BoschIndegoHandler extends BaseThingHandler {
             updateState(READY, new DecimalType(ready ? 1 : 0));
             updateState(ERRORCODE, new DecimalType(error));
             updateState(MOWED, new PercentType(mowed));
-            updateState(STATE, new DecimalType(eshStatus));
+            updateState(STATE, new DecimalType(status));
             updateState(TEXTUAL_STATE, new StringType(statusWithMessage.getMessage()));
 
         } catch (IndegoAuthenticationException e) {
@@ -200,22 +200,22 @@ public class BoschIndegoHandler extends BaseThingHandler {
         return true;
     }
 
-    private int getEshStatusFromCommand(DeviceCommand command) {
-        int eshStatus;
+    private int getStatusFromCommand(DeviceCommand command) {
+        int status;
         switch (command) {
             case MOW:
-                eshStatus = 1;
+                status = 1;
                 break;
             case RETURN:
-                eshStatus = 2;
+                status = 2;
                 break;
             case PAUSE:
-                eshStatus = 3;
+                status = 3;
                 break;
             default:
-                eshStatus = 0;
+                status = 0;
         }
-        return eshStatus;
+        return status;
     }
 
     @Override

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/discovery/CaddxDiscoveryService.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/discovery/CaddxDiscoveryService.java
@@ -56,7 +56,7 @@ public class CaddxDiscoveryService extends AbstractDiscoveryService implements T
     }
 
     /**
-     * Method to add a Thing to the Smarthome Inbox.
+     * Method to add a Thing to the Inbox.
      *
      * @param bridge
      * @param caddxThingType

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/handler/DeviceHandler.java
@@ -314,7 +314,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
                     if (deviceStateUpdate.isSensorUpdateType()) {
                         updateState(getSensorChannelID(deviceStateUpdate.getTypeAsSensorEnum()),
                                 new DecimalType(deviceStateUpdate.getValueAsFloat()));
-                        logger.debug("Update ESH-State");
+                        logger.debug("Update state");
                         return;
                     }
                     if (deviceStateUpdate.isBinarayInputType()) {
@@ -405,7 +405,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
                     }
                     updateState(DsChannelTypeProvider.SHADE, new PercentType(percent));
                 }
-                logger.debug("Update ESH-State");
+                logger.debug("Update state");
             }
         }
     }
@@ -739,14 +739,14 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         if (!channelList.isEmpty()) {
             Iterator<Channel> channelInter = channelList.iterator();
             while (channelInter.hasNext()) {
-                Channel eshChannel = channelInter.next();
-                if (DsChannelTypeProvider.isOutputChannel(eshChannel.getUID().getId())) {
-                    if (!eshChannel.getUID().getId().equals(currentChannel)
-                            && !(device.isShade() && eshChannel.getUID().getId().equals(DsChannelTypeProvider.SHADE))) {
+                Channel channel = channelInter.next();
+                if (DsChannelTypeProvider.isOutputChannel(channel.getUID().getId())) {
+                    if (!channel.getUID().getId().equals(currentChannel)
+                            && !(device.isShade() && channel.getUID().getId().equals(DsChannelTypeProvider.SHADE))) {
                         channelInter.remove();
                         channelListChanged = true;
                     } else {
-                        if (!eshChannel.getUID().getId().equals(DsChannelTypeProvider.SHADE)) {
+                        if (!channel.getUID().getId().equals(DsChannelTypeProvider.SHADE)) {
                             channelIsAlreadyLoaded = true;
                         }
                     }

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/event/constants/EventResponseEnum.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/event/constants/EventResponseEnum.java
@@ -76,7 +76,7 @@ public enum EventResponseEnum {
     }
 
     /**
-     * Returns true, if the given property exists at the ESH event properties, otherwise false.
+     * Returns true, if the given property exists at the event properties, otherwise false.
      *
      * @param property to check
      * @return contains property (true = yes | false = no)

--- a/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
+++ b/bundles/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
@@ -277,35 +277,35 @@ public class DeviceStatusManagerImpl implements DeviceStatusManager {
             while (!currentDeviceList.isEmpty()) {
                 Device currentDevice = currentDeviceList.remove(0);
                 DSID currentDeviceDSID = currentDevice.getDSID();
-                Device eshDevice = tempDeviceMap.remove(currentDeviceDSID);
+                Device device = tempDeviceMap.remove(currentDeviceDSID);
 
-                if (eshDevice != null) {
-                    checkDeviceConfig(currentDevice, eshDevice);
+                if (device != null) {
+                    checkDeviceConfig(currentDevice, device);
 
-                    if (eshDevice.isPresent()) {
+                    if (device.isPresent()) {
                         // check device state updates
-                        while (!eshDevice.isDeviceUpToDate()) {
-                            DeviceStateUpdate deviceStateUpdate = eshDevice.getNextDeviceUpdateState();
+                        while (!device.isDeviceUpToDate()) {
+                            DeviceStateUpdate deviceStateUpdate = device.getNextDeviceUpdateState();
                             if (deviceStateUpdate != null) {
                                 switch (deviceStateUpdate.getType()) {
                                     case DeviceStateUpdate.OUTPUT:
                                     case DeviceStateUpdate.SLAT_ANGLE_INCREASE:
                                     case DeviceStateUpdate.SLAT_ANGLE_DECREASE:
-                                        filterCommand(deviceStateUpdate, eshDevice);
+                                        filterCommand(deviceStateUpdate, device);
                                         break;
                                     case DeviceStateUpdate.UPDATE_SCENE_CONFIG:
                                     case DeviceStateUpdate.UPDATE_SCENE_OUTPUT:
-                                        updateSceneData(eshDevice, deviceStateUpdate);
+                                        updateSceneData(device, deviceStateUpdate);
                                         break;
                                     case DeviceStateUpdate.UPDATE_OUTPUT_VALUE:
                                         if (deviceStateUpdate.getValueAsInteger() > -1) {
-                                            readOutputValue(eshDevice);
+                                            readOutputValue(device);
                                         } else {
-                                            removeSensorJob(eshDevice, deviceStateUpdate);
+                                            removeSensorJob(device, deviceStateUpdate);
                                         }
                                         break;
                                     default:
-                                        sendComandsToDSS(eshDevice, deviceStateUpdate);
+                                        sendComandsToDSS(device, deviceStateUpdate);
                                 }
                             }
                         }
@@ -475,32 +475,32 @@ public class DeviceStatusManagerImpl implements DeviceStatusManager {
         }
     }
 
-    private void removeSensorJob(Device eshDevice, DeviceStateUpdate deviceStateUpdate) {
+    private void removeSensorJob(Device device, DeviceStateUpdate deviceStateUpdate) {
         switch (deviceStateUpdate.getType()) {
             case DeviceStateUpdate.UPDATE_SCENE_CONFIG:
                 if (sceneJobExecutor != null) {
-                    sceneJobExecutor.removeSensorJob(eshDevice,
-                            SceneConfigReadingJob.getID(eshDevice, deviceStateUpdate.getSceneId()));
+                    sceneJobExecutor.removeSensorJob(device,
+                            SceneConfigReadingJob.getID(device, deviceStateUpdate.getSceneId()));
                 }
                 break;
             case DeviceStateUpdate.UPDATE_SCENE_OUTPUT:
                 if (sceneJobExecutor != null) {
-                    sceneJobExecutor.removeSensorJob(eshDevice,
-                            SceneOutputValueReadingJob.getID(eshDevice, deviceStateUpdate.getSceneId()));
+                    sceneJobExecutor.removeSensorJob(device,
+                            SceneOutputValueReadingJob.getID(device, deviceStateUpdate.getSceneId()));
                 }
                 break;
             case DeviceStateUpdate.UPDATE_OUTPUT_VALUE:
                 if (sensorJobExecutor != null) {
-                    sensorJobExecutor.removeSensorJob(eshDevice, DeviceOutputValueSensorJob.getID(eshDevice));
+                    sensorJobExecutor.removeSensorJob(device, DeviceOutputValueSensorJob.getID(device));
                 }
                 break;
         }
         if (deviceStateUpdate.isSensorUpdateType()) {
             if (sensorJobExecutor != null) {
                 logger.debug("remove SensorJob with ID: {}",
-                        DeviceConsumptionSensorJob.getID(eshDevice, deviceStateUpdate.getTypeAsSensorEnum()));
-                sensorJobExecutor.removeSensorJob(eshDevice,
-                        DeviceConsumptionSensorJob.getID(eshDevice, deviceStateUpdate.getTypeAsSensorEnum()));
+                        DeviceConsumptionSensorJob.getID(device, deviceStateUpdate.getTypeAsSensorEnum()));
+                sensorJobExecutor.removeSensorJob(device,
+                        DeviceConsumptionSensorJob.getID(device, deviceStateUpdate.getTypeAsSensorEnum()));
             }
         }
     }
@@ -751,35 +751,35 @@ public class DeviceStatusManagerImpl implements DeviceStatusManager {
      * Updates the {@link Device} status of the given {@link Device} with handling outstanding commands, which are saved
      * as {@link DeviceStateUpdate}'s.
      *
-     * @param eshDevice to update
+     * @param device to update
      */
-    public synchronized void updateDevice(Device eshDevice) {
+    public synchronized void updateDevice(Device device) {
         logger.debug("Check device updates");
         // check device state updates
-        while (!eshDevice.isDeviceUpToDate()) {
-            DeviceStateUpdate deviceStateUpdate = eshDevice.getNextDeviceUpdateState();
+        while (!device.isDeviceUpToDate()) {
+            DeviceStateUpdate deviceStateUpdate = device.getNextDeviceUpdateState();
             if (deviceStateUpdate != null) {
                 if (deviceStateUpdate.getType() != DeviceStateUpdate.OUTPUT) {
                     if (deviceStateUpdate.getType() == DeviceStateUpdate.UPDATE_SCENE_CONFIG
                             || deviceStateUpdate.getType() == DeviceStateUpdate.UPDATE_SCENE_OUTPUT) {
-                        updateSceneData(eshDevice, deviceStateUpdate);
+                        updateSceneData(device, deviceStateUpdate);
                     } else {
-                        sendComandsToDSS(eshDevice, deviceStateUpdate);
+                        sendComandsToDSS(device, deviceStateUpdate);
                     }
                 } else {
-                    DeviceStateUpdate nextDeviceStateUpdate = eshDevice.getNextDeviceUpdateState();
+                    DeviceStateUpdate nextDeviceStateUpdate = device.getNextDeviceUpdateState();
                     while (nextDeviceStateUpdate != null
                             && nextDeviceStateUpdate.getType() == DeviceStateUpdate.OUTPUT) {
                         deviceStateUpdate = nextDeviceStateUpdate;
-                        nextDeviceStateUpdate = eshDevice.getNextDeviceUpdateState();
+                        nextDeviceStateUpdate = device.getNextDeviceUpdateState();
                     }
-                    sendComandsToDSS(eshDevice, deviceStateUpdate);
+                    sendComandsToDSS(device, deviceStateUpdate);
                     if (nextDeviceStateUpdate != null) {
                         if (deviceStateUpdate.getType() == DeviceStateUpdate.UPDATE_SCENE_CONFIG
                                 || deviceStateUpdate.getType() == DeviceStateUpdate.UPDATE_SCENE_OUTPUT) {
-                            updateSceneData(eshDevice, deviceStateUpdate);
+                            updateSceneData(device, deviceStateUpdate);
                         } else {
-                            sendComandsToDSS(eshDevice, deviceStateUpdate);
+                            sendComandsToDSS(device, deviceStateUpdate);
                         }
                     }
                 }

--- a/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/dmxoverethernet/SacnPacket.java
+++ b/bundles/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/dmxoverethernet/SacnPacket.java
@@ -141,7 +141,7 @@ public class SacnPacket extends DmxOverEthernetPacket {
         rawPacket[114] = (byte) (this.universeId % 256);
 
         /* set sender name in packet */
-        String senderName = new String("ESH DMX binding (sACN) <" + String.format("%05d", this.universeId) + ">");
+        String senderName = new String("openHAB DMX binding (sACN) <" + String.format("%05d", this.universeId) + ">");
         byte[] senderNameBytes = senderName.getBytes(StandardCharsets.UTF_8);
         System.arraycopy(senderNameBytes, 0, rawPacket, 44, senderName.length());
 

--- a/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
+++ b/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmBridgeDiscovery.java
@@ -52,12 +52,12 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
     };
 
     /**
-     * Method to add an Envisalink Bridge to the Smarthome Inbox.
+     * Method to add an Envisalink Bridge to the Inbox.
      *
      * @param ipAddress
      */
     public void addEnvisalinkBridge(String ipAddress) {
-        logger.trace("addBridge(): Adding new Envisalink Bridge on {} to Smarthome inbox", ipAddress);
+        logger.trace("addBridge(): Adding new Envisalink Bridge on {} to inbox", ipAddress);
 
         String bridgeID = ipAddress.replace('.', '_');
         Map<String, Object> properties = new HashMap<>(0);
@@ -69,7 +69,7 @@ public class DSCAlarmBridgeDiscovery extends AbstractDiscoveryService {
             thingDiscovered(DiscoveryResultBuilder.create(thingUID).withProperties(properties)
                     .withLabel("EyezOn Envisalink Bridge - " + ipAddress).build());
 
-            logger.trace("addBridge(): '{}' was added to Smarthome inbox.", thingUID);
+            logger.trace("addBridge(): '{}' was added to inbox.", thingUID);
         } catch (Exception e) {
             logger.error("addBridge(): Error", e);
         }

--- a/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmDiscoveryService.java
+++ b/bundles/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/discovery/DSCAlarmDiscoveryService.java
@@ -71,14 +71,14 @@ public class DSCAlarmDiscoveryService extends AbstractDiscoveryService {
     }
 
     /**
-     * Method to add a Thing to the Smarthome Inbox.
+     * Method to add a Thing to the Inbox.
      *
      * @param bridge
      * @param dscAlarmThingType
      * @param event
      */
     public void addThing(Bridge bridge, DSCAlarmThingType dscAlarmThingType, DSCAlarmEvent event) {
-        logger.trace("addThing(): Adding new DSC Alarm {} to the smarthome inbox", dscAlarmThingType.getLabel());
+        logger.trace("addThing(): Adding new DSC Alarm {} to the inbox", dscAlarmThingType.getLabel());
 
         ThingUID thingUID = null;
         String thingID = "";

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/discovery/EnOceanUsbSerialDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/discovery/EnOceanUsbSerialDiscoveryParticipant.java
@@ -28,8 +28,8 @@ import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * Discovery for Enocean USB dongles, integrated in Eclipse SmartHome's USB-serial discovery by implementing
- * a component of type {@link UsbSerialDiscoveryParticipant}.
+ * Discovery for Enocean USB dongles, integrated in USB-serial discovery by implementing a component of type
+ * {@link UsbSerialDiscoveryParticipant}.
  * <p/>
  * Currently, this {@link UsbSerialDiscoveryParticipant} supports the Enocean USB300 dongles.
  *

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandler.java
@@ -563,7 +563,7 @@ public class HomematicThingHandler extends BaseThingHandler {
     public synchronized void deviceRemoved() {
         deviceDeletionPending = false;
         if (getThing().getStatus() == ThingStatus.REMOVING) {
-            // thing removal was initiated on ESH side
+            // thing removal was initiated
             updateStatus(ThingStatus.REMOVED);
         } else {
             // device removal was initiated on homematic side, thing is not removed

--- a/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.homematic/src/main/resources/OH-INF/thing/bridge.xml
@@ -35,7 +35,7 @@
 			<parameter name="callbackHost" type="text">
 				<context>network-address</context>
 				<label>Callback Network Address</label>
-				<description>Callback network address of the ESH runtime, default is auto-discovery</description>
+				<description>Callback network address of the runtime, default is auto-discovery</description>
 			</parameter>
 			<parameter name="bindAddress" type="text">
 				<context>network-address</context>

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStateConverter.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/LightStateConverter.java
@@ -27,8 +27,7 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StringType;
 
 /**
- * The {@link LightStateConverter} is responsible for mapping Eclipse SmartHome
- * types to jue types and vice versa.
+ * The {@link LightStateConverter} is responsible for mapping to/from jue types.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Oliver Libutzki - Adjustments

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -55,6 +55,7 @@ import org.openhab.binding.ihc.internal.ws.projectfile.ProjectFileUtils;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSEnumValue;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSResourceValue;
+import org.openhab.core.OpenHAB;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -167,11 +168,7 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
     }
 
     private String getFilePathInUserDataFolder(String fileName) {
-        String progArg = System.getProperty("smarthome.userdata");
-        if (progArg != null) {
-            return progArg + File.separator + fileName;
-        }
-        return fileName;
+        return OpenHAB.getUserDataFolder() + File.separator + fileName;
     }
 
     @Override

--- a/bundles/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/handler/EthernetBridgeHandler.java
+++ b/bundles/org.openhab.binding.irtrans/src/main/java/org/openhab/binding/irtrans/internal/handler/EthernetBridgeHandler.java
@@ -124,7 +124,7 @@ public class EthernetBridgeHandler extends BaseBridgeHandler implements Transcei
         if (selector != null) {
             if (getConfig().get(IP_ADDRESS) != null && getConfig().get(PORT_NUMBER) != null) {
                 if (pollingThread == null) {
-                    pollingThread = new Thread(pollingRunnable, "ESH-IRtrans-Polling " + getThing().getUID());
+                    pollingThread = new Thread(pollingRunnable, "OH-binding-" + getThing().getUID() + "-polling");
                     pollingThread.start();
                 }
             } else {

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/internal/kostal/inverter/thirdgeneration/ThirdGenerationHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/internal/kostal/inverter/thirdgeneration/ThirdGenerationHandler.java
@@ -244,7 +244,7 @@ public class ThirdGenerationHandler extends BaseThingHandler {
                 break;
             }
             case AMPERE_HOUR: {
-                // Ampere hours are not supported by ESH, but 1 AH is equal tp 3600 coulomb...
+                // Ampere hours is not a supported unit, but 1 AH is equal tp 3600 coulomb...
                 updateState(channeluid, new QuantityType<>(value * 3600, Units.COULOMB));
                 break;
             }

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -156,8 +156,7 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
 
     private void discoveryResultSubmission(String IpAddress, String cubeSerialNumber, String rfAddress) {
         if (cubeSerialNumber != null) {
-            logger.trace("Adding new MAX! Cube Lan Gateway on {} with id '{}' to Smarthome inbox", IpAddress,
-                    cubeSerialNumber);
+            logger.trace("Adding new MAX! Cube Lan Gateway on {} with id '{}' to inbox", IpAddress, cubeSerialNumber);
             Map<String, Object> properties = new HashMap<>(2);
             properties.put(PROPERTY_IP_ADDRESS, IpAddress);
             properties.put(PROPERTY_SERIAL_NUMBER, cubeSerialNumber);

--- a/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxDeviceDiscoveryService.java
@@ -89,7 +89,7 @@ public class MaxDeviceDiscoveryService extends AbstractDiscoveryService
 
     @Override
     public void onDeviceAdded(Bridge bridge, Device device) {
-        logger.trace("Adding new MAX! {} with id '{}' to smarthome inbox", device.getType(), device.getSerialNumber());
+        logger.trace("Adding new MAX! {} with id '{}' to inbox", device.getType(), device.getSerialNumber());
         ThingUID thingUID = null;
         switch (device.getType()) {
             case WallMountedThermostat:

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
@@ -20,7 +20,7 @@ import org.openhab.core.types.Type;
  * The {@link ApplianceChannelSelector} class defines a common interface for
  * all the data structures used by appliance thing handlers. It is used to traverse
  * the channels that possibly exist for an appliance, and convert data
- * returned by the appliance to a ESH compatible State
+ * returned by the appliance to a compatible State
  *
  * @author Karel Goderis - Initial contribution
  */
@@ -30,7 +30,7 @@ public interface ApplianceChannelSelector {
     String toString();
 
     /**
-     * Returns the ESH ChannelID for the given datapoint
+     * Returns the ChannelID for the given datapoint
      */
     String getChannelID();
 

--- a/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/discovery/MinecraftDiscoveryService.java
+++ b/bundles/org.openhab.binding.minecraft/src/main/java/org/openhab/binding/minecraft/internal/discovery/MinecraftDiscoveryService.java
@@ -145,7 +145,7 @@ public class MinecraftDiscoveryService extends AbstractDiscoveryService {
     }
 
     /**
-     * Submit the discovered Devices to the Smarthome inbox,
+     * Submit the discovered Devices to the inbox.
      *
      * @param bridgeUID
      * @param name name of the player
@@ -161,7 +161,7 @@ public class MinecraftDiscoveryService extends AbstractDiscoveryService {
     }
 
     /**
-     * Submit the discovered Signs to the Smarthome inbox,
+     * Submit the discovered Signs to the inbox.
      *
      * @param bridgeUID
      * @param sign data describing sign

--- a/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java
@@ -188,7 +188,7 @@ public class ChannelState implements MqttMessageSubscriber {
             return;
         }
 
-        // Map the string to an ESH command, update the cached value and post the command to the framework
+        // Map the string to a command, update the cached value and post the command to the framework
         try {
             cachedValue.update(command);
         } catch (IllegalArgumentException | IllegalStateException e) {

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/AbstractComponent.java
@@ -36,7 +36,7 @@ import org.openhab.core.thing.type.ChannelGroupTypeBuilder;
 import org.openhab.core.thing.type.ChannelGroupTypeUID;
 
 /**
- * A HomeAssistant component is comparable to an ESH channel group.
+ * A HomeAssistant component is comparable to a channel group.
  * It has a name and consists of multiple channels.
  *
  * @author David Graeff - Initial contribution
@@ -61,7 +61,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
     protected boolean configSeen;
 
     /**
-     * Provide a thingUID and HomeAssistant topic ID to determine the ESH channel group UID and type.
+     * Provide a thingUID and HomeAssistant topic ID to determine the channel group UID and type.
      *
      * @param thing A ThingUID
      * @param haID A HomeAssistant topic ID
@@ -147,14 +147,14 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
     }
 
     /**
-     * Each HomeAssistant component corresponds to an ESH Channel Group Type.
+     * Each HomeAssistant component corresponds to a Channel Group Type.
      */
     public ChannelGroupTypeUID groupTypeUID() {
         return channelGroupTypeUID;
     }
 
     /**
-     * The unique id of this component within the ESH framework.
+     * The unique id of this component.
      */
     public ChannelGroupUID uid() {
         return channelGroupUID;
@@ -168,7 +168,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
     }
 
     /**
-     * Each component consists of multiple ESH Channels.
+     * Each component consists of multiple Channels.
      */
     public Map<String, CChannel> channelTypes() {
         return channels;
@@ -176,7 +176,7 @@ public abstract class AbstractComponent<C extends BaseChannelConfiguration> {
 
     /**
      * Return a components channel. A HomeAssistant MQTT component consists of multiple functions
-     * and those are mapped to one or more ESH channels. The channel IDs are constants within the
+     * and those are mapped to one or more channels. The channel IDs are constants within the
      * derived Component, like the {@link ComponentSwitch#switchChannelID}.
      *
      * @param channelID The channel ID

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/CChannel.java
@@ -42,12 +42,12 @@ import org.openhab.core.types.StateDescription;
 
 /**
  * An {@link AbstractComponent}s derived class consists of one or multiple channels.
- * Each component channel consists of the determined ESH channel type, channel type UID and the
- * ESH channel description itself as well as the the channels state.
+ * Each component channel consists of the determined channel type, channel type UID and the
+ * channel description itself as well as the the channels state.
  *
  * After the discovery process has completed and the tree of components and component channels
  * have been built up, the channel types are registered to a custom channel type provider
- * before adding the channel descriptions to the ESH Thing themselves.
+ * before adding the channel descriptions to the Thing themselves.
  * <br>
  * <br>
  * An object of this class creates the required {@link ChannelType} and {@link ChannelTypeUID} as well
@@ -60,8 +60,8 @@ public class CChannel {
     private static final String JINJA = "JINJA";
 
     private final ChannelUID channelUID;
-    private final ChannelState channelState; // Channel state (value)
-    private final Channel channel; // ESH Channel
+    private final ChannelState channelState;
+    private final Channel channel;
     private final ChannelType type;
     private final ChannelTypeUID channelTypeUID;
     private final ChannelStateUpdateListener channelStateUpdateListener;
@@ -191,8 +191,8 @@ public class CChannel {
 
         public CChannel build(boolean addToComponent) {
             ChannelUID channelUID;
-            ChannelState channelState; // Channel state (value)
-            Channel channel; // ESH Channel
+            ChannelState channelState;
+            Channel channel;
             ChannelType type;
             ChannelTypeUID channelTypeUID;
 

--- a/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/src/main/java/org/openhab/binding/mqtt/homeassistant/internal/handler/HomeAssistantThingHandler.java
@@ -68,7 +68,7 @@ import com.google.gson.GsonBuilder;
  * The specification does not cover the case of disappearing Components. This handler doesn't as well therefore.<br>
  * <br>
  *
- * A Component Instance equals an ESH Channel Group and the Component parts equal ESH Channels.<br>
+ * A Component Instance equals a Channel Group and the Component parts equal Channels.<br>
  * <br>
  *
  * If a Components configuration changes, the known ChannelGroupType and ChannelTypes are replaced with the new ones.

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Device.java
@@ -151,7 +151,7 @@ public class Device implements AbstractMqttAttributeClass.AttributeChanged {
     }
 
     /**
-     * Get a homie property (which translates to an ESH channel).
+     * Get a homie property (which translates to a channel).
      *
      * @param channelUID The group ID corresponds to the Homie Node, the channel ID (without group ID) corresponds to
      *            the Nodes Property.

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Node.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * Homie 3.x Node.
  *
  * A Homie Node contains Homie Properties ({@link Property}) but can also have attributes ({@link NodeAttributes}).
- * It corresponds to an ESH ChannelGroup.
+ * It corresponds to a ChannelGroup.
  *
  * @author David Graeff - Initial contribution
  */
@@ -53,7 +53,6 @@ public class Node implements AbstractMqttAttributeClass.AttributeChanged {
     public ChildMap<Property> properties;
     // Runtime
     public final DeviceCallback callback;
-    // ESH
     protected final ChannelGroupUID channelGroupUID;
     public final ChannelGroupTypeUID channelGroupTypeUID;
     private final String topic;

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/NodeAttributes.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/NodeAttributes.java
@@ -27,7 +27,7 @@ import org.openhab.binding.mqtt.generic.mapping.TopicPrefix;
 public class NodeAttributes extends AbstractMqttAttributeClass {
     public @MandatoryField String name;
     public @MandatoryField @MQTTvalueTransform(splitCharacter = ",") String[] properties;
-    // Type has no meaning for ESH yet and is currently purely of textual, descriptive nature
+    // Type has no meaning yet and is currently purely of textual, descriptive nature
     public String type;
 
     @Override

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/Property.java
@@ -52,7 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A homie Property (which translates into an ESH channel).
+ * A homie Property (which translates into a channel).
  *
  * @author David Graeff - Initial contribution
  */
@@ -65,7 +65,6 @@ public class Property implements AttributeChanged {
     public final String propertyID;
     // Runtime state
     protected @Nullable ChannelState channelState;
-    // ESH
     public final ChannelUID channelUID;
     public final ChannelTypeUID channelTypeUID;
     private ChannelType type;

--- a/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/discovery/NeatoAccountDiscoveryService.java
+++ b/bundles/org.openhab.binding.neato/src/main/java/org/openhab/binding/neato/internal/discovery/NeatoAccountDiscoveryService.java
@@ -88,7 +88,7 @@ public class NeatoAccountDiscoveryService extends AbstractDiscoveryService {
             return;
         }
 
-        logger.debug("addThing(): Adding new Neato unit {} to the smarthome inbox", robot.getName());
+        logger.debug("addThing(): Adding new Neato unit {} to the inbox", robot.getName());
 
         Map<String, Object> properties = new HashMap<>();
         String serial = robot.getSerial();

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDeviceDiscoveryService.java
@@ -88,8 +88,8 @@ public class PulseaudioDeviceDiscoveryService extends AbstractDiscoveryService i
         }
 
         if (thingType != null) {
-            logger.trace("Adding new pulseaudio {} with name '{}' to smarthome inbox",
-                    device.getClass().getSimpleName(), uidName);
+            logger.trace("Adding new pulseaudio {} with name '{}' to inbox", device.getClass().getSimpleName(),
+                    uidName);
             ThingUID thingUID = new ThingUID(thingType, bridge.getUID(), device.getUIDName());
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
                     .withBridge(bridge.getUID()).withLabel(device.getUIDName()).build();

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/discovery/RFXComDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/discovery/RFXComDeviceDiscoveryService.java
@@ -107,7 +107,7 @@ public class RFXComDeviceDiscoveryService extends AbstractDiscoveryService
         if (handler == null) {
             logger.trace("Ignoring RFXCOM {} with id '{}' - bridge handler is null", thingUID, id);
         } else if (!handler.getConfiguration().disableDiscovery) {
-            logger.trace("Adding new RFXCOM {} with id '{}' to smarthome inbox", thingUID, id);
+            logger.trace("Adding new RFXCOM {} with id '{}' to inbox", thingUID, id);
             DiscoveryResultBuilder discoveryResultBuilder = DiscoveryResultBuilder.create(thingUID).withBridge(bridge)
                     .withTTL(DISCOVERY_TTL);
             message.addDevicePropertiesTo(discoveryResultBuilder);

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosBindingConstants.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/SonosBindingConstants.java
@@ -31,7 +31,7 @@ import org.openhab.core.thing.ThingTypeUID;
 public class SonosBindingConstants {
 
     public static final String BINDING_ID = "sonos";
-    public static final String ESH_PREFIX = "smarthome-";
+    public static final String TITLE_PREFIX = "smarthome-";
 
     // List of all Thing Type UIDs
     // Column (:) is not used for PLAY:1, PLAY:3, PLAY:5 and CONNECT:AMP because of

--- a/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/bundles/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -1461,19 +1461,19 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                             String existingList = "";
                             List<SonosEntry> playLists = getPlayLists();
                             for (SonosEntry someList : playLists) {
-                                if (someList.getTitle().equals(ESH_PREFIX + getUDN())) {
+                                if (someList.getTitle().equals(TITLE_PREFIX + getUDN())) {
                                     existingList = someList.getId();
                                     break;
                                 }
                             }
 
-                            saveQueue(ESH_PREFIX + getUDN(), existingList);
+                            saveQueue(TITLE_PREFIX + getUDN(), existingList);
 
                             // get all the playlists and a ref to our
                             // saved list
                             playLists = getPlayLists();
                             for (SonosEntry someList : playLists) {
-                                if (someList.getTitle().equals(ESH_PREFIX + getUDN())) {
+                                if (someList.getTitle().equals(TITLE_PREFIX + getUDN())) {
                                     savedState.entry = new SonosEntry(someList.getId(), someList.getTitle(),
                                             someList.getParentId(), "", "", "", someList.getUpnpClass(),
                                             someList.getRes());

--- a/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
+++ b/bundles/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/discovery/TellstickDiscoveryService.java
@@ -80,8 +80,8 @@ public class TellstickDiscoveryService extends AbstractDiscoveryService implemen
 
     @Override
     public void onDeviceAdded(Bridge bridge, Device device) {
-        logger.debug("Adding new TellstickDevice! '{}' with id '{}' and type '{}' to smarthome inbox", device,
-                device.getId(), device.getDeviceType());
+        logger.debug("Adding new TellstickDevice! '{}' with id '{}' and type '{}' to inbox", device, device.getId(),
+                device.getDeviceType());
         ThingUID thingUID = getThingUID(bridge, device);
         logger.debug("Detected thingUID: {}", thingUID);
         if (thingUID != null) {

--- a/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/jaxb/MediaChannel.java
+++ b/bundles/org.openhab.binding.xmltv/src/main/java/org/openhab/binding/xmltv/internal/jaxb/MediaChannel.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * Java class for an channel XML element
- * Renamed to MediaChannel in order to avoid confusion with ESH Channels
+ * Renamed to MediaChannel in order to avoid confusion with Framework Channels
  *
  * @author Gaël L'hopital - Initial contribution
  */

--- a/bundles/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/discovery/ZWayDeviceDiscoveryService.java
@@ -131,7 +131,7 @@ public class ZWayDeviceDiscoveryService extends AbstractDiscoveryService {
                     /*
                      * Properties
                      * - Configuration: DEVICE_CONFIG_NODE_ID
-                     * - ESH default properties:
+                     * - System properties:
                      * --- PROPERTY_VENDOR
                      * --- other default properties not available
                      * - Custom properties:

--- a/bundles/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/handler/ZWayBridgeHandler.java
+++ b/bundles/org.openhab.binding.zway/src/main/java/org/openhab/binding/zway/internal/handler/ZWayBridgeHandler.java
@@ -292,7 +292,7 @@ public class ZWayBridgeHandler extends BaseBridgeHandler implements IZWayApiCall
         ZWaveController zwaveController = mZWayApi.getZWaveController();
         if (zwaveController != null) {
             Map<String, String> properties = editProperties();
-            // ESH default properties
+            // System properties
             properties.put(Thing.PROPERTY_FIRMWARE_VERSION, zwaveController.getData().getAPIVersion().getValue());
             properties.put(Thing.PROPERTY_HARDWARE_VERSION, zwaveController.getData().getZWaveChip().getValue());
             // Thing.PROPERTY_MODEL_ID not available, only manufacturerProductId

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitAuthInfoImpl.java
@@ -28,7 +28,7 @@ import io.github.hapjava.server.impl.HomekitServer;
 
 /**
  * Provides a mechanism to store authenticated HomeKit client details inside the
- * ESH StorageService, by implementing HomekitAuthInfo.
+ * StorageService, by implementing HomekitAuthInfo.
  *
  * @author Andy Lintner - Initial contribution
  */

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -77,7 +77,7 @@ import com.google.gson.GsonBuilder;
 public class ConfigStore {
 
     public static final String METAKEY = "HUEEMU";
-    public static final String EVENT_ADDRESS_CHANGED = "ESH_EMU_CONFIG_ADDR_CHANGED";
+    public static final String EVENT_ADDRESS_CHANGED = "HUE_EMU_CONFIG_ADDR_CHANGED";
 
     private final Logger logger = LoggerFactory.getLogger(ConfigStore.class);
 

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/StateUtils.java
@@ -259,7 +259,7 @@ public class StateUtils {
         if (newState.ct != null) {
             try {
                 // We can't do anything here with a white color temperature.
-                // The core ESH color type does not support setting it.
+                // The color type does not support setting it.
 
                 // Adjusting the color temperature implies setting the mode to ct
                 if (state instanceof HueStateColorBulb) {
@@ -279,7 +279,7 @@ public class StateUtils {
         if (newState.ct_inc != null) {
             try {
                 // We can't do anything here with a white color temperature.
-                // The core ESH color type does not support setting it.
+                // The color type does not support setting it.
 
                 // Adjusting the color temperature implies setting the mode to ct
                 if (state instanceof HueStateColorBulb) {

--- a/bundles/org.openhab.transform.bin2json/src/main/java/org/openhab/transform/bin2json/internal/Bin2JsonTransformationService.java
+++ b/bundles/org.openhab.transform.bin2json/src/main/java/org/openhab/transform/bin2json/internal/Bin2JsonTransformationService.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @author Pauli Anttila - Initial contribution
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=BIN2JSON" })
+@Component(property = { "openhab.transform=BIN2JSON" })
 public class Bin2JsonTransformationService implements TransformationService {
 
     private Logger logger = LoggerFactory.getLogger(Bin2JsonTransformationService.class);

--- a/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationService.java
+++ b/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/ExecTransformationService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Jan N. Klug - added command whitelist service
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=EXEC" })
+@Component(property = { "openhab.transform=EXEC" })
 public class ExecTransformationService implements TransformationService {
     private final Logger logger = LoggerFactory.getLogger(ExecTransformationService.class);
     private final ExecTransformationWhitelistWatchService execTransformationWhitelistWatchService;

--- a/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/profiles/ExecTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.exec/src/main/java/org/openhab/transform/exec/internal/profiles/ExecTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class ExecTransformationProfileFactory implements ProfileFactory, Profile
         return Arrays.asList(ExecTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=EXEC)")
+    @Reference(target = "(openhab.transform=EXEC)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/JavaScriptTransformationService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas Kordelle - pre compiled scripts
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=JS" })
+@Component(property = { "openhab.transform=JS" })
 public class JavaScriptTransformationService implements TransformationService {
 
     private Logger logger = LoggerFactory.getLogger(JavaScriptTransformationService.class);

--- a/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/profiles/JavascriptTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.javascript/src/main/java/org/openhab/transform/javascript/internal/profiles/JavascriptTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class JavascriptTransformationProfileFactory implements ProfileFactory, P
         return Arrays.asList(JavascriptTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=JS)")
+    @Reference(target = "(openhab.transform=JS)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/JinjaTransformationService.java
+++ b/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/JinjaTransformationService.java
@@ -40,7 +40,7 @@ import com.hubspot.jinjava.Jinjava;
  *
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=JINJA" })
+@Component(property = { "openhab.transform=JINJA" })
 public class JinjaTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(JinjaTransformationService.class);

--- a/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/profiles/JinjaTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.jinja/src/main/java/org/openhab/transform/jinja/internal/profiles/JinjaTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class JinjaTransformationProfileFactory implements ProfileFactory, Profil
         return Arrays.asList(JinjaTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=JINJA)")
+    @Reference(target = "(openhab.transform=JINJA)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -38,7 +38,7 @@ import com.jayway.jsonpath.PathNotFoundException;
  *
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=JSONPATH" })
+@Component(property = { "openhab.transform=JSONPATH" })
 public class JSonPathTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(JSonPathTransformationService.class);

--- a/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.jsonpath/src/main/java/org/openhab/transform/jsonpath/internal/profiles/JSonPathTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class JSonPathTransformationProfileFactory implements ProfileFactory, Pro
         return Arrays.asList(JSonPathTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=JSONPATH)")
+    @Reference(target = "(openhab.transform=JSONPATH)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/MapTransformationService.java
+++ b/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/MapTransformationService.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution and API
  * @author Gaël L'hopital - Make it localizable
  */
-@Component(service = TransformationService.class, property = { "smarthome.transform=MAP" })
+@Component(service = TransformationService.class, property = { "openhab.transform=MAP" })
 public class MapTransformationService extends AbstractFileTransformationService<Properties> {
 
     private final Logger logger = LoggerFactory.getLogger(MapTransformationService.class);

--- a/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/profiles/MapTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.map/src/main/java/org/openhab/transform/map/internal/profiles/MapTransformationProfileFactory.java
@@ -61,7 +61,7 @@ public class MapTransformationProfileFactory implements ProfileFactory, ProfileT
         return Arrays.asList(MapTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=MAP)")
+    @Reference(target = "(openhab.transform=MAP)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/RegExTransformationService.java
+++ b/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/RegExTransformationService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas.Eichstaedt-Engelen
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=REGEX" })
+@Component(property = { "openhab.transform=REGEX" })
 public class RegExTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(RegExTransformationService.class);

--- a/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/profiles/RegexTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.regex/src/main/java/org/openhab/transform/regex/internal/profiles/RegexTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class RegexTransformationProfileFactory implements ProfileFactory, Profil
         return Arrays.asList(RegexTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=REGEX)")
+    @Reference(target = "(openhab.transform=REGEX)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/ScaleTransformationService.java
+++ b/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/ScaleTransformationService.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Gaël L'hopital
  * @author Markus Rathgeb - drop usage of Guava
  */
-@Component(service = TransformationService.class, property = { "smarthome.transform=SCALE" })
+@Component(service = TransformationService.class, property = { "openhab.transform=SCALE" })
 public class ScaleTransformationService extends AbstractFileTransformationService<Map<Range, String>> {
 
     private final Logger logger = LoggerFactory.getLogger(ScaleTransformationService.class);

--- a/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/profiles/ScaleTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/profiles/ScaleTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class ScaleTransformationProfileFactory implements ProfileFactory, Profil
         return Arrays.asList(ScaleTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=SCALE)")
+    @Reference(target = "(openhab.transform=SCALE)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/XPathTransformationService.java
+++ b/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/XPathTransformationService.java
@@ -38,7 +38,7 @@ import org.xml.sax.InputSource;
  * @author Thomas.Eichstaedt-Engelen
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=XPATH" })
+@Component(property = { "openhab.transform=XPATH" })
 public class XPathTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(XPathTransformationService.class);

--- a/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/profiles/XPathTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.xpath/src/main/java/org/openhab/transform/xpath/internal/profiles/XPathTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class XPathTransformationProfileFactory implements ProfileFactory, Profil
         return Arrays.asList(XPathTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=XPATH)")
+    @Reference(target = "(openhab.transform=XPATH)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/XsltTransformationService.java
+++ b/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/XsltTransformationService.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas.Eichstaedt-Engelen
  */
 @NonNullByDefault
-@Component(property = { "smarthome.transform=XSLT" })
+@Component(property = { "openhab.transform=XSLT" })
 public class XsltTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(XsltTransformationService.class);

--- a/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/profiles/XSLTTransformationProfileFactory.java
+++ b/bundles/org.openhab.transform.xslt/src/main/java/org/openhab/transform/xslt/internal/profiles/XSLTTransformationProfileFactory.java
@@ -60,7 +60,7 @@ public class XSLTTransformationProfileFactory implements ProfileFactory, Profile
         return Arrays.asList(XSLTTransformationProfile.PROFILE_TYPE_UID);
     }
 
-    @Reference(target = "(smarthome.transform=XSLT)")
+    @Reference(target = "(openhab.transform=XSLT)")
     public void addTransformationService(TransformationService service) {
         this.service = service;
     }

--- a/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleCloudAPI.java
+++ b/bundles/org.openhab.voice.googletts/src/main/java/org/openhab/voice/googletts/internal/GoogleCloudAPI.java
@@ -303,7 +303,7 @@ class GoogleCloudAPI {
     }
 
     /**
-     * Converts ESH audio format to Google parameters.
+     * Converts audio format to Google parameters.
      *
      * @param codec Requested codec
      * @return String array of Google audio format and the file extension to use.

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
@@ -217,7 +217,7 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
 
     protected void mockTransformation(String name, TransformationService service) {
         Dictionary<String, Object> params = new Hashtable<>();
-        params.put("smarthome.transform", name);
+        params.put("openhab.transform", name);
         registerService(service, params);
     }
 

--- a/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
+++ b/itests/org.openhab.binding.ntp.tests/src/main/java/org/openhab/binding/ntp/test/NtpOSGiTest.java
@@ -100,7 +100,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
     private static final String TEST_ITEM_NAME = "testItem";
     private static final String TEST_THING_ID = "testThingId";
 
-    // No bundle in ESH is exporting a package from which we can use item types
+    // No bundle is exporting a package from which we can use item types
     // as constants, so we will use String.
     private static final String ACCEPTED_ITEM_TYPE_STRING = "String";
     private static final String ACCEPTED_ITEM_TYPE_DATE_TIME = "DateTime";


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/1901

The "SmartHome" references in these classes may also need an update:

* HueBridgeHandler
* MiCloudConnector
* SonosBindingConstants

I haven't changed these as it was not clear how much it would break existing configurations.