### PR TITLE
[bluetooth] Try to make tests more stable No.2

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
@@ -153,10 +153,12 @@ class RetryFutureTest extends JavaTest {
             if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                 fail("Timeout while waiting for latch");
             }
-            retryFuture.cancel(false);
-
-            waitForAssert(() -> assertTrue(composedFuture.isCancelled()));
-        } catch (InterruptedException e) {
+            Future<Boolean> future = scheduler.submit(() -> {
+                retryFuture.cancel(false);
+                return composedFuture.isCancelled();
+            });
+            assertTrue(future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             fail(e);
         }
         assertEquals(2, visitCount.get());

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
@@ -28,13 +28,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.common.NamedThreadFactory;
-import org.openhab.core.test.java.JavaTest;
 
 /**
  * @author Connor Petty - Initial contribution
  *
  */
-class RetryFutureTest extends JavaTest {
+class RetryFutureTest {
 
     private static final int TIMEOUT_MS = 1000;
     private ScheduledExecutorService scheduler;

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/util/RetryFutureTest.java
@@ -28,12 +28,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.common.NamedThreadFactory;
+import org.openhab.core.test.java.JavaTest;
 
 /**
  * @author Connor Petty - Initial contribution
  *
  */
-class RetryFutureTest {
+class RetryFutureTest extends JavaTest {
 
     private static final int TIMEOUT_MS = 1000;
     private ScheduledExecutorService scheduler;
@@ -115,7 +116,7 @@ class RetryFutureTest {
     }
 
     @Test
-    void composeWithRetry1() throws InterruptedException {
+    void composeWithRetry1() {
         AtomicInteger visitCount = new AtomicInteger();
         CompletableFuture<String> composedFuture = new CompletableFuture<>();
         Future<String> retryFuture = RetryFuture.composeWithRetry(() -> {
@@ -152,10 +153,9 @@ class RetryFutureTest {
             if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                 fail("Timeout while waiting for latch");
             }
-            Thread.sleep(1);
             retryFuture.cancel(false);
 
-            assertTrue(composedFuture.isCancelled());
+            waitForAssert(() -> assertTrue(composedFuture.isCancelled()));
         } catch (InterruptedException e) {
             fail(e);
         }


### PR DESCRIPTION
See https://ci.openhab.org/view/Pull%20Request%20Builds/job/PR-openHAB-Addons/org.openhab.addons.bundles$org.openhab.binding.bluetooth/1293/testReport/junit/org.openhab.binding.bluetooth.util/RetryFutureTest/composeWithRetry1Cancel/

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>