### PR TITLE
[homematic] For non HmIP dimmers stateDescription values must be corrected too

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -280,7 +280,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 BigDecimal max = MetadataUtils.createBigDecimal(dp.getMaxValue());
                 BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
                 if (ITEM_TYPE_DIMMER.equals(itemType) && dp.getMaxValue().doubleValue() > 0.9d 
-                        && dp.getMaxValue().doubleValue() <= 1.01d)) {
+                        && dp.getMaxValue().doubleValue() <= 1.01d) {
                     // For dimmers with a max value of 1.01 or 1.0 the values must be corrected
                     min = MetadataUtils.createBigDecimal(0);
                     max = MetadataUtils.createBigDecimal(100);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -279,8 +279,9 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 BigDecimal min = MetadataUtils.createBigDecimal(dp.getMinValue());
                 BigDecimal max = MetadataUtils.createBigDecimal(dp.getMaxValue());
                 BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
-                if (ITEM_TYPE_DIMMER.equals(itemType) && dp.getMaxValue().doubleValue() == 1.01d) {
-                    // For dimmers with a max value of 1.01 the values must be corrected
+                if (ITEM_TYPE_DIMMER.equals(itemType)
+                        && (dp.getMaxValue().doubleValue() == 1.01d || dp.getMaxValue().doubleValue() == 1.0d)) {
+                    // For dimmers with a max value of 1.01 or 1.0 the values must be corrected
                     min = MetadataUtils.createBigDecimal(0);
                     max = MetadataUtils.createBigDecimal(100);
                     step = MetadataUtils.createBigDecimal(1);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -279,8 +279,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 BigDecimal min = MetadataUtils.createBigDecimal(dp.getMinValue());
                 BigDecimal max = MetadataUtils.createBigDecimal(dp.getMaxValue());
                 BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
-                if (ITEM_TYPE_DIMMER.equals(itemType) && dp.getMaxValue().doubleValue() > 0.9d 
-                        && dp.getMaxValue().doubleValue() <= 1.01d) {
+                if (ITEM_TYPE_DIMMER.equals(itemType)
+                        && (max.compareTo(new BigDecimal("1.0")) == 0 || max.compareTo(new BigDecimal("1.01")) == 0)) {
                     // For dimmers with a max value of 1.01 or 1.0 the values must be corrected
                     min = MetadataUtils.createBigDecimal(0);
                     max = MetadataUtils.createBigDecimal(100);

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -279,8 +279,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 BigDecimal min = MetadataUtils.createBigDecimal(dp.getMinValue());
                 BigDecimal max = MetadataUtils.createBigDecimal(dp.getMaxValue());
                 BigDecimal step = MetadataUtils.createBigDecimal(dp.getStep());
-                if (ITEM_TYPE_DIMMER.equals(itemType)
-                        && (dp.getMaxValue().doubleValue() == 1.01d || dp.getMaxValue().doubleValue() == 1.0d)) {
+                if (ITEM_TYPE_DIMMER.equals(itemType) && dp.getMaxValue().doubleValue() > 0.9d 
+                        && dp.getMaxValue().doubleValue() <= 1.01d)) {
                     // For dimmers with a max value of 1.01 or 1.0 the values must be corrected
                     min = MetadataUtils.createBigDecimal(0);
                     max = MetadataUtils.createBigDecimal(100);


### PR DESCRIPTION
This patch corrects issue #8799 also for older, non HmIP dimmers.

Signed-off-by: Martin Herbst <develop@mherbst.de>

