### PR TITLE
[atlona] Volume level should be a whole number

### DIFF
--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/StatefulHandlerCallback.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/StatefulHandlerCallback.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.lang.StringUtils;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.types.State;
@@ -88,7 +87,7 @@ public class StatefulHandlerCallback implements AtlonaHandlerCallback {
      */
     @Override
     public void stateChanged(String channelId, State state) {
-        if (StringUtils.isEmpty(channelId)) {
+        if (channelId == null || "".equals(channelId)) {
             return;
         }
 
@@ -116,7 +115,7 @@ public class StatefulHandlerCallback implements AtlonaHandlerCallback {
      * @param channelId the channel id to remove state
      */
     public void removeState(String channelId) {
-        if (StringUtils.isEmpty(channelId)) {
+        if (channelId == null || "".equals(channelId)) {
             return;
         }
         state.remove(channelId);

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3Handler.java
@@ -323,7 +323,7 @@ public class AtlonaPro3Handler extends AtlonaHandler<AtlonaPro3Capabilities> {
                             break;
                         case AtlonaPro3Constants.CHANNEL_VOLUME:
                             if (command instanceof DecimalType) {
-                                final double level = ((DecimalType) command).doubleValue();
+                                final int level = ((DecimalType) command).intValue();
                                 atlonaHandler.setVolume(portNbr, level);
                             } else {
                                 logger.debug("Received a VOLUME channel command with a non DecimalType: {}", command);

--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.atlona.internal.AtlonaHandlerCallback;
 import org.openhab.binding.atlona.internal.net.SocketSession;
 import org.openhab.binding.atlona.internal.net.SocketSessionListener;
@@ -599,7 +598,7 @@ class AtlonaPro3PortocolHandler {
      * @param portNbr a greater than zero port number
      * @param level a volume level in decibels (must range from -79 to +15)
      */
-    void setVolume(int portNbr, double level) {
+    void setVolume(int portNbr, int level) {
         if (portNbr <= 0) {
             throw new IllegalArgumentException("portNbr must be greater than 0");
         }
@@ -906,7 +905,7 @@ class AtlonaPro3PortocolHandler {
                 int hdmiPortNbr = Integer.parseInt(m.group(1));
 
                 // could be "off" (if mirror off), "on"/"Out" (with 3rd group representing out)
-                String oper = StringUtils.trimToEmpty(m.group(2)).toLowerCase();
+                String oper = (m.group(2) == null ? "" : m.group(2).trim()).toLowerCase();
 
                 if (oper.equals("off")) {
                     callback.stateChanged(AtlonaPro3Utilities.createChannelID(AtlonaPro3Constants.GROUP_MIRROR,


### PR DESCRIPTION
This PR fixes a bug with setting the volume level on Atlona Matrix switches. The API expects the volume to be a whole number but the binding was using double to hold the volume resulting in the number being sent having the format 'NN.0'. I also removed the dependency on Apache StringUtils.