### PR TITLE
[yioremote] BugFix sendIRCode action

### DIFF
--- a/bundles/org.openhab.binding.yioremote/src/main/java/org/openhab/binding/yioremote/internal/YIOremoteDockHandler.java
+++ b/bundles/org.openhab.binding.yioremote/src/main/java/org/openhab/binding/yioremote/internal/YIOremoteDockHandler.java
@@ -283,12 +283,20 @@ public class YIOremoteDockHandler extends BaseThingHandler {
     }
 
     public void sendIRCode(@Nullable String irCode) {
-        if (irCode != null && yioRemoteDockActualStatus.equals(YioRemoteDockHandleStatus.AUTHENTICATION_COMPLETE)) {
-            if (irCode.matches("[0-9]?[0-9][;]0[xX][0-9a-fA-F]+[;][0-9]+[;][0-9]")) {
-                sendMessage(YioRemoteMessages.IR_SEND, irCode);
+        if (irCode != null) {
+            if (yioRemoteDockActualStatus.equals(YioRemoteDockHandleStatus.AUTHENTICATION_COMPLETE)
+                    || yioRemoteDockActualStatus.equals(YioRemoteDockHandleStatus.SEND_PING)
+                    || yioRemoteDockActualStatus.equals(YioRemoteDockHandleStatus.CHECK_PONG)) {
+                if (irCode.matches("[0-9]?[0-9][;]0[xX][0-9a-fA-F]+[;][0-9]+[;][0-9]")) {
+                    sendMessage(YioRemoteMessages.IR_SEND, irCode);
+                } else {
+                    logger.warn("Wrong ir code format {}", irCode);
+                }
             } else {
-                logger.warn("Wrong ir code format {}", irCode);
+                logger.debug("Wrong Dock Statusfor sending  {}", irCode);
             }
+        } else {
+            logger.warn("No ir code {}", irCode);
         }
     }
 
@@ -456,7 +464,7 @@ public class YIOremoteDockHandler extends BaseThingHandler {
             case IR_SEND:
                 irCodeSendHandler.setCode(messagePayload);
                 yioremoteDockwebSocketClient.sendMessage(irCodeSendMessageHandler.getIRcodeSendMessageString());
-                logger.debug("sending heartBeat message: {}", irCodeSendMessageHandler.getIRcodeSendMessageString());
+                logger.debug("sending IR code: {}", irCodeSendMessageHandler.getIRcodeSendMessageString());
                 break;
         }
     }

--- a/bundles/org.openhab.binding.yioremote/src/main/java/org/openhab/binding/yioremote/internal/YIOremoteDockHandler.java
+++ b/bundles/org.openhab.binding.yioremote/src/main/java/org/openhab/binding/yioremote/internal/YIOremoteDockHandler.java
@@ -199,7 +199,6 @@ public class YIOremoteDockHandler extends BaseThingHandler {
                     success = false;
                 }
             } else if (message.get("command").toString().equalsIgnoreCase("\"ir_receive\"")) {
-                // sendMessage(YioRemoteMessages.IR_RECEIVER_OFF, "");
                 receivedStatus = message.get("code").toString().replace("\"", "");
                 if (receivedStatus.matches("[0-9]?[0-9][;]0[xX][0-9a-fA-F]+[;][0-9]+[;][0-9]")) {
                     irCodeReceivedHandler.setCode(message.get("code").toString().replace("\"", ""));


### PR DESCRIPTION
<!-- Provide a general summary of the issue in the *Title* above -->
<!-- If the issue is related to a binding, please include its short name in -->
<!-- square brackets in the title - Example: "[astro] My issue..." -->

<!-- Important: Please contact the openHAB community forum for questions or -->
<!-- for configuration and usage guidance: https://community.openhab.org -->

<!-- Feel free to delete any comment lines in the template (starting with "<!--") -->

## Expected Behavior
if the action sendIRCode is used in a rule it should send out an IR code

## Current Behavior
action sendIRCode is not sending out any IR code

## Possible Solution
Correct implementation of sendIR action routine
In addition:
Updating IR receiver switch handler so it's running now

Solved issue during triggering channel while it was disposed