### PR TITLE
[netatmo] Only log stack traces to openhab.log if debug is enabled

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoBridgeHandler.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/NetatmoBridgeHandler.java
@@ -173,7 +173,11 @@ public class NetatmoBridgeHandler extends BaseBridgeHandler {
                                 "Unable to connect Netatmo API : " + e.getLocalizedMessage());
                 }
             } catch (RuntimeException e) {
-                logger.warn("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                if (logger.isDebugEnabled()) {
+                    logger.warn("Unable to connect Netatmo API : {}", e.getMessage(), e);
+                } else {
+                    logger.warn("Unable to connect Netatmo API : {}", e.getMessage());
+                }
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                         "Netatmo Access Failed, will retry in " + configuration.reconnectInterval + " seconds.");
             }

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -199,7 +199,11 @@ public class CloudClient {
         }).on(Socket.EVENT_ERROR, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                logger.error("Error connecting to the openHAB Cloud instance: {}", args[0]);
+                if (logger.isDebugEnabled()) {
+                    logger.error("Error connecting to the openHAB Cloud instance: {}", args[0]);
+                } else {
+                    logger.error("Error connecting to the openHAB Cloud instance");
+                }
             }
         }).on("request", new Emitter.Listener() {
             @Override


### PR DESCRIPTION
This fixes https://github.com/openhab/openhab-addons/issues/9405 and https://github.com/openhab/openhab-addons/issues/9406