### PR TITLE
[hue] Make sure the serial number will be in lowercase

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -53,7 +53,7 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
     public @Nullable DiscoveryResult createResult(RemoteDevice device) {
         String serialNumber = device.getDetails().getSerialNumber();
         ThingUID uid = getThingUID(device);
-        if (uid != null && serialNumber != null) {
+        if (uid != null && serialNumber != null && !serialNumber.isBlank()) {
             Map<String, Object> properties = new HashMap<>();
             properties.put(HOST, device.getDetails().getBaseURL().getHost());
             properties.put(PORT, device.getDetails().getBaseURL().getPort());
@@ -75,7 +75,7 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
         if (details != null) {
             ModelDetails modelDetails = details.getModelDetails();
             String serialNumber = details.getSerialNumber();
-            if (modelDetails != null && serialNumber != null) {
+            if (modelDetails != null && serialNumber != null && !serialNumber.isBlank()) {
                 String modelName = modelDetails.getModelName();
                 if (modelName != null) {
                     if (modelName.startsWith("Philips hue bridge")) {

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -57,7 +57,7 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
             properties.put(HOST, device.getDetails().getBaseURL().getHost());
             properties.put(PORT, device.getDetails().getBaseURL().getPort());
             properties.put(PROTOCOL, device.getDetails().getBaseURL().getProtocol());
-            properties.put(PROPERTY_SERIAL_NUMBER, device.getDetails().getSerialNumber());
+            properties.put(PROPERTY_SERIAL_NUMBER, device.getDetails().getSerialNumber().toLowerCase());
 
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
                     .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(PROPERTY_SERIAL_NUMBER)
@@ -77,7 +77,7 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
                 String modelName = modelDetails.getModelName();
                 if (modelName != null) {
                     if (modelName.startsWith("Philips hue bridge")) {
-                        return new ThingUID(THING_TYPE_BRIDGE, details.getSerialNumber());
+                        return new ThingUID(THING_TYPE_BRIDGE, details.getSerialNumber().toLowerCase());
                     }
                 }
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -51,13 +51,14 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     @Override
     public @Nullable DiscoveryResult createResult(RemoteDevice device) {
+        String serialNumber = device.getDetails().getSerialNumber();
         ThingUID uid = getThingUID(device);
-        if (uid != null) {
+        if (uid != null && serialNumber != null) {
             Map<String, Object> properties = new HashMap<>();
             properties.put(HOST, device.getDetails().getBaseURL().getHost());
             properties.put(PORT, device.getDetails().getBaseURL().getPort());
             properties.put(PROTOCOL, device.getDetails().getBaseURL().getProtocol());
-            properties.put(PROPERTY_SERIAL_NUMBER, device.getDetails().getSerialNumber().toLowerCase());
+            properties.put(PROPERTY_SERIAL_NUMBER, serialNumber.toLowerCase());
 
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
                     .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(PROPERTY_SERIAL_NUMBER)
@@ -73,11 +74,12 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
         DeviceDetails details = device.getDetails();
         if (details != null) {
             ModelDetails modelDetails = details.getModelDetails();
-            if (modelDetails != null) {
+            String serialNumber = details.getSerialNumber();
+            if (modelDetails != null && serialNumber != null) {
                 String modelName = modelDetails.getModelName();
                 if (modelName != null) {
                     if (modelName.startsWith("Philips hue bridge")) {
-                        return new ThingUID(THING_TYPE_BRIDGE, details.getSerialNumber().toLowerCase());
+                        return new ThingUID(THING_TYPE_BRIDGE, serialNumber.toLowerCase());
                     }
                 }
             }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -51,18 +51,24 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     @Override
     public @Nullable DiscoveryResult createResult(RemoteDevice device) {
-        String serialNumber = device.getDetails().getSerialNumber();
         ThingUID uid = getThingUID(device);
-        if (uid != null && serialNumber != null && !serialNumber.isBlank()) {
+        if (uid != null) {
             Map<String, Object> properties = new HashMap<>();
             properties.put(HOST, device.getDetails().getBaseURL().getHost());
             properties.put(PORT, device.getDetails().getBaseURL().getPort());
             properties.put(PROTOCOL, device.getDetails().getBaseURL().getProtocol());
-            properties.put(PROPERTY_SERIAL_NUMBER, serialNumber.toLowerCase());
+            String serialNumber = device.getDetails().getSerialNumber();
+            DiscoveryResult result;
+            if (serialNumber != null && !serialNumber.isBlank()) {
+                properties.put(PROPERTY_SERIAL_NUMBER, serialNumber.toLowerCase());
 
-            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(PROPERTY_SERIAL_NUMBER)
-                    .build();
+                result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                        .withLabel(device.getDetails().getFriendlyName())
+                        .withRepresentationProperty(PROPERTY_SERIAL_NUMBER).build();
+            } else {
+                result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                        .withLabel(device.getDetails().getFriendlyName()).build();
+            }
             return result;
         } else {
             return null;

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -16,7 +16,13 @@ import static org.openhab.binding.hue.internal.HueBindingConstants.*;
 import static org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -82,6 +88,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
             if (isReachableAndValidHueBridge(bridge)) {
                 String host = bridge.getInternalIpAddress();
                 String serialNumber = bridge.getId().substring(0, 6) + bridge.getId().substring(10);
+                serialNumber = serialNumber.toLowerCase();
                 ThingUID uid = new ThingUID(THING_TYPE_BRIDGE, serialNumber);
                 DiscoveryResult result = DiscoveryResultBuilder.create(uid)
                         .withProperties(buildProperties(host, serialNumber))

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -734,6 +734,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             if (config != null) {
                 Map<String, String> properties = editProperties();
                 String serialNumber = config.getBridgeId().substring(0, 6) + config.getBridgeId().substring(10);
+                serialNumber = serialNumber.toLowerCase();
                 properties.put(PROPERTY_SERIAL_NUMBER, serialNumber);
                 properties.put(PROPERTY_MODEL_ID, config.getModelId());
                 properties.put(PROPERTY_MAC_ADDRESS, config.getMACAddress());


### PR DESCRIPTION
Necessary for the auto-ignore discovery feature with the representation property.

Fix #9364

Signed-off-by: Laurent Garnier <lg.hc@free.fr>
