### PR TITLE
[KNX] Fixed DateTime Control channel label

### DIFF
--- a/bundles/org.openhab.binding.knx/src/main/resources/OH-INF/thing/device.xml
+++ b/bundles/org.openhab.binding.knx/src/main/resources/OH-INF/thing/device.xml
@@ -143,7 +143,7 @@
 	</channel-type>
 	<channel-type id="datetime-control">
 		<item-type>DateTime Control</item-type>
-		<label>DateTime</label>
+		<label>DateTime Control</label>
 		<description>Control a date/time item (i.e. the status is not owned by KNX)</description>
 		<config-description-ref uri="channel-type:knx:single"/>
 	</channel-type>


### PR DESCRIPTION
Small fix for a wrong labeled channel.

Reference: https://github.com/openhab/openhab-addons/issues/9462#issuecomment-751388840


