### PR TITLE
[deconz] improve initialization

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/Util.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/Util.java
@@ -25,8 +25,6 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.PercentType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link Util} class defines common utility methods
@@ -35,7 +33,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class Util {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
 
     public static String buildUrl(String host, int port, String... urlParts) {
         StringBuilder url = new StringBuilder();

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/BridgeFullState.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/BridgeFullState.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deconz.internal.types.ResourceType;
 
 /**
  * http://dresden-elektronik.github.io/deconz-rest-doc/configuration/
@@ -42,4 +44,17 @@ public class BridgeFullState {
     public Map<String, SensorMessage> sensors = Collections.emptyMap();
     public Map<String, LightMessage> lights = Collections.emptyMap();
     public Map<String, GroupMessage> groups = Collections.emptyMap();
+
+    public @Nullable DeconzBaseMessage getMessage(ResourceType resourceType, String id) {
+        switch (resourceType) {
+            case LIGHTS:
+                return lights.get(id);
+            case SENSORS:
+                return sensors.get(id);
+            case GROUPS:
+                return groups.get(id);
+            default:
+                return null;
+        }
+    }
 }

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/DeconzBridgeHandler.java
@@ -16,10 +16,7 @@ import static org.openhab.binding.deconz.internal.BindingConstants.*;
 import static org.openhab.binding.deconz.internal.Util.buildUrl;
 
 import java.net.SocketTimeoutException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledFuture;
@@ -34,6 +31,7 @@ import org.openhab.binding.deconz.internal.dto.BridgeFullState;
 import org.openhab.binding.deconz.internal.netutils.AsyncHttpClient;
 import org.openhab.binding.deconz.internal.netutils.WebSocketConnection;
 import org.openhab.binding.deconz.internal.netutils.WebSocketConnectionListener;
+import org.openhab.core.cache.ExpiringCacheAsync;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.net.http.WebSocketFactory;
 import org.openhab.core.thing.Bridge;
@@ -64,7 +62,6 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(BRIDGE_TYPE);
 
     private final Logger logger = LoggerFactory.getLogger(DeconzBridgeHandler.class);
-    private @Nullable ThingDiscoveryService thingDiscoveryService;
     private final WebSocketConnection websocket;
     private final AsyncHttpClient http;
     private DeconzBridgeConfig config = new DeconzBridgeConfig();
@@ -74,6 +71,8 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
     /** Prevent a dispose/init cycle while this flag is set. Use for property updates */
     private boolean ignoreConfigurationUpdate;
     private boolean websocketReconnect = false;
+
+    private final ExpiringCacheAsync<Optional<BridgeFullState>> fullStateCache = new ExpiringCacheAsync<>(1000);
 
     /** The poll frequency for the API Key verification */
     private static final int POLL_FREQUENCY_SEC = 10;
@@ -130,7 +129,7 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
             stopTimer();
             scheduledFuture = scheduler.schedule(() -> requestApiKey(), POLL_FREQUENCY_SEC, TimeUnit.SECONDS);
         } else if (r.getResponseCode() == 200) {
-            ApiKeyMessage[] response = gson.fromJson(r.getBody(), ApiKeyMessage[].class);
+            ApiKeyMessage[] response = Objects.requireNonNull(gson.fromJson(r.getBody(), ApiKeyMessage[].class));
             if (response.length == 0) {
                 throw new IllegalStateException("Authorisation request response is empty");
             }
@@ -139,65 +138,65 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
             configuration.put(CONFIG_APIKEY, config.apikey);
             updateConfiguration(configuration);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Waiting for configuration");
-            requestFullState(true);
+            initializeBridgeState();
         } else {
             throw new IllegalStateException("Unknown status code for authorisation request");
         }
     }
 
     /**
-     * Parses the response message to the REST API for retrieving the full bridge state with all sensors and switches
-     * and configuration.
+     * get the full state of the bridge from the cache
      *
-     * @param r The response
+     * @return a CompletableFuture that returns an Optional of the bridge full state
      */
