### PR TITLE
[homekit] fix for minValue/maxValue

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitTaggedItem.java
@@ -193,9 +193,19 @@ public class HomekitTaggedItem {
     public <T> T getConfiguration(String key, T defaultValue) {
         if (configuration != null) {
             final @Nullable Object value = configuration.get(key);
-            if (value != null && value.getClass().equals(defaultValue.getClass())) {
-                return (T) value;
+            if (value != null) {
+                if (value.getClass().equals(defaultValue.getClass())) {
+                    return (T) value;
+                }
+                // fix for different handling of numbers via .items and via mainUI, see #1904
+                if ((value instanceof BigDecimal) && (defaultValue instanceof Double)) {
+                    return (T) Double.valueOf(((BigDecimal) value).doubleValue());
+                }
+                if ((value instanceof Double) && (defaultValue instanceof BigDecimal)) {
+                    return (T) BigDecimal.valueOf(((Double) value).doubleValue());
+                }
             }
+
         }
         return defaultValue;
     }


### PR DESCRIPTION
this PR fixes the issue #9089 

the main reason for the issue is different handling of numbers in meta data created via mainUI and via .items file configuration. MainUI creates values of type Double. .items results in values of type BigDecimal
this issue is reported here https://github.com/openhab/openhab-core/issues/1904
