### PR TITLE
[senechome] Bugfix BatteryState, should be a String

### DIFF
--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,7 +16,7 @@
 			<channel id="energyProduction" typeId="energyProduction"/>
 			<channel id="batteryPower" typeId="batteryPower"/>
 			<channel id="batteryFuelCharge" typeId="batteryFuelCharge"/>
-			<channel id="batteryState" typeId="system.battery-level"/>
+			<channel id="batteryState" typeId="batteryState"/>
 			<channel id="batteryStateValue" typeId="batteryStateValue"/>
 			<channel id="gridPower" typeId="gridPower"/>
 			<channel id="gridPowerSupply" typeId="gridPowerSupply"/>
@@ -96,6 +96,13 @@
 		<label>Battery Fuel</label>
 		<category>Battery</category>
 		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+
+	<channel-type id="batteryState">
+		<item-type>String</item-type>
+		<label>Battery State</label>
+		<category>Battery</category>
+		<state readOnly="true" pattern="%s"/>
 	</channel-type>
 
 	<channel-type id="batteryStateValue">


### PR DESCRIPTION
Hello,

in the [OpenHAB Community](https://community.openhab.org/t/senechome-binding/108152/2?u=kobip) I got feedback that the BatteryState is not working as expected in OH3. I figured out that the channel "batteryState" was of the type system.battery-level. This is wrong, batteryFuelCharge could be system.battery-level. batteryState is something like "CHARGING" or "BATTERY EMPTY". A simple String with a human readable description.

To fix the problem I changed batteryState to a item-type string.

Here my self compiled jar:
[org.openhab.binding.senechome-3.1.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab-addons/files/5742457/org.openhab.binding.senechome-3.1.0-SNAPSHOT.jar.zip)

Cheers