### PR TITLE
[nikobus] refresh impacted modules on simulated button press

### DIFF
--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPushButtonHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusPushButtonHandler.java
@@ -148,6 +148,7 @@ public class NikobusPushButtonHandler extends NikobusBaseThingHandler {
             if (pcLink != null) {
                 pcLink.sendCommand(new NikobusCommand(getAddress() + END_OF_TRANSMISSION));
             }
+            processImpactedModules();
         }
     }
 
@@ -163,6 +164,10 @@ public class NikobusPushButtonHandler extends NikobusBaseThingHandler {
             triggerProcessors.forEach(processor -> processor.process(currentTimeMillis));
         }
 
+        processImpactedModules();
+    }
+
+    private void processImpactedModules() {
         if (!impactedModules.isEmpty()) {
             Utils.cancel(requestUpdateFuture);
             requestUpdateFuture = scheduler.schedule(this::update, 400, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
In case of simulated Nikobus push button event refresh impacted modules too, so binding fetches the updated state from affected modules.

Signed-off-by: Boris Krivonog boris.krivonog@inova.si
