### PR TITLE
[kostalinverter] Fixed package structure

### DIFF
--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/KostalInverterFactory.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/KostalInverterFactory.java
@@ -10,9 +10,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter;
+package org.openhab.binding.kostalinverter.internal;
 
-import static org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationBindingConstants.*;
+import static org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,9 +20,9 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
-import org.openhab.binding.internal.kostal.inverter.firstgeneration.WebscrapeHandler;
-import org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationHandler;
-import org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationInverterTypes;
+import org.openhab.binding.kostalinverter.internal.firstgeneration.WebscrapeHandler;
+import org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationHandler;
+import org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationInverterTypes;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/ChannelConfig.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/ChannelConfig.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.firstgeneration;
+package org.openhab.binding.kostalinverter.internal.firstgeneration;
 
 import javax.measure.Unit;
 

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/SourceConfig.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/SourceConfig.java
@@ -10,16 +10,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.firstgeneration;
 
 /**
- * The {@link ThirdGenerationConfiguration} class contains fields mapping thing configuration parameters.
- *
- * @author René Stakemeier - Initial contribution
+ * @author Christian Schneider - Initial contribution
  */
-public class ThirdGenerationConfiguration {
-
+public class SourceConfig {
     public String url;
-    public String userPassword;
-    public int refreshInternalInSeconds;
+    public String userName;
+    public String password;
+    public int refreshInterval;
 }

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/WebscrapeHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/firstgeneration/WebscrapeHandler.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.firstgeneration;
+package org.openhab.binding.kostalinverter.internal.firstgeneration;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationBindingConstants.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationBindingConstants.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationChannelDatatypes.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationChannelDatatypes.java
@@ -10,14 +10,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.firstgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 /**
- * @author Christian Schneider - Initial contribution
+ * The {@link ThirdGenerationChannelDatatypes} enumeration contains the data types provided by the device
+ *
+ * @author René Stakemeier - Initial contribution
  */
-public class SourceConfig {
-    public String url;
-    public String userName;
-    public String password;
-    public int refreshInterval;
+enum ThirdGenerationChannelDatatypes {
+    INTEGER,
+    PERCEMTAGE,
+    KILOGRAM,
+    SECONDS,
+    KILOWATT_HOUR,
+    WATT,
+    AMPERE,
+    AMPERE_HOUR,
+    VOLT
 }

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationChannelMappingToWebApi.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationChannelMappingToWebApi.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 /***
  * The {@link ThirdGenerationChannelMappingToWebApi}} is used to map the channel name to the web API commands

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationConfiguration.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationConfiguration.java
@@ -10,21 +10,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 /**
- * The {@link ThirdGenerationChannelDatatypes} enumeration contains the data types provided by the device
+ * The {@link ThirdGenerationConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author René Stakemeier - Initial contribution
  */
-enum ThirdGenerationChannelDatatypes {
-    INTEGER,
-    PERCEMTAGE,
-    KILOGRAM,
-    SECONDS,
-    KILOWATT_HOUR,
-    WATT,
-    AMPERE,
-    AMPERE_HOUR,
-    VOLT
+public class ThirdGenerationConfiguration {
+
+    public String url;
+    public String userPassword;
+    public int refreshInternalInSeconds;
 }

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationEncryptionHelper.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationEncryptionHelper.java
@@ -10,9 +10,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
-import static org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationBindingConstants.*;
+import static org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationBindingConstants.*;
 
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationHandler.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationHandler.java
@@ -10,9 +10,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
-import static org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationBindingConstants.*;
+import static org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationBindingConstants.*;
 
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationHttpHelper.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationHttpHelper.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationInverterTypes.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationInverterTypes.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
 /**
  * The {@link ThirdGenerationInverterTypes} contains the list of supported devices

--- a/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationMappingInverterToChannel.java
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/java/org/openhab/binding/kostalinverter/internal/thirdgeneration/ThirdGenerationMappingInverterToChannel.java
@@ -10,9 +10,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.internal.kostal.inverter.thirdgeneration;
+package org.openhab.binding.kostalinverter.internal.thirdgeneration;
 
-import static org.openhab.binding.internal.kostal.inverter.thirdgeneration.ThirdGenerationBindingConstants.*;
+import static org.openhab.binding.kostalinverter.internal.thirdgeneration.ThirdGenerationBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
The internal package was placed before the binding specific package, and it should be the other way around.