### PR TITLE
[robonect] Fix breaking common HttpClient on shutdown (#9429)

### DIFF
--- a/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
+++ b/bundles/org.openhab.binding.robonect/src/main/java/org/openhab/binding/robonect/internal/handler/RobonectHandler.java
@@ -381,14 +381,8 @@ public class RobonectHandler extends BaseThingHandler {
             pollingJob.cancel(true);
             pollingJob = null;
         }
-        try {
-            if (httpClient != null) {
-                httpClient.stop();
-                httpClient = null;
-            }
-        } catch (Exception e) {
-            logger.debug("Could not stop http client", e);
-        }
+
+        httpClient = null;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Stefan Triller <github@stefantriller.de>

Fix for #9428 for branch 2.5.x

This is not my own work. It is simply a cherry pick from the pull request https://github.com/openhab/openhab-addons/pull/9429 (commit ca574a943db6e77b5ecd61739cfc1814c75b897b) from the main branch to the branch 2.5.x. So I left the "signed-off-by" from the original commit.

**Reason:** 

In my opinion, the bug #9428 is critical, because if the Robonect binding is not able to communicate with the Robonect module (which is most likely the case in winter, when the mower is turned off), it will tear down all other bindings that make use of `httpClientFactory.getCommonHttpClient()`.

In my setup Robonect causes the OpenWeatherMap binding, the Denon/Marantz binding and the Tankerkoenig binding to go into an error state.