### PR TITLE
[satel] Thing discovery fix

### DIFF
--- a/bundles/org.openhab.binding.satel/README.md
+++ b/bundles/org.openhab.binding.satel/README.md
@@ -289,7 +289,7 @@ The result of this action is compatible with channels of `event-log` thing and c
 Usage:
 
 ```
-    val actions = getActions("satel", "satel:event-log:home")
+    val actions = getActions("satel", "satel:event-log:home:EventLog")
     val eventRec = actions.readEvent(-1)
     logInfo("EventLog", eventRec.get("description"))
 ```
@@ -309,9 +309,9 @@ Bridge satel:ethm-1:home [ host="192.168.0.2", refresh=1000, userCode="1234", en
     Thing shutter KitchenWindow [ upId=2, downId=3 ]
     Thing output Siren [ id=17, wireless=true ]
     Thing atd-100 KitchenTemp [ id=10, refresh=30 ]
+    Thing system System []
+    Thing event-log EventLog []
 }
-Thing satel:system:home "System" (satel:ethm-1:home) []
-Thing satel:event-log:home "Event log" (satel:ethm-1:home) []
 
 ```
 
@@ -328,9 +328,9 @@ Switch BEDROOM_TAMPER "Bedroom PIR tampered" (Satel) { channel="satel:zone:home:
 Switch BEDROOM_TAMPER_M "Bedroom PIR tamper memory" (Satel) { channel="satel:zone:home:BedroomPIR:tamper_alarm_memory" }
 Switch KITCHEN_LAMP "Kitchen lamp" (Satel) { channel="satel:output:home:KitchenLamp:state" }
 Rollershutter KITCHEN_BLIND "Kitchen blind" (Satel) { channel="satel:shutter:home:KitchenWindow:shutter_state" }
-Switch SYSTEM_TROUBLES "Troubles in the system" (Satel) { channel="satel:system:home:troubles" }
+Switch SYSTEM_TROUBLES "Troubles in the system" (Satel) { channel="satel:system:home:System:troubles" }
 String KEYPAD_CHAR ">" <none> (Satel)
-String USER_CODE "User code" (Satel) { channel="satel:system:home:user_code" }
+String USER_CODE "User code" (Satel) { channel="satel:system:home:System:user_code" }
 Switch SIREN_LOBATT "Siren: low battery level" (Satel) { channel="satel:output:home:Siren:device_lobatt" }
 Switch SIREN_NOCOMM "Siren: no communication" (Satel) { channel="satel:output:home:Siren:device_nocomm" }
 Number:Temperature KITCHEN_TEMP "Kitchen temperature [%.1f °C]" <temperature> (Satel) { channel="satel:atd-100:home:KitchenTemp:temperature" }
@@ -380,7 +380,7 @@ rule "Keypad char entered"
 when
     Item KEYPAD_CHAR changed
 then
-    val org.joda.time.DateTime timeout = now.plusSeconds(20)
+    val timeout = now.plusSeconds(20)
 
     if (KEYPAD_CHAR.state == "-") {
         logInfo("Keypad", "Changing user code")
@@ -414,7 +414,7 @@ rule "Send event log"
 when
     Item Alarms changed to ON
 then
-    val actions = getActions("satel", "satel:event-log:home")
+    val actions = getActions("satel", "satel:event-log:home:EventLog")
     if (null === actions) {
         logInfo("EventLog", "Actions not found, check thing ID")
         return

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelHandlerFactory.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelHandlerFactory.java
@@ -80,8 +80,6 @@ public class SatelHandlerFactory extends BaseThingHandlerFactory {
         if (effectiveUID == null) {
             if (DEVICE_THING_TYPES_UIDS.contains(thingTypeUID)) {
                 effectiveUID = getDeviceUID(thingTypeUID, thingUID, configuration, bridgeUID);
-            } else if (VIRTUAL_THING_TYPES_UIDS.contains(thingTypeUID) && bridgeUID != null) {
-                effectiveUID = new ThingUID(thingTypeUID, bridgeUID.getId());
             }
         }
         return super.createThing(thingTypeUID, configuration, effectiveUID, bridgeUID);

--- a/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/discovery/SatelDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/discovery/SatelDeviceDiscoveryService.java
@@ -152,14 +152,10 @@ public class SatelDeviceDiscoveryService extends AbstractDiscoveryService {
 
     private void addThing(ThingTypeUID thingTypeUID, @Nullable String deviceId, String label,
             Map<String, Object> properties) {
-        ThingUID bridgeUID = bridgeHandler.getThing().getUID();
-        ThingUID thingUID;
-        if (deviceId == null) {
-            thingUID = new ThingUID(thingTypeUID, bridgeUID.getId());
-        } else {
-            thingUID = new ThingUID(thingTypeUID, bridgeUID, deviceId);
-        }
-        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+        final ThingUID bridgeUID = bridgeHandler.getThing().getUID();
+        final ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID,
+                deviceId == null ? toCamelCase(thingTypeUID.getId()) : deviceId);
+        final DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
                 .withBridge(bridgeUID).withLabel(label).withProperties(properties).build();
         thingDiscovered(discoveryResult);
     }
@@ -192,5 +188,20 @@ public class SatelDeviceDiscoveryService extends AbstractDiscoveryService {
             default:
                 return false;
         }
+    }
+
+    private static String toCamelCase(String s) {
+        StringBuilder result = new StringBuilder();
+        boolean makeUpper = true;
+        for (int i = 0; i < s.length(); ++i) {
+            char c = s.charAt(i);
+            if (c == '-') {
+                makeUpper = true;
+            } else {
+                result.append(makeUpper ? Character.toUpperCase(c) : c);
+                makeUpper = false;
+            }
+        }
+        return result.toString();
     }
 }


### PR DESCRIPTION
This PR fixes discovery of event-log and system things in OH3. 
The issue is related to thing UID validation introduced in OH3 and both things did not pass this validation (missing bridge segment). The fix changes the way UID are created and now they are correct for both of things.

Related discussion is here: https://community.openhab.org/t/satel-binding-support-announcements-and-feature-requests/56135/245

Signed-off-by: Krzysztof Goworek <krzysztof.goworek@gmail.com>