### PR TITLE
[deconz] Provide battery level as QuantityType with unit [%]

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -146,7 +146,7 @@ The sensor devices support some of the following channels:
 | vibration       | Switch                   |      R      | Status of vibration: `ON` = vibration was detected; `OFF` = no vibration                  | alarmsensor                                  |
 | light           | String                   |      R      | Light level: `Daylight`; `Sunset`; `Dark`                                                 | daylightsensor                               |
 | value           | Number                   |      R      | Sun position: `130` = dawn; `140` = sunrise; `190` = sunset; `210` = dusk                 | daylightsensor                               |
-| battery_level   | Number                   |      R      | Battery level (in %)                                                                      | any battery-powered sensor                   |
+| battery_level   | Number:Dimensionless     |      R      | Battery level (in %)                                                                      | any battery-powered sensor                   |
 | battery_low     | Switch                   |      R      | Battery level low: `ON`; `OFF`                                                            | any battery-powered sensor                   |
 | carbonmonoxide  | Switch                   |      R      | `ON` = carbon monoxide detected                                                           | carbonmonoxide                               |
 | color           | Color                    |      R      | Color set by remote                                                                       | colorcontrol                                 |

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorBaseThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorBaseThingHandler.java
@@ -32,6 +32,7 @@ import org.openhab.binding.deconz.internal.types.ResourceType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -181,9 +182,6 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler {
             ChannelUID channelUID = new ChannelUID(thing.getUID(), channelId);
             ChannelTypeUID channelTypeUID;
             switch (channelId) {
-                case CHANNEL_BATTERY_LEVEL:
-                    channelTypeUID = new ChannelTypeUID("system:battery-level");
-                    break;
                 case CHANNEL_BATTERY_LOW:
                     channelTypeUID = new ChannelTypeUID("system:low-battery");
                     break;
@@ -207,7 +205,7 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler {
         switch (channelUID.getId()) {
             case CHANNEL_BATTERY_LEVEL:
                 if (batteryLevel != null) {
-                    updateState(channelUID, new DecimalType(batteryLevel.longValue()));
+                    updateQuantityTypeChannel(CHANNEL_BATTERY_LEVEL, batteryLevel.longValue(), Units.PERCENT);
                 }
                 break;
             case CHANNEL_BATTERY_LOW:

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorThingHandler.java
@@ -28,6 +28,7 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -96,7 +97,7 @@ public class SensorThingHandler extends SensorBaseThingHandler {
         super.valueUpdated(channelID, newState, initializing);
         switch (channelID) {
             case CHANNEL_BATTERY_LEVEL:
-                updateDecimalTypeChannel(channelID, newState.battery);
+                updateQuantityTypeChannel(channelID, newState.battery, Units.PERCENT);
                 break;
             case CHANNEL_LIGHT:
                 Boolean dark = newState.dark;

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
@@ -469,7 +469,7 @@
 		<label>Battery Sensor</label>
 		<description>A battery sensor</description>
 		<channels>
-			<channel typeId="battery" id="battery_level"/>
+			<channel typeId="battery_level" id="battery_level"/>
 			<channel typeId="last_updated" id="last_updated"/>
 		</channels>
 
@@ -478,11 +478,11 @@
 		<config-description-ref uri="thing-type:deconz:sensor"/>
 	</thing-type>
 
-	<channel-type id="battery">
-		<item-type>Number</item-type>
+	<channel-type id="battery_level">
+		<item-type>Number:Dimensionless</item-type>
 		<label>Battery</label>
 		<description>The battery state.</description>
-		<state pattern="%d %%" readOnly="true"/>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 	<thing-type id="carbonmonoxidesensor">


### PR DESCRIPTION
Provide battery level as QuantityType Dimensionless with unit [%].

Signed-off-by: Lukas Agethen <lukas83@gmx.de>
