### PR TITLE
[jdbc] Add missing item types

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -150,8 +150,10 @@ public class JdbcBaseDAO {
         sqlTypes.put("CONTACTITEM", "VARCHAR(6)");
         sqlTypes.put("DATETIMEITEM", "TIMESTAMP");
         sqlTypes.put("DIMMERITEM", "TINYINT");
+        sqlTypes.put("IMAGEITEM", "VARCHAR(65500)");// jdbc max 21845
         sqlTypes.put("LOCATIONITEM", "VARCHAR(30)");
         sqlTypes.put("NUMBERITEM", "DOUBLE");
+        sqlTypes.put("PLAYERITEM", "VARCHAR(20)");
         sqlTypes.put("ROLLERSHUTTERITEM", "TINYINT");
         sqlTypes.put("STRINGITEM", "VARCHAR(65500)");// jdbc max 21845
         sqlTypes.put("SWITCHITEM", "VARCHAR(6)");
@@ -486,7 +488,7 @@ public class JdbcBaseDAO {
                     ZonedDateTime.ofInstant(Instant.ofEpochMilli(objectAsLong(v)), ZoneId.systemDefault()));
         } else if (item instanceof StringItem) {
             return StringType.valueOf(((String) v).toString());
-        } else {// Call, Location, String
+        } else {// Call, Image, Location, Player, String
             return StringType.valueOf(((String) v).toString());
         }
     }

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcDerbyDAO.java
@@ -63,6 +63,7 @@ public class JdbcDerbyDAO extends JdbcBaseDAO {
     private void initSqlTypes() {
         sqlTypes.put("DATETIMEITEM", "TIMESTAMP");
         sqlTypes.put("DIMMERITEM", "SMALLINT");
+        sqlTypes.put("IMAGEITEM", "VARCHAR(32000)");
         sqlTypes.put("ROLLERSHUTTERITEM", "SMALLINT");
         sqlTypes.put("STRINGITEM", "VARCHAR(32000)");
         sqlTypes.put("tablePrimaryValue", "CURRENT_TIMESTAMP");

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcPostgresqlDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcPostgresqlDAO.java
@@ -73,8 +73,10 @@ public class JdbcPostgresqlDAO extends JdbcBaseDAO {
         sqlTypes.put("CONTACTITEM", "VARCHAR");
         sqlTypes.put("DATETIMEITEM", "TIMESTAMP");
         sqlTypes.put("DIMMERITEM", "SMALLINT");
+        sqlTypes.put("IMAGEITEM", "VARCHAR");
         sqlTypes.put("LOCATIONITEM", "VARCHAR");
         sqlTypes.put("NUMBERITEM", "DOUBLE PRECISION");
+        sqlTypes.put("PLAYERITEM", "VARCHAR");
         sqlTypes.put("ROLLERSHUTTERITEM", "SMALLINT");
         sqlTypes.put("STRINGITEM", "VARCHAR");
         sqlTypes.put("SWITCHITEM", "VARCHAR");


### PR DESCRIPTION
The jdbc binding generates a warning in the log for Image and Player item types, but it stores the values in the database as VARCHARs anyway.

This PR adds those items types so that they are stored as they are today, but without the warning.

See discussion [here](https://community.openhab.org/t/jdbc-mysql-persistence-in-oh3/109922/13).

Fixes #2819

Signed-off-by: Mark Hilbush <mark@hilbush.com>
