### PR TITLE
[enocean] Added tariff info for AutomatedMeterSensor ThingType channels

### DIFF
--- a/bundles/org.openhab.binding.enocean/README.md
+++ b/bundles/org.openhab.binding.enocean/README.md
@@ -287,6 +287,7 @@ Some channels can be configured with parameters.
 | teachInCMD    | manufacturerId | Id is used for 4BS teach in with EEP                                 | HEX                                                                                                                                 |
 |               | teachInMSG     | Use this message if teach in type and/or manufacturer id are unknown | HEX                                                                                                                                 |
 |  totalusage   | validateValue  | Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh | true / false                                                                                                                     |
+|               | tariff         | Tariff info or measurement channel to listen to | 0-15 |
 |  contact      | inverted       | Swap OPEN / CLOSED. Set True for Eltako FPE-2.                    | true / false. Defaults to false.                                                                                                    |
 
 Possible declaration in Thing DSL:

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTariffInfoConfig.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnOceanChannelTariffInfoConfig.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.enocean.internal.config;
+
+/**
+ *
+ * @author Daniel Weber - Initial contribution
+ */
+public class EnOceanChannelTariffInfoConfig {
+    public int tariff = 0;
+}

--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_12/A5_12.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/A5_12/A5_12.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.enocean.internal.EnOceanBindingConstants.*;
 
 import java.util.function.Function;
 
+import org.openhab.binding.enocean.internal.config.EnOceanChannelTariffInfoConfig;
 import org.openhab.binding.enocean.internal.eep.Base._4BSMessage;
 import org.openhab.binding.enocean.internal.eep.EEPHelper;
 import org.openhab.binding.enocean.internal.messages.ERP1Message;
@@ -112,10 +113,19 @@ public abstract class A5_12 extends _4BSMessage {
         return UnDefType.UNDEF;
     }
 
+    protected int getTariffInfo() {
+        return ((getDB_0() >>> 4) & 0xff);
+    }
+
     @Override
     protected State convertToStateImpl(String channelId, String channelTypeId,
             Function<String, State> getCurrentStateFunc, Configuration config) {
-        switch (channelId) {
+
+        EnOceanChannelTariffInfoConfig c = config.as(EnOceanChannelTariffInfoConfig.class);
+        if (c.tariff != getTariffInfo())
+            return UnDefType.UNDEF;
+
+        switch (channelTypeId) {
             case CHANNEL_INSTANTPOWER:
             case CHANNEL_CURRENTFLOW:
             case CHANNEL_CURRENTNUMBER:

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/AutomatedMeterSensor.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/AutomatedMeterSensor.xml
@@ -4,7 +4,8 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="automatedMeterSensor">
+	<thing-type id="automatedMeterSensor"
+		extensible="currentFlow, cumulativeValue, counter, currentNumber, instantpower, totalusage">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge"/>
 		</supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/channels.xml
@@ -163,6 +163,18 @@
 		<label>Instant Power</label>
 		<description>Instant power consumption in Watts</description>
 		<state pattern="%d %unit%" readOnly="true"/>
+		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
+			<parameter name="validateValue" type="boolean">
+				<label>Validate Value</label>
+				<description>Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh</description>
+				<default>false</default>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="totalusage">
@@ -171,6 +183,11 @@
 		<description>Used energy in Kilowatt hours</description>
 		<state pattern="%.1f %unit%" readOnly="true"/>
 		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
 			<parameter name="validateValue" type="boolean">
 				<label>Validate Value</label>
 				<description>Filter out increases more than 10.0 kWh and decreases less than 1.0 kWh</description>
@@ -324,12 +341,26 @@
 		<item-type>Number:VolumetricFlowRate</item-type>
 		<label>Current Flow</label>
 		<state pattern="%d %unit%" readOnly="true"/>
+		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="cumulativeValue">
 		<item-type>Number:Volume</item-type>
 		<label>Cumulative Value</label>
 		<state pattern="%d %unit%" readOnly="true"/>
+		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="counter">
@@ -337,6 +368,13 @@
 		<label>Counter</label>
 		<description>Counter</description>
 		<state readOnly="true"/>
+		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="currentNumber">
@@ -344,6 +382,13 @@
 		<label>Current</label>
 		<description>Current</description>
 		<state readOnly="true"/>
+		<config-description>
+			<parameter name="tariff" type="integer" min="0" max="15">
+				<label>Tariff info</label>
+				<description>Number of tariff this channel listens to</description>
+				<default>0</default>
+			</parameter>
+		</config-description>
 	</channel-type>
 
 	<channel-type id="rainStatus">


### PR DESCRIPTION
 * Added new channel parameter tariff to channels instantpower, totalusage, currentFlow, cumulativeValue, counter and currentNumber
 * Parameter is currently just read by EEP A5_12, which is used by AutomatedMeterSensor ThingType
 * AutomatedMeterSensor ThingType has extensible channels now to support more than one tariff channel

Fixes #9333

Signed-off-by: Daniel Weber <uni@fruggy.de>
