### PR TITLE
[draytonwiser] Fix typos in log messages and class names

### DIFF
--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserDiscoveryService.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserDiscoveryService.java
@@ -79,7 +79,7 @@ public class DraytonWiserDiscoveryService extends AbstractDiscoveryService
 
     @Override
     public void onRefresh(final DraytonWiserDTO domainDTOProxy) {
-        logger.debug("Received data from Drayton Wise device. Parsing to discover devices.");
+        logger.debug("Received data from Drayton Wiser device. Parsing to discover devices.");
         onControllerAdded(domainDTOProxy);
         domainDTOProxy.getRooms().forEach(this::onRoomAdded);
         domainDTOProxy.getRoomStats().forEach(r -> onRoomStatAdded(domainDTOProxy, r));

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/DraytonWiserThingHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/DraytonWiserThingHandler.java
@@ -51,7 +51,7 @@ abstract class DraytonWiserThingHandler<T> extends BaseThingHandler implements D
 
     private @Nullable DraytonWiserApi api;
     private @Nullable T data;
-    private @Nullable DraytonWiserDTO draytonWiseDTO;
+    private @Nullable DraytonWiserDTO draytonWiserDTO;
     private @Nullable ScheduledFuture<?> handleCommandRefreshFuture;
 
     protected DraytonWiserThingHandler(final Thing thing) {
@@ -120,11 +120,11 @@ abstract class DraytonWiserThingHandler<T> extends BaseThingHandler implements D
     protected abstract void handleCommand(String channelId, Command command) throws DraytonWiserApiException;
 
     @Override
-    public final void onRefresh(final DraytonWiserDTO draytonWiseDTO) {
-        this.draytonWiseDTO = draytonWiseDTO;
+    public final void onRefresh(final DraytonWiserDTO draytonWiserDTO) {
+        this.draytonWiserDTO = draytonWiserDTO;
         try {
             if (ThingHandlerHelper.isHandlerInitialized(this)) {
-                data = api == null ? null : collectData(draytonWiseDTO);
+                data = api == null ? null : collectData(draytonWiserDTO);
                 refresh();
                 if (data == null) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
@@ -162,11 +162,11 @@ abstract class DraytonWiserThingHandler<T> extends BaseThingHandler implements D
      * Returns the handler specific data object only if all data is available.
      * If not all data is available it should return null.
      *
-     * @param draytonWiseDTO data object with domain data as received from the hub
+     * @param draytonWiserDTO data object with domain data as received from the hub
      * @return handler data object if available else null
      * @throws DraytonWiserApiException
      */
-    protected abstract @Nullable T collectData(DraytonWiserDTO draytonWiseDTO) throws DraytonWiserApiException;
+    protected abstract @Nullable T collectData(DraytonWiserDTO draytonWiserDTO) throws DraytonWiserApiException;
 
     protected DraytonWiserApi getApi() {
         final DraytonWiserApi api = this.api;
@@ -186,13 +186,13 @@ abstract class DraytonWiserThingHandler<T> extends BaseThingHandler implements D
         return data;
     }
 
-    protected DraytonWiserDTO getDraytonWiseDTO() {
-        final DraytonWiserDTO draytonWiseDTO = this.draytonWiseDTO;
+    protected DraytonWiserDTO getDraytonWiserDTO() {
+        final DraytonWiserDTO draytonWiserDTO = this.draytonWiserDTO;
 
-        if (draytonWiseDTO == null) {
-            throw new IllegalStateException("DraytonWiseDTO not set");
+        if (draytonWiserDTO == null) {
+            throw new IllegalStateException("DraytonWiserDTO not set");
         }
-        return draytonWiseDTO;
+        return draytonWiserDTO;
     }
 
     @Override

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/HeatHubHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/HeatHubHandler.java
@@ -115,10 +115,10 @@ public class HeatHubHandler extends BaseBridgeHandler {
                     if (getThing().getStatus() != ThingStatus.ONLINE) {
                         updateStatus(ThingStatus.ONLINE);
                     }
-                    final DraytonWiserDTO draytonWiseDTO = new DraytonWiserDTO(domain);
+                    final DraytonWiserDTO draytonWiserDTO = new DraytonWiserDTO(domain);
 
-                    updateProperties(draytonWiseDTO);
-                    notifyListeners(draytonWiseDTO);
+                    updateProperties(draytonWiserDTO);
+                    notifyListeners(draytonWiserDTO);
                 }
                 logger.debug("Finished refreshing devices");
             }

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomHandler.java
@@ -118,7 +118,7 @@ public class RoomHandler extends DraytonWiserThingHandler<RoomDTO> {
 
     private State getHumidity() {
         if (getData().getId() != null && getData().getRoomStatId() != null) {
-            final RoomStatDTO roomStat = getDraytonWiseDTO().getRoomStat(getData().getRoomStatId());
+            final RoomStatDTO roomStat = getDraytonWiserDTO().getRoomStat(getData().getRoomStatId());
 
             if (roomStat != null) {
                 final Integer humidity = roomStat.getMeasuredHumidity();


### PR DESCRIPTION
In some cases "DraytonWiser" was mis-spelled as "DraytonWise"