### PR TITLE
[icalendar] optimization of eventfilter-search and more debug output

### DIFF
--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
@@ -314,6 +314,7 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
                 ICalendarHandler.this.updateStates();
                 ICalendarHandler.this.rescheduleCalendarStateUpdate();
             }, currentEvent.end.getEpochSecond() - now.getEpochSecond(), TimeUnit.SECONDS);
+            logger.debug("Scheduled update in {} seconds", currentEvent.end.getEpochSecond() - now.getEpochSecond());
         } else {
             final Event nextEvent = currentCalendar.getNextEvent(now);
             final ICalendarConfiguration currentConfig = this.configuration;
@@ -326,11 +327,14 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
                 updateJobFuture = scheduler.schedule(() -> {
                     ICalendarHandler.this.rescheduleCalendarStateUpdate();
                 }, 1L, TimeUnit.DAYS);
+                logger.debug("Scheduled reschedule in 1 day");
             } else {
                 updateJobFuture = scheduler.schedule(() -> {
                     ICalendarHandler.this.updateStates();
                     ICalendarHandler.this.rescheduleCalendarStateUpdate();
                 }, nextEvent.start.getEpochSecond() - now.getEpochSecond(), TimeUnit.SECONDS);
+                logger.debug("Scheduled update in {} seconds", nextEvent.start.getEpochSecond() - now.getEpochSecond());
+
             }
         }
     }

--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/handler/ICalendarHandler.java
@@ -266,6 +266,7 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
      * @return Whether the calendar was loaded successfully.
      */
     private boolean reloadCalendar() {
+        logger.trace("reloading calendar of {}", getThing().getUID());
         if (!calendarFile.isFile()) {
             logger.info("Local file for reloading calendar is missing.");
             return false;
@@ -343,6 +344,7 @@ public class ICalendarHandler extends BaseBridgeHandler implements CalendarUpdat
      * Updates the states of the Thing and its channels.
      */
     private void updateStates() {
+        logger.trace("updating states of {}", getThing().getUID());
         final AbstractPresentableCalendar calendar = runtimeCalendar;
         if (calendar == null) {
             updateStatus(ThingStatus.OFFLINE);

--- a/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
+++ b/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
@@ -151,6 +151,7 @@ public class BiweeklyPresentableCalendarTest {
      * This test checks for Events that have just begun or ended, and if so it checks for Command Tags
      * and checks if these tags are valid
      */
+    @SuppressWarnings("null")
     @Test
     public void testCommandTagCode() {
         List<Event> events = null;


### PR DESCRIPTION
I've limited search of filtered events as it does not make a difference in the result set whether only the requested count or all events in a time frame get retrieved. If the filter is not limited with a start or end date and the events recur with very short intervals (e.g. a day) it's possible the searching for events takes longer than necessary.

Added also a bit more output for debugging/tracing if scheduling seems not to work.

Fixes #9498.