### PR TITLE
[hueemulation] Correct format of UDN and serialNumber fields in description.xml

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -15,6 +15,7 @@ package org.openhab.io.hueemulation.internal;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.IllegalFormatException;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -351,7 +352,14 @@ public class ConfigStore {
      * @return The unique id
      */
     public String getHueUniqueId(final String hueId) {
-        return hueIDPrefix + "-" + String.format("%02X", Integer.valueOf(hueId));
+        String unique = hueId;
+        try {
+            unique = String.format("%02X", Integer.valueOf(hueId));
+        } catch (final NumberFormatException | IllegalFormatException e) {
+            // Use the hueId as is
+        }
+
+        return hueIDPrefix + "-" + unique;
     }
 
     public boolean isReady() {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -341,16 +341,17 @@ public class ConfigStore {
             metadataRegistry.add(new Metadata(key, String.valueOf(hueId), null));
         }
 
-        return String.format("%02X", hueId);
+        return String.valueOf(hueId);
     }
 
     /**
-     * Get the prefix used to create a unique id
+     * Get the unique id
      *
-     * @return The prefix
+     * @param hueId The item hueID
+     * @return The unique id
      */
-    public String getHueIDPrefix() {
-        return hueIDPrefix;
+    public String getHueUniqueId(final String hueId) {
+        return hueIDPrefix + "-" + String.format("%02X", Integer.valueOf(hueId));
     }
 
     public boolean isReady() {

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/ConfigStore.java
@@ -262,12 +262,27 @@ public class ConfigStore {
         }
     }
 
+    /**
+     * Get the prefix used to create a unique id
+     *
+     * @param uuid The uuid
+     * @return The prefix in the format of AA:BB:CC:DD:EE:FF:00:11 if uuid is a valid UUID, otherwise uuid is returned.
+     */
     private String getHueIDPrefixFromUUID(final String uuid) {
-        // Hue API example is AA:BB:CC:DD:EE:FF:00:11-XX
+        // Hue API example of a unique id is AA:BB:CC:DD:EE:FF:00:11-XX
         // XX is generated from the item.
-        String prefix = uuid.replace("-", "").toUpperCase().replaceAll("..", "$0:");
-        if (prefix.length() > 23) {
-            prefix = prefix.substring(0, 23);
+        String prefix = uuid;
+        try {
+            // Generate prefix if uuid is a randomly generated UUID
+            if (UUID.fromString(uuid).version() == 4) {
+                final StringBuilder sb = new StringBuilder(23);
+                sb.append(uuid, 0, 2).append(":").append(uuid, 2, 4).append(":").append(uuid, 4, 6).append(":")
+                        .append(uuid, 6, 8).append(":").append(uuid, 9, 11).append(":").append(uuid, 11, 13).append(":")
+                        .append(uuid, 14, 16).append(":").append(uuid, 16, 18);
+                prefix = sb.toString().toUpperCase();
+            }
+        } catch (final IllegalArgumentException e) {
+            // uuid is not a valid UUID
         }
 
         return prefix;
@@ -332,7 +347,7 @@ public class ConfigStore {
     /**
      * Get the prefix used to create a unique id
      *
-     * @return The prefix in the form of AA:BB:CC:DD:EE:FF:00:11
+     * @return The prefix
      */
     public String getHueIDPrefix() {
         return hueIDPrefix;

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
@@ -180,7 +180,7 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
 
             cs.ds.groups.put(hueID, group);
         } else {
-            HueLightEntry device = new HueLightEntry(element, cs.getHueIDPrefix() + "-" + hueID.toString(), deviceType);
+            HueLightEntry device = new HueLightEntry(element, cs.getHueUniqueId(hueID), deviceType);
             device.item = element;
             cs.ds.lights.put(hueID, device);
             updateGroup0();

--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroups.java
@@ -180,7 +180,7 @@ public class LightsAndGroups implements RegistryChangeListener<Item> {
 
             cs.ds.groups.put(hueID, group);
         } else {
-            HueLightEntry device = new HueLightEntry(element, cs.ds.config.uuid + "-" + hueID.toString(), deviceType);
+            HueLightEntry device = new HueLightEntry(element, cs.getHueIDPrefix() + "-" + hueID.toString(), deviceType);
             device.item = element;
             cs.ds.lights.put(hueID, device);
             updateGroup0();

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/ItemUIDtoHueIDMappingTests.java
@@ -88,7 +88,7 @@ public class ItemUIDtoHueIDMappingTests {
         itemRegistry.add(item);
 
         String hueID = cs.mapItemUIDtoHueID(item);
-        assertThat(hueID, CoreMatchers.is("02"));
+        assertThat(hueID, CoreMatchers.is("2"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
         assertThat(device.item, is(item));
@@ -108,7 +108,7 @@ public class ItemUIDtoHueIDMappingTests {
         itemRegistry.add(item);
 
         String hueID = cs.mapItemUIDtoHueID(item);
-        assertThat(hueID, CoreMatchers.is("0A"));
+        assertThat(hueID, CoreMatchers.is("10"));
 
         HueLightEntry device = cs.ds.lights.get(hueID);
         assertThat(device.item, is(item));


### PR DESCRIPTION
Fixes #9452

A previous change to fix Alexa device discovery inadvertently changed the format of the UDN and serialNumber fields in the description.xml response.

The UDN should be a UUID string. 

The serialNumber is used by the OH Hue binding directly as the ThingUID and will throw an exception if it contains invalid characters such as `:`. Some users are using both Hue Emulation and the Hue Binding, so the serialNumber has been reverted back to its previous format.

Also the previous change resulted in the id used for lights and groups changing to hexadecimal. Although this doesn't seem to cause any issues with Alexa or Logitech Harmony, it may break other implementations. The id has been reverted back which will mean users will have to refresh their hue devices to pick up the new ids and possibly remove duplicates from the Alexa app.

This change should now only change (compared to 2.5.x) the `uniqueid` which is what was causing problems with Alexa device discovery.

Signed-off-by: Mike Major <mike_j_major@hotmail.com>

