### PR TITLE
[hue] Refactor: change category to one that exists

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/thing/channels.xml
@@ -25,7 +25,7 @@
 			It is also possible to switch the
 			light on and off.
 		</description>
-		<category>DimmableLight</category>
+		<category>Light</category>
 		<tags>
 			<tag>Lighting</tag>
 		</tags>


### PR DESCRIPTION
 <category>DimmableLight</category>
The above category does not exist here <https://www.openhab.org/docs/concepts/categories.html> and the new UI does not have this as a valid option to select when creating an item.

Signed-off-by: Matthew Skinner <matt@pcmus.com>