### PR TITLE
[hue] Try to make tests more stable

### DIFF
--- a/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
+++ b/itests/org.openhab.binding.hue.tests/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandlerOSGiTest.java
@@ -182,7 +182,8 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTestParent {
 
         assertNull(bridge.getConfiguration().get(USER_NAME));
         waitForAssert(() -> assertEquals(ThingStatus.OFFLINE, bridge.getStatus()));
-        assertEquals(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, bridge.getStatusInfo().getStatusDetail());
+        waitForAssert(() -> assertEquals(ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                bridge.getStatusInfo().getStatusDetail()));
     }
 
     @Test


### PR DESCRIPTION
See https://ci.openhab.org/job/PR-openHAB-Addons/1415/consoleText
```
TEST org.openhab.binding.hue.internal.handler.HueBridgeHandlerOSGiTest#verifyStatusIfNewUserCannotBeCreated() <<< ERROR: expected: <CONFIGURATION_ERROR> but was: <NONE>
org.opentest4j.AssertionFailedError: expected: <CONFIGURATION_ERROR> but was: <NONE>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
	at org.openhab.binding.hue.internal.handler.HueBridgeHandlerOSGiTest.verifyStatusIfNewUserCannotBeCreated(HueBridgeHandlerOSGiTest.java:185)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>