### PR TITLE
[epsonprojector] Fix keycode channel to allow non-numeric characters

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -52,36 +52,36 @@ Some notes:
 
 ## Channels
 
-| Channel            | Item Type | Purpose                                             | Values    | 
-| ------------------ | --------- | --------------------------------------------------- | --------- | 
-| power              | Switch    | Powers the projector on or off.                     |           | 
-| powerstate         | String    | Retrieves the textual power state of the projector. | Read only | 
-| source             | String    | Retrieve or set the input source.                   | See above | 
-| aspectratio        | String    | Retrieve or set the aspect ratio.                   | See above | 
-| colormode          | String    | Retrieve or set the color mode.                     | See above | 
-| freeze             | Switch    | Turn the freeze screen mode on or off.              |           | 
-| mute               | Switch    | Turn the AV mute on or off.                         |           | 
-| volume             | Number    | Retrieve or set the volume.                         | 0   - +20 | 
-| luminance          | String    | Retrieve or set the lamp mode.                      | See above | 
-| brightness         | Number    | Retrieve or set the brightness.                     | -24 - +24 | 
-| contrast           | Number    | Retrieve or set the contrast.                       | -24 - +24 | 
-| density            | Number    | Retrieve or set the density (color saturation).     | -32 - +32 | 
-| tint               | Number    | Retrieve or set the tint.                           | -32 - +32 | 
-| colortemperature   | Number    | Retrieve or set the color temperature.              | 0   - +9  | 
-| fleshtemperature   | Number    | Retrieve or set the flesh temperature.              | 0   - +6  | 
-| gamma              | String    | Retrieve or set the gamma setting.                  | See above | 
-| autokeystone       | Switch    | Turn the auto keystone mode on or off.              |           | 
-| verticalkeystone   | Number    | Retrieve or set the vertical keystone.              | -30 - +30 | 
-| horizontalkeystone | Number    | Retrieve or set the horizontal keystone.            | -30 - +30 | 
-| verticalposition   | Number    | Retrieve or set the vertical position.              | -8  - +10 | 
-| horizontalposition | Number    | Retrieve or set the horizontal position.            | -23 - +26 | 
-| verticalreverse    | Switch    | Turn the vertical reverse mode on or off.           |           | 
-| horizontalreverse  | Switch    | Turn the horizontal reverse mode on or off.         |           | 
-| background         | String    | Retrieve or set the background color/logo.          | See above | 
-| keycode            | Number    | Send a key operation command to the projector.      | Send only | 
-| lamptime           | Number    | Retrieves the lamp hours.                           | Read only | 
-| errcode            | Number    | Retrieves the last error code.                      | Read only | 
-| errmessage         | String    | Retrieves the description of the last error.        | Read only | 
+| Channel            | Item Type | Purpose                                                           | Values    | 
+| ------------------ | --------- | ----------------------------------------------------------------- | --------- | 
+| power              | Switch    | Powers the projector on or off.                                   |           | 
+| powerstate         | String    | Retrieves the textual power state of the projector.               | Read only | 
+| source             | String    | Retrieve or set the input source.                                 | See above | 
+| aspectratio        | String    | Retrieve or set the aspect ratio.                                 | See above | 
+| colormode          | String    | Retrieve or set the color mode.                                   | See above | 
+| freeze             | Switch    | Turn the freeze screen mode on or off.                            |           | 
+| mute               | Switch    | Turn the AV mute on or off.                                       |           | 
+| volume             | Number    | Retrieve or set the volume.                                       | 0   - +20 | 
+| luminance          | String    | Retrieve or set the lamp mode.                                    | See above | 
+| brightness         | Number    | Retrieve or set the brightness.                                   | -24 - +24 | 
+| contrast           | Number    | Retrieve or set the contrast.                                     | -24 - +24 | 
+| density            | Number    | Retrieve or set the density (color saturation).                   | -32 - +32 | 
+| tint               | Number    | Retrieve or set the tint.                                         | -32 - +32 | 
+| colortemperature   | Number    | Retrieve or set the color temperature.                            | 0   - +9  | 
+| fleshtemperature   | Number    | Retrieve or set the flesh temperature.                            | 0   - +6  | 
+| gamma              | String    | Retrieve or set the gamma setting.                                | See above | 
+| autokeystone       | Switch    | Turn the auto keystone mode on or off.                            |           | 
+| verticalkeystone   | Number    | Retrieve or set the vertical keystone.                            | -30 - +30 | 
+| horizontalkeystone | Number    | Retrieve or set the horizontal keystone.                          | -30 - +30 | 
+| verticalposition   | Number    | Retrieve or set the vertical position.                            | -8  - +10 | 
+| horizontalposition | Number    | Retrieve or set the horizontal position.                          | -23 - +26 | 
+| verticalreverse    | Switch    | Turn the vertical reverse mode on or off.                         |           | 
+| horizontalreverse  | Switch    | Turn the horizontal reverse mode on or off.                       |           | 
+| background         | String    | Retrieve or set the background color/logo.                        | See above | 
+| keycode            | String    | Send a key operation command to the projector. (2 character code) | Send only | 
+| lamptime           | Number    | Retrieves the lamp hours.                                         | Read only | 
+| errcode            | Number    | Retrieves the last error code.                                    | Read only | 
+| errmessage         | String    | Retrieves the description of the last error.                      | Read only | 
 
 ## Full Example
 
