### PR TITLE
[zoneminder] Fixed most recent event query

### DIFF
--- a/bundles/org.openhab.binding.zoneminder/README.md
+++ b/bundles/org.openhab.binding.zoneminder/README.md
@@ -98,15 +98,15 @@ The following configuration parameters are available on the Monitor thing:
 | totalEvents       | Number      | Total number of events  |
 | imageUrl          | String      | URL for image snapshot  |
 | videoUrl          | String      | URL for JPEG video stream  |
-| eventId           | String      | Event ID  |
-| eventName         | String      | Event name  |
-| eventCause        | String      | Event cause  |
-| eventNotes        | String      | Event notes  |
-| eventStart        | DateTime    | Event start date/time |
-| eventEnd          | DateTime    | Event end date/time  |
-| eventFrames       | Number      | Event frames  |
-| eventAlarmFrames  | Number      | Event alarm frames |
-| eventLength       | Number:Time | Event length in seconds  |
+| eventId           | String      | ID of most recently completed event  |
+| eventName         | String      | Name of most recently completed event |
+| eventCause        | String      | Cause of most recently completed event |
+| eventNotes        | String      | Notes of most recently completed event |
+| eventStart        | DateTime    | Start date/time of most recently completed event |
+| eventEnd          | DateTime    | End date/time of most recently completed event |
+| eventFrames       | Number      | Number of frames of most recently completed event |
+| eventAlarmFrames  | Number      | Number of alarm frames of most recently completed event |
+| eventLength       | Number:Time | Length in seconds of most recently completed event |
 
 ## Thing Actions
 
@@ -256,18 +256,17 @@ end
 ```
 
 ```
-val int NUM_MONITORS = 6
-var int monitorId = 1
+val monitors = newArrayList("1", "3", "4", "6")
+var int index = 0
 
-rule "Rotate Through All Monitor Images Every 10 Seconds"
+rule "Rotate Through a List of Monitor Images Every 10 Seconds"
 when
     Time cron "0/10 * * ? * * *"
 then
