### PR TITLE
[deconz] fix colorlight not updating color channel

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -89,6 +89,10 @@ The transition time is the time to move between two states and is configured in 
 The resolution provided is 1/10s.
 If no value is provided, the default value of the device is used.
 
+`extendedcolorlight` and `colorlight` have different modes for setting the color.
+Some devices accept only XY, others HSB, others both modes and the binding tries to autodetect the correct mode.
+If this fails, the advanced `colormode` parameter can be set to `xy` or `hs`.
+
 ### Textual Thing Configuration - Retrieving an API Key
 
 If you use the textual configuration, the thing file without an API key will look like this, for example:

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -78,6 +78,7 @@ public class LightThingHandler extends DeconzBaseThingHandler {
      */
     private LightState lightStateCache = new LightState();
     private LightState lastCommand = new LightState();
+    private String colorMode = "";
 
     // set defaults, we can override them later if we receive better values
     private int ctMax = ZCL_CT_MAX;
@@ -179,7 +180,7 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                     }
                 } else if (command instanceof HSBType) {
                     HSBType hsbCommand = (HSBType) command;
-                    if ("xy".equals(lightStateCache.colormode)) {
+                    if ("xy".equals(colorMode)) {
                         PercentType[] xy = hsbCommand.toXY();
                         if (xy.length < 2) {
                             logger.warn("Failed to convert {} to xy-values", command);
@@ -268,6 +269,7 @@ public class LightThingHandler extends DeconzBaseThingHandler {
         }
 
         LightMessage lightMessage = (LightMessage) stateResponse;
+
         if (needsPropertyUpdate) {
             // if we did not receive an ctmin/ctmax, then we probably don't need it
             needsPropertyUpdate = false;
@@ -425,6 +427,13 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                     // skip for SKIP_UPDATE_TIMESPAN after last command if lightState is different from command
                     logger.trace("Ignoring differing update after last command until {}", lastCommandExpireTimestamp);
                     return;
+                }
+                if (colorMode.isEmpty()) {
+                    String cmode = lightState.colormode;
+                    if (cmode != null && ("hs".equals(cmode) || "xy".equals(cmode))) {
+                        // only set the color mode if it is hs or xy, not ct
+                        colorMode = cmode;
+                    }
                 }
                 lightStateCache = lightState;
                 if (Boolean.TRUE.equals(lightState.reachable)) {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
@@ -25,4 +25,5 @@ public class ThingConfig {
     public String id = "";
     public int lastSeenPolling = 1440;
     public @Nullable Double transitiontime;
+    public String colormode = "";
 }

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
@@ -47,7 +47,6 @@
 		</parameter>
 	</config-description>
 
-
 	<config-description uri="thing-type:deconz:light">
 		<parameter name="id" type="text" required="true">
 			<label>Device ID</label>
@@ -56,6 +55,26 @@
 		<parameter name="transitiontime" type="decimal" required="false" min="0" unit="s">
 			<label>Transition Time</label>
 			<description>Time to move between two states. If empty, the default of the device is used. Resolution is 1/10 second.</description>
+		</parameter>
+	</config-description>
+
+	<config-description uri="thing-type:deconz:colorlight">
+		<parameter name="id" type="text" required="true">
+			<label>Device ID</label>
+			<description>The deCONZ bridge assigns an integer number ID to each device.</description>
+		</parameter>
+		<parameter name="transitiontime" type="decimal" required="false" min="0" unit="s">
+			<label>Transition Time</label>
+			<description>Time to move between two states. If empty, the default of the device is used. Resolution is 1/10 second.</description>
+		</parameter>
+		<parameter name="colormode" type="text" required="false">
+			<label>Color Mode</label>
+			<description>Override the default color mode (auto-detect)</description>
+			<options>
+				<option value="hs">HSB</option>
+				<option value="xy">XY</option>
+			</options>
+			<advanced>true</advanced>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
@@ -97,7 +97,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description-ref uri="thing-type:deconz:light"/>
+		<config-description-ref uri="thing-type:deconz:colorlight"/>
 	</thing-type>
 
 	<thing-type id="extendedcolorlight">
@@ -114,7 +114,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description-ref uri="thing-type:deconz:light"/>
+		<config-description-ref uri="thing-type:deconz:colorlight"/>
 	</thing-type>
 
 	<thing-type id="doorlock">


### PR DESCRIPTION
In some cases auto-detection of the color mode (hsb, xy) is not working properly. This allows to optionally set a fixed color mode.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