@@ -99,36 +99,37 @@ epsonprojector:projector-tcp:hometheater "Projector"  [ host="192.168.0.10", por
 items/epson.items
 
 ```
-Switch epsonPower                                      { channel="epsonprojector:projector:hometheater:power" }
-String epsonSource       "Source [%s]"                 { channel="epsonprojector:projector:hometheater:source" }
-String epsonAspectRatio  "Aspect Ratio [%s]"           { channel="epsonprojector:projector:hometheater:aspectratio" }
-String epsonColorMode    "Color Mode [%s]"             { channel="epsonprojector:projector:hometheater:colormode" }
-Switch epsonFreeze                                     { channel="epsonprojector:projector:hometheater:freeze" }
-Switch epsonMute                                       { channel="epsonprojector:projector:hometheater:mute" }
-Number epsonVolume                                     { channel="epsonprojector:projector:hometheater:volume" }
-String epsonLuminance    "Lamp Mode [%s]"              { channel="epsonprojector:projector:hometheater:luminance" }
+Switch epsonPower                                      { channel="epsonprojector:projector-serial:hometheater:power" }
+String epsonSource       "Source [%s]"                 { channel="epsonprojector:projector-serial:hometheater:source" }
+String epsonAspectRatio  "Aspect Ratio [%s]"           { channel="epsonprojector:projector-serial:hometheater:aspectratio" }
+String epsonColorMode    "Color Mode [%s]"             { channel="epsonprojector:projector-serial:hometheater:colormode" }
+Switch epsonFreeze                                     { channel="epsonprojector:projector-serial:hometheater:freeze" }
+Switch epsonMute                                       { channel="epsonprojector:projector-serial:hometheater:mute" }
+Number epsonVolume                                     { channel="epsonprojector:projector-serial:hometheater:volume" }
+String epsonLuminance    "Lamp Mode [%s]"              { channel="epsonprojector:projector-serial:hometheater:luminance" }
 
-Number epsonBrightness                                 { channel="epsonprojector:projector:hometheater:brightness" }
-Number epsonContrast                                   { channel="epsonprojector:projector:hometheater:contrast" }
-Number epsonDensity                                    { channel="epsonprojector:projector:hometheater:density" }
-Number epsonTint                                       { channel="epsonprojector:projector:hometheater:tint" }
-Number epsonColorTemperature                           { channel="epsonprojector:projector:hometheater:colortemperature" }
-Number epsonFleshTemperature                           { channel="epsonprojector:projector:hometheater:fleshtemperature" }
-String epsonGamma        "Gamma [%s]"                  { channel="epsonprojector:projector:hometheater:gamma" }
+Number epsonBrightness                                 { channel="epsonprojector:projector-serial:hometheater:brightness" }
+Number epsonContrast                                   { channel="epsonprojector:projector-serial:hometheater:contrast" }
+Number epsonDensity                                    { channel="epsonprojector:projector-serial:hometheater:density" }
+Number epsonTint                                       { channel="epsonprojector:projector-serial:hometheater:tint" }
+Number epsonColorTemperature                           { channel="epsonprojector:projector-serial:hometheater:colortemperature" }
+Number epsonFleshTemperature                           { channel="epsonprojector:projector-serial:hometheater:fleshtemperature" }
+String epsonGamma        "Gamma [%s]"                  { channel="epsonprojector:projector-serial:hometheater:gamma" }
 
-Switch epsonAutokeystone                               { channel="epsonprojector:projector:hometheater:autokeystone" }
-Number epsonVerticalKeystone                           { channel="epsonprojector:projector:hometheater:verticalkeystone" }
-Number epsonHorizontalKeystone                         { channel="epsonprojector:projector:hometheater:horizontalkeystone" }
-Number epsonVerticalPosition                           { channel="epsonprojector:projector:hometheater:verticalposition" }
-Number epsonHorizontalPosition                         { channel="epsonprojector:projector:hometheater:horizontalposition" }
-Switch epsonVerticalReverse                            { channel="epsonprojector:projector:hometheater:verticalreverse" }
-Switch epsonHorizontalReverse                          { channel="epsonprojector:projector:hometheater:horizontalreverse" }
+Switch epsonAutokeystone                               { channel="epsonprojector:projector-serial:hometheater:autokeystone" }
+Number epsonVerticalKeystone                           { channel="epsonprojector:projector-serial:hometheater:verticalkeystone" }
+Number epsonHorizontalKeystone                         { channel="epsonprojector:projector-serial:hometheater:horizontalkeystone" }
+Number epsonVerticalPosition                           { channel="epsonprojector:projector-serial:hometheater:verticalposition" }
+Number epsonHorizontalPosition                         { channel="epsonprojector:projector-serial:hometheater:horizontalposition" }
+Switch epsonVerticalReverse                            { channel="epsonprojector:projector-serial:hometheater:verticalreverse" }
+Switch epsonHorizontalReverse                          { channel="epsonprojector:projector-serial:hometheater:horizontalreverse" }
 
-String epsonBackground  "Background [%s]"              { channel="epsonprojector:projector:hometheater:background" }
-String epsonPowerState  "Power State [%s]"   <switch>  { channel="epsonprojector:projector:hometheater:powerstate" }
-Number epsonLampTime    "Lamp Time [%d h]"   <switch>       { channel="epsonprojector:projector:hometheater:lamptime" }
-Number epsonErrCode     "Error Code [%d]"    <"siren-on">   { channel="epsonprojector:projector:hometheater:errcode" }
-String epsonErrMessage  "Error Message [%s]" <"siren-off">  { channel="epsonprojector:projector:hometheater:errmessage" }
+String epsonBackground  "Background [%s]"              { channel="epsonprojector:projector-serial:hometheater:background" }
+String epsonKeyCode     "Key Code [%s]"                { channel="epsonprojector:projector-serial:hometheater:keycode", autoupdate="false" }
+String epsonPowerState  "Power State [%s]"   <switch>  { channel="epsonprojector:projector-serial:hometheater:powerstate" }
+Number epsonLampTime    "Lamp Time [%d h]"   <switch>       { channel="epsonprojector:projector-serial:hometheater:lamptime" }
+Number epsonErrCode     "Error Code [%d]"    <"siren-on">   { channel="epsonprojector:projector-serial:hometheater:errcode" }
+String epsonErrMessage  "Error Message [%s]" <"siren-off">  { channel="epsonprojector:projector-serial:hometheater:errmessage" }
 ```
 
 sitemaps/epson.sitemap
@@ -137,12 +138,12 @@ sitemaps/epson.sitemap
 sitemap epson label="Epson Projector Demo"
 {
     Frame label="Controls" {
-        Switch     item=epsonPower  label="Power"
-        Selection  item=epsonSource label="Source" mappings=["30"="HDMI1", "A0"="HDMI2", "14"="Component", "20"="PC DSUB", "41"="Video", "42"="S-Video"]
-        Switch     item=epsonFreeze label="Freeze"
-        Switch     item=epsonMute   label="AV Mute"
-        Setpoint   item=epsonVolume label="Volume"
-
+        Switch     item=epsonPower   label="Power"
+        Selection  item=epsonSource  label="Source" mappings=["30"="HDMI1", "A0"="HDMI2", "14"="Component", "20"="PC DSUB", "41"="Video", "42"="S-Video"]
+        Switch     item=epsonFreeze  label="Freeze"
+        Switch     item=epsonMute    label="AV Mute"
+        Setpoint   item=epsonVolume  label="Volume"
+        Switch     item=epsonKeyCode label="Navigation" icon="screen" mappings=["03"="Menu", "35"="˄", "36"="˅", "37"="<", "38"=">", "16"="Enter"]
     }
     Frame label="Adjust Image" {
         Setpoint   item=epsonBrightness         label="Brightness"

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorCommandType.java
@@ -31,7 +31,7 @@ public enum EpsonProjectorCommandType {
     POWER("Power", SwitchItem.class),
     POWER_STATE("PowerState", StringItem.class),
     LAMP_TIME("LampTime", NumberItem.class),
-    KEY_CODE("KeyCode", NumberItem.class),
+    KEY_CODE("KeyCode", StringItem.class),
     VKEYSTONE("VerticalKeystone", NumberItem.class),
     HKEYSTONE("HorizontalKeystone", NumberItem.class),
     AKEYSTONE("AutoKeystone", SwitchItem.class),

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -232,8 +232,8 @@ public class EpsonProjectorDevice {
     /*
      * Key code
      */
-    public void sendKeyCode(int value) throws EpsonProjectorCommandException, EpsonProjectorException {
-        sendCommand(String.format("KEY %02X", value));
+    public void sendKeyCode(String value) throws EpsonProjectorCommandException, EpsonProjectorException {
+        sendCommand(String.format("KEY %s", value));
     }
 
     /*

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/ColorMode.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public enum ColorMode {
+    AUTO(0x00),
     SRGB(0x01),
     NORMAL(0x02),
     MEETING(0x03),

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/enums/PowerStatus.java
@@ -32,6 +32,7 @@ public enum PowerStatus {
     COOLDOWN(0x03),
     STANDBYNETWORKON(0x04),
     ABNORMALSTANDBY(0x05),
+    WIRELESSHDSTANDBY(0x07),
     UNKNOWN(0xFF);
 
     private final int value;

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
@@ -351,7 +351,7 @@ public class EpsonProjectorHandler extends BaseThingHandler {
                     remoteController.setHorizontalReverse((command == OnOffType.ON ? Switch.ON : Switch.OFF));
                     break;
                 case KEY_CODE:
-                    remoteController.sendKeyCode(((DecimalType) command).intValue());
+                    remoteController.sendKeyCode(command.toString());
                     break;
                 case LAMP_TIME:
                     logger.warn("'{}' is read only parameter", commandType);

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
@@ -271,6 +271,7 @@
 				<option value="SILVER">SILVER</option>
 				<option value="XVCOLOR">XVCOLOR</option>
 				<option value="DICOMSIM">DICOMSIM</option>
+				<option value="AUTO">AUTO</option>
 			</options>
 		</state>
 	</channel-type>

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
@@ -130,7 +130,7 @@
 		<state readOnly="true" pattern="%d h"/>
 	</channel-type>
 	<channel-type id="keycode" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>String</item-type>
 		<label>KeyCode</label>
 		<description>Send a KEY Operation Command to the Projector</description>
 	</channel-type>


### PR DESCRIPTION
Upon reviewing the documentation for different projectors, I discovered that the keycode channel for the epsonprojector binding needs to be modified to allow non-numeric characters to be sent. I changed the channel type from Number to String and updated the documentation to include an example of using the keycode channel.