### PR TITLE
[teleinfo] Fix memory leak

### DIFF
--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractControllerHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractControllerHandler.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.binding.teleinfo.internal.handler;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.teleinfo.internal.TeleinfoDiscoveryService;
@@ -32,7 +32,7 @@ import org.openhab.core.thing.binding.ThingHandlerService;
 @NonNullByDefault
 public abstract class TeleinfoAbstractControllerHandler extends BaseBridgeHandler {
 
-    private List<TeleinfoControllerHandlerListener> listeners = Collections.synchronizedList(new ArrayList<>());
+    private Set<TeleinfoControllerHandlerListener> listeners = new CopyOnWriteArraySet<>();
 
     public TeleinfoAbstractControllerHandler(Bridge bridge) {
         super(bridge);

--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractElectricityMeterHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractElectricityMeterHandler.java
@@ -65,10 +65,7 @@ public abstract class TeleinfoAbstractElectricityMeterHandler extends BaseThingH
 
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
-        Bridge bridge = getBridge();
-        TeleinfoAbstractControllerHandler controllerHandler = bridge != null
-                ? (TeleinfoAbstractControllerHandler) bridge.getHandler()
-                : null;
+        TeleinfoAbstractControllerHandler controllerHandler = getControllerHandler();
         if (bridgeStatusInfo.getStatus() != ThingStatus.ONLINE) {
             if (controllerHandler != null) {
                 controllerHandler.removeListener(this);
@@ -81,6 +78,20 @@ public abstract class TeleinfoAbstractElectricityMeterHandler extends BaseThingH
             controllerHandler.addListener(this);
             updateStatus(ThingStatus.ONLINE);
         }
+    }
+
+    @Override
+    public void dispose() {
+        TeleinfoAbstractControllerHandler controllerHandler = getControllerHandler();
+        if (controllerHandler != null) {
+            controllerHandler.removeListener(this);
+        }
+        super.dispose();
+    }
+
+    private @Nullable TeleinfoAbstractControllerHandler getControllerHandler() {
+        Bridge bridge = getBridge();
+        return bridge != null ? (TeleinfoAbstractControllerHandler) bridge.getHandler() : null;
     }
 
     @Override

--- a/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractElectricityMeterHandler.java
+++ b/bundles/org.openhab.binding.teleinfo/src/main/java/org/openhab/binding/teleinfo/internal/handler/TeleinfoAbstractElectricityMeterHandler.java
@@ -65,19 +65,21 @@ public abstract class TeleinfoAbstractElectricityMeterHandler extends BaseThingH
 
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        Bridge bridge = getBridge();
+        TeleinfoAbstractControllerHandler controllerHandler = bridge != null
+                ? (TeleinfoAbstractControllerHandler) bridge.getHandler()
+                : null;
         if (bridgeStatusInfo.getStatus() != ThingStatus.ONLINE) {
+            if (controllerHandler != null) {
+                controllerHandler.removeListener(this);
+            }
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, ERROR_OFFLINE_CONTROLLER_OFFLINE);
             return;
         }
 
-        Bridge bridge = getBridge();
-        if (bridge != null) {
-            TeleinfoAbstractControllerHandler controllerHandler = (TeleinfoAbstractControllerHandler) bridge
-                    .getHandler();
-            if (controllerHandler != null) {
-                controllerHandler.addListener(this);
-                updateStatus(ThingStatus.ONLINE);
-            }
+        if (controllerHandler != null) {
+            controllerHandler.addListener(this);
+            updateStatus(ThingStatus.ONLINE);
         }
     }
 


### PR DESCRIPTION
Resolve #9546.

This PR prevents the `ThingHandler` from registering more than once to the bridge event when a `bridgeStatusChanged` is triggered.  