### PR TITLE
[feed] Try to make tests more stable

### DIFF
--- a/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
+++ b/itests/org.openhab.binding.feed.tests/src/main/java/org/openhab/binding/feed/test/FeedHandlerTest.java
@@ -104,6 +104,7 @@ public class FeedHandlerTest extends JavaOSGiTest {
     private Thing feedThing;
     private FeedHandler feedHandler;
     private ChannelUID channelUID;
+    private HttpService httpService;
 
     /**
      * This class is used as a mock for HTTP web server, serving XML feed content.
@@ -175,9 +176,8 @@ public class FeedHandlerTest extends JavaOSGiTest {
         });
     }
 
-    private void registerFeedTestServlet() {
-        HttpService httpService = getService(HttpService.class);
-        assertThat(httpService, is(notNullValue()));
+    private synchronized void registerFeedTestServlet() {
+        waitForAssert(() -> assertThat(httpService = getService(HttpService.class), is(notNullValue())));
         servlet = new FeedServiceMock(DEFAULT_MOCK_CONTENT);
         try {
             httpService.registerServlet(MOCK_SERVLET_PATH, servlet, null, null);
@@ -186,9 +186,8 @@ public class FeedHandlerTest extends JavaOSGiTest {
         }
     }
 
-    private void unregisterFeedTestServlet() {
-        HttpService httpService = getService(HttpService.class);
-        assertThat(httpService, is(notNullValue()));
+    private synchronized void unregisterFeedTestServlet() {
+        waitForAssert(() -> assertThat(httpService = getService(HttpService.class), is(notNullValue())));
         httpService.unregister(MOCK_SERVLET_PATH);
         servlet = null;
     }


### PR DESCRIPTION
I don't know if this is the solution. The Jenkins logs show a lot of:
```
Components implementing org.osgi.service.http.HttpService:
No component implementing org.osgi.service.http.HttpService is currently registered.
Make sure to add the appropriate bundle and set 'Default Auto-Start=true' in the launch config.
```

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>