### PR TITLE
[amazonechocontrol] Fixed duplicate serialNumbers

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/Connection.java
@@ -26,20 +26,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -1052,15 +1039,13 @@ public class Connection {
     }
 
     public List<Device> getDeviceList() throws IOException, URISyntaxException, InterruptedException {
-        String json = getDeviceListJson();
-        JsonDevices devices = parseJson(json, JsonDevices.class);
-        if (devices != null) {
-            Device[] result = devices.devices;
-            if (result != null) {
-                return new ArrayList<>(Arrays.asList(result));
-            }
-        }
-        return Collections.emptyList();
+        JsonDevices devices = Objects.requireNonNull(parseJson(getDeviceListJson(), JsonDevices.class));
+        logger.trace("Devices {}", devices.devices);
+
+        // @Nullable because of a limitation of the null-checker, we filter null-serialNumbers before
+        Set<@Nullable String> serialNumbers = ConcurrentHashMap.newKeySet();
+        return devices.devices.stream().filter(d -> d.serialNumber != null && serialNumbers.add(d.serialNumber))
+                .collect(Collectors.toList());
     }
 
     public String getDeviceListJson() throws IOException, URISyntaxException, InterruptedException {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/handler/AccountHandler.java
@@ -93,7 +93,7 @@ import com.google.gson.JsonSyntaxException;
 @NonNullByDefault
 public class AccountHandler extends BaseBridgeHandler implements IWebSocketCommandHandler, IAmazonThingHandler {
     private final Logger logger = LoggerFactory.getLogger(AccountHandler.class);
-    private Storage<String> stateStorage;
+    private final Storage<String> stateStorage;
     private @Nullable Connection connection;
     private @Nullable WebSocketConnection webSocketConnection;
 
@@ -651,7 +651,7 @@ public class AccountHandler extends BaseBridgeHandler implements IWebSocketComma
         if (devices != null) {
             return devices;
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     public void setEnabledFlashBriefingsJson(String flashBriefingJson) {

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDevices.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/jsons/JsonDevices.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.amazonechocontrol.internal.jsons;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -33,7 +36,16 @@ public class JsonDevices {
         public @Nullable String softwareVersion;
         public boolean online;
         public @Nullable String @Nullable [] capabilities;
+
+        @Override
+        public String toString() {
+            return "Device{" + "accountName='" + accountName + '\'' + ", serialNumber='" + serialNumber + '\''
+                    + ", deviceOwnerCustomerId='" + deviceOwnerCustomerId + '\'' + ", deviceAccountId='"
+                    + deviceAccountId + '\'' + ", deviceFamily='" + deviceFamily + '\'' + ", deviceType='" + deviceType
+                    + '\'' + ", softwareVersion='" + softwareVersion + '\'' + ", online=" + online + ", capabilities="
+                    + Arrays.toString(capabilities) + '}';
+        }
     }
 
-    public @Nullable Device @Nullable [] devices;
+    public List<Device> devices = List.of();
 }


### PR DESCRIPTION
Fixes #9416 

There should be no duplicate serial numbers, but it seems that in some circumstances Amazon's servers return them. Since we use the serial numbers for device-identification, we need to filter duplicates.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
