### PR TITLE
[opensprinkler] Cleanup NOTICE. pi4j library not used anymore

### DIFF
--- a/bundles/org.openhab.binding.opensprinkler/NOTICE
+++ b/bundles/org.openhab.binding.opensprinkler/NOTICE
@@ -11,10 +11,3 @@ https://www.eclipse.org/legal/epl-2.0/.
 == Source Code
 
 https://github.com/openhab/openhab-addons
-
-== Third-party Content
-
-pi4j
-* License: LGPL v3.0 License
-* Project: http://pi4j.com
-* Source:  https://github.com/Pi4J/pi4j


### PR DESCRIPTION
Support was removed in https://github.com/openhab/openhab2-addons/commit/8aeeb49c693db7f64b5672c80a1dff484b49effe#diff-b6edf78e29afc34859018f4e11ec53bded97a615b62040712227b883ba5c13f8