### PR TITLE
[tr064] Adds new channels for DSL Max & Current Down-/Upstream Rate

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -78,12 +78,16 @@ This is an optional parameter and multiple values are allowed.
 | `callList`                 | `String`                  |     x    | A string containing the call list as JSON (see below)          |    
 | `deviceLog`                | `String`                  |     x    | A string containing the last log messages                      |
 | `dslCRCErrors`             | `Number:Dimensionless`    |     x    | DSL CRC Errors                                                 |
+| `dslDownstreamMaxRate`     | `Number:DataTransferRate` |     x    | DSL Max Downstream Rate                                        |
+| `dslDownstreamCurrRate`    | `Number:DataTransferRate` |     x    | DSL Curr. Downstream Rate                                      |
 | `dslDownstreamNoiseMargin` | `Number:Dimensionless`    |     x    | DSL Downstream Noise Margin                                    |
 | `dslDownstreamAttenuation` | `Number:Dimensionless`    |     x    | DSL Downstream Attenuation                                     |
 | `dslEnable`                | `Switch`                  |          | DSL Enable                                                     |
 | `dslFECErrors`             | `Number:Dimensionless`    |     x    | DSL FEC Errors                                                 |
 | `dslHECErrors`             | `Number:Dimensionless`    |     x    | DSL HEC Errors                                                 |
 | `dslStatus`                | `Switch`                  |          | DSL Status                                                     |
+| `dslUpstreamMaxRate`       | `Number:DataTransferRate` |     x    | DSL Max Upstream Rate                                          |
+| `dslUpstreamCurrRate`      | `Number:DataTransferRate` |     x    | DSL Curr. Upstream Rate                                        |
 | `dslUpstreamNoiseMargin`   | `Number:Dimensionless`    |     x    | DSL Upstream Noise Margin                                      |
 | `dslUpstreamAttenuation`   | `Number:Dimensionless`    |     x    | DSL Upstream Attenuation                                       |
 | `inboundCalls`             | `Number`                  |     x    | Number of inbound calls within the given number of days.       |

--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/soap/SOAPValueConverter.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/soap/SOAPValueConverter.java
@@ -85,6 +85,7 @@ public class SOAPValueConverter {
             switch (dataType) {
                 case "ui2":
                     return Optional.of(String.valueOf(value.shortValue()));
+                case "i4":
                 case "ui4":
                     return Optional.of(String.valueOf(value.intValue()));
                 default:
@@ -94,6 +95,7 @@ public class SOAPValueConverter {
             switch (dataType) {
                 case "ui2":
                     return Optional.of(String.valueOf(value.shortValue()));
+                case "i4":
                 case "ui4":
                     return Optional.of(String.valueOf(value.intValue()));
                 default:
@@ -132,6 +134,7 @@ public class SOAPValueConverter {
                 case "string":
                     return new StringType(rawValue);
                 case "ui2":
+                case "i4":
                 case "ui4":
                     if (!unit.isEmpty()) {
                         return new QuantityType<>(rawValue + " " + unit);

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -194,6 +194,30 @@
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
 		<getAction name="GetInfo" argument="NewStatus"/>
 	</channel>
+	<channel name="dslDownstreamMaxRate" label="DSL Max Downstream Rate">
+		<item type="Number:DataTransferRate" unit="kbit/s" statePattern="%.1f Mbit/s"/>
+		<service deviceType="urn:dslforum-org:device:WANDevice:1"
+			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
+		<getAction name="GetInfo" argument="NewDownstreamMaxRate"/>
+	</channel>
+	<channel name="dslUpstreamMaxRate" label="DSL Max Upstream Rate">
+		<item type="Number:DataTransferRate" unit="kbit/s" statePattern="%.1f Mbit/s"/>
+		<service deviceType="urn:dslforum-org:device:WANDevice:1"
+			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
+		<getAction name="GetInfo" argument="NewUpstreamMaxRate"/>
+	</channel>
+	<channel name="dslDownstreamCurrRate" label="DSL Curr. Downstream Rate">
+		<item type="Number:DataTransferRate" unit="kbit/s" statePattern="%.1f Mbit/s"/>
+		<service deviceType="urn:dslforum-org:device:WANDevice:1"
+			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
+		<getAction name="GetInfo" argument="NewDownstreamCurrRate"/>
+	</channel>
+	<channel name="dslUpstreamCurrRate" label="DSL Curr. Upstream Rate">
+		<item type="Number:DataTransferRate" unit="kbit/s" statePattern="%.1f Mbit/s"/>
+		<service deviceType="urn:dslforum-org:device:WANDevice:1"
+			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
+		<getAction name="GetInfo" argument="NewUpstreamCurrRate"/>
+	</channel>
 	<channel name="dslDownstreamNoiseMargin" label="DSL Downstream Noise Margin">
 		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"


### PR DESCRIPTION
This PR adds the following new channels to the wan subdevice of tr064 binding

| channel                    | item-type                 | description                                                    |
|----------------------------|---------------------------|----------------------------------------------------------------|
| `dslDownstreamMaxRate`     | `Number:DataTransferRate` | DSL Max Downstream Rate                                      |
| `dslDownstreamCurrRate`    | `Number:DataTransferRate` | DSL Curr. Downstream Rate                                      |
| `dslUpstreamMaxRate`       | `Number:DataTransferRate` | DSL Max Upstream Rate                                        |
| `dslUpstreamCurrRate`      | `Number:DataTransferRate` | DSL Curr. Upstream Rate                                        |

I needed to add support for the data type `i4`, as that data type was returned for `dslUpstreamCurrRate` from my Fritz!Box 7390

Note: I've used to use the [fritzboxtr064](https://github.com/openhab/openhab1-addons/tree/master/bundles/binding/org.openhab.binding.fritzboxtr064) binding, which is no longer usable with OH3. This binding had those channels available.

Signed-off-by: Stefan Giehl <stefangiehl@gmail.com>