-    private @Nullable BridgeFullState parseBridgeFullStateResponse(AsyncHttpClient.Result r) {
-        if (r.getResponseCode() == 403) {
-            return null;
-        } else if (r.getResponseCode() == 200) {
-            return gson.fromJson(r.getBody(), BridgeFullState.class);
-        } else {
-            throw new IllegalStateException("Unknown status code for full state request");
+    public CompletableFuture<Optional<BridgeFullState>> getBridgeFullState() {
+        return fullStateCache.getValue(this::refreshFullStateCache);
+    }
+
+    /**
+     * refresh the full bridge state (used for initial processing and state-lookup)
+     *
+     * @return Completable future with an Optional of the BridgeFullState
+     */
+    private CompletableFuture<Optional<BridgeFullState>> refreshFullStateCache() {
+        logger.trace("{} starts refreshing the fullStateCache", thing.getUID());
+        if (config.apikey == null) {
+            return CompletableFuture.completedFuture(Optional.empty());
         }
+        String url = buildUrl(config.getHostWithoutPort(), config.httpPort, config.apikey);
+        return http.get(url, config.timeout).thenApply(r -> {
+            if (r.getResponseCode() == 403) {
+                return Optional.ofNullable((BridgeFullState) null);
+            } else if (r.getResponseCode() == 200) {
+                return Optional.ofNullable(gson.fromJson(r.getBody(), BridgeFullState.class));
+            } else {
+                throw new IllegalStateException("Unknown status code for full state request");
+            }
+        }).handle((v, t) -> {
+            if (t == null) {
+                return v;
+            } else if (t instanceof SocketTimeoutException || t instanceof TimeoutException
+                    || t instanceof CompletionException) {
+                logger.debug("Get full state failed", t);
+            } else if (t != null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, t.getMessage());
+            }
+            return Optional.empty();
+        });
     }
 
     /**
      * Perform a request to the REST API for retrieving the full bridge state with all sensors and switches
      * and configuration.
      */
-    public void requestFullState(boolean isInitialRequest) {
-        if (config.apikey == null) {
-            return;
-        }
-        String url = buildUrl(config.getHostWithoutPort(), config.httpPort, config.apikey);
-        http.get(url, config.timeout).thenApply(this::parseBridgeFullStateResponse).exceptionally(e -> {
-            if (e instanceof SocketTimeoutException || e instanceof TimeoutException
-                    || e instanceof CompletionException) {
-                logger.debug("Get full state failed", e);
-            } else {
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-            }
-            return null;
-        }).whenComplete((value, error) -> {
-            final ThingDiscoveryService thingDiscoveryService = this.thingDiscoveryService;
-            if (thingDiscoveryService != null) {
-                // Hand over sensors to discovery service
-                thingDiscoveryService.stateRequestFinished(value);
-            }
-        }).thenAccept(fullState -> {
-            if (fullState == null) {
-                if (isInitialRequest) {
-                    scheduledFuture = scheduler.schedule(() -> requestFullState(true), POLL_FREQUENCY_SEC,
-                            TimeUnit.SECONDS);
-                }
-                return;
-            }
-            if (fullState.config.name.isEmpty()) {
+    public void initializeBridgeState() {
+        getBridgeFullState().thenAccept(fullState -> fullState.ifPresentOrElse(state -> {
+            if (state.config.name.isEmpty()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                         "You are connected to a HUE bridge, not a deCONZ software!");
                 return;
             }
-            if (fullState.config.websocketport == 0) {
+            if (state.config.websocketport == 0) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                         "deCONZ software too old. No websocket support!");
                 return;
@@ -205,35 +204,37 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
 
             // Add some information about the bridge
             Map<String, String> editProperties = editProperties();
-            editProperties.put("apiversion", fullState.config.apiversion);
-            editProperties.put("swversion", fullState.config.swversion);
-            editProperties.put("fwversion", fullState.config.fwversion);
-            editProperties.put("uuid", fullState.config.uuid);
-            editProperties.put("zigbeechannel", String.valueOf(fullState.config.zigbeechannel));
-            editProperties.put("ipaddress", fullState.config.ipaddress);
+            editProperties.put("apiversion", state.config.apiversion);
+            editProperties.put("swversion", state.config.swversion);
+            editProperties.put("fwversion", state.config.fwversion);
+            editProperties.put("uuid", state.config.uuid);
+            editProperties.put("zigbeechannel", String.valueOf(state.config.zigbeechannel));
+            editProperties.put("ipaddress", state.config.ipaddress);
             ignoreConfigurationUpdate = true;
             updateProperties(editProperties);
             ignoreConfigurationUpdate = false;
 
             // Use requested websocket port if no specific port is given
-            websocketPort = config.port == 0 ? fullState.config.websocketport : config.port;
+            websocketPort = config.port == 0 ? state.config.websocketport : config.port;
             websocketReconnect = true;
             startWebsocket();
-        }).exceptionally(e -> {
+        }, () -> {
+            // initial response was empty, re-trying in POLL_FREQUENCY_SEC seconds
+            scheduledFuture = scheduler.schedule(this::initializeBridgeState, POLL_FREQUENCY_SEC, TimeUnit.SECONDS);
+        })).exceptionally(e -> {
             if (e != null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, e.getMessage());
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE);
             }
-            logger.warn("Full state parsing failed", e);
+            logger.warn("Initial full state parsing failed", e);
             return null;
         });
     }
 
     /**
      * Starts the websocket connection.
-     *
-     * {@link #requestFullState} need to be called first to obtain the websocket port.
+     * {@link #initializeBridgeState} need to be called first to obtain the websocket port.
      */
     private void startWebsocket() {
         if (websocket.isConnected() || websocketPort == 0 || websocketReconnect == false) {
@@ -269,7 +270,7 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
         if (config.apikey == null) {
             requestApiKey();
         } else {
-            requestFullState(true);
+            initializeBridgeState();
         }
     }
 
@@ -323,14 +324,5 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
      */
     public DeconzBridgeConfig getBridgeConfig() {
         return config;
-    }
-
-    /**
-     * Called by the {@link ThingDiscoveryService}. Informs the bridge handler about the service.
-     *
-     * @param thingDiscoveryService The service
-     */
-    public void setDiscoveryService(ThingDiscoveryService thingDiscoveryService) {
-        this.thingDiscoveryService = thingDiscoveryService;
     }
 }

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
@@ -17,13 +17,11 @@ import static org.openhab.binding.deconz.internal.BindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.deconz.internal.Util;
 import org.openhab.binding.deconz.internal.dto.DeconzBaseMessage;
 import org.openhab.binding.deconz.internal.dto.GroupAction;
 import org.openhab.binding.deconz.internal.dto.GroupMessage;
 import org.openhab.binding.deconz.internal.dto.GroupState;
-import org.openhab.binding.deconz.internal.netutils.AsyncHttpClient;
 import org.openhab.binding.deconz.internal.types.ResourceType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -55,7 +53,7 @@ import com.google.gson.Gson;
  * @author Jan N. Klug - Initial contribution
  */
 @NonNullByDefault
-public class GroupThingHandler extends DeconzBaseThingHandler<GroupMessage> {
+public class GroupThingHandler extends DeconzBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPE_UIDS = Set.of(THING_TYPE_LIGHTGROUP);
     private final Logger logger = LoggerFactory.getLogger(GroupThingHandler.class);
 
@@ -128,21 +126,7 @@ public class GroupThingHandler extends DeconzBaseThingHandler<GroupMessage> {
     }
 
     @Override
-    protected @Nullable GroupMessage parseStateResponse(AsyncHttpClient.Result r) {
-        if (r.getResponseCode() == 403) {
-            return null;
-        } else if (r.getResponseCode() == 200) {
-            return gson.fromJson(r.getBody(), GroupMessage.class);
-        } else {
-            throw new IllegalStateException("Unknown status code " + r.getResponseCode() + " for full state request");
-        }
-    }
-
-    @Override
-    protected void processStateResponse(@Nullable GroupMessage stateResponse) {
-        if (stateResponse == null) {
-            return;
-        }
+    protected void processStateResponse(DeconzBaseMessage stateResponse) {
         messageReceived(config.id, stateResponse);
     }
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/netutils/WebSocketConnection.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/netutils/WebSocketConnection.java
@@ -26,9 +26,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.openhab.binding.deconz.internal.dto.DeconzBaseMessage;
-import org.openhab.binding.deconz.internal.dto.GroupMessage;
-import org.openhab.binding.deconz.internal.dto.LightMessage;
-import org.openhab.binding.deconz.internal.dto.SensorMessage;
 import org.openhab.binding.deconz.internal.types.ResourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,10 +42,6 @@ import com.google.gson.Gson;
 @WebSocket
 @NonNullByDefault
 public class WebSocketConnection {
-    private static final Map<ResourceType, Class<? extends DeconzBaseMessage>> EXPECTED_MESSAGE_TYPES = Map.of(
-            ResourceType.GROUPS, GroupMessage.class, ResourceType.LIGHTS, LightMessage.class, ResourceType.SENSORS,
-            SensorMessage.class);
-
     private final Logger logger = LoggerFactory.getLogger(WebSocketConnection.class);
 
     private final WebSocketClient client;
@@ -130,7 +123,7 @@ public class WebSocketConnection {
             return;
         }
 
-        Class<? extends DeconzBaseMessage> expectedMessageType = EXPECTED_MESSAGE_TYPES.get(changedMessage.r);
+        Class<? extends DeconzBaseMessage> expectedMessageType = changedMessage.r.getExpectedMessageType();
         if (expectedMessageType == null) {
             logger.warn("BUG! Could not get expected message type for resource type {}. Please report this incident.",
                     changedMessage.r);

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/types/ResourceType.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/types/ResourceType.java
@@ -17,6 +17,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.deconz.internal.dto.DeconzBaseMessage;
+import org.openhab.binding.deconz.internal.dto.GroupMessage;
+import org.openhab.binding.deconz.internal.dto.LightMessage;
+import org.openhab.binding.deconz.internal.dto.SensorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,10 +32,10 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public enum ResourceType {
-    GROUPS("groups", "action"),
-    LIGHTS("lights", "state"),
-    SENSORS("sensors", "config"),
-    UNKNOWN("", "");
+    GROUPS("groups", "action", GroupMessage.class),
+    LIGHTS("lights", "state", LightMessage.class),
+    SENSORS("sensors", "config", SensorMessage.class),
+    UNKNOWN("", "", null);
 
     private static final Map<String, ResourceType> MAPPING = Arrays.stream(ResourceType.values())
             .collect(Collectors.toMap(v -> v.identifier, v -> v));
@@ -38,10 +43,13 @@ public enum ResourceType {
 
     private String identifier;
     private String commandUrl;
+    private @Nullable Class<? extends DeconzBaseMessage> expectedMessageType;
 
-    ResourceType(String identifier, String commandUrl) {
+    ResourceType(String identifier, String commandUrl,
+            @Nullable Class<? extends DeconzBaseMessage> expectedMessageType) {
         this.identifier = identifier;
         this.commandUrl = commandUrl;
+        this.expectedMessageType = expectedMessageType;
     }
 
     /**
@@ -60,6 +68,15 @@ public enum ResourceType {
      */
     public String getCommandUrl() {
         return commandUrl;
+    }
+
+    /**
+     * get the expected message type for this resource type
+     *
+     * @return
+     */
+    public @Nullable Class<? extends DeconzBaseMessage> getExpectedMessageType() {
+        return expectedMessageType;
     }
 
     /**

--- a/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/DeconzTest.java
+++ b/bundles/org.openhab.binding.deconz/src/test/java/org/openhab/binding/deconz/DeconzTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,11 +80,12 @@ public class DeconzTest {
         assertEquals(6, bridgeFullState.lights.size());
         assertEquals(9, bridgeFullState.sensors.size());
 
+        Mockito.doAnswer(answer -> CompletableFuture.completedFuture(Optional.of(bridgeFullState))).when(bridgeHandler)
+                .getBridgeFullState();
         ThingDiscoveryService discoveryService = new ThingDiscoveryService();
         discoveryService.setThingHandler(bridgeHandler);
         discoveryService.addDiscoveryListener(discoveryListener);
-
-        discoveryService.stateRequestFinished(bridgeFullState);
+        discoveryService.startScan();
         Mockito.verify(discoveryListener, times(20)).thingDiscovered(any(), any());
     }
 


### PR DESCRIPTION
Fixes #9264 

The reason for the high CPU load with a lot of things is that during binding initialization each thing handler executes a seperate request request to the deconz REST API and runs into timeouts. This refactoring caches the response for 1s which allows faster processing and reduces network load.  

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
