### PR TITLE
[nikobus] open connection on refresh even if no modules exist

### DIFF
--- a/bundles/org.openhab.binding.daikin/deploy.sh
+++ b/bundles/org.openhab.binding.daikin/deploy.sh
@@ -1,0 +1,2 @@
+cp ./target/org.openhab.binding.daikin-3.1.0-SNAPSHOT.jar /Volumes/openhab/share/addons/
+

--- a/bundles/org.openhab.binding.daikin/deploy.sh
+++ b/bundles/org.openhab.binding.daikin/deploy.sh
@@ -1,2 +1,0 @@
-cp ./target/org.openhab.binding.daikin-3.1.0-SNAPSHOT.jar /Volumes/openhab/share/addons/
-

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
@@ -329,7 +329,7 @@ public class NikobusPcLinkHandler extends BaseBridgeHandler {
         List<Thing> things = getThing().getThings().stream()
                 .filter(thing -> thing.getHandler() instanceof NikobusModuleHandler).collect(Collectors.toList());
 
-        // if there are command listeners then we need an open connection even if no modules exist
+        // if there are command listeners (buttons) then we need an open connection even if no modules exist
         if (!commandListeners.isEmpty()) {
             NikobusConnection connection = this.connection;
             if (connection == null) {
@@ -340,6 +340,7 @@ public class NikobusPcLinkHandler extends BaseBridgeHandler {
             } catch (IOException e) {
                 connection.close();
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                return;
             }
         }
 

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
@@ -50,8 +50,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link NikobusPcLinkHandler} is responsible for handling commands, which are
- * sent or received from the PC-Link Nikobus component.
+ * The {@link NikobusPcLinkHandler} is responsible for handling commands, which
+ * are sent or received from the PC-Link Nikobus component.
  *
  * @author Boris Krivonog - Initial contribution
  */
@@ -329,6 +329,22 @@ public class NikobusPcLinkHandler extends BaseBridgeHandler {
         List<Thing> things = getThing().getThings().stream()
                 .filter(thing -> thing.getHandler() instanceof NikobusModuleHandler).collect(Collectors.toList());
 
+
+        // if there are command listeners then we need an open connection even if no modules exist
+        if (!commandListeners.isEmpty()) {
+            NikobusConnection connection = this.connection;
+            if (connection == null) {
+                return;
+            }        	
+            try {
+                connectIfNeeded(connection);
+            } catch (IOException e) {
+                logger.debug("refresh failed due {}", e.getMessage(), e);
+                connection.close();
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+            }
+        }
+
         if (things.isEmpty()) {
             logger.debug("Nothing to refresh");
             return;
@@ -349,8 +365,8 @@ public class NikobusPcLinkHandler extends BaseBridgeHandler {
         if (!connection.isConnected()) {
             connection.connect();
 
-            // Send connection sequence, mimicking the Nikobus software. If this is not send, PC-Link
-            // sometimes does not forward button presses via serial interface.
+            // Send connection sequence, mimicking the Nikobus software. If this is not
+            // sent, PC-Link sometimes does not forward button presses via serial interface.
             Stream.of(new String[] { "++++", "ATH0", "ATZ", "$10110000B8CF9D", "#L0", "#E0", "#L0", "#E1" })
                     .map(NikobusCommand::new).forEach(this::sendCommand);
 

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPcLinkHandler.java
@@ -329,17 +329,15 @@ public class NikobusPcLinkHandler extends BaseBridgeHandler {
         List<Thing> things = getThing().getThings().stream()
                 .filter(thing -> thing.getHandler() instanceof NikobusModuleHandler).collect(Collectors.toList());
 
-
         // if there are command listeners then we need an open connection even if no modules exist
         if (!commandListeners.isEmpty()) {
             NikobusConnection connection = this.connection;
             if (connection == null) {
                 return;
-            }        	
+            }
             try {
                 connectIfNeeded(connection);
             } catch (IOException e) {
-                logger.debug("refresh failed due {}", e.getMessage(), e);
                 connection.close();
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             }


### PR DESCRIPTION
Signed-off-by: Wouter Denayer <wouter@denayer.com>

open connection on refresh even if no modules exist

currently, when no modules are defined the connection to nikobus is not opened and therefore the button presses are not detected.