### PR TITLE
[milight] Refactor: change category to one that exist

### DIFF
--- a/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/channels.xml
@@ -75,7 +75,7 @@
 		<description>White leds and RGBWW allow to change between a cold and a warm color temperature. White support 16, RGBWW
 			support 64 steps
 		</description>
-		<category>DimmableLight</category>
+		<category>Light</category>
 		<state min="0" max="100" step="1" pattern="%d"></state>
 	</channel-type>
 


### PR DESCRIPTION
 <category>DimmableLight</category>
The above category does not exist here <https://www.openhab.org/docs/concepts/categories.html> and the new UI does not have this as a valid option to select when creating an item.

Signed-off-by: Matthew Skinner <matt@pcmus.com>