-    var String id = String::format("%d", monitorId)
-    ZmServer_ImageMonitorId.sendCommand(id)
-    monitorId = monitorId + 1
-    if (monitorId > NUM_MONITORS) {
-        monitorId = 1
+    ZmServer_ImageMonitorId.sendCommand(monitors.get(index))
+    index = index + 1
+    if (index >= monitors.size) {
+        index = 0
     }
 end
 ```

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/Monitor.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/Monitor.java
@@ -191,7 +191,7 @@ public class Monitor {
         this.videoUrl = videoUrl;
     }
 
-    public @Nullable Event getLastEvent() {
+    public @Nullable Event getMostRecentCompletedEvent() {
         return lastEvent;
     }
 

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
@@ -350,8 +350,8 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
             parameters.add("sort=StartTime");
             parameters.add("direction=desc");
             parameters.add("limit=1");
-            String response = executeGet(
-                    buildUrlWithParameters(String.format("/api/events/index/MonitorId:%s.json", id), parameters));
+            String response = executeGet(buildUrlWithParameters(
+                    String.format("/api/events/index/MonitorId:%s/Name!=:New%%20Event.json", id), parameters));
             EventsDTO events = GSON.fromJson(response, EventsDTO.class);
             if (events != null && events.eventsList != null && events.eventsList.size() == 1) {
                 EventDTO e = events.eventsList.get(0).event;

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmMonitorHandler.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmMonitorHandler.java
@@ -181,7 +181,7 @@ public class ZmMonitorHandler extends BaseThingHandler {
 
     @SuppressWarnings("null")
     public void updateStatus(Monitor m) {
-        logger.debug("Monitor {}: Updating: {}", m.getId(), m.toString());
+        logger.debug("Monitor {}: Updating Monitor: {}", m.getId(), m);
         updateChannelState(CHANNEL_ID, new StringType(m.getId()));
         updateChannelState(CHANNEL_NAME, new StringType(m.getName()));
         updateChannelState(CHANNEL_FUNCTION, new StringType(m.getFunction()));
@@ -198,25 +198,26 @@ public class ZmMonitorHandler extends BaseThingHandler {
         if (!m.isAlarm()) {
             updateChannelState(CHANNEL_TRIGGER_ALARM, m.isAlarm() ? OnOffType.ON : OnOffType.OFF);
         }
-        Event event = m.getLastEvent();
+        Event event = m.getMostRecentCompletedEvent();
         if (event == null) {
+            // No most recent event, so clear out the event channels
             clearEventChannels();
-        } else if (event.getEnd() != null) {
-            // If end is null, assume event hasn't completed yet
-            logger.trace("Monitor {}: Id:{}, Frames:{}, AlarmFrames:{}, Length:{}", m.getId(), event.getId(),
-                    event.getFrames(), event.getAlarmFrames(), event.getLength());
-            updateChannelState(CHANNEL_EVENT_ID, new StringType(event.getId()));
-            updateChannelState(CHANNEL_EVENT_NAME, new StringType(event.getName()));
-            updateChannelState(CHANNEL_EVENT_CAUSE, new StringType(event.getCause()));
-            updateChannelState(CHANNEL_EVENT_NOTES, new StringType(event.getNotes()));
-            updateChannelState(CHANNEL_EVENT_START, new DateTimeType(
-                    ZonedDateTime.ofInstant(event.getStart().toInstant(), timeZoneProvider.getTimeZone())));
-            updateChannelState(CHANNEL_EVENT_END, new DateTimeType(
-                    ZonedDateTime.ofInstant(event.getEnd().toInstant(), timeZoneProvider.getTimeZone())));
-            updateChannelState(CHANNEL_EVENT_FRAMES, new DecimalType(event.getFrames()));
-            updateChannelState(CHANNEL_EVENT_ALARM_FRAMES, new DecimalType(event.getAlarmFrames()));
-            updateChannelState(CHANNEL_EVENT_LENGTH, new QuantityType<Time>(event.getLength(), Units.SECOND));
+            return;
         }
+        // Update channels for most recent completed event
+        logger.debug("Monitor {}: Updating Event Id:{}, Name:{}, Frames:{}, AlarmFrames:{}, Length:{}", m.getId(),
+                event.getId(), event.getName(), event.getFrames(), event.getAlarmFrames(), event.getLength());
+        updateChannelState(CHANNEL_EVENT_ID, new StringType(event.getId()));
+        updateChannelState(CHANNEL_EVENT_NAME, new StringType(event.getName()));
+        updateChannelState(CHANNEL_EVENT_CAUSE, new StringType(event.getCause()));
+        updateChannelState(CHANNEL_EVENT_NOTES, new StringType(event.getNotes()));
+        updateChannelState(CHANNEL_EVENT_START, new DateTimeType(
+                ZonedDateTime.ofInstant(event.getStart().toInstant(), timeZoneProvider.getTimeZone())));
+        updateChannelState(CHANNEL_EVENT_END,
+                new DateTimeType(ZonedDateTime.ofInstant(event.getEnd().toInstant(), timeZoneProvider.getTimeZone())));
+        updateChannelState(CHANNEL_EVENT_FRAMES, new DecimalType(event.getFrames()));
+        updateChannelState(CHANNEL_EVENT_ALARM_FRAMES, new DecimalType(event.getAlarmFrames()));
+        updateChannelState(CHANNEL_EVENT_LENGTH, new QuantityType<Time>(event.getLength(), Units.SECOND));
     }
 
     private void clearEventChannels() {


### PR DESCRIPTION
The method of getting the most recent event was not working correctly when Zoneminder monitors were configured for Mocord and Record. The Zoneminder query now excludes events with the name "New Event".

Signed-off-by: Mark Hilbush <mark@hilbush.com>
