### PR TITLE
[magentatv] Fix "MR400 doesn't get online after discovery"

### DIFF
--- a/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/discovery/MagentaTVDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/discovery/MagentaTVDiscoveryParticipant.java
@@ -74,6 +74,9 @@ public class MagentaTVDiscoveryParticipant implements UpnpDiscoveryParticipant {
                         .substring(device.getIdentity().getUdn().getIdentifierString().length() - 12);
                 String mac = hex.substring(0, 2) + ":" + hex.substring(2, 4) + ":" + hex.substring(4, 6) + ":"
                         + hex.substring(6, 8) + ":" + hex.substring(8, 10) + ":" + hex.substring(10, 12);
+                if (port.equals("49153")) { // MR400 reports the rong
+                    port = MR400_DEF_REMOTE_PORT;
+                }
                 properties.put(PROPERTY_VENDOR, VENDOR + "(" + manufacturer + ")");
                 properties.put(PROPERTY_MODEL_ID, modelName);
                 properties.put(PROPERTY_HARDWARE_VERSION, device.getDetails().getModelDetails().getModelNumber());


### PR DESCRIPTION
The MR400 reports a port 49153 on discovery, which is wrong. Therefore the connect fails and the Thing stays OFFLINE.
This fix makes sure that 49152 is written to the thing config.