### PR TITLE
Removed remaining outdated reference to modbus transport bundle

### DIFF
--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1433,11 +1433,6 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
-      <artifactId>org.openhab.io.transport.modbus</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.persistence.dynamodb</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
This fixes our broken release build: https://ci.openhab.org/view/Sandbox/job/sandbox-openhab3-release/

Signed-off-by: Kai Kreuzer <kai@openhab.org>