### PR TITLE
[teleinfo] Use new apparent power unit

### DIFF
--- a/bundles/org.openhab.binding.teleinfo/pom.xml
+++ b/bundles/org.openhab.binding.teleinfo/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/cbemm/evoicc/TeleinfoAbstractCbemmEvoIccElectricityMeterHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/cbemm/evoicc/TeleinfoAbstractCbemmEvoIccElectricityMeterHandler.java
@@ -38,6 +38,6 @@ public abstract class TeleinfoAbstractCbemmEvoIccElectricityMeterHandler
 
     protected void updateStatesForCommonCbemmEvolutionIccChannels(FrameCbemmEvolutionIcc frame) {
         updateStatesForCommonCbemmChannels(frame);
-        updateState(CHANNEL_CBEMM_EVOLUTION_ICC_PAPP, QuantityType.valueOf(frame.getPapp(), Units.WATT));
+        updateState(CHANNEL_CBEMM_EVOLUTION_ICC_PAPP, QuantityType.valueOf(frame.getPapp(), Units.VOLT_AMPERE));
     }
 }

--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/cbetm/TeleinfoAbstractCbetmElectricityMeterHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/cbetm/TeleinfoAbstractCbetmElectricityMeterHandler.java
@@ -68,7 +68,7 @@ public abstract class TeleinfoAbstractCbetmElectricityMeterHandler extends Telei
             }
 
             updateState(CHANNEL_CBETM_LONG_PMAX, QuantityType.valueOf(frameCbetmLong.getPmax(), Units.WATT));
-            updateState(CHANNEL_CBETM_LONG_PAPP, QuantityType.valueOf(frameCbetmLong.getPapp(), Units.WATT));
+            updateState(CHANNEL_CBETM_LONG_PAPP, QuantityType.valueOf(frameCbetmLong.getPapp(), Units.VOLT_AMPERE));
             updateState(CHANNEL_CBETM_LONG_PPOT, new StringType(frameCbetmLong.getPpot()));
 
             updateState(CHANNEL_CBETM_SHORT_ADIR1, UnDefType.NULL);


### PR DESCRIPTION
Since OH3 provides a new apparent power unit, this PR replace `WATT` by `VOLT_AMPERE` when needed.
