### PR TITLE
[hueemulation] Fix nginx example configuration

### DIFF
--- a/bundles/org.openhab.io.hueemulation/README.md
+++ b/bundles/org.openhab.io.hueemulation/README.md
@@ -158,11 +158,13 @@ You must either
   ```
   server {
     listen 80;
-    proxy_pass                              http://localhost:8080/;
-    proxy_set_header Host                   $http_host;
-    proxy_set_header X-Real-IP              $remote_addr;
-    proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto      $scheme;
+    location / {
+      proxy_pass                              http://localhost:8080/;
+      proxy_set_header Host                   $http_host;
+      proxy_set_header X-Real-IP              $remote_addr;
+      proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto      $scheme;
+    }
   }
   ```
 * or let openHAB run on port 80 (the entire java process requires elevated privileges).


### PR DESCRIPTION
## Fix nginx example configuration

Just a little fix in an example configuration. Nginx won't start with the previous example what confused me when I tried to set up a reverse proxy.

Also please consider highlighting the following part:
  ```
  server {
    listen 80;
    location /api {
      proxy_pass http://localhost:8080/api/;
    }
  }
  ```

I struggled a lot since I didn't read this and my Alexa couldn't find my emulated devices.