### PR TITLE
[danfossairunit] removed "advanced" attribute in channel-group-type (…

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/README.md
+++ b/bundles/org.openhab.binding.danfossairunit/README.md
@@ -47,7 +47,7 @@ These are the available configuration parameters:
 
 ### Things
 
-Suppose your autodiscovered air unit is identified by the id "danfossairunit:airunit:-1062731769" (see section "Discovery").
+Suppose your autodiscovered air unit is identified by the id "danfossairunit:airunit:myairunit" (see section "Discovery").
 The channel will then be identified by `<air unit id>:<channel group>#<channel>`
 
 You can also manually configure your air unit in case you don't want to use autodiscovery
@@ -62,12 +62,12 @@ updateUnchangedValuesEveryMillis=30000]
 ### Items
 
 ```
-Dimmer Lueftung_Drehzahl_Manuell "Drehzahl Lüftung %" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:main#manual_fan_speed"}
-Number Lueftung_Drehzahl_Supply "Drehzahl Lüftung Zuluft (rpm)" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:main#supply_fan_speed"}
-Number Lueftung_Drehzahl_Extract "Drehzahl Lüftung Abluft (rpm)" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:main#extract_fan_speed"}
-String Lueftung_Mode "Betriebsart Lüftung" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:main#mode"}
-Switch Lueftung_Boost "Stoßlüftung" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:main#boost"}
-Switch Lueftung_Bypass "Lüftung Bypass" (All,Lueftung) {channel = "danfossairunit:airunit:-1062731769:recuperator#bypass"}
+Dimmer Lueftung_Drehzahl_Manuell "Drehzahl Lüftung %" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:main#manual_fan_speed"}
+Number Lueftung_Drehzahl_Supply "Drehzahl Lüftung Zuluft (rpm)" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:main#supply_fan_speed"}
+Number Lueftung_Drehzahl_Extract "Drehzahl Lüftung Abluft (rpm)" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:main#extract_fan_speed"}
+String Lueftung_Mode "Betriebsart Lüftung" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:main#mode"}
+Switch Lueftung_Boost "Stoßlüftung" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:main#boost"}
+Switch Lueftung_Bypass "Lüftung Bypass" (All,Lueftung) {channel = "danfossairunit:airunit:myairunit:recuperator#bypass"}
 ```
 
 ### Sitemap

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -40,7 +40,6 @@
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
-
 	</thing-type>
 
 	<!--Cannel Group Definitions -->
@@ -88,7 +87,7 @@
 			<channel id="humidity" typeId="humidity"/>
 		</channels>
 	</channel-group-type>
-	<channel-group-type id="recuperator" advanced="true">
+	<channel-group-type id="recuperator">
 		<label>Recuperator</label>
 		<description>Heat exchaning device in the Air Unit</description>
 		<channels>
@@ -111,7 +110,7 @@
 			</channel>
 		</channels>
 	</channel-group-type>
-	<channel-group-type id="service" advanced="true">
+	<channel-group-type id="service">
 		<label>Service</label>
 		<channels>
 			<channel id="battery_life" typeId="percentage">


### PR DESCRIPTION
…things-types.xml) to address issue #9568 (corresponding core issue https://github.com/openhab/openhab-core/pull/1410)

PR https://github.com/openhab/openhab-core/pull/1410 removed the advanced attribute from channel-group-type member, which led the danfossairunit binding to fail during startup after migration to OH3. This change removes the advanced attribute from things-types.xml and includes some minor fixes to the configuration samples in the README (the proposed (generated) thing id is invalid after OH3 upgrade).