### PR TITLE
[draytonwiser] Expose Smart Plug Power Metering, Improve null handling

### DIFF
--- a/bundles/org.openhab.binding.draytonwiser/README.md
+++ b/bundles/org.openhab.binding.draytonwiser/README.md
@@ -111,11 +111,13 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 
 #### Smart Plug
 
-| Channel             | Item Type | Description                        |
-|---------------------|-----------|------------------------------------|
-| `currentSignalRSSI` | Number    | Relative Signal Strength Indicator |
-| `currentSignalLQI`  | Number    | Link Quality Indicator             |
-| `zigbeeConnected`   | Switch    | Is the TRV joined to network       |
+| Channel                  | Item Type     | Description                                |
+|--------------------------|---------------|--------------------------------------------|
+| `currentSignalRSSI`      | Number        | Relative Signal Strength Indicator         |
+| `currentSignalLQI`       | Number        | Link Quality Indicator                     |
+| `zigbeeConnected`        | Switch        | Is the TRV joined to network               |
+| `plugInstantaneousPower` | Number:Power  | Current Power being drawn through the plug |
+| `plugEnergyDelivered`    | Number:Energy | Cumulative energy drawn through the plug   |
 
 ### Command Channels
 

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
@@ -105,6 +105,8 @@ public class DraytonWiserBindingConstants {
     public static final String CHANNEL_SMARTPLUG_OUTPUT_STATE = "plugOutputState";
     public static final String CHANNEL_SMARTPLUG_AWAY_ACTION = "plugAwayAction";
     public static final String CHANNEL_COMFORT_MODE_STATE = "comfortModeState";
+    public static final String CHANNEL_SMARTPLUG_INSTANTANEOUS_POWER = "plugInstantaneousPower";
+    public static final String CHANNEL_SMARTPLUG_ENERGY_DELIVERED = "plugEnergyDelivered";
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(THING_TYPE_CONTROLLER, THING_TYPE_ROOM, THING_TYPE_ROOMSTAT,

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.types.State;
@@ -151,11 +152,15 @@ public class DraytonWiserBindingConstants {
             this.batteryLevel = batteryLevel;
         }
 
-        public static State toBatteryLevel(final String level) {
-            try {
-                return new DecimalType(BatteryLevel.valueOf(level.toUpperCase()).batteryLevel);
-            } catch (final IllegalArgumentException e) {
-                // Catch unrecognized values.
+        public static State toBatteryLevel(final @Nullable String level) {
+            if (level != null) {
+                try {
+                    return new DecimalType(BatteryLevel.valueOf(level.toUpperCase()).batteryLevel);
+                } catch (final IllegalArgumentException e) {
+                    // Catch unrecognized values.
+                    return UnDefType.UNDEF;
+                }
+            } else {
                 return UnDefType.UNDEF;
             }
         }

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomStatHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomStatHandler.java
@@ -104,11 +104,13 @@ public class RoomStatHandler extends DraytonWiserThingHandler<RoomStatData> {
     }
 
     private State getSignalRSSI() {
-        return new DecimalType(getData().device.getRssi());
+        final Integer rssi = getData().device.getRssi();
+        return rssi == null ? UnDefType.UNDEF : new QuantityType<>(rssi, Units.DECIBEL_MILLIWATTS);
     }
 
     private State getSignalLQI() {
-        return new DecimalType(getData().device.getLqi());
+        final Integer lqi = getData().device.getLqi();
+        return lqi == null ? UnDefType.UNDEF : new DecimalType(lqi);
     }
 
     private State getWiserSignalStrength() {
@@ -120,7 +122,8 @@ public class RoomStatHandler extends DraytonWiserThingHandler<RoomStatData> {
     }
 
     private State getBatteryVoltage() {
-        return new QuantityType<>(getData().device.getBatteryVoltage() / 10.0, Units.VOLT);
+        final Integer voltage = getData().device.getBatteryVoltage();
+        return voltage == null ? UnDefType.UNDEF : new QuantityType<>(voltage / 10.0, Units.VOLT);
     }
 
     private State getWiserBatteryLevel() {

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/SmartPlugHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/SmartPlugHandler.java
@@ -104,11 +104,13 @@ public class SmartPlugHandler extends DraytonWiserThingHandler<SmartPlugData> {
     }
 
     private State getSignalRSSI() {
-        return new DecimalType(getData().device.getRssi());
+        final Integer rssi = getData().device.getRssi();
+        return rssi == null ? UnDefType.UNDEF : new QuantityType<>(rssi, Units.DECIBEL_MILLIWATTS);
     }
 
     private State getSignalLQI() {
-        return new DecimalType(getData().device.getLqi());
+        final Integer lqi = getData().device.getLqi();
+        return lqi == null ? UnDefType.UNDEF : new DecimalType(lqi);
     }
 
     private State getZigbeeConnected() {

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/SmartPlugHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/SmartPlugHandler.java
@@ -23,6 +23,8 @@ import org.openhab.binding.draytonwiser.internal.model.DraytonWiserDTO;
 import org.openhab.binding.draytonwiser.internal.model.SmartPlugDTO;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
@@ -79,6 +81,8 @@ public class SmartPlugHandler extends DraytonWiserThingHandler<SmartPlugData> {
         updateState(CHANNEL_ZIGBEE_CONNECTED, this::getZigbeeConnected);
         updateState(CHANNEL_DEVICE_LOCKED, this::getDeviceLocked);
         updateState(CHANNEL_MANUAL_MODE_STATE, this::getManualModeState);
+        updateState(CHANNEL_SMARTPLUG_INSTANTANEOUS_POWER, this::getInstantaneousDemand);
+        updateState(CHANNEL_SMARTPLUG_ENERGY_DELIVERED, this::getCurrentSummationDelivered);
     }
 
     @Override
@@ -134,6 +138,16 @@ public class SmartPlugHandler extends DraytonWiserThingHandler<SmartPlugData> {
 
     private void setAwayAction(final Boolean awayAction) throws DraytonWiserApiException {
         getApi().setSmartPlugAwayAction(getData().smartPlug.getId(), awayAction);
+    }
+
+    private State getInstantaneousDemand() {
+        final Integer demand = getData().smartPlug.getInstantaneousDemand();
+        return demand == null ? UnDefType.UNDEF : new QuantityType<>(demand, Units.WATT);
+    }
+
+    private State getCurrentSummationDelivered() {
+        final Integer delivered = getData().smartPlug.getCurrentSummationDelivered();
+        return delivered == null ? UnDefType.UNDEF : new QuantityType<>(delivered, Units.WATT_HOUR);
     }
 
     static class SmartPlugData {

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/TRVHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/TRVHandler.java
@@ -93,7 +93,8 @@ public class TRVHandler extends DraytonWiserThingHandler<SmartValveData> {
     }
 
     private State getDemand() {
-        return new QuantityType<>(getData().smartValve.getPercentageDemand(), Units.PERCENT);
+        final Integer demand = getData().smartValve.getPercentageDemand();
+        return demand == null ? UnDefType.UNDEF : new QuantityType<>(demand, Units.PERCENT);
     }
 
     private State getTemperature() {
@@ -104,11 +105,13 @@ public class TRVHandler extends DraytonWiserThingHandler<SmartValveData> {
     }
 
     private State getSignalRSSI() {
-        return new DecimalType(getData().device.getRssi());
+        final Integer rssi = getData().device.getRssi();
+        return rssi == null ? UnDefType.UNDEF : new QuantityType<>(rssi, Units.DECIBEL_MILLIWATTS);
     }
 
     private State getSignalLQI() {
-        return new DecimalType(getData().device.getLqi());
+        final Integer lqi = getData().device.getLqi();
+        return lqi == null ? UnDefType.UNDEF : new DecimalType(lqi);
     }
 
     private State getWiserSignalStrength() {
@@ -120,7 +123,8 @@ public class TRVHandler extends DraytonWiserThingHandler<SmartValveData> {
     }
 
     private State getBatteryVoltage() {
-        return new QuantityType<>(getData().device.getBatteryVoltage() / 10.0, Units.VOLT);
+        final Integer voltage = getData().device.getBatteryVoltage();
+        return voltage == null ? UnDefType.UNDEF : new QuantityType<>(voltage / 10.0, Units.VOLT);
     }
 
     private State getWiserBatteryLevel() {

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/model/DeviceDTO.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/model/DeviceDTO.java
@@ -88,8 +88,8 @@ public class DeviceDTO {
         return displayedSignalStrength;
     }
 
-    public int getBatteryVoltage() {
-        return batteryVoltage == null ? Integer.MIN_VALUE : batteryVoltage;
+    public Integer getBatteryVoltage() {
+        return batteryVoltage;
     }
 
     public String getBatteryLevel() {

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/model/SmartPlugDTO.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/model/SmartPlugDTO.java
@@ -31,6 +31,8 @@ public class SmartPlugDTO {
     private String targetState;
     private Integer debounceCount;
     private String overrideState;
+    private Integer currentSummationDelivered;
+    private Integer instantaneousDemand;
 
     public Integer getId() {
         return id;
@@ -74,5 +76,13 @@ public class SmartPlugDTO {
 
     public String getMode() {
         return mode;
+    }
+
+    public Integer getCurrentSummationDelivered() {
+        return currentSummationDelivered;
+    }
+
+    public Integer getInstantaneousDemand() {
+        return instantaneousDemand;
     }
 }

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/OH-INF/thing/thing-types.xml
@@ -219,6 +219,8 @@
 			<channel id="zigbeeConnected" typeId="zigbeeConnected-channel"/>
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 			<channel id="manualModeState" typeId="manualModeState-channel"/>
+			<channel id="plugInstantaneousPower" typeId="plugInstantaneousPower-channel"/>
+			<channel id="plugEnergyDelivered" typeId="plugEnergyDelivered-channel"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>
@@ -427,6 +429,20 @@
 		<item-type>Switch</item-type>
 		<label>Comfort Mode Active</label>
 		<description>Should the room pre-heat to achieve the desired temperature</description>
+	</channel-type>
+
+	<channel-type id="plugInstantaneousPower-channel">
+		<item-type>Number:Power</item-type>
+		<label>Plug Instantaneous Power</label>
+		<description>Current Power being drawn through the plug</description>
+		<state readOnly="true" pattern="%d %unit%"/>
+	</channel-type>
+
+	<channel-type id="plugEnergyDelivered-channel">
+		<item-type>Number:Energy</item-type>
+		<label>Plug Energy Delivered</label>
+		<description>Cumulative energy drawn through the plug</description>
+		<state readOnly="true" pattern="%d %unit%"/>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
Expose Smart Plug Power Metering, Improve null handling

The Drayton Wiser API now exposes instantaneous power metering and cumulative energy usage for Wiser Smart Plug devices through the API. This PR adds channels to report this data. Capability mentioned by @andrew-schofield in this [post ](https://community.openhab.org/t/drayton-wiser-thermostat-binding/35640/402)- sorry I couldn't wait so thought I should share!

Additionally, when Wiser wireless devices are offline some properties in the API response are nulled and the binding would fail to fully update all the device's channels. Added checks to update all channels, tested with registered Smart Plug / TRV / RoomStat with power removed.