### PR TITLE
[remoteopenhab] Handle IllegalArgumentException when building channels

### DIFF
--- a/bundles/org.openhab.binding.remoteopenhab/src/main/java/org/openhab/binding/remoteopenhab/internal/handler/RemoteopenhabBridgeHandler.java
+++ b/bundles/org.openhab.binding.remoteopenhab/src/main/java/org/openhab/binding/remoteopenhab/internal/handler/RemoteopenhabBridgeHandler.java
@@ -213,77 +213,85 @@ public class RemoteopenhabBridgeHandler extends BaseBridgeHandler
         }
     }
 
-    private void createChannels(List<RemoteopenhabItem> items, boolean replace) {
+    private boolean createChannels(List<RemoteopenhabItem> items, boolean replace) {
         synchronized (updateThingLock) {
-            int nbGroups = 0;
-            List<Channel> channels = new ArrayList<>();
-            for (RemoteopenhabItem item : items) {
-                String itemType = item.type;
-                boolean readOnly = false;
-                if ("Group".equals(itemType)) {
-                    if (item.groupType.isEmpty()) {
-                        // Standard groups are ignored
-                        nbGroups++;
-                        continue;
+            try {
+                int nbGroups = 0;
+                List<Channel> channels = new ArrayList<>();
+                for (RemoteopenhabItem item : items) {
+                    String itemType = item.type;
+                    boolean readOnly = false;
+                    if ("Group".equals(itemType)) {
+                        if (item.groupType.isEmpty()) {
+                            // Standard groups are ignored
+                            nbGroups++;
+                            continue;
+                        } else {
+                            itemType = item.groupType;
+                        }
                     } else {
-                        itemType = item.groupType;
+                        if (item.stateDescription != null && item.stateDescription.readOnly) {
+                            readOnly = true;
+                        }
                     }
-                } else {
-                    if (item.stateDescription != null && item.stateDescription.readOnly) {
-                        readOnly = true;
+                    String channelTypeId = String.format("item%s%s", itemType.replace(":", ""), readOnly ? "RO" : "");
+                    ChannelTypeUID channelTypeUID = new ChannelTypeUID(BINDING_ID, channelTypeId);
+                    ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID, null);
+                    String label;
+                    String description;
+                    if (channelType == null) {
+                        logger.trace("Create the channel type {} for item type {}", channelTypeUID, itemType);
+                        label = String.format("Remote %s Item", itemType);
+                        description = String.format("An item of type %s from the remote server.", itemType);
+                        channelType = ChannelTypeBuilder.state(channelTypeUID, label, itemType)
+                                .withDescription(description)
+                                .withStateDescriptionFragment(
+                                        StateDescriptionFragmentBuilder.create().withReadOnly(readOnly).build())
+                                .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+                        channelTypeProvider.addChannelType(channelType);
                     }
+                    ChannelUID channelUID = new ChannelUID(getThing().getUID(), item.name);
+                    logger.trace("Create the channel {} of type {}", channelUID, channelTypeUID);
+                    label = "Item " + item.name;
+                    description = String.format("Item %s from the remote server.", item.name);
+                    channels.add(ChannelBuilder.create(channelUID, itemType).withType(channelTypeUID)
+                            .withKind(ChannelKind.STATE).withLabel(label).withDescription(description).build());
                 }
-                String channelTypeId = String.format("item%s%s", itemType.replace(":", ""), readOnly ? "RO" : "");
-                ChannelTypeUID channelTypeUID = new ChannelTypeUID(BINDING_ID, channelTypeId);
-                ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID, null);
-                String label;
-                String description;
-                if (channelType == null) {
-                    logger.trace("Create the channel type {} for item type {}", channelTypeUID, itemType);
-                    label = String.format("Remote %s Item", itemType);
-                    description = String.format("An item of type %s from the remote server.", itemType);
-                    channelType = ChannelTypeBuilder.state(channelTypeUID, label, itemType).withDescription(description)
-                            .withStateDescriptionFragment(
-                                    StateDescriptionFragmentBuilder.create().withReadOnly(readOnly).build())
-                            .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
-                    channelTypeProvider.addChannelType(channelType);
-                }
-                ChannelUID channelUID = new ChannelUID(getThing().getUID(), item.name);
-                logger.trace("Create the channel {} of type {}", channelUID, channelTypeUID);
-                label = "Item " + item.name;
-                description = String.format("Item %s from the remote server.", item.name);
-                channels.add(ChannelBuilder.create(channelUID, itemType).withType(channelTypeUID)
-                        .withKind(ChannelKind.STATE).withLabel(label).withDescription(description).build());
-            }
-            ThingBuilder thingBuilder = editThing();
-            if (replace) {
-                thingBuilder.withChannels(channels);
-                updateThing(thingBuilder.build());
-                logger.debug("{} channels defined for the thing {} (from {} items including {} groups)",
-                        channels.size(), getThing().getUID(), items.size(), nbGroups);
-            } else if (channels.size() > 0) {
-                int nbRemoved = 0;
-                for (Channel channel : channels) {
-                    if (getThing().getChannel(channel.getUID()) != null) {
-                        thingBuilder.withoutChannel(channel.getUID());
-                        nbRemoved++;
-                    }
-                }
-                if (nbRemoved > 0) {
-                    logger.debug("{} channels removed for the thing {} (from {} items)", nbRemoved, getThing().getUID(),
-                            items.size());
-                }
-                for (Channel channel : channels) {
-                    thingBuilder.withChannel(channel);
-                }
-                updateThing(thingBuilder.build());
-                if (nbGroups > 0) {
-                    logger.debug("{} channels added for the thing {} (from {} items including {} groups)",
+                ThingBuilder thingBuilder = editThing();
+                if (replace) {
+                    thingBuilder.withChannels(channels);
+                    updateThing(thingBuilder.build());
+                    logger.debug("{} channels defined for the thing {} (from {} items including {} groups)",
                             channels.size(), getThing().getUID(), items.size(), nbGroups);
-                } else {
-                    logger.debug("{} channels added for the thing {} (from {} items)", channels.size(),
-                            getThing().getUID(), items.size());
+                } else if (channels.size() > 0) {
+                    int nbRemoved = 0;
+                    for (Channel channel : channels) {
+                        if (getThing().getChannel(channel.getUID()) != null) {
+                            thingBuilder.withoutChannel(channel.getUID());
+                            nbRemoved++;
+                        }
+                    }
+                    if (nbRemoved > 0) {
+                        logger.debug("{} channels removed for the thing {} (from {} items)", nbRemoved,
+                                getThing().getUID(), items.size());
+                    }
+                    for (Channel channel : channels) {
+                        thingBuilder.withChannel(channel);
+                    }
+                    updateThing(thingBuilder.build());
+                    if (nbGroups > 0) {
+                        logger.debug("{} channels added for the thing {} (from {} items including {} groups)",
+                                channels.size(), getThing().getUID(), items.size(), nbGroups);
+                    } else {
+                        logger.debug("{} channels added for the thing {} (from {} items)", channels.size(),
+                                getThing().getUID(), items.size());
+                    }
                 }
+                return true;
+            } catch (IllegalArgumentException e) {
+                logger.warn("An error occurred while creating the channels for the server {}: {}", getThing().getUID(),
+                        e.getMessage());
+                return false;
             }
         }
     }
@@ -333,15 +341,20 @@ public class RemoteopenhabBridgeHandler extends BaseBridgeHandler
             } else if (getThing().getStatus() != ThingStatus.ONLINE) {
                 List<RemoteopenhabItem> items = restClient.getRemoteItems("name,type,groupType,state,stateDescription");
 
-                createChannels(items, true);
-                setStateOptions(items);
-                for (RemoteopenhabItem item : items) {
-                    updateChannelState(item.name, null, item.state, false);
+                if (createChannels(items, true)) {
+                    setStateOptions(items);
+                    for (RemoteopenhabItem item : items) {
+                        updateChannelState(item.name, null, item.state, false);
+                    }
+
+                    updateStatus(ThingStatus.ONLINE);
+
+                    restartStreamingUpdates();
+                } else {
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
+                            "Dynamic creation of the channels for the remote server items failed");
+                    stopStreamingUpdates();
                 }
-
-                updateStatus(ThingStatus.ONLINE);
-
-                restartStreamingUpdates();
             }
         } catch (RemoteopenhabException e) {
             logger.debug("{}", e.getMessage());


### PR DESCRIPTION
This PR fixes the failing of the binding reported by a user on the forum because he has several items with the same name on his remote server. I don't know how it is possible to define several items with the same name (I was not able to do it) but by the way, this PR makes sure to catch this exception (IllegalArgumentException), log a message that should help the user, and put the thing to OFFLINE in case the creation of the channels is failing due to this exception.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>