### PR TITLE
[http] fix initial refresh

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
@@ -59,11 +59,7 @@ public class RefreshingUrlCache {
         this.headers = thingConfig.headers;
         fallbackEncoding = thingConfig.encoding;
 
-        // do initial refresh
-        refresh();
-
-        // schedule next refreshes
-        future = executor.scheduleWithFixedDelay(this::refresh, 0, thingConfig.refresh, TimeUnit.SECONDS);
+        future = executor.scheduleWithFixedDelay(this::refresh, 1, thingConfig.refresh, TimeUnit.SECONDS);
         logger.trace("Started refresh task for URL '{}' with interval {}s", url, thingConfig.refresh);
     }
 

--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/http/RefreshingUrlCache.java
@@ -59,6 +59,10 @@ public class RefreshingUrlCache {
         this.headers = thingConfig.headers;
         fallbackEncoding = thingConfig.encoding;
 
+        // do initial refresh
+        refresh();
+
+        // schedule next refreshes
         future = executor.scheduleWithFixedDelay(this::refresh, 0, thingConfig.refresh, TimeUnit.SECONDS);
         logger.trace("Started refresh task for URL '{}' with interval {}s", url, thingConfig.refresh);
     }
@@ -94,7 +98,7 @@ public class RefreshingUrlCache {
                 response.exceptionally(e -> {
                     if (e instanceof HttpAuthException) {
                         if (isRetry) {
-                            logger.warn("Retry after authentication  failure failed again for '{}', failing here", uri);
+                            logger.warn("Retry after authentication failure failed again for '{}', failing here", uri);
                         } else {
                             AuthenticationStore authStore = httpClient.getAuthenticationStore();
                             Authentication.Result authResult = authStore.findAuthenticationResult(uri);


### PR DESCRIPTION
As reported in the community forum the first refresh occured after the refreshTime, not immediately after the channel was configured. Especially for channels with a long refreshTime this was very inconvenient. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
