### PR TITLE
[groovyscripting] Fix build warnings

### DIFF
--- a/bundles/org.openhab.automation.groovyscripting/pom.xml
+++ b/bundles/org.openhab.automation.groovyscripting/pom.xml
@@ -13,13 +13,7 @@
   <name>openHAB Add-ons :: Automation :: Groovy Scripting</name>
 
   <properties>
-    <bnd.importpackage>
-      com.ibm.icu.*;resolution:=optional,
-      groovy.runtime.metaclass;resolution:=optional,
-      groovyjarjarantlr4.stringtemplate;resolution:=optional,
-      org.abego.treelayout.*;resolution:=optional,
-      org.apache.ivy.*;resolution:=optional,
-      org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
+    <bnd.importpackage>com.ibm.icu.*;resolution:=optional,groovy.runtime.metaclass;resolution:=optional,groovyjarjarantlr4.stringtemplate;resolution:=optional,org.abego.treelayout.*;resolution:=optional,org.apache.ivy.*;resolution:=optional,org.stringtemplate.v4.*;resolution:=optional</bnd.importpackage>
     <groovy.version>3.0.6</groovy.version>
   </properties>
 


### PR DESCRIPTION
Fixes these warnings:

```
[WARNING] /openhab-addons/bundles/org.openhab.automation.groovyscripting/pom.xml [10:52]: Invalid property key: `groovy.runtime.metaclass;resolution`: <<      groovy.runtime.metaclass;resolution:=optional,>>
[WARNING] /openhab-addons/bundles/org.openhab.automation.groovyscripting/pom.xml [11:61]: Invalid property key: `groovyjarjarantlr4.stringtemplate;resolution`: <<      groovyjarjarantlr4.stringtemplate;resolution:=optional,>>
[WARNING] /openhab-addons/bundles/org.openhab.automation.groovyscripting/pom.xml [12:50]: Invalid property key: `org.abego.treelayout.*;resolution`: <<      org.abego.treelayout.*;resolution:=optional,>>
[WARNING] /openhab-addons/bundles/org.openhab.automation.groovyscripting/pom.xml [13:44]: Invalid property key: `org.apache.ivy.*;resolution`: <<      org.apache.ivy.*;resolution:=optional,>>
[WARNING] /openhab-addons/bundles/org.openhab.automation.groovyscripting/pom.xml [14:53]: Invalid property key: `org.stringtemplate.v4.*;resolution`: <<      org.stringtemplate.v4.*;resolution:=optional,\\>>
```