### PR TITLE
Migrate maxcul binding from OH1 to OH3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,8 @@
 /bundles/org.openhab.binding.comfoair/ @boehan
 /bundles/org.openhab.binding.coolmasternet/ @projectgus
 /bundles/org.openhab.binding.coronastats/ @DerOetzi
+/bundles/org.openhab.binding.cul/ @johgoe
+/bundles/org.openhab.binding.cul.max/ @johgoe
 /bundles/org.openhab.binding.daikin/ @caffineehacker
 /bundles/org.openhab.binding.danfossairunit/ @pravussum
 /bundles/org.openhab.binding.darksky/ @cweitkamp

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -213,6 +213,16 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.cul</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.cul.max</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.daikin</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.cul.max/NOTICE
+++ b/bundles/org.openhab.binding.cul.max/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.cul.max/README.md
+++ b/bundles/org.openhab.binding.cul.max/README.md
@@ -1,0 +1,204 @@
+# MAX!CUL Binding
+
+The aim of this binding is to allow the connection from openHAB to [eQ-3 MAX! Home Solution](http://www.eq-3.de/) devices (wall thermostat/radiator valves)
+using the [CUL USB dongle](http://busware.de/tiki-index.php?page=CUL) rather than the MAX!Cube.
+This should allow greater control over the devices than the cube offers as all interaction is handled manually.
+
+## Supported Things
+
+This binding support 6 different things types
+
+| Thing          | Type   | Description                                                                                                        |
+|----------------|--------|--------------------------------------------------------------------------------------------------------------------|
+| cul_max_bridge | Bridge | CUL if using a serial CUL
+| cun_max_bridge | Bridge | CUN if using a network CUL
+| maxcul_bridge  | Bridge | This is the MAX! Cube emulation for the CUL.                                                                                 |
+| thermostat     | Thing  | This is for the MAX! Heating Thermostat. This is also used for the power plug switch "Zwischenstecker-Schaltaktor". |
+| thermostatplus | Thing  | This is for the MAX! Heating Thermostat+. This is the type that can hold the program by itself.                    |
+| wallthermostat | Thing  | MAX! Wall Thermostat.                                                                                              |
+| ecoswitch      | Thing  | MAX! Ecoswitch.                                                                                                    |
+| shuttercontact | Thing  | MAX! Shuttercontact / Window Contact.                                                                              |
+
+Generally one does not have to worry about the thing types as they are automatically defined.
+If for any reason you need to manually define the Things and you are not exactly sure what type of thermostat you have, you can choose `thermostat` for both the thermostat and thermostat+, this will not affect their working.
+
+## Discovery
+
+Start pairing at your MAX! device. It will show up in the inbox and you can it to your configuration. Serial number and rfAddress is set already
+After adding too your configuration you have to set channel pair_mode to ON on your maxcul_bridge and restart
+the pairing on your MAX! device to start the pairing sequence. 
+If the device is already paired and starts re-pairing e.g. after battery change, the state of channel pair_mode is ignored.
+
+## Binding Configuration
+
+There are no binding wide settings as all configuration settings.
+When using a serial port, you may need to add `-Dgnu.io.rxtx.SerialPorts=/dev/ttyACM0` in your server startup.  Please consult the [forum](https://community.openhab.org) for the latest information.
+
+## Thing Configuration
+
+### CUL Bridge Configuration
+| Property | Default | Required | Description |
+|----------|---------|:--------:|-------------|
+| device   |         |   Yes    | in the form `<device>`, where `<device>` is a local serial port eg `/dev/ttyACM0` |
+| baudrate |         |   No     | one of 75, 110, 300, 1200, 2400, 4800, 9600, 19200, **38400**, 57600, 115200 |
+| parity   |         |   No     | one of EVEN, ODD, MARK, **NONE**, SPACE |
+
+When using a serial port, you may need to add `-Dgnu.io.rxtx.SerialPorts=/dev/ttyACM0` in your server startup.  Please consult the [forum](https://community.openhab.org) for the latest information.
+
+### CUN Bridge Configuration
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| networkPath   |         |   Yes    | in the form `<device>`, where `<device>` is `<host>:<port>`, where `<host>` is the host name or IP address and `<port>` is the port number. If no `<port>` is provided the default `2323` is assumed |
+
+### MAX! CUL Bridge Configuration
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| timezone | Europe/London | No | set timezone you want the units to be set to |
+
+### Linking devices
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| associate|  | No | Comma seperated list of serials|
+
+### All devices
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| serial        |         |   Yes    | eg. KEQ12345|
+| rfAddress     |         |   Yes    | eg. 071234  |
+
+
+### Additional Properties if available
+
+* comfort - the defined 'comfort' temperature (default 21.0)
+* eco - the defined eco setback temperature (default 17.0)
+* max - maximum temperature that can be set on the thermostat (default 30.5, which is the maximum value and corresponds to "open valve")
+* min - minimum temperature that can be set on the thermostat (default 4.5, which is the minimum value and corresponds to "closed valve")
+* windowOpenDetectTemp - set point in the event that a window open event is triggered by a shutter, if set to 4.5, this function is deactivated.
+* windowOpenDetectTime - Rounded down to the nearest 5 minutes. (default is 0)
+* measurement offset - offset applied to measure temperature (range is -3.5 to +3.5) - default is 0.0
+* weekprofile - eg. `Mon;17,17-30,21,23-00,17;Tue;17,17-30,21,23-00,17;Wen;17,17-30,21,23-00,17;Thu;17,17-30,21,23-00,17;Fri;17,17-30,21,23-30,17;Sat;17,09-00,21,23-00,17;Sun;17,09-00,21,23-00,17`
+
+## Channels
+
+Depending on the thing it supports different Channels
+
+| Channel Type ID | Item Type          | Description                                                                                                                                                                                                                                               | Available on thing                                                    |
+|-----------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| mode            | String             | This channel indicates the mode of a thermostat (AUTOMATIC/MANUAL/BOOST/VACATION).                                                                                                                                                                        | thermostat, thermostatplus, wallthermostat                            |
+| battery_low     | Switch             | This channel indicates if the device battery is low (ON/OFF).                                                                                                                                                                                             | thermostat, thermostatplus, wallthermostat, ecoswitch, shuttercontact |
+| set_temp        | Number:Temperature | This channel indicates the sets temperature of a thermostat.                                                                                                                                                                                              | thermostat, thermostatplus, wallthermostat                            |
+| actual_temp     | Number:Temperature | This channel indicates the measured temperature of a thermostat (see below for more details).                                                                                                                                                             | thermostat, thermostatplus, wallthermostat                            |
+| valve           | Number             | This channel indicates the valve opening in %. Note this is an advanced setting, normally not visible.                                                                                                                                                    | thermostat, thermostatplus, wallthermostat                            |
+| locked          | Contact            | This channel indicates if the thermostat is locked for adjustments (OPEN/CLOSED). Note this is an advanced setting, normally not visible.                                                                                                                 | thermostat, thermostatplus, wallthermostat                            |
+| display_actual_temp | Switch         | Turns on / off if the thermostat displays the actual temperature instead of the set temperature                                                                                                                                                           | wallthermostat                            |
+| contact_state   | Contact            | This channel indicates the contact state for a shutterswitch (OPEN/CLOSED).
+| credits         | Number             | This channel indicates the remaining credits. Due to regulatory compliance reasons in Europe, the cul is allowed to send at no more than 1% of the time, which sums up to 36 seconds per hour. Once the threshold has been reached, the cul stops sending commands for the remaining time of the hour.  | cul_max_bridge, cun_max_bridge |
+| led             | Switch             | Turns on / off the led on the CUL. This channel is write only and may indicate false values after restart as it assume the led is always after restart | cul_max_bridge, cun_max_bridge |
+| pair_mode       | Switch             | Turns on / off the pair_mode on the MAX!CUL. It will switch to off after 1 minute | maxcul_bridge |
+| listen_mode     | Switch             | Turns on / off the listen_mode. In listen mode all messages are just logged. | maxcul_bridge |
+
+## Status
+
+The binding is currently in beta and it is recommended that you only use it expecting there to be bugs and issues. It is has enough features to be useful as a heating system, though lacks some of the finer features. This page will be updated as things progress.
+
+## Tutorial
+
+There was a tutorial using a Raspberry Pi with OH1 available at [technpol](https://technpol.wordpress.com/2016/04/09/configuration-of-maxcul-and-cul-dongle/), which addresses some of the configuration issues.
+
+## Features
+
+The binding currently offers the following features:
+
+* Listen mode - this allows you to listen in on MAX! network activity from a MAX!Cube for example. A trace will be output in debug mode that decodes implemented messages
+* Pairing - can pair devices with OpenHAB by triggering Pair Mode using a Switch item
+* Wall Thermostat
+* Can send set point temperature
+* Can receive set point temperature
+* Can receive measured temperature
+* Can receive battery status
+* Can receive operating mode
+* Can factory reset device
+* Can be configured to display current temperature or current setpoint (_likely 1.8.0+_)
+* Radiator Thermostat Valve
+* Can send set point temperature
+* Can receive set point temperature
+* Can receive measured temperature
+* Can receive valve position
+* Can receive battery status
+* Can receive operating mode
+* Can factory reset device
+* Push Button
+* Can receive either AUTO or ECO depending on button press (translated to ON/OFF)
+* Can factory reset device
+* Association
+* It is possible to link devices together so that they communicate directly with each other, for example a wall thermostat and a radiator valve.
+* TX Credit Monitoring
+
+## Limitations
+
+Aside from understanding what the binding does do which is documented here there are some key things to be aware of that may limit what you hope to achieve.
+
+1. Radiator thermostat data is updated quite sporadically. Items such as set point temperature, measured temperature, valve position, battery status and operating mode are only sent when the state of the valve changes - i.e. valve moves or the dial used to manually set a temperature. If you want measured temperature it is much better to use a wall thermostat.
+1. The binding has no concept of 'auto' mode: It currently has no ability to retrieve from any source and subsequently send a schedule to devices. This may change in the future, which would allow basic operation should OpenHAB fail for some reason.
+1. If a wall thermostat is set to 'OFF' (mapped to 4.5deg) it won't update the measured temperature.
+
+## Pairing
+
+A device needs to be associated with the Max!CUL binding to work correctly. This is a simple process:
+
+1. Ensure you have an item that has the correct device serial and settings you want configured in openhab
+1. If you haven't already then create a seperate item and sitemap entry that is a switch that allows you to turn on pairing mode (NB. it will turn off automatically after 30s)
+1. Switch on pairing mode
+1. Once pairing mode is activated then you need to pair the device by pressing and holding the pairing button the device (see your device manual). You should see it start to count down a timer from 30. Once the pairing process has begun then you will see AC displayed (on Wall and Radiator thermostats at least) or for devices without a display the LED will flash as described in the manual.
+
+**Please note:** If the device has been paired before you will need to factory reset it before use. Please see the device user manual for details on how to do this.
+
+### Example Rule
+
+demo.rules:
+
+```java
+rule "Reset MAX! Heating Thermostat to inital settings"
+when
+    ...
+then
+    val maxCubeActions = getActions("maxcul", "maxcul:thermostat:KEQ0565026")
+    val Boolean success = maxCubeActions.reset()
+    logInfo("max", "Action 'reset' returned '{}'", success)
+end
+```
+
+## Technical Information
+
+### Implemented Messages
+The table below shows what messages are implemented and to what extent. Transmit means we can build and transmit a packet of that type with relevant data. Decode means we can extract data into some meaningful form. All message types can be received, identified and the raw payloads displayed. Messages not identified in this table cannot be transmitted by the binding and can only be decoded as a raw payload.
+
+| Message               | Transmit | Decode           |Comments                                    |
+|-----------------------|:--------:|:----------------:|--------------------------------------------|
+|ACK                      | Y        | Y                |                                            |
+|PAIR PING                | N        | Y                |                                            |
+|PAIR PONG                | Y        | Y                |                                            |
+|SET GROUP ID             | Y        | Y                |                                            |
+|SET TEMPERATURE          | Y        | Y                | Allows setting of temperature of (wall)therm |
+|TIME INFO                | Y        | Y                |                                            |
+|WAKEUP                   | Y        | N                |                                            |
+|WALL THERMOSTAT CONTROL  | N        | Y                | Provides measured temp and set point       |
+|THERMOSTAT STATE         | N        | Y                | Provides battery/valvepos/temperature/thermostat set point |
+| WALL THERMOSTAT STATE   | N        | Y                | Provides battery/valvepos/temperature/thermostat set point |
+| PUSH BUTTON STATE       | N        | Y                | Auto maps to ON, Eco maps to OFF           |
+| ADD LINK PARTNER        | Y        | N                | Links a device with another                |
+| SET DISPLAY ACTUAL TEMP | Y        | Y                | Set a wall thermostat to show current measured or current setpoint temperature |
+
+## Message Sequences
+
+For situations such as the pairing where a whole sequences of messages is required the binding has implemented a message sequencing system. This allows the implementation of a state machine for the system to pass through as messages are passed back and forth.
+
+This will be documented in more detail in due course.
+
+## Planned Future Features
+
+These are in no particular priority and are simply ideas. They may not get implemented at all.
+
+1. If there is a pending SET_TEMPERATURE message in the queue and we receive a SET_TEMPERATURE from the thermostat we are waiting to send to then we should clear the message from the queue as it will be outdated.
+1. Explore how to avoid the queue getting too long due to lack of credits with many devices.
+1. Add ability to setup device groups which should help reduce lack of credit issue

--- a/bundles/org.openhab.binding.cul.max/pom.xml
+++ b/bundles/org.openhab.binding.cul.max/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.cul.max</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: MAX!CUL Binding</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.cul</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bundles/org.openhab.binding.cul.max/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.cul.max/src/main/feature/feature.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.cul.max-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-cul.max" description="MAX!CUL Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-serial</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.cul/${project.version}</bundle>
+		<bundle start-level="81">mvn:org.openhab.addons.bundles/org.openhab.binding.cul.max/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/MaxCulBindingConstants.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/MaxCulBindingConstants.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link MaxCulBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+public class MaxCulBindingConstants {
+
+    public static final String PROPERTY_THING_VERSION = "thing_version";
+    public static final String CURRENT_THING_VERSION = "1.1";
+
+    private static final String BINDING_ID = "maxcul";
+
+    // List of main device types
+    public static final String DEVICE_THERMOSTAT = "thermostat";
+    public static final String DEVICE_THERMOSTATPLUS = "thermostatplus";
+    public static final String DEVICE_WALLTHERMOSTAT = "wallthermostat";
+    public static final String DEVICE_ECOSWITCH = "ecoswitch";
+    public static final String DEVICE_SHUTTERCONTACT = "shuttercontact";
+    public static final String BRIDGE_MAXCUL = "maxcul_bridge";
+    public static final String BRIDGE_CUL_MORIZ = "cul_max_bridge";
+    public static final String BRIDGE_CUN_MORIZ = "cun_max_bridge";
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID HEATINGTHERMOSTAT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_THERMOSTAT);
+    public static final ThingTypeUID HEATINGTHERMOSTATPLUS_THING_TYPE = new ThingTypeUID(BINDING_ID,
+            DEVICE_THERMOSTATPLUS);
+    public static final ThingTypeUID WALLTHERMOSTAT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_WALLTHERMOSTAT);
+    public static final ThingTypeUID ECOSWITCH_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_ECOSWITCH);
+    public static final ThingTypeUID SHUTTERCONTACT_THING_TYPE = new ThingTypeUID(BINDING_ID, DEVICE_SHUTTERCONTACT);
+    public static final ThingTypeUID MAXCULBRIDGE_THING_TYPE = new ThingTypeUID(BINDING_ID, BRIDGE_MAXCUL);
+    // List of all Channel ids
+    public static final String CHANNEL_VALVE = "valve";
+    public static final String CHANNEL_BATTERY = "battery_low";
+    public static final String CHANNEL_MODE = "mode";
+    public static final String CHANNEL_ACTUALTEMP = "actual_temp";
+    public static final String CHANNEL_SETTEMP = "set_temp";
+    public static final String CHANNEL_LOCKED = "locked";
+    public static final String CHANNEL_CONTACT_STATE = "contact_state";
+    public static final String CHANNEL_SWITCH = "switch";
+    public static final String CHANNEL_DISPLAY_ACTUAL_TEMP = "display_actual_temp";
+
+    public static final String CHANNEL_LISTEN_MODE = "listen_mode";
+    public static final String CHANNEL_PAIR_MODE = "pair_mode";
+
+    // Custom Properties
+    public static final String PROPERTY_RFADDRESS = "rfAddress";
+    public static final String PROPERTY_TIMEZONE = "timezone";
+
+    // Thermostat settings properties
+    public static final String PROPERTY_THERMO_COMFORT_TEMP = "comfortTemp";
+    public static final String PROPERTY_THERMO_ECO_TEMP = "ecoTemp";
+    public static final String PROPERTY_THERMO_MAX_TEMP_SETPOINT = "maxTempSetpoint";
+    public static final String PROPERTY_THERMO_MIN_TEMP_SETPOINT = "minTempSetpoint";
+    public static final String PROPERTY_THERMO_OFFSET_TEMP = "offsetTemp";
+    public static final String PROPERTY_THERMO_WINDOW_OPEN_TEMP = "windowOpenTemp";
+    public static final String PROPERTY_THERMO_WINDOW_OPEN_DURATION = "windowOpenDuration";
+    public static final String PROPERTY_THERMO_WEEK_PROFILE = "weekProfile";
+    public static final String PROPERTY_ASSOSIATE = "associate";
+
+    // List of actions
+    public static final String ACTION_DEVICE_RESET = "action-deviceReset";
+    public static final String BUTTON_ACTION_VALUE = "1234";
+    public static final int BUTTON_NOACTION_VALUE = -1;
+
+    public static final Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            Stream.of(HEATINGTHERMOSTAT_THING_TYPE, HEATINGTHERMOSTATPLUS_THING_TYPE, WALLTHERMOSTAT_THING_TYPE,
+                    ECOSWITCH_THING_TYPE, SHUTTERCONTACT_THING_TYPE).collect(Collectors.toSet()));
+
+    public static final Set<ThingTypeUID> SUPPORTED_BRIDGE_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(MAXCULBRIDGE_THING_TYPE).collect(Collectors.toSet()));
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            Stream.concat(SUPPORTED_DEVICE_THING_TYPES_UIDS.stream(), SUPPORTED_BRIDGE_THING_TYPES_UIDS.stream())
+                    .collect(Collectors.toSet()));
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/actions/MaxDevicesActions.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/actions/MaxDevicesActions.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.actions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.handler.MaxDevicesHandler;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link MaxDevicesActions} class defines rule actions for MAX! devices
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@ThingActionsScope(name = "maxcul")
+@NonNullByDefault
+public class MaxDevicesActions implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(MaxDevicesActions.class);
+
+    private @Nullable MaxDevicesHandler handler;
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof MaxDevicesHandler) {
+            this.handler = (MaxDevicesHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "reset the device", description = "Reset the device. Pairing is required again")
+    public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean resetDevice() {
+        MaxDevicesHandler actionsHandler = handler;
+        if (actionsHandler == null) {
+            logger.info("MaxDevicesActions: Action service ThingHandler is null!");
+            return false;
+        }
+        actionsHandler.resetDevice();
+        return true;
+    }
+
+    public static boolean resetDevice(ThingActions actions) {
+        return ((MaxDevicesActions) actions).resetDevice();
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/config/WeekProfileConfigHelper.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/config/WeekProfileConfigHelper.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.config;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.cul.max.internal.messages.MaxCulWeekProfile;
+import org.openhab.binding.cul.max.internal.messages.MaxCulWeekProfileControlPoint;
+import org.openhab.binding.cul.max.internal.messages.MaxCulWeekProfilePart;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulWeekdays;
+import org.openhab.core.model.item.BindingConfigParseException;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class WeekProfileConfigHelper {
+
+    public static MaxCulWeekProfile parseWeekProfileString(String weekProfile) throws BindingConfigParseException {
+        MaxCulWeekProfile result = new MaxCulWeekProfile();
+        String[] args = weekProfile.split(";");
+        if (args.length % 2 == 1) {
+            throw new BindingConfigParseException("Number of arguments must be even.");
+        }
+        for (int i = 0; i < args.length; i += 2) {
+            MaxCulWeekProfilePart weekProfilePart = new MaxCulWeekProfilePart();
+            MaxCulWeekdays day = MaxCulWeekdays.getWeekDayFromShortName(args[i]);
+            weekProfilePart.setDay(day);
+            String[] controlPoints = args[i + 1].split(",");
+            if (controlPoints.length > 13 * 2) {
+                throw new BindingConfigParseException("Not more than 13 control points are allowed!");
+            }
+            // Each day has 2 bytes * 13 controlpoints = 26 bytes = 52 hex characters
+            // we don't have to update the rest, because the active part is terminated by the time 0:00
+            for (int j = 0; j < 13 * 2; j += 2) {
+                MaxCulWeekProfileControlPoint controlPoint = new MaxCulWeekProfileControlPoint();
+                if (j + 1 == controlPoints.length) {
+                    controlPoint.setHour(0);
+                    controlPoint.setMin(0);
+                    controlPoint.setTemperature(0.0f);
+                    break;
+                } else {
+
+                    String timeRegex = "^(\\d{1,2})-(\\d{1,2})$";
+                    Pattern pattern = Pattern.compile(timeRegex);
+                    Matcher matcher = pattern.matcher(controlPoints[j + 1]);
+                    if (matcher.matches()) {
+                        controlPoint.setHour(Integer.parseInt(matcher.group(1)));
+                        controlPoint.setMin(Integer.parseInt(matcher.group(2)));
+                    }
+                }
+                if (controlPoint.getHour() == null || controlPoint.getMin() == null || controlPoint.getHour() > 23
+                        || controlPoint.getMin() > 59)
+                    throw new IllegalArgumentException("Invalid time");
+                controlPoint.setTemperature(Float.parseFloat(controlPoints[j]));
+                weekProfilePart.addControlPoint(controlPoint);
+
+            }
+            result.addWeekProfilePart(weekProfilePart);
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/discovery/MaxDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/discovery/MaxDeviceDiscoveryService.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.discovery;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.PROPERTY_RFADDRESS;
+
+import java.util.Date;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.MaxCulBindingConstants;
+import org.openhab.binding.cul.max.internal.handler.DevicePairingListener;
+import org.openhab.binding.cul.max.internal.handler.MaxCulCunBridgeHandler;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link MaxDeviceDiscoveryService} class is used to discover MAX!
+ * devices that are connected to the Cul/Cun.
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+public class MaxDeviceDiscoveryService extends AbstractDiscoveryService
+        implements DevicePairingListener, DiscoveryService, ThingHandlerService {
+
+    private static final int SEARCH_TIME = 60;
+    private final Logger logger = LoggerFactory.getLogger(MaxDeviceDiscoveryService.class);
+
+    private @Nullable MaxCulCunBridgeHandler maxCulCunBridgeHandler;
+
+    public MaxDeviceDiscoveryService() {
+        super(MaxCulBindingConstants.SUPPORTED_DEVICE_THING_TYPES_UIDS, SEARCH_TIME, true);
+    }
+
+    @Override
+    public void setThingHandler(@NonNullByDefault({}) ThingHandler handler) {
+        if (handler instanceof MaxCulCunBridgeHandler) {
+            this.maxCulCunBridgeHandler = (MaxCulCunBridgeHandler) handler;
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return maxCulCunBridgeHandler;
+    }
+
+    @Override
+    public void activate() {
+        MaxCulCunBridgeHandler localMaxCulCunBridgeHandler = maxCulCunBridgeHandler;
+        if (localMaxCulCunBridgeHandler != null) {
+            localMaxCulCunBridgeHandler.registerDeviceStatusListener(this);
+        }
+    }
+
+    @Override
+    public void deactivate() {
+        MaxCulCunBridgeHandler localMaxCulCunBridgeHandler = maxCulCunBridgeHandler;
+        if (localMaxCulCunBridgeHandler != null) {
+            localMaxCulCunBridgeHandler.unregisterDeviceStatusListener(this);
+            removeOlderResults(new Date().getTime(), localMaxCulCunBridgeHandler.getThing().getUID());
+        }
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypes() {
+        return MaxCulBindingConstants.SUPPORTED_DEVICE_THING_TYPES_UIDS;
+    }
+
+    @Override
+    public void onDeviceAdded(Bridge bridge, String rfAddress, MaxCulDevice deviceType, String serialNumber) {
+        logger.trace("Adding new MAX! {} with id '{}' to inbox", deviceType, serialNumber);
+        ThingUID thingUID = null;
+        switch (deviceType) {
+            case WALL_THERMOSTAT:
+                thingUID = new ThingUID(MaxCulBindingConstants.WALLTHERMOSTAT_THING_TYPE, bridge.getUID(),
+                        serialNumber);
+                break;
+            case RADIATOR_THERMOSTAT:
+                thingUID = new ThingUID(MaxCulBindingConstants.HEATINGTHERMOSTAT_THING_TYPE, bridge.getUID(),
+                        serialNumber);
+                break;
+            case RADIATOR_THERMOSTAT_PLUS:
+                thingUID = new ThingUID(MaxCulBindingConstants.HEATINGTHERMOSTATPLUS_THING_TYPE, bridge.getUID(),
+                        serialNumber);
+                break;
+            case SHUTTER_CONTACT:
+                thingUID = new ThingUID(MaxCulBindingConstants.SHUTTERCONTACT_THING_TYPE, bridge.getUID(),
+                        serialNumber);
+                break;
+            case PUSH_BUTTON:
+                thingUID = new ThingUID(MaxCulBindingConstants.ECOSWITCH_THING_TYPE, bridge.getUID(), serialNumber);
+                break;
+            default:
+                break;
+        }
+        if (thingUID != null) {
+            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID)
+                    .withProperty(Thing.PROPERTY_SERIAL_NUMBER, serialNumber)
+                    .withProperty(PROPERTY_RFADDRESS, rfAddress).withBridge(bridge.getUID())
+                    .withLabel(deviceType + ": " + serialNumber)
+                    .withRepresentationProperty(Thing.PROPERTY_SERIAL_NUMBER).build();
+            thingDiscovered(discoveryResult);
+        } else {
+            logger.debug("Discovered MAX! device is unsupported: type '{}' with id '{}'", deviceType, serialNumber);
+        }
+    }
+
+    @Override
+    protected void startScan() {
+        // this can be ignored here
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/factory/MaxCulHandlerFactory.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/factory/MaxCulHandlerFactory.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.factory;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.handler.MaxCulCunBridgeHandler;
+import org.openhab.binding.cul.max.internal.handler.MaxDevicesHandler;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link MaxCulHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.maxcul", service = ThingHandlerFactory.class)
+public class MaxCulHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(MaxCulHandlerFactory.class);
+
+    @Override
+    public @Nullable Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration,
+            @Nullable ThingUID thingUID, @Nullable ThingUID bridgeUID) {
+        if (supportsThingType(thingTypeUID) && bridgeUID != null) {
+            ThingUID deviceUID = getMaxCulDeviceUID(thingTypeUID, thingUID, configuration, bridgeUID);
+            return super.createThing(thingTypeUID, configuration, deviceUID, bridgeUID);
+        }
+        throw new IllegalArgumentException("The thing type " + thingTypeUID + " is not supported by the binding.");
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    private ThingUID getBridgeThingUID(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID,
+            Configuration configuration) {
+        if (thingUID == null) {
+            String serialNumber = (String) configuration.get(Thing.PROPERTY_SERIAL_NUMBER);
+            return new ThingUID(thingTypeUID, serialNumber);
+        }
+        return thingUID;
+    }
+
+    private ThingUID getMaxCulDeviceUID(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID,
+            Configuration configuration, ThingUID bridgeUID) {
+        if (thingUID == null) {
+            String serialNumber = (String) configuration.get(Thing.PROPERTY_SERIAL_NUMBER);
+            return new ThingUID(thingTypeUID, serialNumber, bridgeUID.getId());
+        }
+        return thingUID;
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        if (MAXCULBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            return new MaxCulCunBridgeHandler((Bridge) thing);
+        } else if (SUPPORTED_DEVICE_THING_TYPES_UIDS.contains(thingTypeUID)) {
+            return new MaxDevicesHandler(thing);
+        } else {
+            logger.debug("ThingHandler not found for {}", thingTypeUID);
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/DevicePairingListener.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/DevicePairingListener.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.core.thing.Bridge;
+
+/**
+ * The {@link DevicePairingListener} is notified when a new device tries pairing
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+public interface DevicePairingListener {
+
+    /**
+     * This method is called whenever a device tries pairing.
+     *
+     * @param bridge The MAX! CUL bridge the added device was connected to
+     * @param rfAddress The device rfAddress which is added
+     * @param deviceType The device type which is added
+     * @param serialNumber The device serialNumber which is added
+     */
+    void onDeviceAdded(Bridge bridge, String rfAddress, MaxCulDevice deviceType, String serialNumber);
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxCulCunBridgeHandler.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxCulCunBridgeHandler.java
@@ -1,0 +1,383 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.handler;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.*;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.CULHandler;
+import org.openhab.binding.cul.CULListener;
+import org.openhab.binding.cul.max.internal.discovery.MaxDeviceDiscoveryService;
+import org.openhab.binding.cul.max.internal.message.sequencers.PairingInitialisationSequence;
+import org.openhab.binding.cul.max.internal.message.sequencers.TimeUpdateRequestSequence;
+import org.openhab.binding.cul.max.internal.messages.*;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.*;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.BridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxCulCunBridgeHandler extends BaseBridgeHandler implements CULHandler, CULListener {
+
+    /**
+     * This sets the address of the controller i.e. us!
+     */
+    private final String srcAddr = "010203";
+
+    /**
+     * Set default group ID
+     */
+    private final byte DEFAULT_GROUP_ID = 0x1;
+
+    private final Logger logger = LoggerFactory.getLogger(MaxCulCunBridgeHandler.class);
+
+    private MaxCulMsgHandler messageHandler;
+    private final Set<DevicePairingListener> devicePairingListeners = new CopyOnWriteArraySet<>();
+    private final Map<String, MaxDevicesHandler> childThingHandlers = new HashMap<>();
+    private final Set<String> knownChildSerials = new CopyOnWriteArraySet<>();
+    private final Set<String> rfAddressesToSpyOn = new CopyOnWriteArraySet<>();
+    private Timer pairModeTimer = null;
+    private int pairModeTimeout = 60000;
+    private boolean pairMode = false;
+    protected String tzStr;
+
+    public MaxCulCunBridgeHandler(Bridge thing) {
+        super(thing);
+        messageHandler = new MaxCulMsgHandler(srcAddr, rfAddressesToSpyOn, this);
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.unmodifiableSet(Stream.of(MaxDeviceDiscoveryService.class).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public void initialize() {
+        logger.trace("ThingHandler initialize: {}", getThing().getLabel());
+        final Configuration config = getThing().getConfiguration();
+        final String timezone = (String) config.get(PROPERTY_TIMEZONE);
+        if (timezone == null || timezone.isEmpty()) {
+            this.tzStr = "Europe/London";
+        } else {
+            this.tzStr = timezone;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (ThingStatus.ONLINE != thing.getStatus()) {
+            return;
+        }
+        switch (channelUID.getIdWithoutGroup()) {
+            case CHANNEL_PAIR_MODE:
+                if (command instanceof OnOffType) {
+                    switch ((OnOffType) command) {
+                        case ON:
+                            /*
+                             * turn on pair mode and schedule disabling of pairing
+                             * mode
+                             */
+                            pairMode = true;
+                            TimerTask task = new TimerTask() {
+                                @Override
+                                public void run() {
+                                    logger.debug("{} pairMode timeout executed", getThing().getLabel());
+                                    pairMode = false;
+                                    updateState(channelUID, OnOffType.OFF);
+                                }
+                            };
+                            if (pairModeTimer != null) {
+                                pairModeTimer.cancel();
+                                pairModeTimer = null;
+                            }
+                            pairModeTimer = new Timer();
+                            pairModeTimer.schedule(task, pairModeTimeout);
+                            logger.debug("{} pairMode enabled & timeout scheduled", getThing().getLabel());
+                            break;
+                        case OFF:
+                            /*
+                             * we are manually disabling, so clear the timer and the
+                             * flag
+                             */
+                            pairMode = false;
+                            if (pairModeTimer != null) {
+                                logger.debug("{} pairMode timer cancelled", getThing().getLabel());
+                                pairModeTimer.cancel();
+                                pairModeTimer = null;
+                            }
+                            logger.debug("{} pairMode cleared", getThing().getLabel());
+                            break;
+                    }
+                } else if (command instanceof RefreshType) {
+                    updateState(channelUID, pairMode ? OnOffType.ON : OnOffType.OFF);
+                } else {
+                    logger.debug("{}: Unhandled command type: {}: {}", getThing().getLabel(), channelUID,
+                            command.getClass());
+                }
+                break;
+            case CHANNEL_LISTEN_MODE:
+                if (command instanceof OnOffType) {
+                    messageHandler.setListenMode((command == OnOffType.ON));
+                } else if (command instanceof RefreshType) {
+                    updateState(channelUID, messageHandler.getListenMode() ? OnOffType.ON : OnOffType.OFF);
+                } else {
+                    logger.debug("{}: Unhandled command type: {}: {}", getThing().getLabel(), channelUID,
+                            command.getClass());
+                }
+                break;
+        }
+    }
+
+    public boolean registerDeviceStatusListener(DevicePairingListener devicePairingListener) {
+        if (devicePairingListener == null) {
+            throw new IllegalArgumentException("It's not allowed to pass a null deviceStatusListener.");
+        }
+        return devicePairingListeners.add(devicePairingListener);
+    }
+
+    public boolean unregisterDeviceStatusListener(DevicePairingListener devicePairingListener) {
+        if (devicePairingListener == null) {
+            throw new IllegalArgumentException("It's not allowed to pass a null deviceStatusListener.");
+        }
+        boolean result = devicePairingListeners.remove(devicePairingListener);
+        return result;
+    }
+
+    @Override
+    public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
+        super.childHandlerInitialized(childHandler, childThing);
+        if (childHandler instanceof MaxDevicesHandler) {
+            try {
+                String serialNumber = ((MaxDevicesHandler) childHandler).getDeviceSerial();
+                String rfAddress = ((MaxDevicesHandler) childHandler).getRfAddress();
+                synchronized (childHandler) {
+                    childThingHandlers.put(rfAddress, (MaxDevicesHandler) childHandler);
+                    rfAddressesToSpyOn.add(rfAddress);
+                    knownChildSerials.add(serialNumber);
+                    logger.trace("{}: Bridge added handling for rfAddress {} for serial {}", getThing().getLabel(),
+                            rfAddress, serialNumber);
+                }
+            } catch (Exception e) {
+                logger.warn("{}: Bridge can't add handle child {}", getThing().getLabel(), childThing.getLabel(), e);
+            }
+        }
+    }
+
+    @Override
+    public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+        if (childHandler instanceof MaxDevicesHandler) {
+            try {
+                String serialNumber = ((MaxDevicesHandler) childHandler).getDeviceSerial();
+                String rfAddress = ((MaxDevicesHandler) childHandler).getRfAddress();
+                synchronized (childHandler) {
+                    knownChildSerials.remove(serialNumber);
+                    rfAddressesToSpyOn.remove(rfAddress);
+                    childThingHandlers.remove(rfAddress);
+                    logger.trace("{}: Bridge removed handling for rfAddress {} for serial {}", getThing().getLabel(),
+                            rfAddress, serialNumber);
+                }
+            } catch (Exception e) {
+                logger.warn("{}: Bridge can't remove handle child {}", getThing().getLabel(), childThing.getLabel(), e);
+            }
+        }
+        super.childHandlerDisposed(childHandler, childThing);
+    }
+
+    public void checkDevice(String rfAddress, int type, String serialNumber) {
+        if (!knownChildSerials.contains(serialNumber)) {
+            // New device, not seen before, pass to Discovery
+            for (DevicePairingListener devicePairingListener : devicePairingListeners) {
+                try {
+                    devicePairingListener.onDeviceAdded(getThing(), rfAddress, MaxCulDevice.getDeviceTypeFromInt(type),
+                            serialNumber);
+                } catch (Exception e) {
+                    logger.error("An exception occurred while calling the DeviceStatusListener", e);
+                }
+                knownChildSerials.add(serialNumber);
+            }
+        }
+    }
+
+    /**
+     * @return Returns the list of associated MAX! devices with this bridge.
+     */
+    public List<MaxDevicesHandler> getMaxDevicesHandles() {
+        return getThing().getThings().stream().map(Thing::getHandler).filter(MaxDevicesHandler.class::isInstance)
+                .map(MaxDevicesHandler.class::cast).collect(Collectors.toList());
+    }
+
+    public void maxCulMsgReceived(String data, boolean isBroadcast) {
+        logger.debug("Received data from CUL: {}", data);
+        MaxCulMsgType msgType = BaseMsg.getMsgType(data);
+        logger.debug("Received msg type from CUL: {}; Broadcast: {}", msgType, isBroadcast);
+        if (msgType == MaxCulMsgType.PAIR_PING) {
+            logger.debug("Got PAIR_PING message");
+            PairPingMsg pkt = new PairPingMsg(data);
+            pkt.printMessage();
+            if (!childThingHandlers.containsKey(pkt.srcAddrStr)) {
+                checkDevice(pkt.srcAddrStr, pkt.type, pkt.serial);
+            } else {
+                /*
+                 * Check if it's broadcast and we're in pair mode or a PAIR_PING message
+                 * directly for us
+                 */
+                if (((pairMode && isBroadcast) || !isBroadcast)) {
+                    logger.debug("Creating pairing sequencer");
+                    PairingInitialisationSequence ps = new PairingInitialisationSequence(this.DEFAULT_GROUP_ID,
+                            messageHandler, childThingHandlers.get(pkt.srcAddrStr));
+                    messageHandler.startSequence(ps, pkt);
+                }
+            }
+        } else {
+            switch (msgType) {
+                case WALL_THERMOSTAT_CONTROL: {
+                    WallThermostatControlMsg wallThermCtrlMsg = new WallThermostatControlMsg(data);
+                    wallThermCtrlMsg.printMessage();
+                    sendMessageToChildThingHandler(wallThermCtrlMsg, isBroadcast);
+                    break;
+                }
+                case SET_TEMPERATURE: {
+                    SetTemperatureMsg setTempMsg = new SetTemperatureMsg(data);
+                    setTempMsg.printMessage();
+                    sendMessageToChildThingHandler(setTempMsg, isBroadcast);
+                    break;
+                }
+                case THERMOSTAT_STATE: {
+                    ThermostatStateMsg thermStateMsg = new ThermostatStateMsg(data);
+                    thermStateMsg.printMessage();
+                    sendMessageToChildThingHandler(thermStateMsg, isBroadcast);
+                    break;
+                }
+                case WALL_THERMOSTAT_STATE: {
+                    WallThermostatStateMsg wallThermStateMsg = new WallThermostatStateMsg(data);
+                    wallThermStateMsg.printMessage();
+                    sendMessageToChildThingHandler(wallThermStateMsg, isBroadcast);
+                    break;
+                }
+                case TIME_INFO: {
+                    TimeInfoMsg timeMsg = new TimeInfoMsg(data);
+                    timeMsg.printMessage();
+                    TimeUpdateRequestSequence timeSeq = new TimeUpdateRequestSequence(this.tzStr, messageHandler);
+                    messageHandler.startSequence(timeSeq, timeMsg);
+                    break;
+                }
+                case PUSH_BUTTON_STATE: {
+                    PushButtonMsg pbMsg = new PushButtonMsg(data);
+                    pbMsg.printMessage();
+                    sendMessageToChildThingHandler(pbMsg, isBroadcast);
+                    break;
+                }
+                case SHUTTER_CONTACT_STATE: {
+                    ShutterContactStateMsg shutterContactStateMsg = new ShutterContactStateMsg(data);
+                    shutterContactStateMsg.printMessage();
+                    sendMessageToChildThingHandler(shutterContactStateMsg, isBroadcast);
+                    break;
+                }
+                case ACK: {
+                    AckMsg ackMsg = new AckMsg(data);
+                    ackMsg.printMessage();
+                    sendMessageToChildThingHandler(ackMsg, isBroadcast);
+                    break;
+                }
+                default:
+                    logger.debug("Unhandled message type {}", msgType.toString());
+                    break;
+            }
+        }
+    }
+
+    private void sendMessageToChildThingHandler(BaseMsg msg, boolean isBroadcast) {
+        MaxDevicesHandler childThingHandler = childThingHandlers.get(msg.srcAddrStr);
+        if (childThingHandler == null) {
+            logger.warn("No handler for rfAddress {} found", msg.srcAddrStr);
+        }
+        childThingHandler.processMessage(msg);
+        if (!isBroadcast) {
+            this.messageHandler.sendAck(msg);
+        }
+    }
+
+    public void resetDevice(MaxDevicesHandler maxDevicesHandler) {
+        messageHandler.sendReset(maxDevicesHandler.getRfAddress());
+    }
+
+    public void sendSetDisplayActualTemp(MaxDevicesHandler maxDevicesHandler, boolean b) {
+        messageHandler.sendSetDisplayActualTemp(maxDevicesHandler.getRfAddress(), b);
+    }
+
+    public void sendSetTemperature(MaxDevicesHandler maxDevicesHandler, ThermostatControlMode mode, double temp) {
+        messageHandler.sendSetTemperature(maxDevicesHandler.getRfAddress(), mode, temp);
+    }
+
+    private CULHandler getCulHandler() {
+        Bridge bridge = getBridge();
+        BridgeHandler bridgeHandler = bridge.getHandler();
+        if (bridgeHandler instanceof CULHandler) {
+            updateStatus(ThingStatus.ONLINE);
+            return (CULHandler) bridgeHandler;
+        }
+        updateStatus(ThingStatus.OFFLINE);
+        return null;
+    }
+
+    @Override
+    public void send(String command) throws CULCommunicationException {
+        CULHandler culHandler = getCulHandler();
+        if (culHandler != null) {
+            culHandler.send(command);
+        } else {
+            logger.warn("Could not send command {}", command);
+        }
+    }
+
+    @Override
+    public int getCredit10ms() {
+        CULHandler culHandler = getCulHandler();
+        if (culHandler != null) {
+            return culHandler.getCredit10ms();
+        } else {
+            logger.warn("Could not getCredit10ms");
+            return 0;
+        }
+    }
+
+    @Override
+    public void dataReceived(String data) {
+        updateStatus(ThingStatus.ONLINE);
+        messageHandler.dataReceived(data);
+    }
+
+    @Override
+    public void error(Exception e) {
+        updateStatus(ThingStatus.ONLINE);
+        messageHandler.error(e);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxCulMsgHandler.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxCulMsgHandler.java
@@ -1,0 +1,625 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.handler;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.CULListener;
+import org.openhab.binding.cul.max.internal.message.sequencers.MessageSequencer;
+import org.openhab.binding.cul.max.internal.messages.*;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handle messages going to and from the CUL device. Make sure to intercept
+ * control command responses first before passing on valid MAX! messages to the
+ * binding itself for processing.
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class MaxCulMsgHandler implements CULListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(MaxCulMsgHandler.class);
+
+    class SenderQueueItem {
+        BaseMsg msg;
+        Date expiry;
+        int retryCount = 0;
+    }
+
+    private Date lastTransmit = new Date();
+    private Date endOfQueueTransmit;
+
+    private int msgCount = 0;
+    private MaxCulCunBridgeHandler cul = null;
+    private String srcAddr;
+    private HashMap<Byte, MessageSequencer> sequenceRegister;
+    private LinkedList<SenderQueueItem> sendQueue;
+    private ConcurrentHashMap<Byte, SenderQueueItem> pendingAckQueue;
+
+    private Map<SenderQueueItem, Timer> sendQueueTimers = new HashMap<SenderQueueItem, Timer>();
+
+    private final Set<String> rfAddressesToSpyOn;
+
+    private boolean listenMode = false;
+
+    private final int MESSAGE_EXPIRY_PERIOD = 10000;
+
+    public MaxCulMsgHandler(String srcAddr, Set<String> rfAddressesToSpyOn, MaxCulCunBridgeHandler cul) {
+        this.srcAddr = srcAddr;
+        this.sequenceRegister = new HashMap<Byte, MessageSequencer>();
+        this.sendQueue = new LinkedList<SenderQueueItem>();
+        this.pendingAckQueue = new ConcurrentHashMap<Byte, SenderQueueItem>();
+        this.lastTransmit = new Date(); /* init as now */
+        this.endOfQueueTransmit = this.lastTransmit;
+        this.rfAddressesToSpyOn = rfAddressesToSpyOn;
+        this.cul = cul;
+    }
+
+    private byte getMessageCount() {
+        this.msgCount += 1;
+        this.msgCount &= 0xFF;
+        return (byte) this.msgCount;
+    }
+
+    private boolean enoughCredit(int requiredCredit, boolean fastSend) {
+        int availableCredit = getCreditStatus();
+        int preambleCredit = fastSend ? 0 : 100;
+        boolean result = (availableCredit >= (requiredCredit + preambleCredit));
+        logger.debug("Fast Send? {}, preambleCredit = {}, requiredCredit = {}, availableCredit = {}, enoughCredit? {}",
+                fastSend, preambleCredit, requiredCredit, availableCredit, result);
+        return result;
+    }
+
+    private int getCreditStatus() {
+        return cul.getCredit10ms();
+    }
+
+    private void transmitMessage(BaseMsg data, SenderQueueItem queueItem) {
+        try {
+            cul.send(data.rawMsg);
+        } catch (CULCommunicationException e) {
+            logger.error("Unable to send CUL message {} because: {}", data, e.getMessage());
+        }
+        /* update surplus credit value */
+        boolean fastSend = false;
+        if (data.isPartOfSequence()) {
+            fastSend = data.getMessageSequencer().useFastSend();
+        }
+        enoughCredit(data.requiredCredit(), fastSend);
+        this.lastTransmit = new Date();
+        if (this.endOfQueueTransmit.before(this.lastTransmit)) {
+            /* hit a time after the queue finished tx'ing */
+            this.endOfQueueTransmit = this.lastTransmit;
+        }
+
+        if (data.msgType != MaxCulMsgType.ACK) {
+            /* awaiting ack now */
+            SenderQueueItem qi = queueItem;
+            if (qi == null) {
+                qi = new SenderQueueItem();
+                qi.msg = data;
+            }
+
+            qi.expiry = new Date(this.lastTransmit.getTime() + MESSAGE_EXPIRY_PERIOD);
+            this.pendingAckQueue.put(qi.msg.msgCount, qi);
+
+            /* schedule a check of pending acks */
+            TimerTask ackCheckTask = new TimerTask() {
+                @Override
+                public void run() {
+                    checkPendingAcks();
+                }
+            };
+            Timer timer = new Timer();
+            timer.schedule(ackCheckTask, qi.expiry);
+        }
+    }
+
+    public void sendMessage(BaseMsg msg) {
+        sendMessage(msg, null);
+    }
+
+    /**
+     * Send a raw Base Message
+     *
+     * @param msg Base message to send
+     * @param queueItem queue item (used for retransmission)
+     */
+    private void sendMessage(BaseMsg msg, SenderQueueItem queueItem) {
+        Timer timer = null;
+
+        if (msg.readyToSend()) {
+            if (enoughCredit(msg.requiredCredit(), msg.isFastSend()) && this.sendQueue.isEmpty()) {
+                /*
+                 * send message as we have enough credit and nothing is on the
+                 * queue waiting
+                 */
+                logger.debug("Sending message immediately. Message is {} => {}", msg.msgType, msg.rawMsg);
+                transmitMessage(msg, queueItem);
+                logger.debug("Credit required {}", msg.requiredCredit());
+            } else {
+                /*
+                 * message is going on the queue - this means that the device
+                 * may well go to standby before it receives it so change into
+                 * long slow send format with big preamble
+                 */
+                msg.setFastSend(false);
+                /*
+                 * don't have enough credit or there are messages ahead of us so
+                 * queue up the item and schedule a task to process it
+                 */
+                SenderQueueItem qi = queueItem;
+                if (qi == null) {
+                    qi = new SenderQueueItem();
+                    qi.msg = msg;
+                }
+
+                TimerTask task = new TimerTask() {
+                    @Override
+                    public void run() {
+                        SenderQueueItem topItem = sendQueue.remove();
+                        logger.debug("Checking credit");
+                        if (enoughCredit(topItem.msg.requiredCredit(), topItem.msg.isFastSend())) {
+                            logger.debug("Sending item from queue. Message is {} => {}", topItem.msg.msgType,
+                                    topItem.msg.rawMsg);
+                            if (topItem.msg.msgType == MaxCulMsgType.TIME_INFO) {
+                                ((TimeInfoMsg) topItem.msg).updateTime();
+                            }
+                            transmitMessage(topItem.msg, topItem);
+                        } else {
+                            logger.error("Not enough credit after waiting. This is bad. Queued command is discarded");
+                        }
+                    }
+                };
+
+                timer = new Timer();
+                sendQueueTimers.put(qi, timer);
+                /*
+                 * calculate when we want to TX this item in the queue, with a
+                 * margin of 2 credits. x1000 as we accumulate 1 x 10ms credit
+                 * every 1000ms
+                 */
+                int requiredCredit = msg.isFastSend() ? 0 : 100 + msg.requiredCredit() + 2;
+                this.endOfQueueTransmit = new Date(this.endOfQueueTransmit.getTime() + (requiredCredit * 1000));
+                timer.schedule(task, this.endOfQueueTransmit);
+                this.sendQueue.add(qi);
+
+                logger.debug("Added message to queue to be TX'd at {}", this.endOfQueueTransmit.toString());
+            }
+
+            if (msg.isPartOfSequence()) {
+                /* add to sequence register if part of a sequence */
+                logger.debug("Message {} is part of sequence. Adding to register.", msg.msgCount);
+                sequenceRegister.put(msg.msgCount, msg.getMessageSequencer());
+            }
+        } else {
+            logger.error("Tried to send a message that wasn't ready!");
+        }
+    }
+
+    /**
+     * Check the ACK queue for any pending acks that have expired
+     */
+    public void checkPendingAcks() {
+        Date now = new Date();
+
+        for (SenderQueueItem qi : pendingAckQueue.values()) {
+            if (now.after(qi.expiry)) {
+                logger.error("Packet {} ({}) lost - timeout", qi.msg.msgCount, qi.msg.msgType);
+                pendingAckQueue.remove(qi.msg.msgCount); // remove from ACK
+                // queue
+                if (sequenceRegister.containsKey(qi.msg.msgCount)) {
+                    /* message sequencer handles failed packet */
+                    MessageSequencer msgSeq = sequenceRegister.get(qi.msg.msgCount);
+                    sequenceRegister.remove(qi.msg.msgCount); // remove from
+                    // register
+                    // first as
+                    // packetLost
+                    // could add it
+                    // again
+                    msgSeq.packetLost(qi.msg);
+                } else if (qi.retryCount < 3) {
+                    /* retransmit */
+                    qi.retryCount++;
+                    logger.debug("Retransmitting packet {} attempt {}", qi.msg.msgCount, qi.retryCount);
+                    sendMessage(qi.msg, qi);
+                } else {
+                    logger.error("Transmission of packet {} failed 3 times, message was: {} to address {} => {}",
+                            qi.msg.msgCount, qi.msg.msgType, qi.msg.dstAddrStr, qi.msg.rawMsg);
+                }
+            }
+        }
+    }
+
+    private void listenModeHandler(String data) {
+        switch (BaseMsg.getMsgType(data)) {
+            case WALL_THERMOSTAT_CONTROL:
+                new WallThermostatControlMsg(data).printMessage();
+                break;
+            case TIME_INFO:
+                new TimeInfoMsg(data).printMessage();
+                break;
+            case SET_TEMPERATURE:
+                new SetTemperatureMsg(data).printMessage();
+                break;
+            case ACK:
+                new AckMsg(data).printMessage();
+                break;
+            case PAIR_PING:
+                new PairPingMsg(data).printMessage();
+                break;
+            case PAIR_PONG:
+                new PairPongMsg(data).printMessage();
+                break;
+            case THERMOSTAT_STATE:
+                new ThermostatStateMsg(data).printMessage();
+                break;
+            case SET_GROUP_ID:
+                new SetGroupIdMsg(data).printMessage();
+                break;
+            case WAKEUP:
+                new WakeupMsg(data).printMessage();
+                break;
+            case WALL_THERMOSTAT_STATE:
+                new WallThermostatStateMsg(data).printMessage();
+                break;
+            case PUSH_BUTTON_STATE:
+                new PushButtonMsg(data).printMessage();
+                break;
+            case SHUTTER_CONTACT_STATE:
+                new ShutterContactStateMsg(data).printMessage();
+                break;
+            case ADD_LINK_PARTNER:
+            case CONFIG_TEMPERATURES:
+            case CONFIG_VALVE:
+            case CONFIG_WEEK_PROFILE:
+            case REMOVE_GROUP_ID:
+            case REMOVE_LINK_PARTNER:
+            case RESET:
+            case SET_COMFORT_TEMPERATURE:
+            case SET_DISPLAY_ACTUAL_TEMP:
+            case SET_ECO_TEMPERATURE:
+            case UNKNOWN:
+            default:
+                BaseMsg baseMsg = new BaseMsg(data);
+                baseMsg.printMessage();
+                break;
+
+        }
+    }
+
+    @Override
+    public synchronized void dataReceived(String data) {
+        logger.debug("MaxCulSender Received {}", data);
+        if (data.startsWith("Z")) {
+            if (listenMode) {
+                listenModeHandler(data);
+                return;
+            }
+
+            /* Check message is destined for us */
+            if (BaseMsg.isForUs(data, srcAddr)) {
+                boolean passToBinding = true;
+                /* Handle Internal Messages */
+                MaxCulMsgType msgType = BaseMsg.getMsgType(data);
+                if (msgType == MaxCulMsgType.ACK) {
+                    passToBinding = false;
+                    AckMsg msg = new AckMsg(data);
+                    if (pendingAckQueue.containsKey(msg.msgCount) && msg.dstAddrStr.compareTo(srcAddr) == 0) {
+                        SenderQueueItem qi = pendingAckQueue.remove(msg.msgCount);
+                        /* verify ACK */
+                        if ((qi.msg.dstAddrStr.equalsIgnoreCase(msg.srcAddrStr))
+                                && (qi.msg.srcAddrStr.equalsIgnoreCase(msg.dstAddrStr))) {
+                            if (msg.getIsNack()) {
+                                /* NAK'd! */
+                                // TODO resend?
+                                logger.error("Message was NAK'd, packet lost");
+                            } else {
+                                logger.debug("Message {} ACK'd ok!", msg.msgCount);
+                                try {
+                                    forwardAsBroadcastIfSpyIsEnabled(data);
+                                } catch (Exception e1) {
+                                    logger.warn("Could not forward msg {}", data, e1);
+                                }
+                            }
+                        }
+                    } else {
+                        logger.info("Got ACK for message {} but it wasn't in the queue", msg.msgCount);
+                    }
+                }
+
+                if (sequenceRegister.containsKey(new BaseMsg(data).msgCount)) {
+                    passToBinding = false;
+                    /*
+                     * message found in sequence register, so it will be handled
+                     * by the sequence
+                     */
+                    BaseMsg bMsg = new BaseMsg(data);
+                    logger.debug("Message {} is part of sequence. Running next step in sequence.", bMsg.msgCount);
+                    sequenceRegister.get(bMsg.msgCount).runSequencer(bMsg);
+                    sequenceRegister.remove(bMsg.msgCount);
+                }
+
+                if (passToBinding) {
+                    /* pass data to binding for processing */
+                    this.cul.maxCulMsgReceived(data, false);
+                }
+            } else if (BaseMsg.isForUs(data, "000000")) {
+                switch (BaseMsg.getMsgType(data)) {
+                    case PAIR_PING:
+                    case WALL_THERMOSTAT_CONTROL:
+                    case THERMOSTAT_STATE:
+                    case WALL_THERMOSTAT_STATE:
+                        this.cul.maxCulMsgReceived(data, true);
+                        break;
+                    default:
+                        /* TODO handle other broadcast */
+                        logger.debug("Unhandled broadcast message of type {}", BaseMsg.getMsgType(data).toString());
+                        break;
+
+                }
+            } else {
+                forwardAsBroadcastIfSpyIsEnabled(data);
+            }
+        }
+    }
+
+    private void forwardAsBroadcastIfSpyIsEnabled(String data) {
+        BaseMsg bMsg = new BaseMsg(data);
+        if (rfAddressesToSpyOn.contains(bMsg.srcAddrStr) && (BaseMsg.getMsgType(data) != MaxCulMsgType.PAIR_PING)) {
+            /*
+             * pass data to binding for processing - pretend it is
+             * broadcast so as not to ACK
+             */
+            this.cul.maxCulMsgReceived(data, true);
+        }
+    }
+
+    @Override
+    public void error(Exception e) {
+        /*
+         * Ignore errors for now - not sure what I would need to handle here at
+         * the moment TODO lookup error cases
+         */
+        logger.error("Received CUL Error", e);
+    }
+
+    public void startSequence(MessageSequencer ps, BaseMsg msg) {
+        logger.debug("Starting sequence");
+        ps.runSequencer(msg);
+    }
+
+    /**
+     * Send response to PairPing as part of a message sequence
+     *
+     * @param dstAddr Address of device to respond to
+     * @param msgSeq Message sequence to associate
+     */
+    public void sendPairPong(String dstAddr, MessageSequencer msgSeq) {
+        PairPongMsg pp = new PairPongMsg(getMessageCount(), (byte) 0, (byte) 0, this.srcAddr, dstAddr);
+        pp.setMessageSequencer(msgSeq);
+        sendMessage(pp);
+    }
+
+    public void sendPairPong(String dstAddr) {
+        sendPairPong(dstAddr, null);
+    }
+
+    /**
+     * Send a wakeup message as part of a message sequence
+     *
+     * @param devAddr Address of device to respond to
+     * @param msgSeq Message sequence to associate
+     */
+    public void sendWakeup(String devAddr, MessageSequencer msgSeq) {
+        WakeupMsg msg = new WakeupMsg(getMessageCount(), (byte) 0x0, (byte) 0, this.srcAddr, devAddr);
+        msg.setMessageSequencer(msgSeq);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send time information to device that has requested it as part of a
+     * message sequence
+     *
+     * @param dstAddr Address of device to respond to
+     * @param tzStr Time Zone String
+     * @param msgSeq Message sequence to associate
+     */
+    public void sendTimeInfo(String dstAddr, String tzStr, MessageSequencer msgSeq) {
+        TimeInfoMsg msg = new TimeInfoMsg(getMessageCount(), (byte) 0x0, (byte) 0, this.srcAddr, dstAddr, tzStr);
+        msg.setMessageSequencer(msgSeq);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send time information to device in fast mode
+     *
+     * @param dstAddr Address of device to respond to
+     * @param tzStr Time Zone String
+     */
+    public void sendTimeInfoFast(String dstAddr, String tzStr) {
+        TimeInfoMsg msg = new TimeInfoMsg(getMessageCount(), (byte) 0x0, (byte) 0, this.srcAddr, dstAddr, tzStr);
+        msg.setFastSend(true);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send time information to device that has requested it
+     *
+     * @param dstAddr Address of device to respond to
+     * @param tzStr Time Zone String
+     */
+    public void sendTimeInfo(String dstAddr, String tzStr) {
+        sendTimeInfo(dstAddr, tzStr, null);
+    }
+
+    /**
+     * Set the group ID on a device
+     *
+     * @param devAddr Address of device to set group ID on
+     * @param group_id Group id to set
+     * @param msgSeq Message sequence to associate
+     */
+    public void sendSetGroupId(String devAddr, byte group_id, MessageSequencer msgSeq) {
+        SetGroupIdMsg msg = new SetGroupIdMsg(getMessageCount(), (byte) 0x0, this.srcAddr, devAddr, group_id);
+        msg.setMessageSequencer(msgSeq);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send an ACK response to a message
+     *
+     * @param msg Message we are acking
+     */
+    public void sendAck(BaseMsg msg) {
+        AckMsg ackMsg = new AckMsg(msg.msgCount, (byte) 0x0, msg.groupid, this.srcAddr, msg.srcAddrStr, false);
+        ackMsg.setFastSend(true); // all ACKs are sent to waiting device.
+        sendMessage(ackMsg);
+    }
+
+    /**
+     * Send an NACK response to a message
+     *
+     * @param msg Message we are nacking
+     */
+    public void sendNack(BaseMsg msg) {
+        AckMsg nackMsg = new AckMsg(msg.msgCount, (byte) 0x0, msg.groupid, this.srcAddr, msg.srcAddrStr, false);
+        nackMsg.setFastSend(true); // all NACKs are sent to waiting device.
+        sendMessage(nackMsg);
+    }
+
+    /**
+     * Send a set temperature message
+     *
+     * @param devAddr Radio addr of device
+     * @param mode Mode to set e.g. AUTO or MANUAL
+     * @param temp Temperature value to send
+     */
+    public void sendSetTemperature(String devAddr, ThermostatControlMode mode, double temp) {
+        SetTemperatureMsg msg = new SetTemperatureMsg(getMessageCount(), (byte) 0x0, (byte) 0x0, this.srcAddr, devAddr,
+                temp, mode);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send a set eco temperature message
+     *
+     * @param devAddr Radio addr of device
+     */
+    public void sendSetEcoTemperature(String devAddr) {
+        SetEcoTempMsg msg = new SetEcoTempMsg(getMessageCount(), (byte) 0x0, (byte) 0x0, this.srcAddr, devAddr);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send a set comfort temperature message
+     *
+     * @param devAddr Radio addr of device
+     */
+    public void sendSetComfortTemperature(String devAddr) {
+        SetComfortTempMsg msg = new SetComfortTempMsg(getMessageCount(), (byte) 0x0, (byte) 0x0, this.srcAddr, devAddr);
+        sendMessage(msg);
+    }
+
+    /**
+     * Send week profile
+     *
+     * @param devAddr Radio addr of device
+     * @param msgSeq Message sequencer to associate with this message
+     * @param weekProfilePart week profile value
+     * @param secondHalf flag if the control points > 7 should be send
+     */
+    public void sendWeekProfile(String devAddr, MessageSequencer msgSeq, MaxCulWeekProfilePart weekProfilePart,
+            boolean secondHalf) {
+
+        ConfigWeekProfileMsg cfgWeekProfileMsg = new ConfigWeekProfileMsg(getMessageCount(), (byte) 0, (byte) 0,
+                this.srcAddr, devAddr, weekProfilePart, secondHalf);
+        cfgWeekProfileMsg.setMessageSequencer(msgSeq);
+        sendMessage(cfgWeekProfileMsg);
+    }
+
+    /**
+     * Send temperature configuration message
+     *
+     * @param devAddr Radio addr of device
+     * @param msgSeq Message sequencer to associate with this message
+     * @param comfortTemp comfort temperature value
+     * @param ecoTemp Eco temperature value
+     * @param maxTemp Maximum Temperature value
+     * @param minTemp Minimum temperature value
+     * @param offset Offset Temperature value
+     * @param windowOpenTemp Window open temperature value
+     * @param windowOpenTime Window open time value
+     */
+    public void sendConfigTemperatures(String devAddr, MessageSequencer msgSeq, double comfortTemp, double ecoTemp,
+            double maxTemp, double minTemp, double offset, double windowOpenTemp, double windowOpenTime) {
+        ConfigTemperaturesMsg cfgTempMsg = new ConfigTemperaturesMsg(getMessageCount(), (byte) 0, (byte) 0,
+                this.srcAddr, devAddr, comfortTemp, ecoTemp, maxTemp, minTemp, offset, windowOpenTemp, windowOpenTime);
+        cfgTempMsg.setMessageSequencer(msgSeq);
+        sendMessage(cfgTempMsg);
+    }
+
+    /**
+     * Link one device to another
+     *
+     * @param devAddr Destination device address
+     * @param msgSeq Associated message sequencer
+     * @param partnerAddr Radio address of partner
+     * @param devType Type of device
+     */
+    public void sendAddLinkPartner(String devAddr, MessageSequencer msgSeq, String partnerAddr, MaxCulDevice devType) {
+        AddLinkPartnerMsg addLinkMsg = new AddLinkPartnerMsg(getMessageCount(), (byte) 0, (byte) 0, this.srcAddr,
+                devAddr, partnerAddr, devType);
+        addLinkMsg.setMessageSequencer(msgSeq);
+        sendMessage(addLinkMsg);
+    }
+
+    /**
+     * Send a reset message to device
+     *
+     * @param devAddr Address of device to reset
+     */
+    public void sendReset(String devAddr) {
+        ResetMsg resetMsg = new ResetMsg(getMessageCount(), (byte) 0, (byte) 0, this.srcAddr, devAddr);
+        sendMessage(resetMsg);
+    }
+
+    /**
+     * Set listen mode status. Doing this will stop proper message processing
+     * and will just turn this message handler into a snooper.
+     *
+     * @param listenModeOn TRUE sets listen mode to ON
+     */
+    public void setListenMode(boolean listenModeOn) {
+        listenMode = listenModeOn;
+        logger.debug("Listen Mode is {}", (listenMode ? "ON" : "OFF"));
+    }
+
+    public boolean getListenMode() {
+        return listenMode;
+    }
+
+    public void sendSetDisplayActualTemp(String devAddr, boolean displayActualTemp) {
+        SetDisplayActualTempMsg displaySettingMsg = new SetDisplayActualTempMsg(getMessageCount(), (byte) 0, (byte) 0,
+                this.srcAddr, devAddr, displayActualTemp);
+        sendMessage(displaySettingMsg);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxDevicesHandler.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/handler/MaxDevicesHandler.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.handler;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.*;
+import static org.openhab.core.library.unit.SIUnits.CELSIUS;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.openhab.binding.cul.max.internal.MaxCulBindingConstants;
+import org.openhab.binding.cul.max.internal.actions.MaxDevicesActions;
+import org.openhab.binding.cul.max.internal.config.WeekProfileConfigHelper;
+import org.openhab.binding.cul.max.internal.messages.*;
+import org.openhab.binding.cul.max.internal.messages.constants.PushButtonMode;
+import org.openhab.binding.cul.max.internal.messages.constants.ShutterContactState;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.*;
+import org.openhab.core.model.item.BindingConfigParseException;
+import org.openhab.core.thing.*;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxDevicesHandler extends BaseThingHandler {
+
+    private int PACED_TRANSMIT_TIME = 10000;
+
+    public MaxDevicesHandler(Thing thing) {
+        super(thing);
+    }
+
+    private final Logger logger = LoggerFactory.getLogger(MaxDevicesHandler.class);
+    private MaxCulCunBridgeHandler bridgeHandler;
+
+    private String deviceSerial;
+
+    public String getDeviceSerial() {
+        return deviceSerial;
+    }
+
+    public String getRfAddress() {
+        return rfAddress;
+    }
+
+    private String rfAddress;
+
+    private double comfortTemp = ConfigTemperaturesMsg.DEFAULT_COMFORT_TEMP;
+    private double ecoTemp = ConfigTemperaturesMsg.DEFAULT_ECO_TEMP;
+    private double maxTemp = ConfigTemperaturesMsg.DEFAULT_MAX_TEMP;
+    private double minTemp = ConfigTemperaturesMsg.DEFAULT_MIN_TEMP;
+    private double windowOpenTemperature = ConfigTemperaturesMsg.DEFAULT_WINDOW_OPEN_TEMP;
+    private int windowOpenDuration = ConfigTemperaturesMsg.DEFAULT_WINDOW_OPEN_TIME;
+    private double measurementOffset = ConfigTemperaturesMsg.DEFAULT_OFFSET;
+    private MaxCulWeekProfile weekProfile = ConfigWeekProfileMsg.DEFAULT_WEEK_PROFILE;
+    private Set<String> associatedSerials = new HashSet<>();
+    private Timer pacingTimer = null;
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(MaxDevicesActions.class);
+    }
+
+    @Override
+    public void initialize() {
+        final String thingVersion = this.thing.getProperties().get(MaxCulBindingConstants.PROPERTY_THING_VERSION);
+        if (!MaxCulBindingConstants.CURRENT_THING_VERSION.equals(thingVersion)) {
+            final Map<String, String> newProperties = new HashMap<>(thing.getProperties());
+            newProperties.put(MaxCulBindingConstants.PROPERTY_THING_VERSION,
+                    MaxCulBindingConstants.CURRENT_THING_VERSION);
+
+            final ThingBuilder thingBuilder = editThing();
+            thingBuilder.withProperties(newProperties);
+            updateThing(thingBuilder.build());
+            final Thing localThing = this.thing;
+            scheduler.submit(() -> changeThingType(localThing.getThingTypeUID(), localThing.getConfiguration()));
+            return;
+        }
+        try {
+            final Configuration config = getThing().getConfiguration();
+            final String configDeviceSerial = (String) config.get(Thing.PROPERTY_SERIAL_NUMBER);
+            if (configDeviceSerial != null) {
+                deviceSerial = configDeviceSerial;
+            }
+            if (deviceSerial != null) {
+                logger.debug("Initialized MAX! device handler for {}.", deviceSerial);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Initialized MAX! device missing serialNumber configuration");
+            }
+            final String configRfAdress = (String) config.get(PROPERTY_RFADDRESS);
+            if (configRfAdress != null) {
+                rfAddress = configRfAdress;
+            }
+            if (rfAddress != null) {
+                logger.debug("Initialized MAX! device handler for {} with rfAddress {}.", deviceSerial, rfAddress);
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "Initialized MAX! device missing rfAddress configuration");
+            }
+            final String configAssociated = (String) config.get(PROPERTY_ASSOSIATE);
+            if (configAssociated != null) {
+                associatedSerials.addAll(Arrays.asList(configAssociated.split(",")));
+                logger.debug("Loaded {} associated serials for {}.", associatedSerials.size(), deviceSerial);
+            }
+            getConfigurationValues(config);
+
+            getMaxCulCunBaseBridgeHandler();
+            if (bridgeHandler == null) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Valid bridge is required");
+                return;
+            }
+            updateStatus(ThingStatus.UNKNOWN);
+        } catch (Exception e) {
+            logger.debug("Exception occurred during initialize : {}", e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+        }
+    }
+
+    private void getConfigurationValues(Configuration config) {
+        final String weekProfileString = (String) config.get(PROPERTY_THERMO_WEEK_PROFILE);
+        if (weekProfileString != null && !weekProfileString.isEmpty()) {
+            try {
+                weekProfile = WeekProfileConfigHelper.parseWeekProfileString(weekProfileString);
+                logger.trace("Week profile loaded for for {}", getDeviceSerial());
+            } catch (BindingConfigParseException e) {
+                logger.warn("Could not parse week profile {}", weekProfileString, e);
+            }
+        }
+        final BigDecimal comfortTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_COMFORT_TEMP);
+        if (comfortTempCfg != null) {
+            comfortTemp = comfortTempCfg.doubleValue();
+            logger.trace("Comfort temperature is set to {} for {}", comfortTemp, getDeviceSerial());
+        }
+        final BigDecimal ecoTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_ECO_TEMP);
+        if (ecoTempCfg != null) {
+            ecoTemp = ecoTempCfg.doubleValue();
+            logger.trace("Eco temperature is set to {} for {}", ecoTemp, getDeviceSerial());
+        }
+        final BigDecimal maxTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_MAX_TEMP_SETPOINT);
+        if (maxTempCfg != null) {
+            maxTemp = maxTempCfg.doubleValue();
+            logger.trace("Max temperature is set to {} for {}", maxTemp, getDeviceSerial());
+        }
+        final BigDecimal minTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_MIN_TEMP_SETPOINT);
+        if (minTempCfg != null) {
+            minTemp = minTempCfg.doubleValue();
+            logger.trace("Min temperature is set to {} for {}", minTemp, getDeviceSerial());
+        }
+        final BigDecimal windowOpenDurationCfg = (BigDecimal) config.get(PROPERTY_THERMO_WINDOW_OPEN_DURATION);
+        if (windowOpenDurationCfg != null) {
+            windowOpenDuration = windowOpenDurationCfg.intValue();
+            logger.trace("Window open duration is set to {} for {}", windowOpenDuration, getDeviceSerial());
+        }
+        final BigDecimal windowOpenTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_WINDOW_OPEN_TEMP);
+        if (windowOpenTempCfg != null) {
+            windowOpenTemperature = windowOpenTempCfg.doubleValue();
+            logger.trace("Window open temperature is set to {} for {}", windowOpenTemperature, getDeviceSerial());
+        }
+        final BigDecimal offsetTempCfg = (BigDecimal) config.get(PROPERTY_THERMO_OFFSET_TEMP);
+        if (offsetTempCfg != null) {
+            measurementOffset = offsetTempCfg.doubleValue();
+            logger.trace("Offset temperature is set to {} for {}", measurementOffset, getDeviceSerial());
+        }
+    }
+
+    private synchronized MaxCulCunBridgeHandler getMaxCulCunBaseBridgeHandler() {
+        if (this.bridgeHandler == null) {
+            final Bridge bridge = getBridge();
+            if (bridge == null) {
+                logger.debug("Required bridge not defined for device {}.", deviceSerial);
+                return null;
+            }
+            final ThingHandler handler = bridge.getHandler();
+            if (!(handler instanceof MaxCulCunBridgeHandler)) {
+                logger.debug("No available bridge handler found for {} bridge {} .", deviceSerial, bridge.getUID());
+                return null;
+            }
+            this.bridgeHandler = (MaxCulCunBridgeHandler) handler;
+        }
+        return this.bridgeHandler;
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (ThingStatus.ONLINE != thing.getStatus()) {
+            return;
+        }
+        if (command instanceof RefreshType) {
+            return;
+        }
+        logger.debug("Command '{}' with channel `{}` received", command, channelUID);
+        switch (channelUID.getIdWithoutGroup()) {
+            case CHANNEL_ACTUALTEMP:
+            case CHANNEL_BATTERY:
+            case CHANNEL_LOCKED:
+            case CHANNEL_CONTACT_STATE:
+            case CHANNEL_SWITCH:
+            case CHANNEL_VALVE:
+                logger.debug("Channel {} is a read-only channel and cannot handle command '{}'", channelUID, command);
+                break;
+            case CHANNEL_MODE:
+                // TODO
+                logger.debug(
+                        "Channel {} is currently read-only channel and cannot handle command '{}' as it is not implemented yet",
+                        channelUID, command);
+                break;
+            case CHANNEL_SETTEMP:
+                /* clear out old pacing timer */
+                if (pacingTimer != null) {
+                    pacingTimer.cancel();
+                    pacingTimer = null;
+                }
+                /* schedule new timer */
+                pacingTimer = new Timer();
+                MaxCulPacedThermostatTransmitTask pacedThermostatTransmitTask = null;
+                if (command instanceof OnOffType) {
+                    if (command == OnOffType.ON) {
+                        pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                ThermostatControlMode.MANUAL, getMaxTemp(), this, bridgeHandler);
+
+                    } else if (command == OnOffType.OFF) {
+                        pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                ThermostatControlMode.MANUAL, getMinTemp(), this, bridgeHandler);
+                    }
+                } else if (command instanceof StringType) {
+                    switch (command.toString()) {
+                        case "ON":
+                            pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                    ThermostatControlMode.MANUAL, getMaxTemp(), this, bridgeHandler);
+                        case "OFF":
+                            pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                    ThermostatControlMode.MANUAL, getMinTemp(), this, bridgeHandler);
+                        case "ECO":
+                            pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                    ThermostatControlMode.MANUAL, getEcoTemp(), this, bridgeHandler);
+                        case "COMFORT":
+                            pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(
+                                    ThermostatControlMode.MANUAL, getComfortTemp(), this, bridgeHandler);
+                    }
+                } else if (command instanceof DecimalType) {
+                    pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(ThermostatControlMode.MANUAL,
+                            ((DecimalType) command).doubleValue(), this, bridgeHandler);
+                } else if (command instanceof QuantityType) {
+                    pacedThermostatTransmitTask = new MaxCulPacedThermostatTransmitTask(ThermostatControlMode.MANUAL,
+                            ((QuantityType) command).doubleValue(), this, bridgeHandler);
+                }
+                if (pacedThermostatTransmitTask != null) {
+                    pacingTimer.schedule(pacedThermostatTransmitTask, PACED_TRANSMIT_TIME);
+                }
+                break;
+            case CHANNEL_DISPLAY_ACTUAL_TEMP:
+                bridgeHandler.sendSetDisplayActualTemp(this, ((OnOffType) command == OnOffType.ON));
+                break;
+            default:
+                logger.warn("Channel {} is a unkown channel and cannot handle command '{}'", channelUID, command);
+        }
+    }
+
+    public void processMessage(BaseMsg msg) {
+        if (rfAddress.equals(msg.srcAddrStr)) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+        if (msg instanceof RfErrorStateMsg && ((RfErrorStateMsg) msg).isRfError()) {
+            logger.warn("Message with RfError from {} to {} of type {} received", msg.srcAddrStr, msg.dstAddrStr,
+                    msg.msgType);
+        }
+        if (msg instanceof BatteryStateMsg) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_BATTERY),
+                    ((BatteryStateMsg) msg).isBatteryLow() ? OnOffType.ON : OnOffType.OFF);
+        }
+        if (msg instanceof WallThermostatDisplayMeasuredStateMsg
+                && WALLTHERMOSTAT_THING_TYPE.equals(getThing().getThingTypeUID())) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_DISPLAY_ACTUAL_TEMP),
+                    ((WallThermostatDisplayMeasuredStateMsg) msg).isDisplayMeasuredTemp() ? OnOffType.ON
+                            : OnOffType.OFF);
+        }
+        if (msg instanceof ThermostatValveStateMsg && (HEATINGTHERMOSTAT_THING_TYPE.equals(getThing().getThingTypeUID())
+                || HEATINGTHERMOSTATPLUS_THING_TYPE.equals(getThing().getThingTypeUID()))) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_VALVE),
+                    new DecimalType(((ThermostatValveStateMsg) msg).getValvePos()));
+        }
+        if (msg instanceof DesiredTemperatureStateMsg) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_MODE),
+                    new StringType(((DesiredTemperatureStateMsg) msg).getControlMode().toString()));
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SETTEMP),
+                    new QuantityType<>(((DesiredTemperatureStateMsg) msg).getDesiredTemperature(), CELSIUS));
+            // TODO handlle UntilDate when mode is ThermostatControlMode.TEMPORARY
+            // ((DesiredTemperatureStateMsg) msg).getUntilDateTime()
+        }
+        if (msg instanceof ThermostatCommonStateMsg) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_LOCKED),
+                    ((ThermostatCommonStateMsg) msg).isLockedForManualSetPoint() ? OpenClosedType.CLOSED
+                            : OpenClosedType.OPEN);
+
+        }
+        if (msg instanceof ActualTemperatureStateMsg) {
+            Double actualTemp = ((ActualTemperatureStateMsg) msg).getMeasuredTemperature();
+            if (actualTemp != null && actualTemp != 0) {
+                updateState(new ChannelUID(getThing().getUID(), CHANNEL_ACTUALTEMP),
+                        new QuantityType<>(actualTemp, CELSIUS));
+            }
+        }
+        if (msg instanceof WallThermostatControlMsg) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SETTEMP),
+                    new QuantityType<>(((WallThermostatControlMsg) msg).getDesiredTemperature(), CELSIUS));
+
+        }
+        if (msg instanceof PushButtonMsg && ECOSWITCH_THING_TYPE.equals(getThing().getThingTypeUID())) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_SWITCH),
+                    ((PushButtonMsg) msg).getMode() == PushButtonMode.AUTO ? OnOffType.ON : OnOffType.OFF);
+        }
+        if (msg instanceof ShutterContactStateMsg && SHUTTERCONTACT_THING_TYPE.equals(getThing().getThingTypeUID())) {
+            updateState(new ChannelUID(getThing().getUID(), CHANNEL_CONTACT_STATE),
+                    ((ShutterContactStateMsg) msg).getState() == ShutterContactState.OPEN ? OpenClosedType.OPEN
+                            : OpenClosedType.CLOSED);
+        }
+    }
+
+    @Override
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+        final Configuration configuration = editConfiguration();
+        for (final Map.Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
+            if (configurationParameter.getValue().toString().equals(BUTTON_ACTION_VALUE)) {
+                configuration.put(configurationParameter.getKey(), BigDecimal.valueOf(BUTTON_NOACTION_VALUE));
+                if (configurationParameter.getKey().equals(ACTION_DEVICE_RESET)) {
+                    scheduler.submit(this::resetDevice);
+                }
+
+            } else {
+                configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
+            }
+        }
+        super.handleConfigurationUpdate(configuration.getProperties());
+    }
+
+    public double getComfortTemp() {
+        return comfortTemp;
+    }
+
+    public double getEcoTemp() {
+        return ecoTemp;
+    }
+
+    public double getMaxTemp() {
+        return maxTemp;
+    }
+
+    public double getMinTemp() {
+        return minTemp;
+    }
+
+    public double getWindowOpenTemperature() {
+        return windowOpenTemperature;
+    }
+
+    public int getWindowOpenDuration() {
+        return windowOpenDuration;
+    }
+
+    public double getMeasurementOffset() {
+        return measurementOffset;
+    }
+
+    public MaxCulWeekProfile getWeekProfile() {
+        return weekProfile;
+    }
+
+    public Set<MaxDevicesHandler> getAssociations() {
+        return bridgeHandler.getMaxDevicesHandles().stream()
+                .filter(mdh -> associatedSerials.contains(mdh.getDeviceSerial())).collect(Collectors.toSet());
+    }
+
+    public void resetDevice() {
+        bridgeHandler.resetDevice(this);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/MessageSequencer.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/MessageSequencer.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.message.sequencers;
+
+import org.openhab.binding.cul.max.internal.messages.BaseMsg;
+
+/**
+ * This creates an interface for Message Sequencers. They allow you to run
+ * through a state machine depending on the messages that are received.
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public interface MessageSequencer {
+
+    /**
+     * Main call to sequencer
+     *
+     * @param msg
+     *            Latest received message
+     */
+    void runSequencer(BaseMsg msg);
+
+    /**
+     * Handle case where packet is lost
+     *
+     * @param msg
+     *            Message to retransmit
+     */
+    void packetLost(BaseMsg msg);
+
+    /**
+     * Query if the message sequence is complete
+     *
+     * @return true of is completed and can be discarded
+     */
+    boolean isComplete();
+
+    /**
+     * Returns true if we are at a point in the sequence where we can use fast
+     * send (i.e. no wakeup)
+     *
+     * @return true if we can use fast send
+     */
+    boolean useFastSend();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/PairingInitialisationSequence.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/PairingInitialisationSequence.java
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.message.sequencers;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.openhab.binding.cul.max.internal.handler.MaxCulMsgHandler;
+import org.openhab.binding.cul.max.internal.handler.MaxDevicesHandler;
+import org.openhab.binding.cul.max.internal.messages.AckMsg;
+import org.openhab.binding.cul.max.internal.messages.BaseMsg;
+import org.openhab.binding.cul.max.internal.messages.MaxCulWeekProfilePart;
+import org.openhab.binding.cul.max.internal.messages.PairPingMsg;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handle the pairing and initialisation sequence of a new device. This should
+ * be called when the device has been verified etc as this will just send the
+ * pong without verifying whether we should or not.
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+public class PairingInitialisationSequence implements MessageSequencer {
+
+    private enum PairingInitialisationState {
+        INITIAL_PING,
+        PONG_ACKED,
+        GROUP_ID_ACKED,
+        CONFIG_TEMPS_ACKED,
+        SENDING_ASSOCIATIONS,
+        SENDING_ASSOCIATIONS_ACKED,
+        SENDING_WEEK_PROFILE,
+        RETX_WAKEUP_ACK,
+        SENDING_WEEK_PROFILE_ACKED,
+        FINISHED;
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(PairingInitialisationSequence.class);
+
+    private PairingInitialisationState state = PairingInitialisationState.INITIAL_PING;
+
+    private String devAddr;
+    private byte group_id;
+    private MaxCulMsgHandler messageHandler;
+    private int pktLostCount = 0;
+    private MaxCulDevice deviceType = MaxCulDevice.UNKNOWN;
+    private MaxDevicesHandler maxDevicesHandler;
+    private Iterator<MaxDevicesHandler> assocIter;
+    private Iterator<MaxCulWeekProfilePart> weekProfileIter;
+    private boolean useFast = true;
+
+    /* place to keep stuff when going through ReTx */
+    private BaseMsg reTxMsg;
+    private PairingInitialisationState reTxState;
+
+    private MaxCulWeekProfilePart currentWeekProfilePart;
+    private boolean secondHalf;
+
+    public PairingInitialisationSequence(byte group_id, MaxCulMsgHandler messageHandler,
+            MaxDevicesHandler maxDevicesHandler) {
+        this.group_id = group_id;
+        this.messageHandler = messageHandler;
+        this.maxDevicesHandler = maxDevicesHandler;
+    }
+
+    @Override
+    public void runSequencer(BaseMsg msg) {
+        /*
+         * This sequence is taken from observations of activity between the MAX!
+         * Cube and a wall thermostat and refined using some experimentation :)
+         */
+        if (state != PairingInitialisationState.RETX_WAKEUP_ACK) {
+            pktLostCount = 0; // reset counter - ack received
+        }
+        try {
+            logger.debug("Sequence State: {}", state);
+            switch (state) {
+                case INITIAL_PING:
+                    /* get device type */
+                    PairPingMsg ppMsg = new PairPingMsg(msg.rawMsg);
+                    this.deviceType = MaxCulDevice.getDeviceTypeFromInt(ppMsg.type);
+                    this.devAddr = msg.srcAddrStr;
+                    /* Send PONG - assumes PING is checked */
+                    logger.debug("Sending PONG: {}", this.devAddr);
+                    messageHandler.sendPairPong(devAddr, this);
+                    state = PairingInitialisationState.PONG_ACKED;
+                    break;
+                case PONG_ACKED:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("PONG_ACKED received: {}", this.devAddr);
+                            if (this.deviceType == MaxCulDevice.PUSH_BUTTON
+                                    || this.deviceType == MaxCulDevice.SHUTTER_CONTACT) {
+                                /* for a push button or a shutter contact we're done now */
+                                logger.debug("{} pairing FINISHED: {}", this.deviceType, devAddr);
+                                state = PairingInitialisationState.FINISHED;
+                            } else {
+                                /* send group id information */
+                                logger.debug("Sending GROUP_ID: {}", devAddr);
+                                messageHandler.sendSetGroupId(devAddr, group_id, this);
+                                state = PairingInitialisationState.GROUP_ID_ACKED;
+                            }
+                        } else {
+                            logger.error("PAIR_PONG was nacked. Ending sequence");
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case GROUP_ID_ACKED:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack() && (this.deviceType == MaxCulDevice.RADIATOR_THERMOSTAT
+                                || this.deviceType == MaxCulDevice.WALL_THERMOSTAT
+                                || this.deviceType == MaxCulDevice.RADIATOR_THERMOSTAT_PLUS)) {
+                            logger.debug("GROUP_ID_ACKED received: {}", msg.srcAddrStr);
+                            // send temps for comfort/eco etc
+                            logger.debug("sendConfigTemperatures: {}", devAddr);
+                            messageHandler.sendConfigTemperatures(devAddr, this, maxDevicesHandler.getComfortTemp(),
+                                    maxDevicesHandler.getEcoTemp(), maxDevicesHandler.getMaxTemp(),
+                                    maxDevicesHandler.getMinTemp(), maxDevicesHandler.getMeasurementOffset(),
+                                    maxDevicesHandler.getWindowOpenTemperature(),
+                                    maxDevicesHandler.getWindowOpenDuration());
+                            state = PairingInitialisationState.CONFIG_TEMPS_ACKED;
+                        } else {
+                            logger.error("SET_GROUP_ID was nacked. Ending sequence: {}", msg.srcAddrStr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case CONFIG_TEMPS_ACKED:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("CONFIG_TEMPS_ACKED received: {}", this.devAddr);
+                            /*
+                             * associate device with us so we get updates - we pretend
+                             * to be the MAX! Cube
+                             */
+                            logger.debug("sendAddLinkPartner for us: {}", devAddr);
+                            messageHandler.sendAddLinkPartner(devAddr, this, msg.dstAddrStr, MaxCulDevice.CUBE);
+
+                            /*
+                             * if there are more associations to come then set up
+                             * iterator and goto state to transmit more associations
+                             */
+                            Set<MaxDevicesHandler> associations = maxDevicesHandler.getAssociations();
+                            if (associations != null && associations.isEmpty() == false) {
+                                assocIter = associations.iterator();
+                                logger.debug("prepare next sendAddLinkPartner: {}", devAddr);
+                                state = PairingInitialisationState.SENDING_ASSOCIATIONS;
+                            } else {
+                                logger.debug("No user configured associations: {}", devAddr);
+                                state = PairingInitialisationState.SENDING_ASSOCIATIONS_ACKED;
+                            }
+                        } else {
+                            logger.error("CONFIG_TEMPERATURES was nacked. Ending sequence: {}", devAddr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case SENDING_ASSOCIATIONS:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("SENDING_ASSOCIATIONS_ACKED received: {}", ack.srcAddrStr);
+                            if (assocIter.hasNext()) /*
+                                                      * this should always be true, but
+                                                      * good to check
+                                                      */ {
+                                MaxDevicesHandler partnerCfg = assocIter.next();
+                                logger.debug("sendAddLinkPartner for {}: {}", partnerCfg.getRfAddress(), devAddr);
+                                messageHandler.sendAddLinkPartner(this.devAddr, this, partnerCfg.getRfAddress(),
+                                        MaxCulDevice.getDeviceTypeFromThingTypeUID(
+                                                partnerCfg.getThing().getThingTypeUID()));
+                                /*
+                                 * if it's the last association message then wait for
+                                 * last ACK
+                                 */
+                                if (assocIter.hasNext()) {
+                                    logger.debug("prepare next sendAddLinkPartner: {}", devAddr);
+                                    state = PairingInitialisationState.SENDING_ASSOCIATIONS;
+                                } else {
+                                    logger.debug("last sendAddLinkPartner waiting for ACK: {}", devAddr);
+                                    state = PairingInitialisationState.SENDING_ASSOCIATIONS_ACKED;
+                                }
+                            } else {
+                                // TODO NOTE: if further states are added then ensure
+                                // you go to the right state. I.e. when all associations
+                                // are done
+                                logger.debug("prepare next sendingWeekProfile: {}", devAddr);
+                                state = PairingInitialisationState.SENDING_WEEK_PROFILE;
+                            }
+                        } else {
+                            logger.error("SENDING_ASSOCIATIONS was nacked. Ending sequence: {}", devAddr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case SENDING_ASSOCIATIONS_ACKED:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("SENDING_ASSOCIATIONS_ACKED received: {}", this.devAddr);
+                            if ((this.deviceType == MaxCulDevice.WALL_THERMOSTAT
+                                    || this.deviceType == MaxCulDevice.RADIATOR_THERMOSTAT_PLUS)
+                                    && !maxDevicesHandler.getWeekProfile().getWeekProfileParts().isEmpty()) {
+                                weekProfileIter = maxDevicesHandler.getWeekProfile().getWeekProfileParts().iterator();
+                                secondHalf = false;
+                                if (weekProfileIter.hasNext()) {
+                                    currentWeekProfilePart = weekProfileIter.next();
+                                    logger.debug("sendWeekProfile Part 1: {}", devAddr);
+                                    messageHandler.sendWeekProfile(devAddr, this, currentWeekProfilePart, secondHalf);
+                                    state = PairingInitialisationState.SENDING_WEEK_PROFILE;
+                                } else {
+                                    logger.debug("Pairing FINISHED: {}", devAddr);
+                                    state = PairingInitialisationState.FINISHED;
+                                }
+                            } else {
+                                logger.debug("Pairing FINISHED: {}", devAddr);
+                                state = PairingInitialisationState.FINISHED;
+                            }
+                        } else {
+                            logger.error("SENDING_ASSOCIATIONS_ACKED was nacked. Ending sequence");
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case SENDING_WEEK_PROFILE:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("SENDING_WEEK_PROFILE_ACKED received: {}", this.devAddr);
+                            // And then the remaining 6
+                            if (!secondHalf && currentWeekProfilePart.getControlPoints().size() > 7) {
+                                secondHalf = true;
+                                logger.debug("sendWeekProfile Part 1+: {}", devAddr);
+                                messageHandler.sendWeekProfile(devAddr, this, currentWeekProfilePart, secondHalf);
+                                /*
+                                 * if it's the last week profile part message then wait for
+                                 * last ACK
+                                 */
+                                if (weekProfileIter.hasNext()) {
+                                    logger.debug("prepare next sendingWeekProfile: {}", devAddr);
+                                    state = PairingInitialisationState.SENDING_WEEK_PROFILE;
+                                } else {
+                                    logger.debug("last sendingWeekProfile waiting for ACK: {}", devAddr);
+                                    state = PairingInitialisationState.SENDING_WEEK_PROFILE_ACKED;
+                                }
+                                break;
+                            }
+                            // First 7 controlpoints
+                            secondHalf = false;
+                            if (weekProfileIter.hasNext()) {
+                                currentWeekProfilePart = weekProfileIter.next();
+                                logger.debug("sendWeekProfile Part 1: {}", devAddr);
+                                messageHandler.sendWeekProfile(devAddr, this, currentWeekProfilePart, secondHalf);
+                                /*
+                                 * if it's the last week profile part message then wait for
+                                 * last ACK
+                                 */
+                                if (weekProfileIter.hasNext()) {
+                                    state = PairingInitialisationState.SENDING_WEEK_PROFILE;
+                                } else {
+                                    state = PairingInitialisationState.SENDING_WEEK_PROFILE_ACKED;
+                                }
+                            } else {
+                                // TODO NOTE: if further states are added then ensure
+                                // you go to the right state. I.e. when all week profile parts
+                                // are done
+                                logger.debug("Pairing FINISHED: {}", devAddr);
+                                state = PairingInitialisationState.FINISHED;
+                            }
+                        } else {
+                            logger.error("SENDING_ASSOCIATIONS was nacked. Ending sequence: {}", devAddr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case SENDING_WEEK_PROFILE_ACKED:
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("SENDING_WEEK_PROFILE_ACKED received: {}", this.devAddr);
+                            logger.debug("Pairing FINISHED: {}", devAddr);
+                            state = PairingInitialisationState.FINISHED;
+                        } else {
+                            logger.error("SENDING_WEEK_PROFILE was nacked. Ending sequence: {}", devAddr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                case FINISHED:
+                    /* done, do nothing */
+                    break;
+                case RETX_WAKEUP_ACK:
+                    /* here are waiting for an ACK after sending a wakeup message */
+                    if (msg.msgType == MaxCulMsgType.ACK) {
+                        AckMsg ack = new AckMsg(msg.rawMsg);
+                        if (!ack.getIsNack()) {
+                            logger.debug("Attempt retransmission - resuming: {}", ack.srcAddrStr);
+                            this.useFast = true;
+                            messageHandler.sendMessage(reTxMsg);
+                            state = reTxState; // resume back to previous state
+                        } else {
+                            logger.error("WAKEUP for ReTx was nacked. Ending sequence: {}", ack.srcAddrStr);
+                            state = PairingInitialisationState.FINISHED;
+                        }
+                    } else {
+                        logger.error("Received {} when expecting ACK: {}", msg.msgType, msg.srcAddrStr);
+                    }
+                    break;
+                default:
+                    logger.error("Invalid state for PairingInitialisation Message Sequence!");
+                    break;
+            }
+        } catch (Exception e) {
+            logger.warn("Unexpected exception occurs on run", e);
+        }
+    }
+
+    @Override
+    public boolean isComplete() {
+        return state == PairingInitialisationState.FINISHED;
+    }
+
+    @Override
+    public void packetLost(BaseMsg msg) {
+        pktLostCount++;
+        logger.debug("Lost {} packets", pktLostCount);
+        if (pktLostCount < 3) {
+            /* send WAKEUP to allow us to send messages in fast mode */
+            logger.debug("Attempt retransmission - first wakeup device");
+            this.useFast = false;
+            messageHandler.sendWakeup(msg.dstAddrStr, this);
+            /* save current state, but avoid overwriting on second attempt */
+            if (this.state != PairingInitialisationState.RETX_WAKEUP_ACK) {
+                this.reTxMsg = msg;
+                this.reTxState = state;
+            }
+            state = PairingInitialisationState.RETX_WAKEUP_ACK;
+        } else {
+            logger.error("Lost {} packets. Ending Sequence in state {}", pktLostCount, this.state);
+            state = PairingInitialisationState.FINISHED;
+        }
+    }
+
+    @Override
+    public boolean useFastSend() {
+        // only use fast send when not sending the wakup msg in PONG_ACKED
+        return (useFast);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/TimeUpdateRequestSequence.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/message/sequencers/TimeUpdateRequestSequence.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.message.sequencers;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.openhab.binding.cul.max.internal.handler.MaxCulMsgHandler;
+import org.openhab.binding.cul.max.internal.messages.AckMsg;
+import org.openhab.binding.cul.max.internal.messages.BaseMsg;
+import org.openhab.binding.cul.max.internal.messages.TimeInfoMsg;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handle Time Update requests. Very simple sequence that simply responds to a
+ * time request and then handles the response
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class TimeUpdateRequestSequence implements MessageSequencer {
+
+    private enum TimeUpdateRequestState {
+        RESPOND_TO_REQUEST,
+        HANDLE_RESPONSE,
+        FINISHED
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(TimeUpdateRequestSequence.class);
+
+    private static final long TIME_TOLERANCE = 30000; // 30s margin
+    TimeUpdateRequestState state = TimeUpdateRequestState.RESPOND_TO_REQUEST;
+    private MaxCulMsgHandler messageHandler;
+    private int pktLostCount = 0;
+    private String tzStr;
+
+    public TimeUpdateRequestSequence(String tz, MaxCulMsgHandler messageHandler) {
+        this.tzStr = tz;
+        this.messageHandler = messageHandler;
+    }
+
+    /**
+     * Compare two times and check they are within a certain tolerance
+     *
+     * @param a
+     *            Time A
+     * @param b
+     *            Time B
+     * @param t
+     *            Tolerance in milliseconds
+     * @return true if within tolerance
+     */
+    private boolean isValidDeviation(Calendar a, Calendar b, long t) {
+        return (Math.abs(a.getTimeInMillis() - b.getTimeInMillis()) <= t);
+    }
+
+    @Override
+    public void runSequencer(BaseMsg msg) {
+        pktLostCount = 0;
+        switch (state) {
+            case RESPOND_TO_REQUEST:
+                if (BaseMsg.getMsgType(msg.rawMsg) == MaxCulMsgType.TIME_INFO) {
+                    TimeInfoMsg timeMsg = new TimeInfoMsg(msg.rawMsg);
+                    if (isValidDeviation(timeMsg.getTimeInfo(), new GregorianCalendar(), TIME_TOLERANCE)) {
+                        messageHandler.sendAck(msg);
+                        state = TimeUpdateRequestState.FINISHED;
+                    } else {
+                        messageHandler.sendTimeInfo(msg.srcAddrStr, tzStr, this);
+                        state = TimeUpdateRequestState.HANDLE_RESPONSE;
+                    }
+                } else {
+                    state = TimeUpdateRequestState.FINISHED;
+                    logger.debug("Got invalid message type for Time Update Sequence");
+                }
+                break;
+            case HANDLE_RESPONSE:
+                /* check for ACK */
+                if (msg.msgType == MaxCulMsgType.ACK) {
+                    AckMsg ack = new AckMsg(msg.rawMsg);
+                    if (ack.getIsNack()) {
+                        logger.error("TIME_INFO was nacked. Ending sequence");
+                        state = TimeUpdateRequestState.FINISHED;
+                    } else {
+                        state = TimeUpdateRequestState.FINISHED;
+                    }
+                }
+                state = TimeUpdateRequestState.FINISHED;
+                break;
+            case FINISHED:
+                /* do nothing */
+                break;
+            default:
+                logger.error("Invalid state for TimeUpdate Request Message Sequence!");
+                break;
+
+        }
+    }
+
+    @Override
+    public void packetLost(BaseMsg msg) {
+        pktLostCount++;
+        logger.debug("Lost {} packets", pktLostCount);
+        if (pktLostCount < 3) {
+            logger.debug("Attempt retransmission");
+            messageHandler.sendMessage(msg);
+        } else {
+            logger.error("Lost {} packets. Ending Sequence in state {}", pktLostCount, this.state);
+            state = TimeUpdateRequestState.FINISHED;
+        }
+    }
+
+    @Override
+    public boolean isComplete() {
+        return (state == TimeUpdateRequestState.FINISHED);
+    }
+
+    @Override
+    public boolean useFastSend() {
+        return true;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/AckMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/AckMsg.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle ACK/NACK
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class AckMsg extends BaseMsg implements BatteryStateMsg, RfErrorStateMsg, WallThermostatDisplayMeasuredStateMsg,
+        ThermostatValveStateMsg, ThermostatCommonStateMsg {
+
+    final static private int ACK_MSG_PAYLOAD_LEN = 2;
+    final static private int ACK_MSG_PAYLOAD_MEAS_LEN = 4;
+    final static private int ACK_MSG_PAYLOAD_TIME_LEN = 7;
+    private boolean isNack;
+
+    private static final Logger logger = LoggerFactory.getLogger(AckMsg.class);
+
+    ThermostatControlMode ctrlMode;
+    private boolean dstActive;
+    private boolean lanGateway; // unknown what this is for
+    private boolean lockedForManualSetPoint;
+    private boolean rfError;
+    private boolean batteryLow;
+    // Heating Thermostat (plus) only
+    private int valvePos;
+    // Wallmount Thermostat only
+    private boolean displayMeasuredTemp;
+    private double desiredTemperature;
+    private GregorianCalendar untilDateTime = null;
+
+    public AckMsg(String rawMsg) {
+        super(rawMsg);
+        if (this.payload.length == ACK_MSG_PAYLOAD_LEN || this.payload.length == ACK_MSG_PAYLOAD_MEAS_LEN
+                || this.payload.length == ACK_MSG_PAYLOAD_TIME_LEN) {
+            isNack = (this.payload[0] == 0x81); // !(this.payload[0] == 0x01);
+            /* extract control mode */
+            ctrlMode = ThermostatControlMode.values()[(this.payload[0] & 0x3)];
+            /* extract DST status */
+            dstActive = extractBitFromByte(this.payload[1], 3);
+            /* extract lanGateway */
+            lanGateway = extractBitFromByte(this.payload[1], 4);
+            /* extract locked status */
+            lockedForManualSetPoint = extractBitFromByte(this.payload[1], 5);
+            /* extract rferror status */
+            rfError = extractBitFromByte(this.payload[1], 6);
+            /* extract battery status */
+            batteryLow = extractBitFromByte(this.payload[1], 7);
+
+            if (this.payload.length == ACK_MSG_PAYLOAD_MEAS_LEN) {
+                /*
+                 * extract whether wall therm is configured to show measured or
+                 * desired temperature
+                 */
+                displayMeasuredTemp = (this.payload[2] == 0 ? false : true);
+
+                /* extract valve position */
+                valvePos = this.payload[2];
+
+                /* extract desired temperature information */
+                desiredTemperature = (this.payload[3] & 0x7f) / 2.0;
+            }
+            if (this.payload.length == ACK_MSG_PAYLOAD_TIME_LEN) {
+                untilDateTime = extractDate(this.payload[4], this.payload[5], this.payload[6]);
+            }
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    public AckMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr, boolean isNack) {
+        super(msgCount, msgFlag, MaxCulMsgType.ACK, groupId, srcAddr, dstAddr);
+
+        byte[] payload = new byte[ACK_MSG_PAYLOAD_LEN];
+        payload[0] = 0x01;
+        if (isNack) {
+            payload[0] |= 0x80; // make 0x81 for NACK
+        }
+        super.appendPayload(payload);
+        this.printDebugPayload();
+    }
+
+    private GregorianCalendar extractDate(byte one, byte two, byte three) {
+        int day = (one & 0x1F);
+        int month = ((two & 0xE0) >> 4) | (three >> 7);
+        int year = two & 0x3F;
+        int time = three & 0x3F;
+        return new GregorianCalendar(year + 2000, month, day, time / 2, (time % 2 == 0) ? 0 : 30);
+    }
+
+    public boolean getIsNack() {
+        return isNack;
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tIs ACK?                  => {}", (!this.isNack));
+        logger.debug("\tDesired Temperature => {}", desiredTemperature);
+        logger.debug("\tValve Position      => {}", valvePos);
+        logger.debug("\tDisplay meas. temp  => {}", displayMeasuredTemp);
+        logger.debug("\tControl Mode        => {}", ctrlMode);
+        logger.debug("\tDST Active          => {}", dstActive);
+        logger.debug("\tLAN Gateway         => {}", lanGateway);
+        logger.debug("\tPanel locked        => {}", lockedForManualSetPoint);
+        logger.debug("\tRF Error            => {}", rfError);
+        logger.debug("\tBattery Low         => {}", batteryLow);
+        if (untilDateTime != null) {
+            logger.debug("\tUntil DateTime      => {}-{}-{} {}:{}:{}", untilDateTime.get(Calendar.YEAR),
+                    (untilDateTime.get(Calendar.MONTH) + 1), untilDateTime.get(Calendar.DAY_OF_MONTH),
+                    untilDateTime.get(Calendar.HOUR_OF_DAY), untilDateTime.get(Calendar.MINUTE),
+                    untilDateTime.get(Calendar.SECOND));
+        }
+    }
+
+    @Override
+    public boolean isBatteryLow() {
+        return batteryLow;
+    }
+
+    @Override
+    public boolean isRfError() {
+        return rfError;
+    }
+
+    @Override
+    public boolean isDisplayMeasuredTemp() {
+        return displayMeasuredTemp;
+    }
+
+    @Override
+    public int getValvePos() {
+        return valvePos;
+    }
+
+    @Override
+    public boolean isDstActive() {
+        return dstActive;
+    }
+
+    @Override
+    public boolean isLanGateway() {
+        return lanGateway;
+    }
+
+    @Override
+    public boolean isLockedForManualSetPoint() {
+        return lockedForManualSetPoint;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ActualTemperatureStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ActualTemperatureStateMsg.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+public interface ActualTemperatureStateMsg {
+    @Nullable
+    Double getMeasuredTemperature();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/AddLinkPartnerMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/AddLinkPartnerMsg.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message to associate devices with each other
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class AddLinkPartnerMsg extends BaseMsg {
+    final private int ADD_LINK_PARTNER_PAYLOAD_LEN = 4;
+
+    private static final Logger logger = LoggerFactory.getLogger(AddLinkPartnerMsg.class);
+
+    private MaxCulDevice devType;
+    private String partnerAddr;
+
+    public AddLinkPartnerMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            String partnerAddr, MaxCulDevice devType) {
+        super(msgCount, msgFlag, MaxCulMsgType.ADD_LINK_PARTNER, groupId, srcAddr, dstAddr);
+
+        this.partnerAddr = partnerAddr;
+        this.devType = devType;
+        byte[] payload = new byte[ADD_LINK_PARTNER_PAYLOAD_LEN];
+
+        payload[0] = (byte) (Integer.parseInt(partnerAddr.substring(0, 2), 16) & 0xff);
+        payload[1] = (byte) (Integer.parseInt(partnerAddr.substring(2, 4), 16) & 0xff);
+        payload[2] = (byte) (Integer.parseInt(partnerAddr.substring(4, 6), 16) & 0xff);
+        payload[3] = (byte) devType.getDeviceTypeInt();
+        super.appendPayload(payload);
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        super.printFormattedPayload();
+        logger.debug("\tDevice Type  => {}", this.devType);
+        logger.debug("\tPartner Addr => {}", this.partnerAddr);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/BaseMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/BaseMsg.java
@@ -1,0 +1,444 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.message.sequencers.MessageSequencer;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base Message Class acts as the parent to messages sent and received by the
+ * CUL device to communicate with the Max! devices.
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class BaseMsg {
+    public byte len;
+    public byte msgCount;
+
+    public byte msgFlag;
+    public byte msgTypeRaw;
+    public MaxCulMsgType msgType;
+    public byte[] srcAddr = new byte[3];
+    public String srcAddrStr;
+    public byte[] dstAddr = new byte[3];
+    public String dstAddrStr;
+    public byte groupid;
+    public byte[] payload;
+    public String rawMsg;
+
+    private boolean fastSend = false;
+
+    private boolean flgReadyToSend = false;
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseMsg.class);
+
+    /* define number of characters per byte */
+    private final static int PKT_CHARS_PER_BYTE = 2;
+
+    /* packet structure in terms of character representations of bytes */
+    private final static int PKT_POS_MSG_LEN = 1; /* Account for 'Z' at start */
+    private final static int PKT_POS_MSG_LEN_LEN = PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_MSG_START = PKT_POS_MSG_LEN + PKT_POS_MSG_LEN_LEN;
+
+    private final static int PKT_POS_MSG_COUNT = PKT_POS_MSG_LEN + PKT_POS_MSG_LEN_LEN;
+    private final static int PKT_POS_MSG_COUNT_LEN = PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_MSG_FLAG = PKT_POS_MSG_COUNT + PKT_POS_MSG_COUNT_LEN;
+    private final static int PKT_POS_MSG_FLAG_LEN = PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_MSG_TYPE = PKT_POS_MSG_FLAG + PKT_POS_MSG_FLAG_LEN;
+    private final static int PKT_POS_MSG_TYPE_LEN = PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_SRC_ADDR = PKT_POS_MSG_TYPE + PKT_POS_MSG_TYPE_LEN;
+    private final static int PKT_POS_SRC_ADDR_LEN = 3 * PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_DST_ADDR = PKT_POS_SRC_ADDR + PKT_POS_SRC_ADDR_LEN;
+    private final static int PKT_POS_DST_ADDR_LEN = 3 * PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_GROUP_ID = PKT_POS_DST_ADDR + PKT_POS_DST_ADDR_LEN;
+    private final static int PKT_POS_GROUP_ID_LEN = PKT_CHARS_PER_BYTE;
+
+    private final static int PKT_POS_PAYLOAD_START = PKT_POS_GROUP_ID + PKT_POS_GROUP_ID_LEN;
+
+    private MessageSequencer msgSequencer = null;
+
+    /**
+     * Constructor based on received message
+     *
+     * @param rawMsg
+     */
+    public BaseMsg(String rawMsg) {
+        BaseMsg pkt = this;
+
+        this.rawMsg = rawMsg;
+
+        pkt.len = (byte) (Integer.parseInt(rawMsg.substring(1, 3), 16) & 0xFF); /*
+                                                                                 * length
+                                                                                 * of
+                                                                                 * packet
+                                                                                 */
+        if (pkt.len != ((rawMsg.length() - 5) / 2)) /*
+                                                     * -5 => 'Z' and len byte (2
+                                                     * chars) and checksum at
+                                                     * end?, div by two as it is
+                                                     * a hex string
+                                                     */
+        {
+            logger.error("Unable to process packet {}. Length is not correct.", rawMsg);
+            pkt.len = 0; /* indicate not a valid packet */
+            return;
+        }
+
+        pkt.msgCount = (byte) (Integer
+                .parseInt(rawMsg.substring(PKT_POS_MSG_COUNT, PKT_POS_MSG_COUNT + PKT_POS_MSG_COUNT_LEN), 16) & 0xFF);
+
+        pkt.msgFlag = (byte) (Integer
+                .parseInt(rawMsg.substring(PKT_POS_MSG_FLAG, PKT_POS_MSG_FLAG + PKT_POS_MSG_FLAG_LEN), 16) & 0xFF);
+
+        pkt.msgTypeRaw = (byte) (Integer
+                .parseInt(rawMsg.substring(PKT_POS_MSG_TYPE, PKT_POS_MSG_TYPE + PKT_POS_MSG_TYPE_LEN), 16) & 0xFF);
+        pkt.msgType = MaxCulMsgType.fromByte(pkt.msgTypeRaw);
+
+        pkt.srcAddrStr = rawMsg.substring(PKT_POS_SRC_ADDR, PKT_POS_SRC_ADDR + PKT_POS_SRC_ADDR_LEN);
+        for (int idx = PKT_POS_SRC_ADDR; idx < PKT_POS_SRC_ADDR + PKT_POS_SRC_ADDR_LEN; idx += PKT_CHARS_PER_BYTE) {
+            pkt.srcAddr[(idx - PKT_POS_SRC_ADDR) / PKT_CHARS_PER_BYTE] = (byte) (Integer
+                    .parseInt(rawMsg.substring(idx, idx + PKT_CHARS_PER_BYTE), 16) & 0xFF);
+        }
+
+        pkt.dstAddrStr = rawMsg.substring(PKT_POS_DST_ADDR, PKT_POS_DST_ADDR + PKT_POS_DST_ADDR_LEN);
+        for (int idx = PKT_POS_DST_ADDR; idx < PKT_POS_DST_ADDR + PKT_POS_DST_ADDR_LEN; idx += PKT_CHARS_PER_BYTE) {
+            pkt.dstAddr[(idx - PKT_POS_DST_ADDR) / PKT_CHARS_PER_BYTE] = (byte) (Integer
+                    .parseInt(rawMsg.substring(idx, idx + PKT_CHARS_PER_BYTE), 16) & 0xFF);
+        }
+
+        pkt.groupid = (byte) (Integer
+                .parseInt(rawMsg.substring(PKT_POS_GROUP_ID, PKT_POS_GROUP_ID + PKT_POS_GROUP_ID_LEN), 16) & 0xFF);
+
+        /*
+         * pkt.len accounts for message only (i.e. not first 3 chars) - so
+         * offset for characters that precede the message
+         */
+        int payloadStrLen = ((pkt.len) * PKT_CHARS_PER_BYTE) + PKT_POS_MSG_START - PKT_POS_PAYLOAD_START;
+        int payloadByteLen = payloadStrLen / PKT_CHARS_PER_BYTE;
+        pkt.payload = new byte[payloadByteLen];
+        for (int payIdx = PKT_POS_PAYLOAD_START; payIdx < (PKT_POS_PAYLOAD_START
+                + payloadStrLen); payIdx += PKT_CHARS_PER_BYTE) {
+            pkt.payload[(payIdx - PKT_POS_PAYLOAD_START) / PKT_CHARS_PER_BYTE] = (byte) (Integer
+                    .parseInt(rawMsg.substring(payIdx, payIdx + PKT_CHARS_PER_BYTE), 16) & 0xFF);
+        }
+    }
+
+    /**
+     * This constructor creates an incomplete raw message ready for sending.
+     * Payload must be set before sending.
+     *
+     * @param msgCount
+     *            Message Counter
+     * @param msgFlag
+     *            Message flag
+     * @param msgType
+     *            the message type
+     * @param groupId
+     *            Group ID
+     * @param srcAddr
+     *            Source address of controller
+     * @param dstAddr
+     *            Dest addr of device
+     */
+    public BaseMsg(byte msgCount, byte msgFlag, MaxCulMsgType msgType, byte groupId, String srcAddr, String dstAddr) {
+        buildHeader(msgCount, msgFlag, msgType, groupId, srcAddr, dstAddr);
+    }
+
+    /**
+     * This constructor creates a raw message ready for sending.
+     *
+     * @param msgCount
+     *            Message Counter
+     * @param msgFlag
+     *            Message flag
+     * @param msgType
+     *            the message type
+     * @param groupId
+     *            Group ID
+     * @param srcAddr
+     *            Source address of controller
+     * @param dstAddr
+     *            Dest addr of device
+     * @param payload
+     *            payload of message
+     */
+    public BaseMsg(byte msgCount, byte msgFlag, MaxCulMsgType msgType, byte groupId, String srcAddr, String dstAddr,
+            byte[] payload) {
+        this(msgCount, msgFlag, msgType, groupId, srcAddr, dstAddr);
+        appendPayload(payload);
+    }
+
+    private void buildHeader(byte msgCount, byte msgFlag, MaxCulMsgType msgType, byte groupId, String srcAddr,
+            String dstAddr) {
+        StringBuilder sb = new StringBuilder();
+
+        this.msgCount = msgCount;
+        sb.append(String.format("%02x", msgCount).toUpperCase());
+
+        this.msgFlag = msgFlag;
+        sb.append(String.format("%02x", msgFlag).toUpperCase());
+
+        this.msgType = msgType;
+        this.msgTypeRaw = this.msgType.toByte();
+        sb.append(String.format("%02x", this.msgTypeRaw).toUpperCase());
+
+        this.srcAddrStr = srcAddr;
+        this.srcAddr[0] = (byte) (Integer.parseInt(srcAddr.substring(0, 2), 16) & 0xFF);
+        this.srcAddr[1] = (byte) (Integer.parseInt(srcAddr.substring(2, 4), 16) & 0xFF);
+        this.srcAddr[2] = (byte) (Integer.parseInt(srcAddr.substring(4, 6), 16) & 0xFF);
+        sb.append(srcAddr.toUpperCase());
+
+        this.dstAddrStr = dstAddr;
+        this.dstAddr[0] = (byte) (Integer.parseInt(dstAddr.substring(0, 2), 16) & 0xFF);
+        this.dstAddr[1] = (byte) (Integer.parseInt(dstAddr.substring(2, 4), 16) & 0xFF);
+        this.dstAddr[2] = (byte) (Integer.parseInt(dstAddr.substring(4, 6), 16) & 0xFF);
+        sb.append(dstAddr.toUpperCase());
+
+        this.groupid = groupId;
+        sb.append(String.format("%02x", this.groupid).toUpperCase());
+
+        this.rawMsg = sb.toString();
+    }
+
+    protected void appendPayload(byte[] payload) {
+        if (this.flgReadyToSend) {
+            /* clear out old payload - we're updating */
+            this.flgReadyToSend = false;
+            this.buildHeader(msgCount, msgFlag, msgType, groupid, srcAddrStr, dstAddrStr);
+        }
+        StringBuilder sb = new StringBuilder(this.rawMsg);
+        this.flgReadyToSend = true;
+        this.payload = payload;
+        for (int byteIdx = 0; byteIdx < payload.length; byteIdx++) {
+            sb.append(String.format("%02X", payload[byteIdx]).toUpperCase());
+        }
+
+        /* prepend length & Z command */
+        byte len = (byte) ((sb.length() / PKT_CHARS_PER_BYTE) & 0xFF);
+        if (len * PKT_CHARS_PER_BYTE != sb.length()) {
+            this.flgReadyToSend = false;
+            logger.error("Unable to build raw message. Length is not correct");
+        }
+        if (isFastSend()) {
+            sb.insert(0, String.format("Zf%02X", len));
+        } else {
+            sb.insert(0, String.format("Zs%02X", len));
+        }
+
+        this.len = len;
+        this.rawMsg = sb.toString();
+        this.flgReadyToSend = true;
+    }
+
+    private static boolean pktLenOk(String rawMsg) {
+        int len = (byte) (Integer.parseInt(rawMsg.substring(PKT_POS_MSG_LEN, PKT_POS_MSG_LEN + PKT_POS_MSG_LEN_LEN), 16)
+                & 0xFF); /* length of packet */
+        if (len != ((rawMsg.length() - (PKT_POS_MSG_START + PKT_CHARS_PER_BYTE)) / PKT_CHARS_PER_BYTE)) /*
+                                                                                                         * account
+                                                                                                         * for
+                                                                                                         * preceding
+                                                                                                         * characters
+                                                                                                         * in
+                                                                                                         * the
+                                                                                                         * message
+                                                                                                         * and
+                                                                                                         * a
+                                                                                                         * byte
+                                                                                                         * at
+                                                                                                         * the
+                                                                                                         * end
+                                                                                                         * which
+                                                                                                         * i
+                                                                                                         * think
+                                                                                                         * is
+                                                                                                         * a
+                                                                                                         * checksum
+                                                                                                         */
+        {
+            logger.error("Unable to process packet {}. Length is not correct.", rawMsg);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Extract flag from a byte
+     *
+     * @param b
+     *            Byte to look at
+     * @param pos
+     *            Zero indexed position
+     * @return true if bit is 1, false if it is 0, false if pos>7
+     */
+    protected boolean extractBitFromByte(byte b, int pos) {
+        if (pos > 7) {
+            return false;
+        }
+        return (((b & (0x1 << pos)) >> pos) == 1);
+    }
+
+    /**
+     * Return the type of message that has been received given the message
+     * string
+     *
+     * @param rawMsg
+     *            Message string from CUL device
+     * @return MaxCulMsgType extracted from the message
+     */
+    public static MaxCulMsgType getMsgType(String rawMsg) {
+        if (pktLenOk(rawMsg) == false) {
+            return MaxCulMsgType.UNKNOWN;
+        }
+
+        return MaxCulMsgType.fromByte((byte) (Integer
+                .parseInt(rawMsg.substring(PKT_POS_MSG_TYPE, PKT_POS_MSG_TYPE + PKT_POS_MSG_TYPE_LEN), 16) & 0xff));
+    }
+
+    public static boolean isForUs(String rawMsg, String addr) {
+        if (pktLenOk(rawMsg) == false) {
+            return false; // length is wrong ignore packet
+        }
+
+        return addr.equalsIgnoreCase(rawMsg.substring(PKT_POS_DST_ADDR, PKT_POS_DST_ADDR + PKT_POS_DST_ADDR_LEN));
+    }
+
+    public int requiredCredit() {
+        /*
+         * length in bits = amount of credit needed length in bits = num chars *
+         * 4 This is because each char represents 4 bits of a hex number. RawMsg
+         * length is decremented by one to account for the 'Z[s|f]'
+         */
+        int credit = (this.rawMsg.length() - 2) * 4;
+
+        /* credit is in 10ms units, round up */
+        credit = (int) Math.ceil(credit / 10.0);
+
+        return credit;
+    }
+
+    /**
+     * Indicate if this packet is complete
+     *
+     * @return true if packet is ready to send
+     */
+    public boolean readyToSend() {
+        return this.flgReadyToSend;
+    }
+
+    /**
+     * Print the payload out for debug
+     */
+    protected void printDebugPayload() {
+        for (int i = 0; i < payload.length; i++) {
+            logger.debug("\t{} byte[{}] => 0x{}", this.msgType, i, Integer.toHexString(0xff & payload[i]));
+        }
+    }
+
+    protected void printMessageHeader() {
+        logger.debug("Raw Message: {}", this.rawMsg);
+        logger.debug("\tLength    => {}", Integer.toString(0xff & this.len));
+        logger.debug("\tMsg Count => 0x{}", Integer.toHexString(0xff & this.msgCount));
+        logger.debug("\tMsg Flag  => 0x{}", Integer.toHexString(0xff & this.msgFlag));
+        logger.debug("\tMsg Type  => {}", this.msgType);
+        logger.debug("\tSrc Addr  => {}", this.srcAddrStr);
+        logger.debug("\tDst Addr  => {}", this.dstAddrStr);
+        logger.debug("\tGroup ID  => {}", Integer.toString(0xff & this.groupid));
+    }
+
+    /**
+     * Print output as decoded fields
+     */
+    protected void printFormattedPayload() {
+        logger.debug("\tPrinting raw payload:");
+        printDebugPayload();
+    }
+
+    /**
+     * Print the full message out to debug
+     */
+    public void printMessage() {
+        printMessageHeader();
+        printFormattedPayload();
+    }
+
+    /**
+     * Set this message to be part of a message sequence, also checks if it
+     * should be using fast send for this message or not
+     *
+     * @param msgSeq
+     *            MessageSequence to associate with message
+     */
+    public void setMessageSequencer(MessageSequencer msgSeq) {
+        msgSequencer = msgSeq;
+        if (msgSeq != null) {
+            this.setFastSend(msgSeq.useFastSend());
+        }
+    }
+
+    /**
+     * Get the Message Sequencer associated with this message
+     *
+     * @return MessageSequencer associated with message
+     */
+    public MessageSequencer getMessageSequencer() {
+        return msgSequencer;
+    }
+
+    /**
+     * Check if this message is part of a sequence
+     *
+     * @return true if part of sequence
+     */
+    public boolean isPartOfSequence() {
+        return (msgSequencer != null);
+    }
+
+    /**
+     * Set fast send flag manually
+     *
+     * @param useFastSend
+     *            value to set fast send flag to
+     */
+    public void setFastSend(boolean useFastSend) {
+        this.fastSend = useFastSend;
+        if (this.flgReadyToSend) {
+            logger.debug("Reconfiguring message to {}", (fastSend ? "FAST" : "SLOW"));
+            if (fastSend) {
+                this.rawMsg = rawMsg.replaceFirst("Zs", "Zf"); // replace slow
+                                                               // with fast
+            } else {
+                this.rawMsg = rawMsg.replaceFirst("Zf", "Zs"); // replace fast
+                                                               // with slow
+            }
+        }
+    }
+
+    /**
+     * Get fast send status
+     *
+     * @return true if message is fastSend
+     */
+    public boolean isFastSend() {
+        return fastSend;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/BatteryStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/BatteryStateMsg.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface BatteryStateMsg {
+    boolean isBatteryLow();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigTemperaturesMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigTemperaturesMsg.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Send temperature configuration to the device, setting comfort, eco, max, min,
+ * measurement offset and window parameters.
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class ConfigTemperaturesMsg extends BaseMsg {
+
+    final static private int CONFIG_TEMPERATURES_PAYLOAD_LEN = 7; /* in bytes */
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigTemperaturesMsg.class);
+
+    public static final double DEFAULT_COMFORT_TEMP = 21.0;
+    public static final double DEFAULT_ECO_TEMP = 17.0;
+    public static final double DEFAULT_MAX_TEMP = 30.5;
+    public static final double DEFAULT_MIN_TEMP = 4.5;
+    public static final double DEFAULT_OFFSET = 0.0;
+    public static final double DEFAULT_WINDOW_OPEN_TEMP = 4.5; // OFF
+    public static final int DEFAULT_WINDOW_OPEN_TIME = 0; // OFF
+
+    private double comfortTemp = 21.0;
+    private double ecoTemp = 17.0;
+    private double maxTemp = 30.5;
+    private double minTemp = 4.5;
+    private double offset = 0.0;
+    private double windowOpenTemp = 4.5; // off
+    private double windowOpenTime = 0;
+
+    public ConfigTemperaturesMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == CONFIG_TEMPERATURES_PAYLOAD_LEN) {
+            this.comfortTemp = payload[0] / 2.0;
+            this.ecoTemp = payload[1] / 2.0;
+            this.maxTemp = payload[2] / 2.0;
+            this.minTemp = payload[3] / 2.0;
+            this.offset = (payload[4] / 2.0) - 3.5;
+            this.windowOpenTemp = payload[5] / 2.0;
+            this.windowOpenTime = payload[6] * 5.0;
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    private byte[] buildPayload() {
+        byte[] payload = new byte[CONFIG_TEMPERATURES_PAYLOAD_LEN];
+        payload[0] = (byte) (comfortTemp * 2.0);
+        payload[1] = (byte) (ecoTemp * 2.0);
+        payload[2] = (byte) (maxTemp * 2.0);
+        payload[3] = (byte) (minTemp * 2.0);
+
+        if (offset < -3.5) {
+            offset = -3.5; // cap offset
+        }
+        payload[4] = (byte) ((offset + 3.5) * 2.0);
+        payload[5] = (byte) (windowOpenTemp * 2.0);
+        payload[6] = (byte) (windowOpenTime / 5.0);
+
+        return payload;
+    }
+
+    /**
+     * Construct with default values
+     */
+    public ConfigTemperaturesMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.CONFIG_TEMPERATURES, groupId, srcAddr, dstAddr);
+        super.appendPayload(buildPayload());
+    }
+
+    public ConfigTemperaturesMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            double comfortTemp, double ecoTemp, double maxTemp, double minTemp, double offset, double windowOpenTemp,
+            double windowOpenTime) {
+        super(msgCount, msgFlag, MaxCulMsgType.CONFIG_TEMPERATURES, groupId, srcAddr, dstAddr);
+
+        this.comfortTemp = comfortTemp;
+        this.ecoTemp = ecoTemp;
+        this.maxTemp = maxTemp;
+        this.minTemp = minTemp;
+        this.offset = offset;
+        this.windowOpenTemp = windowOpenTemp;
+        this.windowOpenTime = windowOpenTime;
+
+        super.appendPayload(buildPayload());
+    }
+
+    public double getComfortTemp() {
+        return comfortTemp;
+    }
+
+    public double getEcoTemp() {
+        return ecoTemp;
+    }
+
+    public double getMaxTemp() {
+        return maxTemp;
+    }
+
+    public double getMinTemp() {
+        return minTemp;
+    }
+
+    public double getOffset() {
+        return offset;
+    }
+
+    public double getWindowOpenTemp() {
+        return windowOpenTemp;
+    }
+
+    public double getWindowOpenTime() {
+        return windowOpenTime;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigValveMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigValveMsg.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulBoostDuration;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulWeekdays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class ConfigValveMsg extends BaseMsg {
+
+    final static private int CONFIG_VALVE_PAYLOAD_LEN = 4; /* in bytes */
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigValveMsg.class);
+
+    private MaxCulBoostDuration boostDuration;
+    private int boostValveposition; // 0-100
+    private int decalcificationHour; // 0-23
+    private int maxValveSetting; // 0-100
+    private int valveOffset; // 0-100
+    private MaxCulWeekdays decalcificationDay;
+
+    public ConfigValveMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+        if (this.payload.length == CONFIG_VALVE_PAYLOAD_LEN) {
+            this.boostDuration = MaxCulBoostDuration.getBoostDurationFromIdx(payload[0] >> 5);
+            byte bTemp = payload[0];
+            bTemp &= 0x1F;
+            this.boostValveposition = (int) bTemp * 5;
+            this.decalcificationDay = MaxCulWeekdays.getWeekDayFromInt(payload[1] >> 5);
+            byte dTemp = payload[1];
+            dTemp &= 0x1F;
+            this.decalcificationHour = (int) dTemp;
+            this.maxValveSetting = (int) (payload[2] * 100 / 255f);
+            this.valveOffset = (int) (payload[3] * 100 / 255f);
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    private byte[] buildPayload() {
+        byte[] payload = new byte[CONFIG_VALVE_PAYLOAD_LEN];
+        payload[1] = (byte) (boostDuration.getDurationIndex() << 5 | (int) (boostValveposition / 5f));
+        payload[0] = (byte) (decalcificationDay.getDayIndexInt() << 5 | decalcificationHour);
+        payload[2] = (byte) (maxValveSetting * 255 / 100f);
+        payload[3] = (byte) (valveOffset * 255 / 100f);
+        return payload;
+    }
+
+    /**
+     * Construct with default values
+     */
+    public ConfigValveMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.CONFIG_VALVE, groupId, srcAddr, dstAddr);
+        super.appendPayload(buildPayload());
+    }
+
+    public ConfigValveMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            MaxCulBoostDuration boostDuration, int boostValveposition, MaxCulWeekdays decalcificationDay,
+            int decalcificationHour, int maxValveSetting, int valveOffset) {
+        super(msgCount, msgFlag, MaxCulMsgType.CONFIG_VALVE, groupId, srcAddr, dstAddr);
+
+        this.boostDuration = boostDuration;
+        this.boostValveposition = boostValveposition;
+        this.decalcificationDay = decalcificationDay;
+        this.decalcificationHour = decalcificationHour;
+        this.maxValveSetting = maxValveSetting;
+        this.valveOffset = valveOffset;
+        super.appendPayload(buildPayload());
+    }
+
+    public MaxCulBoostDuration getBoostDuration() {
+        return boostDuration;
+    }
+
+    public double getBoostValveposition() {
+        return boostValveposition;
+    }
+
+    public int getDecalcification() {
+        return decalcificationHour;
+    }
+
+    public MaxCulWeekdays getDecalcificationDay() {
+        return decalcificationDay;
+    }
+
+    public double getMaxValveSetting() {
+        return maxValveSetting;
+    }
+
+    public double getValveOffset() {
+        return valveOffset;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigWeekProfileMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ConfigWeekProfileMsg.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulWeekdays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class ConfigWeekProfileMsg extends BaseMsg {
+
+    final static private int CONFIG_WEEK_PROFILE_LONG_PAYLOAD_LEN = 15; /* in bytes */
+    final static private int CONFIG_WEEK_PROFILE_SHORT_PAYLOAD_LEN = 13; /* in bytes */
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigWeekProfileMsg.class);
+
+    public static final MaxCulWeekProfile DEFAULT_WEEK_PROFILE;
+
+    private MaxCulWeekProfilePart weekProfile;
+
+    private boolean secondHalf;
+
+    static {
+        DEFAULT_WEEK_PROFILE = new MaxCulWeekProfile();
+        {
+            MaxCulWeekProfilePart saturday = new MaxCulWeekProfilePart();
+            saturday.setDay(MaxCulWeekdays.SATURDAY);
+            MaxCulWeekProfileControlPoint satMorning = new MaxCulWeekProfileControlPoint();
+            satMorning.setHour(6);
+            satMorning.setMin(0);
+            satMorning.setTemperature(17.0f);
+            saturday.addControlPoint(satMorning);
+            MaxCulWeekProfileControlPoint satNoon = new MaxCulWeekProfileControlPoint();
+            satNoon.setHour(22);
+            satNoon.setMin(0);
+            satNoon.setTemperature(21.0f);
+            saturday.addControlPoint(satNoon);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(saturday);
+        }
+        {
+            MaxCulWeekProfilePart sunday = new MaxCulWeekProfilePart();
+            sunday.setDay(MaxCulWeekdays.SUNDAY);
+            MaxCulWeekProfileControlPoint sunMorning = new MaxCulWeekProfileControlPoint();
+            sunMorning.setHour(6);
+            sunMorning.setMin(0);
+            sunMorning.setTemperature(17.0f);
+            sunday.addControlPoint(sunMorning);
+            MaxCulWeekProfileControlPoint sunNoon = new MaxCulWeekProfileControlPoint();
+            sunNoon.setHour(22);
+            sunNoon.setMin(0);
+            sunNoon.setTemperature(21.0f);
+            sunday.addControlPoint(sunNoon);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(sunday);
+        }
+        {
+            MaxCulWeekProfilePart monday = new MaxCulWeekProfilePart();
+            monday.setDay(MaxCulWeekdays.MONDAY);
+            MaxCulWeekProfileControlPoint monMorning = new MaxCulWeekProfileControlPoint();
+            monMorning.setHour(6);
+            monMorning.setMin(0);
+            monMorning.setTemperature(17.0f);
+            monday.addControlPoint(monMorning);
+            MaxCulWeekProfileControlPoint monLateMorning = new MaxCulWeekProfileControlPoint();
+            monLateMorning.setHour(9);
+            monLateMorning.setMin(0);
+            monLateMorning.setTemperature(21.0f);
+            monday.addControlPoint(monLateMorning);
+            MaxCulWeekProfileControlPoint monNoon = new MaxCulWeekProfileControlPoint();
+            monNoon.setHour(17);
+            monNoon.setMin(0);
+            monNoon.setTemperature(17.0f);
+            monday.addControlPoint(monNoon);
+            MaxCulWeekProfileControlPoint monEvening = new MaxCulWeekProfileControlPoint();
+            monEvening.setHour(23);
+            monEvening.setMin(0);
+            monEvening.setTemperature(21.0f);
+            monday.addControlPoint(monEvening);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(monday);
+        }
+        {
+            MaxCulWeekProfilePart tuesday = new MaxCulWeekProfilePart();
+            tuesday.setDay(MaxCulWeekdays.TUESDAY);
+            MaxCulWeekProfileControlPoint tueMorning = new MaxCulWeekProfileControlPoint();
+            tueMorning.setHour(6);
+            tueMorning.setMin(0);
+            tueMorning.setTemperature(17.0f);
+            tuesday.addControlPoint(tueMorning);
+            MaxCulWeekProfileControlPoint tueLateMorning = new MaxCulWeekProfileControlPoint();
+            tueLateMorning.setHour(9);
+            tueLateMorning.setMin(0);
+            tueLateMorning.setTemperature(21.0f);
+            tuesday.addControlPoint(tueLateMorning);
+            MaxCulWeekProfileControlPoint tueNoon = new MaxCulWeekProfileControlPoint();
+            tueNoon.setHour(17);
+            tueNoon.setMin(0);
+            tueNoon.setTemperature(17.0f);
+            tuesday.addControlPoint(tueNoon);
+            MaxCulWeekProfileControlPoint tueEvening = new MaxCulWeekProfileControlPoint();
+            tueEvening.setHour(23);
+            tueEvening.setMin(0);
+            tueEvening.setTemperature(21.0f);
+            tuesday.addControlPoint(tueEvening);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(tuesday);
+        }
+        {
+            MaxCulWeekProfilePart wendsday = new MaxCulWeekProfilePart();
+            wendsday.setDay(MaxCulWeekdays.WENDSDAY);
+            MaxCulWeekProfileControlPoint wenMorning = new MaxCulWeekProfileControlPoint();
+            wenMorning.setHour(6);
+            wenMorning.setMin(0);
+            wenMorning.setTemperature(17.0f);
+            wendsday.addControlPoint(wenMorning);
+            MaxCulWeekProfileControlPoint wenLateMorning = new MaxCulWeekProfileControlPoint();
+            wenLateMorning.setHour(9);
+            wenLateMorning.setMin(0);
+            wenLateMorning.setTemperature(21.0f);
+            wendsday.addControlPoint(wenLateMorning);
+            MaxCulWeekProfileControlPoint wenNoon = new MaxCulWeekProfileControlPoint();
+            wenNoon.setHour(17);
+            wenNoon.setMin(0);
+            wenNoon.setTemperature(17.0f);
+            wendsday.addControlPoint(wenNoon);
+            MaxCulWeekProfileControlPoint wenEvening = new MaxCulWeekProfileControlPoint();
+            wenEvening.setHour(23);
+            wenEvening.setMin(0);
+            wenEvening.setTemperature(21.0f);
+            wendsday.addControlPoint(wenEvening);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(wendsday);
+        }
+        {
+            MaxCulWeekProfilePart thursday = new MaxCulWeekProfilePart();
+            thursday.setDay(MaxCulWeekdays.THURSDAY);
+            MaxCulWeekProfileControlPoint thuMorning = new MaxCulWeekProfileControlPoint();
+            thuMorning.setHour(6);
+            thuMorning.setMin(0);
+            thuMorning.setTemperature(17.0f);
+            thursday.addControlPoint(thuMorning);
+            MaxCulWeekProfileControlPoint thuLateMorning = new MaxCulWeekProfileControlPoint();
+            thuLateMorning.setHour(9);
+            thuLateMorning.setMin(0);
+            thuLateMorning.setTemperature(21.0f);
+            thursday.addControlPoint(thuLateMorning);
+            MaxCulWeekProfileControlPoint thuNoon = new MaxCulWeekProfileControlPoint();
+            thuNoon.setHour(17);
+            thuNoon.setMin(0);
+            thuNoon.setTemperature(17.0f);
+            thursday.addControlPoint(thuNoon);
+            MaxCulWeekProfileControlPoint thuEvening = new MaxCulWeekProfileControlPoint();
+            thuEvening.setHour(23);
+            thuEvening.setMin(0);
+            thuEvening.setTemperature(21.0f);
+            thursday.addControlPoint(thuEvening);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(thursday);
+        }
+        {
+            MaxCulWeekProfilePart friday = new MaxCulWeekProfilePart();
+            friday.setDay(MaxCulWeekdays.FRIDAY);
+            MaxCulWeekProfileControlPoint friMorning = new MaxCulWeekProfileControlPoint();
+            friMorning.setHour(6);
+            friMorning.setMin(0);
+            friMorning.setTemperature(17.0f);
+            friday.addControlPoint(friMorning);
+            MaxCulWeekProfileControlPoint friLateMorning = new MaxCulWeekProfileControlPoint();
+            friLateMorning.setHour(9);
+            friLateMorning.setMin(0);
+            friLateMorning.setTemperature(21.0f);
+            friday.addControlPoint(friLateMorning);
+            MaxCulWeekProfileControlPoint friNoon = new MaxCulWeekProfileControlPoint();
+            friNoon.setHour(17);
+            friNoon.setMin(0);
+            friNoon.setTemperature(17.0f);
+            friday.addControlPoint(friNoon);
+            MaxCulWeekProfileControlPoint friEvening = new MaxCulWeekProfileControlPoint();
+            friEvening.setHour(23);
+            friEvening.setMin(0);
+            friEvening.setTemperature(21.0f);
+            friday.addControlPoint(friEvening);
+            DEFAULT_WEEK_PROFILE.addWeekProfilePart(friday);
+        }
+
+    }
+
+    public ConfigWeekProfileMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+        if (this.payload.length == CONFIG_WEEK_PROFILE_LONG_PAYLOAD_LEN) {
+            secondHalf = false;
+            weekProfile = parseWeekProfile();
+
+        } else if (this.payload.length == CONFIG_WEEK_PROFILE_SHORT_PAYLOAD_LEN) {
+            secondHalf = true;
+            weekProfile = parseWeekProfile();
+
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    public ConfigWeekProfileMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            MaxCulWeekProfilePart weekProfile, boolean secondHalf) {
+        super(msgCount, msgFlag, MaxCulMsgType.CONFIG_WEEK_PROFILE, groupId, srcAddr, dstAddr);
+        this.weekProfile = weekProfile;
+        this.secondHalf = secondHalf;
+        super.appendPayload(buildPayload());
+    }
+
+    private byte[] buildPayload() {
+        int day = weekProfile.getDay().getDayIndexInt();
+        int start;
+        int end;
+        if (secondHalf) {
+            start = 0;
+            end = 6;
+            payload = new byte[CONFIG_WEEK_PROFILE_SHORT_PAYLOAD_LEN];
+            payload[0] = 1 << 4;
+            payload[0] |= day;
+        } else {
+            start = 0;
+            end = 7;
+            payload = new byte[CONFIG_WEEK_PROFILE_LONG_PAYLOAD_LEN];
+            payload[0] = 0 << 4;
+            payload[0] |= day;
+        }
+        for (int i = start; i < end; i++) {
+            if ((secondHalf ? i + 7 : i) >= weekProfile.getControlPoints().size()) {
+                int emptyValue = 0x4520;
+                payload[(i * 2) + 2] = (byte) (emptyValue & 0x00FF);
+                payload[(i * 2) + 1] = (byte) ((emptyValue & 0xFF00) >> 8);
+                continue;
+            }
+            MaxCulWeekProfileControlPoint controlPoint = weekProfile.getControlPoints().get(secondHalf ? i + 7 : i);
+            int value = ((int) (controlPoint.getTemperature() * 2) << 9)
+                    | (int) ((controlPoint.getHour() * 60 + controlPoint.getMin()) / 5f);
+            payload[(i * 2) + 2] = (byte) (value & 0x00FF);
+            payload[(i * 2) + 1] = (byte) ((value & 0xFF00) >> 8);
+        }
+        return payload;
+    }
+
+    private MaxCulWeekProfilePart parseWeekProfile() {
+        MaxCulWeekProfilePart result = new MaxCulWeekProfilePart();
+        int secondHalfInt = payload[0] >> 4;
+        if (secondHalfInt == 1 && !this.secondHalf) {
+            logger.warn("Expected CONFIG_WEEK_PROFILE_SHORT_PAYLOAD_LEN");
+        }
+        if (secondHalfInt == 0 && this.secondHalf) {
+            logger.warn("Expected CONFIG_WEEK_PROFILE_LONG_PAYLOAD_LEN");
+        }
+        int day = payload[0] & 0xF;
+        result.setDay(MaxCulWeekdays.getWeekDayFromInt(day));
+        // Format of weekprofile: 16 bit integer (high byte first) for every control point, 13 control points for every
+        // day
+        // each 16 bit integer value is parsed as
+        // int time = (value & 0x1FF) * 5;
+        // int hour = (time / 60) % 24;
+        // int minute = time % 60;
+        // int temperature = ((value >> 9) & 0x3F) / 2;
+        // #parse weekprofiles for each day
+        for (int j = 1; j < (secondHalf ? 12 : 14); j += 2) {
+            MaxCulWeekProfileControlPoint controlPoint = new MaxCulWeekProfileControlPoint();
+            int currentControlPoint = (int) payload[j];
+            currentControlPoint = currentControlPoint << 8;
+            currentControlPoint |= (int) (payload[j + 1] & 0xFF);
+            int time = (currentControlPoint & 0x1FF) * 5;
+            controlPoint.setHour(time / 60 % 24);
+            controlPoint.setMin(time % 60);
+            controlPoint.setTemperature(((currentControlPoint >> 9) & 0x3F) / 2f);
+            if (controlPoint.getHour() == 0 && controlPoint.getMin() == 0) {
+                break;
+            }
+            result.addControlPoint(controlPoint);
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/DesiredTemperatureStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/DesiredTemperatureStateMsg.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.GregorianCalendar;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+@NonNullByDefault
+public interface DesiredTemperatureStateMsg {
+
+    ThermostatControlMode getControlMode();
+
+    double getDesiredTemperature();
+
+    @Nullable
+    GregorianCalendar getUntilDateTime();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulPacedThermostatTransmitTask.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulPacedThermostatTransmitTask.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.*;
+
+import java.util.TimerTask;
+
+import org.openhab.binding.cul.max.internal.handler.MaxCulCunBridgeHandler;
+import org.openhab.binding.cul.max.internal.handler.MaxDevicesHandler;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+public class MaxCulPacedThermostatTransmitTask extends TimerTask {
+
+    private MaxCulCunBridgeHandler messageHandler;
+    private MaxDevicesHandler maxDevicesHandler;
+    private ThermostatControlMode mode;
+    private double temperature;
+
+    public MaxCulPacedThermostatTransmitTask(ThermostatControlMode mode, double temperature,
+            MaxDevicesHandler maxDevicesHandler, MaxCulCunBridgeHandler messageHandler) {
+        this.maxDevicesHandler = maxDevicesHandler;
+        this.messageHandler = messageHandler;
+        this.temperature = temperature;
+        this.mode = mode;
+    }
+
+    private void sendToDevices(ThermostatControlMode mode, double temp) {
+        saveSendTemperature(maxDevicesHandler, mode, temp);
+        /* send temperature to associated devices */
+        for (MaxDevicesHandler associatedDevice : maxDevicesHandler.getAssociations()) {
+            saveSendTemperature(associatedDevice, mode, temp);
+        }
+    }
+
+    private void saveSendTemperature(MaxDevicesHandler device, ThermostatControlMode mode, double temp) {
+        ThingTypeUID thingTypeUID = device.getThing().getThingTypeUID();
+        if (HEATINGTHERMOSTAT_THING_TYPE.equals(thingTypeUID) || HEATINGTHERMOSTATPLUS_THING_TYPE.equals(thingTypeUID)
+                || WALLTHERMOSTAT_THING_TYPE.equals(thingTypeUID)) {
+            messageHandler.sendSetTemperature(device, mode, temp);
+        }
+    }
+
+    @Override
+    public void run() {
+        sendToDevices(mode, temperature);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfile.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfile.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxCulWeekProfile {
+
+    private List<MaxCulWeekProfilePart> weekProfileParts = new ArrayList<MaxCulWeekProfilePart>();
+
+    public void addWeekProfilePart(MaxCulWeekProfilePart weekProfilePart) {
+        weekProfileParts.add(weekProfilePart);
+    }
+
+    public List<MaxCulWeekProfilePart> getWeekProfileParts() {
+        return weekProfileParts;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfileControlPoint.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfileControlPoint.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxCulWeekProfileControlPoint {
+
+    private Integer hour;
+    private Integer min;
+    private float temperature;
+
+    public void setMin(int i) {
+        min = i;
+    }
+
+    public void setHour(int i) {
+        hour = i;
+    }
+
+    public Integer getMin() {
+        return min;
+    }
+
+    public Integer getHour() {
+        return hour;
+    }
+
+    public void setTemperature(float temperature) {
+        this.temperature = temperature;
+    }
+
+    public float getTemperature() {
+        return temperature;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfilePart.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/MaxCulWeekProfilePart.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulWeekdays;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxCulWeekProfilePart {
+
+    private List<MaxCulWeekProfileControlPoint> weekProfileControlPoints = new ArrayList<MaxCulWeekProfileControlPoint>();
+
+    private MaxCulWeekdays day;
+
+    public void setDay(MaxCulWeekdays day) {
+        this.day = day;
+    }
+
+    public MaxCulWeekdays getDay() {
+        return day;
+    }
+
+    public void addControlPoint(MaxCulWeekProfileControlPoint weekProfileControlPoint) {
+        weekProfileControlPoints.add(weekProfileControlPoint);
+    }
+
+    public List<MaxCulWeekProfileControlPoint> getControlPoints() {
+        return weekProfileControlPoints;
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getDay()).append("\r\n");
+        String time_prof_str = "00:00";
+        String temp_prof_str = "";
+        List<MaxCulWeekProfileControlPoint> controlPoints = getControlPoints();
+        for (int k = 0; k < controlPoints.size(); k++) {
+            MaxCulWeekProfileControlPoint controlPoint = controlPoints.get(k);
+            time_prof_str += String.format("-%02d:%02d", controlPoint.getHour(), controlPoint.getMin());
+            temp_prof_str += String.format("%2.1f °C", controlPoint.getTemperature());
+            if (k < controlPoints.size() - 1) {
+                time_prof_str += "  /  " + String.format("%02d:%02d", controlPoint.getHour(), controlPoint.getMin());
+                temp_prof_str += "  /  ";
+            }
+        }
+        sb.append(time_prof_str).append("\r\n");
+        sb.append(temp_prof_str);
+        return sb.toString();
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PairPingMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PairPingMsg.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle Ping message in pairing
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class PairPingMsg extends BaseMsg {
+
+    public int firmwareMajor;
+    public int firmwareMinor;
+    public int type;
+    public int testResult;
+    public String serial = null;
+
+    private static final Logger logger = LoggerFactory.getLogger(PairPingMsg.class);
+
+    public PairPingMsg(String rawMsg) {
+        super(rawMsg);
+
+        /* process payload */
+        if (this.payload.length > 3) {
+            this.firmwareMajor = this.payload[0] / 16;
+            this.firmwareMinor = this.payload[0] % 16;
+            this.type = this.payload[1];
+            this.testResult = this.payload[2];
+            this.serial = new String(Arrays.copyOfRange(this.payload, 3, this.payload.length));
+        }
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tFirmware Version => {}", this.firmwareMajor + "." + this.firmwareMinor);
+        logger.debug("\tDevice Type      => {}", this.type);
+        logger.debug("\tTest Result      => {}", this.testResult);
+        logger.debug("\tSerial Number    => {}", this.serial);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PairPongMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PairPongMsg.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Message class to response to Pair Ping
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class PairPongMsg extends BaseMsg {
+
+    final static private int PAIR_PONG_PAYLOAD_LEN = 1; /* in bytes */
+
+    public PairPongMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.PAIR_PONG, groupId, srcAddr, dstAddr);
+
+        byte[] payload = new byte[PAIR_PONG_PAYLOAD_LEN];
+
+        payload[0] = 0x00;
+
+        super.appendPayload(payload);
+    }
+
+    public PairPongMsg(String data) {
+        super(data);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PushButtonMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/PushButtonMsg.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.PushButtonMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message from Push Button devices
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class PushButtonMsg extends BaseMsg implements BatteryStateMsg, RfErrorStateMsg {
+
+    final static private int PUSH_BUTTON_PAYLOAD_LEN = 2; /* in bytes */
+
+    private PushButtonMode mode = PushButtonMode.UNKNOWN;
+    private boolean isRetransmission = false;
+    private boolean batteryLow;
+
+    private boolean rfError;
+
+    private static final Logger logger = LoggerFactory.getLogger(PushButtonMsg.class);
+
+    public PushButtonMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == PUSH_BUTTON_PAYLOAD_LEN) {
+            if (this.payload[0] == 0x50) {
+                // behaviour
+                isRetransmission = true;
+            }
+
+            if (this.payload[1] == 0x0) {
+                mode = PushButtonMode.ECO;
+            } else if (this.payload[1] == 0x1) {
+                mode = PushButtonMode.AUTO;
+            }
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+        rfError = extractBitFromByte(this.payload[0], 6);
+        /* extract battery status */
+        batteryLow = extractBitFromByte(this.payload[0], 7);
+    }
+
+    public PushButtonMode getMode() {
+        return mode;
+    }
+
+    public boolean isRetransmission() {
+        return isRetransmission;
+    }
+
+    @Override
+    public boolean isBatteryLow() {
+        return batteryLow;
+    }
+
+    @Override
+    public boolean isRfError() {
+        return rfError;
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        super.printFormattedPayload();
+        logger.debug("\tMode                => {}", mode);
+        logger.debug("\tRF Error            => {}", rfError);
+        logger.debug("\tBattery Low         => {}", batteryLow);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RemoveGroupIdMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RemoveGroupIdMsg.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * RemoveGroupId Message
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ */
+public class RemoveGroupIdMsg extends BaseMsg {
+
+    final private int REMOVE_GROUP_ID_PAYLOAD_LEN = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoveGroupIdMsg.class);
+
+    public RemoveGroupIdMsg(byte msgCount, byte msgFlag, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.REMOVE_GROUP_ID, (byte) 0x0, srcAddr, dstAddr);
+        byte[] payload = new byte[REMOVE_GROUP_ID_PAYLOAD_LEN];
+        payload[0] = (byte) 0x0;
+        super.appendPayload(payload);
+    }
+
+    public RemoveGroupIdMsg(String rawmsg) {
+        super(rawmsg);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RemoveLinkPartnerMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RemoveLinkPartnerMsg.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulDevice;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message to remove associate devices with each other
+ *
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+public class RemoveLinkPartnerMsg extends BaseMsg {
+    final private int REMOVE_LINK_PARTNER_PAYLOAD_LEN = 4;
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoveLinkPartnerMsg.class);
+
+    private MaxCulDevice devType;
+    private String partnerAddr;
+
+    public RemoveLinkPartnerMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            String partnerAddr, MaxCulDevice devType) {
+        super(msgCount, msgFlag, MaxCulMsgType.REMOVE_LINK_PARTNER, groupId, srcAddr, dstAddr);
+
+        this.partnerAddr = partnerAddr;
+        this.devType = devType;
+        byte[] payload = new byte[REMOVE_LINK_PARTNER_PAYLOAD_LEN];
+
+        payload[0] = (byte) (Integer.parseInt(partnerAddr.substring(0, 2), 16) & 0xff);
+        payload[1] = (byte) (Integer.parseInt(partnerAddr.substring(2, 4), 16) & 0xff);
+        payload[2] = (byte) (Integer.parseInt(partnerAddr.substring(4, 6), 16) & 0xff);
+        payload[3] = (byte) devType.getDeviceTypeInt();
+        super.appendPayload(payload);
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        super.printFormattedPayload();
+        logger.debug("\tDevice Type  => {}", this.devType);
+        logger.debug("\tPartner Addr => {}", this.partnerAddr);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ResetMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ResetMsg.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Factory reset device
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class ResetMsg extends BaseMsg {
+    final static private int RESET_MESSAGE_PAYLOAD_LEN = 0; /* in bytes */
+
+    public ResetMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.RESET, groupId, srcAddr, dstAddr);
+        /* empty payload */
+        byte[] payload = new byte[RESET_MESSAGE_PAYLOAD_LEN];
+        super.appendPayload(payload);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RfErrorStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/RfErrorStateMsg.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface RfErrorStateMsg {
+    boolean isRfError();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetComfortTempMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetComfortTempMsg.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Factory reset device
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class SetComfortTempMsg extends BaseMsg {
+    final static private int SET_COMFORT_TEMP_MESSAGE_PAYLOAD_LEN = 0; /* in bytes */
+
+    public SetComfortTempMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_COMFORT_TEMPERATURE, groupId, srcAddr, dstAddr);
+        /* empty payload */
+        byte[] payload = new byte[SET_COMFORT_TEMP_MESSAGE_PAYLOAD_LEN];
+        super.appendPayload(payload);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetDisplayActualTempMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetDisplayActualTempMsg.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Message to set either the Wall Thermostat display shows the actual temperature
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ * @since 1.8.0
+ */
+public class SetDisplayActualTempMsg extends BaseMsg {
+
+    private static final int SET_DISPLAY_ACTUAL_TEMP_PAYLOAD_LEN = 1;
+
+    public SetDisplayActualTempMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            boolean displayActualTemp) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_DISPLAY_ACTUAL_TEMP, groupId, srcAddr, dstAddr);
+        byte[] payload = new byte[SET_DISPLAY_ACTUAL_TEMP_PAYLOAD_LEN];
+        payload[0] = displayActualTemp ? (byte) 0x04 : (byte) 0x00;
+        super.appendPayload(payload);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetDstAdjustMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetDstAdjustMsg.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Ajust DST
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ * @since 1.6.0
+ */
+public class SetDstAdjustMsg extends BaseMsg {
+    final static private int SET_DST_AJUST_MESSAGE_PAYLOAD_LEN = 1; /* in bytes */
+
+    public SetDstAdjustMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            boolean dstAjust) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_ECO_TEMPERATURE, groupId, srcAddr, dstAddr);
+        /* empty payload */
+        byte[] payload = new byte[SET_DST_AJUST_MESSAGE_PAYLOAD_LEN];
+        payload[0] = dstAjust ? (byte) 0x1 : (byte) 0x0;
+        super.appendPayload(payload);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetEcoTempMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetEcoTempMsg.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Factory reset device
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class SetEcoTempMsg extends BaseMsg {
+    final static private int SET_ECO_TEMP_MESSAGE_PAYLOAD_LEN = 0; /* in bytes */
+
+    public SetEcoTempMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_ECO_TEMPERATURE, groupId, srcAddr, dstAddr);
+        /* empty payload */
+        byte[] payload = new byte[SET_ECO_TEMP_MESSAGE_PAYLOAD_LEN];
+        super.appendPayload(payload);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetGroupIdMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetGroupIdMsg.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SetGroupId Message
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class SetGroupIdMsg extends BaseMsg {
+
+    final private int SET_GROUP_ID_PAYLOAD_LEN = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(SetGroupIdMsg.class);
+
+    private byte groupIdToSet;
+
+    public SetGroupIdMsg(byte msgCount, byte msgFlag, String srcAddr, String dstAddr, byte groupIdToSet) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_GROUP_ID, (byte) 0x0, srcAddr, dstAddr);
+
+        this.groupIdToSet = groupIdToSet;
+        byte[] payload = new byte[SET_GROUP_ID_PAYLOAD_LEN];
+
+        payload[0] = groupIdToSet;
+
+        super.appendPayload(payload);
+    }
+
+    public SetGroupIdMsg(String rawmsg) {
+        super(rawmsg);
+        groupIdToSet = this.payload[0];
+    }
+
+    /**
+     * Print output as decoded fields
+     */
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\t Group ID => {}", this.groupIdToSet);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetTemperatureMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/SetTemperatureMsg.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle desired temperature updates
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class SetTemperatureMsg extends BaseMsg implements DesiredTemperatureStateMsg {
+
+    final static private int SET_TEMPERATURE_PAYLOAD_LEN = 1; /* in bytes */
+    final static private int SET_TEMPERATURE_UNTIL_PAYLOAD_LEN = 4; /* in bytes */
+
+    private static final Logger logger = LoggerFactory.getLogger(SetTemperatureMsg.class);
+
+    private double desiredTemperature;
+    private ThermostatControlMode ctrlMode;
+    private GregorianCalendar untilDateTime = null;
+
+    private static final double TEMPERATURE_MAX = 30.5;
+    private static final double TEMPERATURE_MIN = 4.5;
+
+    public SetTemperatureMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == SET_TEMPERATURE_PAYLOAD_LEN
+                || this.payload.length == SET_TEMPERATURE_UNTIL_PAYLOAD_LEN) {
+            /* extract temperature information */
+            desiredTemperature = (this.payload[0] & 0x3f) / 2.0;
+            /* extract control mode */
+            ctrlMode = ThermostatControlMode.values()[(this.payload[0] >> 6) & 0x3];
+            if (this.payload.length == SET_TEMPERATURE_UNTIL_PAYLOAD_LEN) {
+                untilDateTime = extractDate(this.payload[1], this.payload[2], this.payload[3]);
+            }
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    private GregorianCalendar extractDate(byte one, byte two, byte three) {
+        int day = (one & 0x1F);
+        int month = ((two & 0xE0) >> 4) | (three >> 7);
+        int year = two & 0x3F;
+        int time = three & 0x3F;
+        return new GregorianCalendar(year + 2000, month, day, time / 2, (time % 2 == 0) ? 0 : 30);
+    }
+
+    public SetTemperatureMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr,
+            double temperature, ThermostatControlMode mode) {
+        super(msgCount, msgFlag, MaxCulMsgType.SET_TEMPERATURE, groupId, srcAddr, dstAddr);
+
+        desiredTemperature = temperature;
+        ctrlMode = mode;
+
+        if (temperature > TEMPERATURE_MAX) {
+            temperature = TEMPERATURE_MAX;
+        } else if (temperature < TEMPERATURE_MIN) {
+            temperature = TEMPERATURE_MIN;
+        }
+
+        byte[] payload = new byte[SET_TEMPERATURE_PAYLOAD_LEN];
+        payload[0] = (byte) (temperature * 2.0);
+        payload[0] |= ((mode.toByte() & 0x3) << 6);
+        super.appendPayload(payload);
+    }
+
+    @Override
+    public ThermostatControlMode getControlMode() {
+        return ctrlMode;
+    }
+
+    @Override
+    public double getDesiredTemperature() {
+        return desiredTemperature;
+    }
+
+    @Override
+    public GregorianCalendar getUntilDateTime() {
+        return untilDateTime;
+    }
+
+    /**
+     * Print output as decoded fields
+     */
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tDesired Temperature => {}", desiredTemperature);
+        logger.debug("\tControl Mode => {}", ctrlMode);
+        if (untilDateTime != null) {
+            logger.debug("\tUntil DateTime      => {}-{}-{} {}:{}:{}", untilDateTime.get(Calendar.YEAR),
+                    (untilDateTime.get(Calendar.MONTH) + 1), untilDateTime.get(Calendar.DAY_OF_MONTH),
+                    untilDateTime.get(Calendar.HOUR_OF_DAY), untilDateTime.get(Calendar.MINUTE),
+                    untilDateTime.get(Calendar.SECOND));
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ShutterContactStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ShutterContactStateMsg.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.ShutterContactState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle shutter contact state messages
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ * @since 1.8.0
+ */
+public class ShutterContactStateMsg extends BaseMsg implements BatteryStateMsg, RfErrorStateMsg {
+
+    private final static int SHUTTER_CONTACT_STATE_PAYLOAD_LEN = 1; /* in bytes */
+
+    private boolean batteryLow;
+
+    private boolean rfError;
+
+    private ShutterContactState state = ShutterContactState.UNKNOWN;
+
+    private static final Logger logger = LoggerFactory.getLogger(ShutterContactStateMsg.class);
+
+    public ShutterContactStateMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == SHUTTER_CONTACT_STATE_PAYLOAD_LEN) {
+            boolean isOpen = extractBitFromByte(this.payload[0], 1);
+            ;
+            if (!isOpen) {
+                state = ShutterContactState.CLOSED;
+            } else {
+                state = ShutterContactState.OPEN;
+            }
+            rfError = extractBitFromByte(this.payload[0], 6);
+            /* extract battery status */
+            batteryLow = extractBitFromByte(this.payload[0], 7);
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    public ShutterContactState getState() {
+        return state;
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        super.printFormattedPayload();
+        logger.debug("\tState               => {}", state);
+        logger.debug("\tRF Error            => {}", rfError);
+        logger.debug("\tBattery Low         => {}", batteryLow);
+    }
+
+    @Override
+    public boolean isBatteryLow() {
+        return batteryLow;
+    }
+
+    @Override
+    public boolean isRfError() {
+        return rfError;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatCommonStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatCommonStateMsg.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface ThermostatCommonStateMsg {
+    boolean isDstActive();
+
+    boolean isLanGateway();
+
+    boolean isLockedForManualSetPoint();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatStateMsg.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import static org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode.TEMPORARY;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thermostate State message
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class ThermostatStateMsg extends BaseMsg implements BatteryStateMsg, RfErrorStateMsg, ThermostatValveStateMsg,
+        ThermostatCommonStateMsg, DesiredTemperatureStateMsg, ActualTemperatureStateMsg {
+
+    final static private int THERMOSTAT_STATE_TIME_PAYLOAD_LEN = 6; /* in bytes */
+    final static private int THERMOSTAT_STATE_MEAS_PAYLOAD_LEN = 5; /* in bytes */
+    final static private int THERMOSTAT_STATE_SHORT_PAYLOAD_LEN = 3; /* in bytes */
+
+    private static final Logger logger = LoggerFactory.getLogger(ThermostatStateMsg.class);
+
+    private double desiredTemperature;
+    private int valvePos;
+    private boolean dstActive;
+    private boolean lanGateway; // unknown what this is for
+    private boolean lockedForManualSetPoint;
+    private boolean rfError;
+    private boolean batteryLow;
+    private Double measuredTemperature = null;
+
+    private GregorianCalendar untilDateTime = null;
+    private ThermostatControlMode ctrlMode;
+
+    public ThermostatStateMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == THERMOSTAT_STATE_SHORT_PAYLOAD_LEN
+                || this.payload.length == THERMOSTAT_STATE_MEAS_PAYLOAD_LEN
+                || this.payload.length == THERMOSTAT_STATE_TIME_PAYLOAD_LEN) {
+            /* extract control mode */
+            ctrlMode = ThermostatControlMode.values()[(this.payload[0] & 0x3)];
+            /* extract DST status */
+            dstActive = extractBitFromByte(this.payload[0], 3);
+            ;
+            /* extract lanGateway */
+            lanGateway = extractBitFromByte(this.payload[0], 4);
+            /* extract locked status */
+            lockedForManualSetPoint = extractBitFromByte(this.payload[0], 5);
+            /* extract rferror status */
+            rfError = extractBitFromByte(this.payload[0], 6);
+            /* extract battery status */
+            batteryLow = extractBitFromByte(this.payload[0], 7);
+            /* extract valve position */
+            valvePos = this.payload[1];
+            /* extract desired temperature information */
+            desiredTemperature = (this.payload[2] & 0x7f) / 2.0;
+
+            /* handle longer packet */
+            if (this.payload.length == THERMOSTAT_STATE_MEAS_PAYLOAD_LEN) {
+                /* extract measured temperature */
+                if (ctrlMode != TEMPORARY) {
+                    int mTemp = (this.payload[3] & 0x1);
+                    mTemp <<= 8;
+                    mTemp |= ((this.payload[4]) & 0xff);
+                    measuredTemperature = mTemp / 10.0; // temperature over 25.5
+                                                        // uses extra bit in
+                                                        // desiredTemperature
+                                                        // byte
+                    if (measuredTemperature < 4.5) {
+                        measuredTemperature = null;
+                    }
+                }
+            } else if (this.payload.length == THERMOSTAT_STATE_TIME_PAYLOAD_LEN) {
+                untilDateTime = extractDate(this.payload[3], this.payload[4], this.payload[5]);
+            }
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    private GregorianCalendar extractDate(byte one, byte two, byte three) {
+        int day = (one & 0x1F);
+        int month = ((two & 0xE0) >> 4) | (three >> 7);
+        int year = two & 0x3F;
+        int time = three & 0x3F;
+        return new GregorianCalendar(year + 2000, month, day, time / 2, (time % 2 == 0) ? 0 : 30);
+    }
+
+    /**
+     * Print output as decoded fields
+     */
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tDesired Temperature => {}", desiredTemperature);
+        logger.debug("\tMeasured Temperature=> {}", measuredTemperature);
+        logger.debug("\tValve Position      => {}", valvePos);
+        logger.debug("\tControl Mode        => {}", ctrlMode);
+        logger.debug("\tDST Active          => {}", dstActive);
+        logger.debug("\tLAN Gateway         => {}", lanGateway);
+        logger.debug("\tPanel locked        => {}", lockedForManualSetPoint);
+        logger.debug("\tRF Error            => {}", rfError);
+        logger.debug("\tBattery Low         => {}", batteryLow);
+        if (untilDateTime != null) {
+            logger.debug("\tUntil DateTime      => {}-{}-{} {}:{}:{}", untilDateTime.get(Calendar.YEAR),
+                    (untilDateTime.get(Calendar.MONTH) + 1), untilDateTime.get(Calendar.DAY_OF_MONTH),
+                    untilDateTime.get(Calendar.HOUR_OF_DAY), untilDateTime.get(Calendar.MINUTE),
+                    untilDateTime.get(Calendar.SECOND));
+        }
+    }
+
+    @Override
+    public @Nullable Double getMeasuredTemperature() {
+        return measuredTemperature;
+    }
+
+    @Override
+    public double getDesiredTemperature() {
+        return desiredTemperature;
+    }
+
+    @Override
+    public ThermostatControlMode getControlMode() {
+        return ctrlMode;
+    }
+
+    @Override
+    public @Nullable GregorianCalendar getUntilDateTime() {
+        return untilDateTime;
+    }
+
+    @Override
+    public int getValvePos() {
+        return (valvePos & 0xff);
+    }
+
+    @Override
+    public boolean isBatteryLow() {
+        return batteryLow;
+    }
+
+    @Override
+    public boolean isRfError() {
+        return rfError;
+    }
+
+    @Override
+    public boolean isDstActive() {
+        return dstActive;
+    }
+
+    @Override
+    public boolean isLanGateway() {
+        return lanGateway;
+    }
+
+    @Override
+    public boolean isLockedForManualSetPoint() {
+        return lockedForManualSetPoint;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatValveStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/ThermostatValveStateMsg.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface ThermostatValveStateMsg {
+    int getValvePos();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/TimeInfoMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/TimeInfoMsg.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle time information
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class TimeInfoMsg extends BaseMsg {
+
+    final static private int TIME_INFO_PAYLOAD_LEN = 5; /* in bytes */
+    final static private int TIME_INFO_REQUEST_PAYLOAD_LEN = 0;
+
+    private static final Logger logger = LoggerFactory.getLogger(TimeInfoMsg.class);
+
+    private Calendar messageTimeInfo;
+    private TimeZone tz = TimeZone.getTimeZone("Europe/London");
+
+    public TimeInfoMsg(String rawMsg) {
+        super(rawMsg);
+
+        if (this.payload.length == TIME_INFO_PAYLOAD_LEN) {
+            logger.debug("Year  => {}", (this.payload[0] + 2000));
+            logger.debug("Month => {}", (((this.payload[3] & 0xC0) >> 4) | ((this.payload[4] & 0xC0) >> 6)));
+            logger.debug("DoM   => {}", this.payload[1]);
+            logger.debug("Hour  => {}", (this.payload[2] & 0x3F));
+            logger.debug("Min   => {}", (this.payload[3] & 0x3F));
+            logger.debug("Sec   => {}", (this.payload[4] & 0x3F));
+
+            messageTimeInfo = new GregorianCalendar(this.payload[0] + 2000, // year
+                    (((this.payload[3] & 0xC0) >> 4) | ((this.payload[4] & 0xC0) >> 6)) - 1, // month
+                    this.payload[1], // day of month
+                    (this.payload[2] & 0x3F), // hour of day
+                    (this.payload[3] & 0x3F), // minute
+                    (this.payload[4] & 0x3F)); // seconds
+        } else if (this.payload.length == TIME_INFO_REQUEST_PAYLOAD_LEN) {
+            /*
+             * set time to the beginning of history - this will trigger time
+             * update
+             */
+            messageTimeInfo = new GregorianCalendar(0, 0, 1);
+            logger.debug("Received Time request - setting time to 1/1/0");
+        } else {
+            logger.error("TimeInfoMsg raw packet was of incorrect length to parse! Expect {} got {}",
+                    TIME_INFO_PAYLOAD_LEN, payload.length);
+        }
+    }
+
+    public TimeInfoMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr, String TimeZoneStr) {
+        super(msgCount, msgFlag, MaxCulMsgType.TIME_INFO, groupId, srcAddr, dstAddr);
+
+        tz = TimeZone.getTimeZone(TimeZoneStr);
+        updateTime();
+    }
+
+    public void updateTime() {
+        byte[] payload = new byte[TIME_INFO_PAYLOAD_LEN];
+        byte tmp;
+        Calendar now = new GregorianCalendar(tz);
+
+        payload[0] = (byte) (now.get(Calendar.YEAR) - 2000);
+        payload[1] = (byte) now.get(Calendar.DAY_OF_MONTH);
+        payload[2] = (byte) now.get(Calendar.HOUR_OF_DAY); // TODO ?? can set
+                                                           // DST flag in
+                                                           // bit[6] to advance
+                                                           // time by 1hour,
+                                                           // but java handles
+                                                           // this
+        /* build byte 3. [0:5] contain minute, [6:7] contain bits [2:3] of month */
+        tmp = (byte) (now.get(Calendar.MONTH) + 1);
+        tmp &= 0x0c;
+        tmp <<= 4;
+        tmp |= (byte) (now.get(Calendar.MINUTE) & 0x3f);
+        payload[3] = tmp;
+
+        /*
+         * build byte 3. [0:5] contain seconds, [6:7] contain bits [0:1] of
+         * month
+         */
+        tmp = (byte) (now.get(Calendar.MONTH) + 1);
+        tmp &= 0x03;
+        tmp <<= 6;
+        tmp |= (byte) (now.get(Calendar.SECOND) & 0x3f);
+        payload[4] = tmp;
+
+        super.appendPayload(payload);
+        super.printDebugPayload();
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        super.printDebugPayload();
+        logger.debug("\tDecoded Time: {}-{}-{} {}:{}:{}", this.messageTimeInfo.get(Calendar.YEAR),
+                this.messageTimeInfo.get(Calendar.MONTH + 1), this.messageTimeInfo.get(Calendar.DAY_OF_MONTH),
+                this.messageTimeInfo.get(Calendar.HOUR_OF_DAY), this.messageTimeInfo.get(Calendar.MINUTE),
+                this.messageTimeInfo.get(Calendar.SECOND));
+    }
+
+    public Calendar getTimeInfo() {
+        return messageTimeInfo;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WakeupMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WakeupMsg.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * Wakeup message
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class WakeupMsg extends BaseMsg {
+
+    final private int WAKEUP_MSG_PAYLOAD_LEN = 1;
+
+    public WakeupMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.WAKEUP, groupId, srcAddr, dstAddr);
+
+        byte[] payload = new byte[WAKEUP_MSG_PAYLOAD_LEN];
+
+        payload[0] = 0x3f; // no idea what this means, just always 0x3f?
+                           // suspected to be number of seconds device is awake
+                           // for?
+
+        super.appendPayload(payload);
+    }
+
+    public WakeupMsg(String rawmsg) {
+        super(rawmsg);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatControlMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatControlMsg.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message class to handle Wall Thermostat Control messages
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class WallThermostatControlMsg extends BaseMsg implements ActualTemperatureStateMsg {
+
+    final static private int WALL_THERMOSTAT_CONTROL_SET_POINT_AND_MEASURED_PAYLOAD_LEN = 2; /*
+                                                                                              * in
+                                                                                              * bytes
+                                                                                              */
+    final static private int WALL_THERMOSTAT_CONTROL_SET_POINT_ONLY_PAYLOAD_LEN = 1; /*
+                                                                                      * in
+                                                                                      * bytes
+                                                                                      */
+
+    private static final Logger logger = LoggerFactory.getLogger(WallThermostatControlMsg.class);
+
+    private Double desiredTemperature;
+    private Double measuredTemperature;
+
+    public WallThermostatControlMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == WALL_THERMOSTAT_CONTROL_SET_POINT_AND_MEASURED_PAYLOAD_LEN) {
+            desiredTemperature = (this.payload[0] & 0x7F) / 2.0;
+            int mTemp = (this.payload[0] & 0x80);
+            mTemp <<= 1;
+            mTemp |= ((this.payload[1]) & 0xff);
+            measuredTemperature = mTemp / 10.0; // temperature over 25.5 uses
+                                                // extra bit in
+                                                // desiredTemperature byte
+        } else if (this.payload.length == WALL_THERMOSTAT_CONTROL_SET_POINT_ONLY_PAYLOAD_LEN) {
+            desiredTemperature = (this.payload[0] & 0x7F) / 2.0;
+            measuredTemperature = null;
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    public WallThermostatControlMsg(byte msgCount, byte msgFlag, byte groupId, String srcAddr, String dstAddr) {
+        super(msgCount, msgFlag, MaxCulMsgType.WALL_THERMOSTAT_STATE, groupId, srcAddr, dstAddr);
+    }
+
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tDesired Temperature  => {}", desiredTemperature);
+        logger.debug("\tMeasured Temperature => {}", measuredTemperature);
+    }
+
+    public Double getMeasuredTemperature() {
+        return measuredTemperature;
+    }
+
+    public Double getDesiredTemperature() {
+        return desiredTemperature;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatDisplayMeasuredStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatDisplayMeasuredStateMsg.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface WallThermostatDisplayMeasuredStateMsg {
+    boolean isDisplayMeasuredTemp();
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatStateMsg.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/WallThermostatStateMsg.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wall Thermostat State message
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public class WallThermostatStateMsg extends BaseMsg
+        implements BatteryStateMsg, RfErrorStateMsg, WallThermostatDisplayMeasuredStateMsg, ThermostatCommonStateMsg,
+        DesiredTemperatureStateMsg, ActualTemperatureStateMsg {
+
+    final static private int WALL_THERMOSTAT_STATE_SHORT_PAYLOAD_LEN = 3; /*
+                                                                           * in
+                                                                           * bytes
+                                                                           * -
+                                                                           * status
+                                                                           * bits,
+                                                                           * display
+                                                                           * status
+                                                                           * and
+                                                                           * set
+                                                                           * point
+                                                                           * temp
+                                                                           */
+    final static private int WALL_THERMOSTAT_STATE_PAIR_THERM_PAYLOAD_LEN = 5; /*
+                                                                                * in
+                                                                                * bytes
+                                                                                * -
+                                                                                * same
+                                                                                * as
+                                                                                * above
+                                                                                * but
+                                                                                * also
+                                                                                * includes
+                                                                                * paired
+                                                                                * thermostat
+                                                                                * measured
+                                                                                * temp
+                                                                                */
+    final static private int WALL_THERMOSTAT_STATE_UNTIL_PAYLOAD_LEN = 6; /*
+                                                                           * in
+                                                                           * bytes
+                                                                           * -
+                                                                           * same
+                                                                           * as
+                                                                           * above
+                                                                           * but
+                                                                           * includes
+                                                                           * time
+                                                                           * until
+                                                                           */
+    final static private int WALL_THERMOSTAT_STATE_TEMP_PAYLOAD_LEN = 7; /*
+                                                                          * in
+                                                                          * bytes
+                                                                          * -
+                                                                          * same
+                                                                          * as
+                                                                          * above
+                                                                          * but
+                                                                          * includes
+                                                                          * measured
+                                                                          * temperature
+                                                                          * as
+                                                                          * well
+                                                                          */
+
+    private static final Logger logger = LoggerFactory.getLogger(WallThermostatStateMsg.class);
+
+    private double desiredTemperature;
+
+    private ThermostatControlMode ctrlMode;
+    private boolean dstActive;
+    private boolean lanGateway; // unknown what this is for
+    private boolean lockedForManualSetPoint;
+    private boolean rfError;
+    private boolean batteryLow;
+    private boolean displayMeasuredTemp;
+
+    private Double measuredTemperature = null;
+    private GregorianCalendar untilDateTime = null;
+
+    public WallThermostatStateMsg(String rawMsg) {
+        super(rawMsg);
+        logger.debug("{} Payload Len -> {}", this.msgType, this.payload.length);
+
+        if (this.payload.length == WALL_THERMOSTAT_STATE_SHORT_PAYLOAD_LEN
+                || this.payload.length == WALL_THERMOSTAT_STATE_PAIR_THERM_PAYLOAD_LEN
+                || this.payload.length == WALL_THERMOSTAT_STATE_UNTIL_PAYLOAD_LEN
+                || this.payload.length == WALL_THERMOSTAT_STATE_TEMP_PAYLOAD_LEN) {
+            /* extract control mode */
+            ctrlMode = ThermostatControlMode.values()[(this.payload[0] & 0x3)];
+            /* extract DST status */
+            dstActive = extractBitFromByte(this.payload[0], 3);
+            ;
+            /* extract lanGateway */
+            lanGateway = extractBitFromByte(this.payload[0], 4);
+            /* extract locked status */
+            lockedForManualSetPoint = extractBitFromByte(this.payload[0], 5);
+            /* extract rferror status */
+            rfError = extractBitFromByte(this.payload[0], 6);
+            /* extract battery status */
+            batteryLow = extractBitFromByte(this.payload[0], 7);
+            /*
+             * extract whether wall therm is configured to show measured or
+             * desired temperature
+             */
+            displayMeasuredTemp = (this.payload[1] == 0 ? false : true);
+            /* extract desired temperature information */
+            desiredTemperature = (this.payload[2] & 0x7f) / 2.0;
+
+            /* handle longer packet */
+            if (this.payload.length == WALL_THERMOSTAT_STATE_PAIR_THERM_PAYLOAD_LEN) {
+                int mTemp = this.payload[3];
+                mTemp &= 0x01;
+                mTemp <<= 8;
+                mTemp |= (this.payload[4] & 0xff);
+                this.measuredTemperature = mTemp / 10.0;
+
+            } else if (this.payload.length == WALL_THERMOSTAT_STATE_UNTIL_PAYLOAD_LEN) {
+                untilDateTime = extractDate(this.payload[3], this.payload[4], this.payload[5]);
+            } else if (this.payload.length == WALL_THERMOSTAT_STATE_TEMP_PAYLOAD_LEN) {
+                int mTemp = this.payload[2];
+                mTemp &= 0x80;
+                mTemp <<= 1;
+                mTemp |= (this.payload[6] & 0xff);
+                this.measuredTemperature = mTemp / 10.0;
+                untilDateTime = extractDate(this.payload[3], this.payload[4], this.payload[5]);
+            }
+        } else {
+            logger.error("Got {} message with incorrect length!", this.msgType);
+        }
+    }
+
+    private GregorianCalendar extractDate(byte one, byte two, byte three) {
+        int day = (one & 0x1F);
+        int month = ((two & 0xE0) >> 4) | (three >> 7);
+        int year = two & 0x3F;
+        int time = three & 0x3F;
+        return new GregorianCalendar(year + 2000, month, day, time / 2, (time % 2 == 0) ? 0 : 30);
+    }
+
+    /**
+     * Print output as decoded fields
+     */
+    @Override
+    protected void printFormattedPayload() {
+        logger.debug("\tDesired Temperature => {}", desiredTemperature);
+        logger.debug("\tMeasured Temperature=> {}", measuredTemperature);
+        logger.debug("\tDisplay meas. temp  => {}", displayMeasuredTemp);
+        logger.debug("\tControl Mode        => {}", ctrlMode);
+        logger.debug("\tDST Active          => {}", dstActive);
+        logger.debug("\tLAN Gateway         => {}", lanGateway);
+        logger.debug("\tPanel locked        => {}", lockedForManualSetPoint);
+        logger.debug("\tRF Error            => {}", rfError);
+        logger.debug("\tBattery Low         => {}", batteryLow);
+        if (untilDateTime != null) {
+            logger.debug("\tUntil DateTime      => {}-{}-{} {}:{}:{}", untilDateTime.get(Calendar.YEAR),
+                    (untilDateTime.get(Calendar.MONTH) + 1), untilDateTime.get(Calendar.DAY_OF_MONTH),
+                    untilDateTime.get(Calendar.HOUR_OF_DAY), untilDateTime.get(Calendar.MINUTE),
+                    untilDateTime.get(Calendar.SECOND));
+        }
+    }
+
+    @Override
+    public @Nullable Double getMeasuredTemperature() {
+        return measuredTemperature;
+    }
+
+    @Override
+    public double getDesiredTemperature() {
+        return desiredTemperature;
+    }
+
+    @Override
+    public ThermostatControlMode getControlMode() {
+        return ctrlMode;
+    }
+
+    @Override
+    public @Nullable GregorianCalendar getUntilDateTime() {
+        return untilDateTime;
+    }
+
+    @Override
+    public boolean isDisplayMeasuredTemp() {
+        return displayMeasuredTemp;
+    }
+
+    @Override
+    public boolean isBatteryLow() {
+        return batteryLow;
+    }
+
+    @Override
+    public boolean isRfError() {
+        return rfError;
+    }
+
+    @Override
+    public boolean isDstActive() {
+        return dstActive;
+    }
+
+    @Override
+    public boolean isLanGateway() {
+        return lanGateway;
+    }
+
+    @Override
+    public boolean isLockedForManualSetPoint() {
+        return lockedForManualSetPoint;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulBoostDuration.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulBoostDuration.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public enum MaxCulBoostDuration {
+    MIN_0(0),
+    MIN_5(1),
+    MIN_10(2),
+    MIN_15(3),
+    MIN_20(4),
+    MIN_25(5),
+    MIN_30(6),
+    MIN_60(7),
+    UNKNOWN(-1);
+
+    private final int durationIndex;
+
+    private MaxCulBoostDuration(int idx) {
+        durationIndex = idx;
+    }
+
+    public int getDurationIndex() {
+        return durationIndex;
+    }
+
+    public static MaxCulBoostDuration getBoostDurationFromIdx(int idx) {
+        for (int i = 0; i < MaxCulBoostDuration.values().length; i++) {
+            if (MaxCulBoostDuration.values()[i].getDurationIndex() == idx)
+                return MaxCulBoostDuration.values()[i];
+        }
+        return UNKNOWN;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulDevice.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulDevice.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+import static org.openhab.binding.cul.max.internal.MaxCulBindingConstants.*;
+
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * Define device types
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public enum MaxCulDevice {
+    CUBE(0),
+    RADIATOR_THERMOSTAT(1),
+    RADIATOR_THERMOSTAT_PLUS(2),
+    WALL_THERMOSTAT(3),
+    SHUTTER_CONTACT(4),
+    PUSH_BUTTON(5),
+    UNKNOWN(0xff); // not official MAX!
+
+    private final int devType;
+
+    private MaxCulDevice(int idx) {
+        devType = idx;
+    }
+
+    public int getDeviceTypeInt() {
+        return devType;
+    }
+
+    public static MaxCulDevice getDeviceTypeFromInt(int idx) {
+        for (int i = 0; i < MaxCulDevice.values().length; i++) {
+            if (MaxCulDevice.values()[i].getDeviceTypeInt() == idx) {
+                return MaxCulDevice.values()[i];
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public static MaxCulDevice getDeviceTypeFromThingTypeUID(ThingTypeUID thingTypeUID) {
+        if (HEATINGTHERMOSTAT_THING_TYPE.equals(thingTypeUID)) {
+            return RADIATOR_THERMOSTAT;
+        } else if (HEATINGTHERMOSTATPLUS_THING_TYPE.equals(thingTypeUID)) {
+            return RADIATOR_THERMOSTAT_PLUS;
+        } else if (WALLTHERMOSTAT_THING_TYPE.equals(thingTypeUID)) {
+            return WALL_THERMOSTAT;
+        } else if (ECOSWITCH_THING_TYPE.equals(thingTypeUID)) {
+            return PUSH_BUTTON;
+        } else if (SHUTTERCONTACT_THING_TYPE.equals(thingTypeUID)) {
+            return SHUTTER_CONTACT;
+        }
+        return UNKNOWN;
+    }
+
+    @Override
+    public String toString() {
+        switch (devType) {
+            case 0:
+                return "Cube";
+            case 1:
+                return "Thermostat";
+            case 2:
+                return "Thermostat+";
+            case 3:
+                return "Wallmounted Thermostat";
+            case 4:
+                return "Shutter Contact";
+            case 5:
+                return "Eco Switch";
+            default:
+                return "Invalid";
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulMsgType.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulMsgType.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * Enumerate the different message types and their identifiers
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public enum MaxCulMsgType {
+    PAIR_PING(0x00),
+    PAIR_PONG(0x01),
+    ACK(0x02),
+    TIME_INFO(0x03),
+
+    CONFIG_WEEK_PROFILE(0x10),
+    CONFIG_TEMPERATURES(0x11),
+    CONFIG_VALVE(0x12),
+
+    ADD_LINK_PARTNER(0x20),
+    REMOVE_LINK_PARTNER(0x21),
+    SET_GROUP_ID(0x22),
+    REMOVE_GROUP_ID(0x23),
+
+    SHUTTER_CONTACT_STATE(0x30),
+
+    SET_TEMPERATURE(0x40),
+    WALL_THERMOSTAT_CONTROL(0x42),
+    SET_COMFORT_TEMPERATURE(0x43),
+    SET_ECO_TEMPERATURE(0x44),
+
+    PUSH_BUTTON_STATE(0x50),
+
+    THERMOSTAT_STATE(0x60),
+
+    WALL_THERMOSTAT_STATE(0x70),
+
+    SET_DST_ADJUST(0x81),
+    SET_DISPLAY_ACTUAL_TEMP(0x82),
+
+    WAKEUP(0xF1),
+    RESET(0xF0),
+
+    UNKNOWN(0xFF);
+
+    private final int msgType;
+
+    MaxCulMsgType(int msgType) {
+        this.msgType = msgType;
+    }
+
+    MaxCulMsgType(byte msgType) {
+        this.msgType = msgType;
+    }
+
+    public byte toByte() {
+        return (byte) msgType;
+    }
+
+    public static MaxCulMsgType fromByte(byte b) {
+        for (MaxCulMsgType m : values()) {
+            if (m.toByte() == b) {
+                return m;
+            }
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulWeekdays.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/MaxCulWeekdays.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public enum MaxCulWeekdays {
+
+    SATURDAY(0, "Sat"),
+    SUNDAY(1, "Sun"),
+    MONDAY(2, "Mon"),
+    TUESDAY(3, "Tue"),
+    WENDSDAY(4, "Wen"),
+    THURSDAY(5, "Thu"),
+    FRIDAY(6, "Fri"),
+    UNKNOWN(-1, "n/a");
+
+    private final int weekDayIndex;
+    private final String shortName;
+
+    private MaxCulWeekdays(int idx, String shortName) {
+        weekDayIndex = idx;
+        this.shortName = shortName;
+    }
+
+    public int getDayIndexInt() {
+        return weekDayIndex;
+    }
+
+    public String getDayShortName() {
+        return shortName;
+    }
+
+    public static MaxCulWeekdays getWeekDayFromInt(int idx) {
+        for (int i = 0; i < MaxCulWeekdays.values().length; i++) {
+            if (MaxCulWeekdays.values()[i].getDayIndexInt() == idx)
+                return MaxCulWeekdays.values()[i];
+        }
+        return UNKNOWN;
+    }
+
+    public static MaxCulWeekdays getWeekDayFromShortName(String shortName) {
+        for (int i = 0; i < MaxCulWeekdays.values().length; i++) {
+            if (MaxCulWeekdays.values()[i].getDayShortName().equals(shortName))
+                return MaxCulWeekdays.values()[i];
+        }
+        return UNKNOWN;
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/PushButtonMode.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/PushButtonMode.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public enum PushButtonMode {
+    AUTO,
+    ECO,
+    UNKNOWN;
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/ShutterContactState.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/ShutterContactState.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ * @since 1.8.0
+ */
+public enum ShutterContactState {
+    OPEN,
+    CLOSED,
+    UNKNOWN;
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/ThermostatControlMode.java
+++ b/bundles/org.openhab.binding.cul.max/src/main/java/org/openhab/binding/cul/max/internal/messages/constants/ThermostatControlMode.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages.constants;
+
+/**
+ * Define Thermostat control modes
+ *
+ * @author Paul Hampson (cyclingengineer) - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.6.0
+ */
+public enum ThermostatControlMode {
+    AUTO(0x0),
+    MANUAL(0x1),
+    TEMPORARY(0x2),
+    BOOST(0x3);
+
+    private final int controlMode;
+
+    ThermostatControlMode(int mode) {
+        this.controlMode = mode;
+    }
+
+    ThermostatControlMode(byte mode) {
+        this.controlMode = mode;
+    }
+
+    public byte toByte() {
+        return (byte) controlMode;
+    }
+
+    public int toInt() {
+        return controlMode;
+    }
+
+    static ThermostatControlMode FromString(String value) {
+        switch (value) {
+            case "AUTOMATIC":
+                return AUTO;
+            case "MANUAL":
+                return MANUAL;
+            case "VACATION":
+                return TEMPORARY;
+            case "BOOST":
+                return BOOST;
+            default:
+                throw new IllegalArgumentException(
+                        value + "is not mapable to " + ThermostatControlMode.class.getName());
+        }
+    }
+
+    @Override
+    public String toString() {
+        switch (controlMode) {
+            case 0x0:
+                return "AUTOMATIC";
+            case 0x1:
+                return "MANUAL";
+            case 0x2:
+                return "VACATION";
+            case 0x3:
+                return "BOOST";
+            default:
+                throw new RuntimeException("Implementation of enum is not complete.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="maxcul" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>MAX! CUL Binding</name>
+	<description>This is the binding for MAX! with a CUL.</description>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/i18n/maxcul_de.properties
+++ b/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/i18n/maxcul_de.properties
@@ -1,0 +1,213 @@
+# binding
+binding.maxcul.name = MAX! Heizungssteuerung mit CUL/CUN Binding
+binding.maxcul.description = Dieses Binding integriert die MAX! Heizungssteuerung \u00FCber einen CUL/CUN (z.B. Heizk\u00F6rperthermostat, Heizk\u00F6rperthermostat+, Wandthermostat+, Eco Taster, Fensterkontakt).
+
+# bridge types
+thing-type.maxcul.cul_max_bridge.description = CUL Bridge
+thing-type.maxcul.cun_max_bridge.description = CUN Bridge
+thing-type.maxcul.maxcul_bridge.description = MAX!CUL Bridge
+
+# thing types
+thing-type.maxcul.thermostat.label = MAX! Heizk\u00F6rperthermostat
+thing-type.maxcul.thermostat.description = MAX! Heizk\u00F6rperthermostat und MAX! Heizk\u00F6rperthermostat basic. Dient zur Steuerung von Heizk\u00F6rpern und liefert Daten wie z.B. Temperatur.
+
+thing-type.maxcul.thermostatplus.label = MAX! Heizk\u00F6rperthermostat+
+thing-type.maxcul.thermostatplus.description = MAX! Heizk\u00F6rperthermostat+. Dient zur Steuerung von Heizk\u00F6rpern und liefert Daten wie z.B. Temperatur.
+
+thing-type.maxcul.wallthermostat.label = MAX! Wandthermostat+
+thing-type.maxcul.wallthermostat.description = MAX! Wandthermostat+. Dient zur Steuerung von Heizk\u00F6rperthermostaten und liefert Daten wie z.B. Temperatur.
+
+thing-type.maxcul.ecoswitch.label = MAX! Eco Taster
+thing-type.maxcul.ecoswitch.description = MAX! Eco Taster. Dient zur Steuerung von Heizk\u00F6rperthermostaten.
+
+thing-type.maxcul.shuttercontact.label = MAX! Fensterkontakt
+thing-type.maxcul.shuttercontact.description = MAX! Fensterkontakt. Liefert Daten wie z.B. Fenster-Zustand.
+
+# thing types config groups
+thing-type.config.maxcul.thermostat.group.identification.label = Identifizierung
+thing-type.config.maxcul.thermostat.group.identification.description = Einstellungen f\u00FCr die Identifizierung des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostat.group.device.label = Ger\u00E4t
+thing-type.config.maxcul.thermostat.group.device.description = Einstellungen f\u00FCr das Ger\u00E4t.
+
+thing-type.config.maxcul.thermostat.group.actions.label = Aktionen
+thing-type.config.maxcul.thermostat.group.actions.description = Einstellungen f\u00FCr Aktionen.
+
+thing-type.config.maxcul.thermostatplus.group.identification.label = Identifizierung
+thing-type.config.maxcul.thermostatplus.group.identification.description = Einstellungen f\u00FCr die Identifizierung des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostatplus.group.device.label = Ger\u00E4t
+thing-type.config.maxcul.thermostatplus.group.device.description = Einstellungen f\u00FCr das Ger\u00E4t.
+
+thing-type.config.maxcul.thermostatplus.group.actions.label = Aktionen
+thing-type.config.maxcul.thermostatplus.group.actions.description = Einstellungen f\u00FCr Aktionen.
+
+thing-type.config.maxcul.wallthermostat.group.identification.label = Identifizierung
+thing-type.config.maxcul.wallthermostat.group.identification.description = Einstellungen f\u00FCr die Identifizierung des Ger\u00E4tes.
+
+thing-type.config.maxcul.wallthermostat.group.device.label = Ger\u00E4t
+thing-type.config.maxcul.wallthermostat.group.device.description = Einstellungen f\u00FCr das Ger\u00E4t.
+
+thing-type.config.maxcul.wallthermostat.group.actions.label = Aktionen
+thing-type.config.maxcul.wallthermostat.group.actions.description = Einstellungen f\u00FCr Aktionen.
+
+thing-type.config.maxcul.ecoswitch.group.identification.label = Identifizierung
+thing-type.config.maxcul.ecoswitch.group.identification.description = Einstellungen f\u00FCr die Identifizierung des Ger\u00E4tes.
+
+thing-type.config.maxcul.ecoswitch.group.device.label = Ger\u00E4t
+thing-type.config.maxcul.ecoswitch.group.device.description = Einstellungen f\u00FCr das Ger\u00E4t.
+
+thing-type.config.maxcul.shuttercontact.group.identification.label = Identifizierung
+thing-type.config.maxcul.shuttercontact.group.identification.description = Einstellungen f\u00FCr die Identifizierung des Ger\u00E4tes.
+
+thing-type.config.maxcul.shuttercontact.group.device.label = Ger\u00E4t
+thing-type.config.maxcul.shuttercontact.group.device.description = Einstellungen f\u00FCr das Ger\u00E4t.
+
+thing-type.config.maxcul.shuttercontact.group.actions.label = Aktionen
+thing-type.config.maxcul.shuttercontact.group.actions.description = Einstellungen f\u00FCr Aktionen.
+
+# thing types config
+thing-type.config.maxcul.thermostat.room.label = Raum
+thing-type.config.maxcul.thermostat.room.description = Benutzerspezifischer Namen des Raumes, dem das Ger\u00E4t zugeordnet ist.
+
+thing-type.config.maxcul.thermostat.name.label = Name
+thing-type.config.maxcul.thermostat.name.description = Benutzerspezifischer Namen des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostat.comfortTemp.label = Komforttemperatur
+thing-type.config.maxcul.thermostat.comfortTemp.description = Gibt die Komforttemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.ecoTemp.label = Absenktemperatur
+thing-type.config.maxcul.thermostat.ecoTemp.description = Gibt die Absenktemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.offsetTemp.label = Temperatur-Offset
+thing-type.config.maxcul.thermostat.offsetTemp.description = Gibt den Temperatur-Offset (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.maxTempSetpoint.label = Max. Solltemperatur
+thing-type.config.maxcul.thermostat.maxTempSetpoint.description = Gibt die maximal einstellbare Solltemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.minTempSetpoint.label = Min. Solltemperatur
+thing-type.config.maxcul.thermostat.minTempSetpoint.description = Gibt die minimal einstellbare Solltemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.windowOpenTemp.label = Fenster-Auf-Temperatur
+thing-type.config.maxcul.thermostat.windowOpenTemp.description = Gibt die Temperatur bei ge\u00F6ffnetem Fenster-Zustand (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.windowOpenDuration.label = Dauer Fenster-Auf-Temperatur
+thing-type.config.maxcul.thermostat.windowOpenDuration.description = Gibt die Dauer der Absenkung auf die Fenster-Auf-Temperatur (in Minuten) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostat.serialNumber.label = Seriennummer
+thing-type.config.maxcul.thermostat.serialNumber.description = Seriennummer des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostat.rfAddress.label = RF-Addresse
+thing-type.config.maxcul.thermostat.rfAddress.description = RF-Addresse des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostat.action-resetDevice.label = Ger\u00E4t zur\u00FCcksetzen
+thing-type.config.maxcul.thermostat.action-resetDevice.description = Erm\u00F6glicht das Trennen des Ger\u00E4tes vom MAX! Gateway.
+thing-type.config.maxcul.thermostat.action-resetDevice.option.1234 = Zur\u00FCcksetzen
+thing-type.config.maxcul.thermostat.action-resetDevice.option.-1 = Keine Aktion
+
+thing-type.config.maxcul.thermostatplus.room.label = Raum
+thing-type.config.maxcul.thermostatplus.room.description = Benutzerspezifischer Namen des Raumes, dem das Ger\u00E4t zugeordnet ist.
+
+thing-type.config.maxcul.thermostatplus.name.label = Name
+thing-type.config.maxcul.thermostatplus.name.description = Benutzerspezifischer Namen des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostatplus.comfortTemp.label = Komforttemperatur
+thing-type.config.maxcul.thermostatplus.comfortTemp.description = Gibt die Komforttemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.ecoTemp.label = Absenktemperatur
+thing-type.config.maxcul.thermostatplus.ecoTemp.description = Gibt die Absenktemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.offsetTemp.label = Temperatur-Offset
+thing-type.config.maxcul.thermostatplus.offsetTemp.description = Gibt den Temperatur-Offset (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.maxTempSetpoint.label = Max. Solltemperatur
+thing-type.config.maxcul.thermostatplus.maxTempSetpoint.description = Gibt die maximal einstellbare Solltemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.minTempSetpoint.label = Min. Solltemperatur
+thing-type.config.maxcul.thermostatplus.minTempSetpoint.description = Gibt die minimal einstellbare Solltemperatur (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.windowOpenTemp.label = Fenster-Auf-Temperatur
+thing-type.config.maxcul.thermostatplus.windowOpenTemp.description = Gibt die Temperatur bei ge\u00F6ffnetem Fenster-Zustand (in \u00B0C) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.windowOpenDuration.label = Dauer Fenster-Auf-Temperatur
+thing-type.config.maxcul.thermostatplus.windowOpenDuration.description = Gibt die Dauer der Absenkung auf die Fenster-Auf-Temperatur (in Minuten) des Heizk\u00F6rperthermostats an.
+
+thing-type.config.maxcul.thermostatplus.serialNumber.label = Seriennummer
+thing-type.config.maxcul.thermostatplus.serialNumber.description = Seriennummer des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostatplus.rfAddress.label = RF-Addresse
+thing-type.config.maxcul.thermostatplus.rfAddress.description = RF-Addresse des Ger\u00E4tes.
+
+thing-type.config.maxcul.thermostatplus.action-resetDevice.label = Ger\u00E4t zur\u00FCcksetzen
+thing-type.config.maxcul.thermostatplus.action-resetDevice.description = Erm\u00F6glicht das Trennen des Ger\u00E4tes vom MAX! Gateway.
+thing-type.config.maxcul.thermostatplus.action-resetDevice.option.1234 = Zur\u00FCcksetzen
+thing-type.config.maxcul.thermostatplus.action-resetDevice.option.-1 = Keine Aktion
+
+thing-type.config.maxcul.wallthermostat.room.label = Raum
+thing-type.config.maxcul.wallthermostat.room.description = Benutzerspezifischer Namen des Raumes, dem das Ger\u00E4t zugeordnet ist.
+
+thing-type.config.maxcul.wallthermostat.name.label = Name
+thing-type.config.maxcul.wallthermostat.name.description = Benutzerspezifischer Namen des Ger\u00E4tes.
+
+thing-type.config.maxcul.wallthermostat.serialNumber.label = Seriennummer
+thing-type.config.maxcul.wallthermostat.serialNumber.description = Seriennummer des Ger\u00E4tes.
+
+thing-type.config.maxcul.wallthermostat.rfAddress.label = RF-Addresse
+thing-type.config.maxcul.wallthermostat.rfAddress.description = RF-Addresse des Ger\u00E4tes.
+
+thing-type.config.maxcul.wallthermostat.action-resetDevice.label = Ger\u00E4t zur\u00FCcksetzen
+thing-type.config.maxcul.wallthermostat.action-resetDevice.description = Erm\u00F6glicht das Trennen des Ger\u00E4tes vom MAX! Gateway.
+thing-type.config.maxcul.wallthermostat.action-resetDevice.option.1234 = Zur\u00FCcksetzen
+thing-type.config.maxcul.wallthermostat.action-resetDevice.option.-1 = Keine Aktion
+
+thing-type.config.maxcul.ecoswitch.room.label = Raum
+thing-type.config.maxcul.ecoswitch.room.description = Benutzerspezifischer Namen des Raumes, dem das Ger\u00E4t zugeordnet ist.
+
+thing-type.config.maxcul.ecoswitch.name.label = Name
+thing-type.config.maxcul.ecoswitch.name.description = Benutzerspezifischer Namen des Ger\u00E4tes.
+
+thing-type.config.maxcul.ecoswitch.serialNumber.label = Seriennummer
+thing-type.config.maxcul.ecoswitch.serialNumber.description = Seriennummer des Ger\u00E4tes.
+
+thing-type.config.maxcul.ecoswitch.rfAddress.label = RF-Addresse
+thing-type.config.maxcul.ecoswitch.rfAddress.description = RF-Addresse des Ger\u00E4tes.
+
+thing-type.config.maxcul.shuttercontact.room.label = Raum
+thing-type.config.maxcul.shuttercontact.room.description = Benutzerspezifischer Namen des Raumes, dem das Ger\u00E4t zugeordnet ist.
+
+thing-type.config.maxcul.shuttercontact.name.label = Name
+thing-type.config.maxcul.shuttercontact.name.description = Benutzerspezifischer Namen des Ger\u00E4tes.
+
+thing-type.config.maxcul.shuttercontact.serialNumber.label = Seriennummer
+thing-type.config.maxcul.shuttercontact.serialNumber.description = Seriennummer des Ger\u00E4tes.
+
+thing-type.config.maxcul.shuttercontact.rfAddress.label = RF-Addresse
+thing-type.config.maxcul.shuttercontact.rfAddress.description = RF-Addresse des Ger\u00E4tes.
+
+thing-type.config.maxcul.shuttercontact.action-resetDevice.label = Ger\u00E4t zur\u00FCcksetzen
+thing-type.config.maxcul.shuttercontact.action-resetDevice.description = Erm\u00F6glicht das Trennen des Ger\u00E4tes vom MAX! Gateway.
+thing-type.config.maxcul.shuttercontact.action-resetDevice.option.1234 = Zur\u00FCcksetzen
+thing-type.config.maxcul.shuttercontact.action-resetDevice.option.-1 = Keine Aktion
+
+# channel types
+channel-type.maxcul.valve.label = Ventil
+channel-type.maxcul.valve.description = Gibt die Ventil\u00F6ffnung des Heizk\u00F6rperreglers (in %) an.
+
+channel-type.maxcul.mode.label = Modus des Ger\u00E4tes
+channel-type.maxcul.mode.description = Gibt den aktuellen Modus des Ger\u00E4tes an (MANUAL/AUTOMATIC/BOOST/VACATION).
+channel-type.maxcul.mode.state.option.AUTOMATIC = Automatisch
+channel-type.maxcul.mode.state.option.MANUAL = Manuell
+channel-type.maxcul.mode.state.option.BOOST = Boost
+channel-type.maxcul.mode.state.option.VACATION = Urlaubsmodus
+
+channel-type.maxcul.actual_temp.label = Temperatur
+channel-type.maxcul.actual_temp.description = Gibt die aktuell gemessene Temperatur des Thermostats an.
+
+channel-type.maxcul.set_temp.label = Solltemperatur
+channel-type.maxcul.set_temp.description = Gibt die aktuell eingestellte Solltemperatur des Thermostats an.
+
+channel-type.maxcul.locked.label = Tastensperre
+channel-type.maxcul.locked.description = Gibt an, ob die Tastensperre am Ger\u00E4t aktiviert ist.
+
+channel-type.maxcul.contact_state.label = Fenster-Zustand
+channel-type.maxcul.contact_state.description = Gibt an, ob ein Fenster offen oder geschlossen ist.

--- a/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/thing/max_bridge.xml
+++ b/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/thing/max_bridge.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="maxcul"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="maxcul_bridge">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="cul_max_bridge"/>
+			<bridge-type-ref id="cun_max_bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>MAX! Bridge</label>
+		<description>This bridge is used when using a MAX! with a CUL/CUN Bridge</description>
+		<channels>
+			<channel id="pair_mode" typeId="onoff"/>
+			<channel id="listen_mode" typeId="onoff"/>
+		</channels>
+		<config-description>
+			<parameter name="timezone" type="text" required="false">
+				<label>Timezone</label>
+				<description>Set timezone you want the units to be set to.</description>
+				<default>Europe/London</default>
+			</parameter>
+		</config-description>
+	</bridge-type>
+	<channel-type id="onoff">
+		<item-type>Switch</item-type>
+		<label>On/Off</label>
+		<category>Switch</category>
+		<tags>
+			<tag>Switchable</tag>
+		</tags>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.cul.max/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,531 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="maxcul"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="thermostat">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="maxcul_bridge"/>
+
+		</supported-bridge-type-refs>
+
+		<label>MAX! HeatingThermostat</label>
+		<description>This is a MAX! HeatingThermostat</description>
+
+		<channels>
+			<channel id="valve" typeId="valve"/>
+			<channel id="battery_low" typeId="system.low-battery"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="actual_temp" typeId="actual_temp"/>
+			<channel id="set_temp" typeId="set_temp"/>
+			<channel id="locked" typeId="locked"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+
+		<config-description>
+			<parameter-group name="identification">
+				<label>Identification</label>
+				<description>Hardware &amp; location identification</description>
+			</parameter-group>
+			<parameter-group name="device">
+				<label>Device Settings</label>
+				<description>Device parameter settings</description>
+				<advanced>true</advanced>
+			</parameter-group>
+			<parameter-group name="associations">
+				<label>Associations Settings</label>
+				<description>Associations settings</description>
+				<advanced>true</advanced>
+			</parameter-group>
+			<!-- Trigger actions from habmin -->
+			<parameter-group name="actions">
+				<context></context>
+				<label>Actions</label>
+				<description>Action Buttons</description>
+			</parameter-group>
+			<parameter name="comfortTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Comfort Temperature</label>
+				<description>Set the Comfort Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="ecoTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Eco Temperature</label>
+				<description>Set the Eco Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="offsetTemp" type="decimal" min="-3.5" max="3.5" step="0.5" required="false"
+				groupName="device">
+				<label>OffSet Temperature</label>
+				<description>Set the Thermostat offset.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="maxTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Max Temperature</label>
+				<description>Set the Thermostat maximum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="minTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Min Temperature</label>
+				<description>Set the Thermostat minimum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Window Open Temp</label>
+				<description>Set the Window Open Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenDuration" type="integer" min="0" max="60" step="5" required="false"
+				groupName="device">
+				<label>Window Open Duration</label>
+				<description>Set the Thermostat Window Open Duration.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="associate" type="text" required="false" groupName="associations">
+				<label>Serial Number of associate devices</label>
+				<description>Comma separated serial numbers of associate devices.</description>
+			</parameter>
+			<!-- Trigger reset action from habmin menu -->
+			<parameter name="action-deviceReset" type="integer" groupName="actions">
+				<label>Reset device Configuration</label>
+				<description>Resets the MAX! device. Devices will
+					need to be paired again!</description>
+				<options>
+					<option value="1234">Reset</option>
+					<option value="-1">No Action</option>
+				</options>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="serialNumber" type="text" required="true" groupName="identification">
+				<label>Serial Number</label>
+				<description>The Serial Number identifies one specific device.</description>
+			</parameter>
+			<parameter name="rfAddress" type="text" required="false" groupName="identification">
+				<label>RF Address</label>
+				<description>The RF Address used for communication between the devices.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<thing-type id="thermostatplus">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="maxcul_bridge"/>
+
+		</supported-bridge-type-refs>
+
+		<label>MAX! HeatingThermostat+</label>
+		<description>This is a MAX! HeatingThermostat+</description>
+
+		<channels>
+			<channel id="valve" typeId="valve"/>
+			<channel id="battery_low" typeId="system.low-battery"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="actual_temp" typeId="actual_temp"/>
+			<channel id="set_temp" typeId="set_temp"/>
+			<channel id="locked" typeId="locked"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+
+		<config-description>
+			<parameter-group name="identification">
+				<label>Identification</label>
+				<description>Hardware &amp; location identification</description>
+			</parameter-group>
+			<parameter-group name="device">
+				<label>Device Settings</label>
+				<description>Device parameter settings</description>
+				<advanced>true</advanced>
+			</parameter-group>
+			<parameter-group name="associations">
+				<label>Associations Settings</label>
+				<description>Associations settings</description>
+				<advanced>true</advanced>
+			</parameter-group>
+			<!-- Trigger actions from habmin -->
+			<parameter-group name="actions">
+				<context></context>
+				<label>Actions</label>
+				<description>Action Buttons</description>
+			</parameter-group>
+			<parameter name="comfortTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Comfort Temperature</label>
+				<description>Set the Comfort Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="ecoTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Eco Temperature</label>
+				<description>Set the Eco Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="offsetTemp" type="decimal" min="-3.5" max="3.5" step="0.5" required="false"
+				groupName="device">
+				<label>OffSet Temperature</label>
+				<description>Set the Thermostat offset.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="maxTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Max Temperature</label>
+				<description>Set the Thermostat maximum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="minTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Min Temperature</label>
+				<description>Set the Thermostat minimum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Window Open Temp</label>
+				<description>Set the Window Open Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenDuration" type="integer" min="0" max="60" step="5" required="false"
+				groupName="device">
+				<label>Window Open Duration</label>
+				<description>Set the Thermostat Window Open Duration.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="weekProfile" type="text" required="false" groupName="device">
+				<label>WeekProfile</label>
+				<description>eg.
+					Mon;17,17-30,21,23-00,17;Tue;17,17-30,21,23-00,17;Wen;17,17-30,21,23-00,17;Thu;17,17-30,21,23-00,17;Fri;17,17-30,21,23-30,17;Sat;17,09-00,21,23-00,17;Sun;17,09-00,21,23-00,17</description>
+			</parameter>
+			<parameter name="associate" type="text" required="false" groupName="associations">
+				<label>Serial Number of associate devices</label>
+				<description>Comma separated serial numbers of associate devices.</description>
+			</parameter>
+			<!-- Trigger reset action from habmin menu -->
+			<parameter name="action-deviceReset" type="integer" groupName="actions">
+				<label>Reset device Configuration</label>
+				<description>Resets the MAX! device. Devices will
+					need to be paired again!</description>
+				<options>
+					<option value="1234">Reset</option>
+					<option value="-1">No Action</option>
+				</options>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="serialNumber" type="text" required="true" groupName="identification">
+				<label>Serial Number</label>
+				<description>The Serial Number identifies one specific device.</description>
+			</parameter>
+			<parameter name="rfAddress" type="text" required="false" groupName="identification">
+				<label>RF Address</label>
+				<description>The RF Address used for communication between the devices.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<thing-type id="wallthermostat">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="maxcul_bridge"/>
+
+		</supported-bridge-type-refs>
+
+		<label>MAX! WallThermostat+</label>
+		<description>This is a MAX! WallThermostat+</description>
+
+		<channels>
+			<channel id="battery_low" typeId="system.low-battery"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="actual_temp" typeId="actual_temp"/>
+			<channel id="set_temp" typeId="set_temp"/>
+			<channel id="locked" typeId="locked"/>
+			<channel id="display_actual_temp" typeId="display_actual_temp"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+
+		<config-description>
+			<parameter-group name="identification">
+				<label>Identification</label>
+				<description>Hardware &amp; location identification</description>
+			</parameter-group>
+			<parameter-group name="device">
+				<label>Device Settings</label>
+				<description>Device parameter settings</description>
+			</parameter-group>
+			<parameter-group name="associations">
+				<label>Associations Settings</label>
+				<description>Associations settings</description>
+				<advanced>true</advanced>
+			</parameter-group>
+			<!-- Trigger actions from habmin -->
+			<parameter-group name="actions">
+				<context></context>
+				<label>Actions</label>
+				<description>Action Buttons</description>
+			</parameter-group>
+			<parameter name="comfortTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Comfort Temperature</label>
+				<description>Set the Comfort Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="ecoTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Eco Temperature</label>
+				<description>Set the Eco Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="offsetTemp" type="decimal" min="-3.5" max="3.5" step="0.5" required="false"
+				groupName="device">
+				<label>OffSet Temperature</label>
+				<description>Set the Thermostat offset.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="maxTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Max Temperature</label>
+				<description>Set the Thermostat maximum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="minTempSetpoint" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Min Temperature</label>
+				<description>Set the Thermostat minimum temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenTemp" type="decimal" min="4.5" max="30.5" step="0.5" required="false"
+				groupName="device">
+				<label>Window Open Temp</label>
+				<description>Set the Window Open Temperature.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="windowOpenDuration" type="integer" min="0" max="60" step="5" required="false"
+				groupName="device">
+				<label>Window Open Duration</label>
+				<description>Set the Thermostat Window Open Duration.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="weekProfile" type="text" required="false" groupName="device">
+				<label>WeekProfile</label>
+				<description>eg.
+					Mon;17,17-30,21,23-00,17;Tue;17,17-30,21,23-00,17;Wen;17,17-30,21,23-00,17;Thu;17,17-30,21,23-00,17;Fri;17,17-30,21,23-30,17;Sat;17,09-00,21,23-00,17;Sun;17,09-00,21,23-00,17</description>
+			</parameter>
+			<parameter name="associate" type="text" required="false" groupName="associations">
+				<label>Serial Number of associate devices</label>
+				<description>Comma separated serial numbers of associate devices.</description>
+			</parameter>
+			<!-- Trigger reset action from habmin menu -->
+			<parameter name="action-deviceReset" type="integer" groupName="actions">
+				<label>Reset device Configuration</label>
+				<description>Resets the MAX! device. Devices will
+					need to be paired again!</description>
+				<options>
+					<option value="1234">Reset</option>
+					<option value="-1">No Action</option>
+				</options>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="serialNumber" type="text" required="true" groupName="identification">
+				<label>Serial Number</label>
+				<description>The Serial Number identifies one specific device.</description>
+			</parameter>
+			<parameter name="rfAddress" type="text" required="false" groupName="identification">
+				<label>RF Address</label>
+				<description>The RF Address used for communication between the devices.</description>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<thing-type id="ecoswitch">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="maxcul_bridge"/>
+
+		</supported-bridge-type-refs>
+
+		<label>MAX! Ecoswitch</label>
+		<description>This is a MAX! EcoSwitch</description>
+
+		<channels>
+			<channel id="switch" typeId="ecoSwitchMode"/>
+			<channel id="battery_low" typeId="system.low-battery"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+
+		<config-description>
+			<parameter-group name="identification">
+				<label>Identification</label>
+				<description>Hardware &amp; location identification</description>
+			</parameter-group>
+			<!-- Trigger actions from habmin -->
+			<parameter-group name="actions">
+				<context></context>
+				<label>Actions</label>
+				<description>Action Buttons</description>
+			</parameter-group>
+			<!-- Trigger reset action from habmin menu -->
+			<parameter name="action-deviceReset" type="integer" groupName="actions">
+				<label>Reset device Configuration</label>
+				<description>Resets the MAX! device. Devices will
+					need to be paired again!</description>
+				<options>
+					<option value="1234">Reset</option>
+					<option value="-1">No Action</option>
+				</options>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="serialNumber" type="text" required="true" groupName="identification">
+				<label>Serial Number</label>
+				<description>The Serial Number identifies one specific device.</description>
+			</parameter>
+			<parameter name="rfAddress" type="text" required="false" groupName="identification">
+				<label>RF Address</label>
+				<description>The RF Address used for communication between the devices.</description>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+	<thing-type id="shuttercontact">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="maxcul_bridge"/>
+
+		</supported-bridge-type-refs>
+
+		<label>MAX! Shutter Contact</label>
+		<description>This is a MAX! Shutter Contact</description>
+
+		<channels>
+			<channel id="contact_state" typeId="contact_state"/>
+			<channel id="battery_low" typeId="system.low-battery"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+
+		<config-description>
+			<parameter-group name="identification">
+				<label>Identification</label>
+				<description>Hardware &amp; location identification</description>
+			</parameter-group>
+			<!-- Trigger actions from habmin -->
+			<parameter-group name="actions">
+				<context></context>
+				<label>Actions</label>
+				<description>Action Buttons</description>
+			</parameter-group>
+			<!-- Trigger reset action from habmin menu -->
+			<parameter name="action-deviceReset" type="integer" groupName="actions">
+				<label>Reset device Configuration</label>
+				<description>Resets the MAX! device. Devices will
+					need to be paired again!</description>
+				<options>
+					<option value="1234">Reset</option>
+					<option value="-1">No Action</option>
+				</options>
+				<default>-1</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="serialNumber" type="text" required="true" groupName="identification">
+				<label>Serial Number</label>
+				<description>The Serial Number identifies one specific device.</description>
+			</parameter>
+			<parameter name="rfAddress" type="text" required="false" groupName="identification">
+				<label>RF Address</label>
+				<description>The RF Address used for communication between the devices.</description>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+
+	<channel-type id="ecoSwitchMode">
+		<item-type>Switch</item-type>
+		<label>Auto/Eco</label>
+		<category>Switch</category>
+		<tags>
+			<tag>Switchable</tag>
+		</tags>
+		<state readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="valve" advanced="true">
+		<item-type>Number</item-type>
+		<label>Valve Position</label>
+		<description>Thermostat Valve Position</description>
+		<state pattern="%d %%" readOnly="true">
+		</state>
+	</channel-type>
+
+	<channel-type id="mode">
+		<item-type>String</item-type>
+		<label>Mode</label>
+		<description>Thermostat Mode Setting</description>
+		<tags>
+			<tag>heating</tag>
+		</tags>
+		<state pattern="%s" readOnly="false">
+			<options>
+				<option value="AUTOMATIC">AUTOMATIC</option>
+				<option value="MANUAL">MANUAL</option>
+				<option value="BOOST">BOOST</option>
+				<option value="VACATION">VACATION</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="actual_temp">
+		<item-type>Number:Temperature</item-type>
+		<label>Current Temperature</label>
+		<description>Current measured room temperature</description>
+		<category>Temperature</category>
+		<tags>
+			<tag>heating</tag>
+		</tags>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="set_temp">
+		<item-type>Number:Temperature</item-type>
+		<label>Setpoint Temperature</label>
+		<description>Thermostat Setpoint temperature</description>
+		<category>Temperature</category>
+		<tags>
+			<tag>heating</tag>
+		</tags>
+		<state min="4.5" max="30.5" step="0.5" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="locked" advanced="true">
+		<item-type>Contact</item-type>
+		<label>Thermostat Locked</label>
+		<description>Thermostat is locked for adjustments</description>
+		<category>Lock</category>
+		<state pattern="%s" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="contact_state">
+		<item-type>Contact</item-type>
+		<label>Contact State</label>
+		<description>Contact state information</description>
+		<category>Contact</category>
+		<state pattern="%s" readOnly="true"></state>
+	</channel-type>
+
+	<channel-type id="display_actual_temp" advanced="true">
+		<item-type>Switch</item-type>
+		<label>On/Off</label>
+		<category>Switch</category>
+		<tags>
+			<tag>Switchable</tag>
+		</tags>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/AckMsgTest.java
+++ b/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/AckMsgTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+
+/**
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+class AckMsgTest {
+    @Test
+    public void checkSampleMessage() {
+        AckMsg testling = new AckMsg("Z0E0102020CCBDD010203000119042B29");
+        assertEquals(MaxCulMsgType.ACK, testling.msgType);
+        assertEquals(ThermostatControlMode.MANUAL, testling.ctrlMode);
+        assertEquals(14, testling.len);
+        assertEquals(4, testling.payload.length);
+        assertEquals(1, testling.msgCount);
+        assertEquals(0x2, testling.msgFlag);
+        assertEquals("0CCBDD", testling.srcAddrStr);
+        assertEquals("010203", testling.dstAddrStr);
+        assertEquals(0, testling.groupid);
+        assertEquals(false, testling.getIsNack());
+        testling.printFormattedPayload();
+    }
+
+    @Test
+    public void checkSampleMessage2() {
+        AckMsg testling = new AckMsg("Z0E0302020CCBDD010203000119042A31"); // WALLMOUNT SHOW ACTUAL TEMP 21°
+        assertEquals(MaxCulMsgType.ACK, testling.msgType);
+        assertEquals(ThermostatControlMode.MANUAL, testling.ctrlMode);
+        assertEquals(14, testling.len);
+        assertEquals(4, testling.payload.length);
+        assertEquals(3, testling.msgCount);
+        assertEquals(0x2, testling.msgFlag);
+        assertEquals("0CCBDD", testling.srcAddrStr);
+        assertEquals("010203", testling.dstAddrStr);
+        assertEquals(0, testling.groupid);
+        assertEquals(false, testling.getIsNack());
+        testling.printFormattedPayload();
+    }
+
+    @Test
+    public void checkSampleMessage3() {
+        AckMsg testling = new AckMsg("Z0E040202072304010203000119002A33"); // VALVE
+        assertEquals(MaxCulMsgType.ACK, testling.msgType);
+        assertEquals(ThermostatControlMode.MANUAL, testling.ctrlMode);
+        assertEquals(14, testling.len);
+        assertEquals(4, testling.payload.length);
+        assertEquals(4, testling.msgCount);
+        assertEquals(0x2, testling.msgFlag);
+        assertEquals("072304", testling.srcAddrStr);
+        assertEquals("010203", testling.dstAddrStr);
+        assertEquals(0, testling.groupid);
+        assertEquals(false, testling.getIsNack());
+        testling.printFormattedPayload();
+    }
+
+    @Test
+
+    public void checkSampleMessage4() {
+        AckMsg testling = new AckMsg("Z0E0502020CCBDD010203000119002A31"); // WALLMOUNT SHOW DESIRED TEMP 21°
+        assertEquals(MaxCulMsgType.ACK, testling.msgType);
+        assertEquals(ThermostatControlMode.MANUAL, testling.ctrlMode);
+        assertEquals(14, testling.len);
+        assertEquals(4, testling.payload.length);
+        assertEquals(5, testling.msgCount);
+        assertEquals(0x2, testling.msgFlag);
+        assertEquals("0CCBDD", testling.srcAddrStr);
+        assertEquals("010203", testling.dstAddrStr);
+        assertEquals(0, testling.groupid);
+        assertEquals(false, testling.getIsNack());
+        testling.printFormattedPayload();
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/SetTemperatureMsgTest.java
+++ b/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/SetTemperatureMsgTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+
+/**
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+class SetTemperatureMsgTest {
+
+    @Test // 7.1 4:30
+    public void checkSampleMessage() {
+
+        SetTemperatureMsg testling = new SetTemperatureMsg("Z0E5805400CCBDD01020300A227150931");
+        assertEquals(MaxCulMsgType.SET_TEMPERATURE, testling.msgType);
+    }
+}

--- a/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/WallThermostatStateMsgTest.java
+++ b/bundles/org.openhab.binding.cul.max/src/test/java/org/openhab/binding/cul/max/internal/messages/WallThermostatStateMsgTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.max.internal.messages;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.cul.max.internal.messages.constants.MaxCulMsgType;
+import org.openhab.binding.cul.max.internal.messages.constants.ThermostatControlMode;
+
+/**
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ */
+class WallThermostatStateMsgTest {
+    // 17:36
+    @Test
+    public void checkSampleMessage() {
+        WallThermostatStateMsg testling = new WallThermostatStateMsg("Z0FCF04700CCBDD0000000018042A00EA30");
+        assertEquals(MaxCulMsgType.WALL_THERMOSTAT_STATE, testling.msgType);
+        assertEquals(15, testling.len);
+        assertEquals(5, testling.payload.length);
+        assertEquals(0, testling.groupid);
+        assertEquals(-49, testling.msgCount);
+        assertEquals(0x4, testling.msgFlag);
+        assertEquals("0CCBDD", testling.srcAddrStr);
+        assertEquals("000000", testling.dstAddrStr);
+        assertEquals(21.0, testling.getDesiredTemperature());
+        assertEquals(23.4, testling.getMeasuredTemperature());
+        assertEquals(ThermostatControlMode.AUTO, testling.getControlMode());
+        assertEquals(false, testling.isLockedForManualSetPoint());
+        assertEquals(false, testling.isBatteryLow());
+    }
+
+    @Test // 05.01.2021 23:00 17C° Mode TEMPORARY
+    public void checkSampleMessage2() {
+        WallThermostatStateMsg testling = new WallThermostatStateMsg("Z104404700CCBDD000000005A002205952E19");
+        assertEquals(MaxCulMsgType.WALL_THERMOSTAT_STATE, testling.msgType);
+        assertEquals(16, testling.len);
+        assertEquals(6, testling.payload.length);
+        assertEquals(0, testling.groupid);
+        assertEquals(68, testling.msgCount);
+        assertEquals(0x4, testling.msgFlag);
+        assertEquals("0CCBDD", testling.srcAddrStr);
+        assertEquals("000000", testling.dstAddrStr);
+        assertEquals(17.0, testling.getDesiredTemperature());
+        assertEquals(null, testling.getMeasuredTemperature());
+        assertEquals(ThermostatControlMode.TEMPORARY, testling.getControlMode());
+        assertEquals(false, testling.isLockedForManualSetPoint());
+        assertEquals(false, testling.isBatteryLow());
+    }
+
+    // Z105B04700CCBDD000000005A002227150924 //07.01.2021 4:30 17C° Mode TEMPORARY
+}

--- a/bundles/org.openhab.binding.cul/NOTICE
+++ b/bundles/org.openhab.binding.cul/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.cul/README.md
+++ b/bundles/org.openhab.binding.cul/README.md
@@ -1,0 +1,48 @@
+# CUL Binding
+
+The aim of this binding is to allow the connection from openHAB to a
+using the [CUL USB dongle](http://busware.de/tiki-index.php?page=CUL) 
+
+## Supported Things
+
+This binding support 6 different things types
+
+| Thing          | Type   | Description                                                                                                        |
+|----------------|--------|--------------------------------------------------------------------------------------------------------------------|
+| cul_max_bridge | Bridge | CUL if using a serial CUL
+| cun_max_bridge | Bridge | CUN if using a network CUL
+
+## Discovery
+
+CUL has no discovery feature
+
+## Binding Configuration
+
+There are no binding wide settings as all configuration settings.
+When using a serial port, you may need to add `-Dgnu.io.rxtx.SerialPorts=/dev/ttyACM0` in your server startup.  Please consult the [forum](https://community.openhab.org) for the latest information.
+
+## Thing Configuration
+
+### CUL Bridge Configuration
+| Property | Default | Required | Description |
+|----------|---------|:--------:|-------------|
+| device   |         |   Yes    | in the form `<device>`, where `<device>` is a local serial port eg `/dev/ttyACM0` |
+| baudrate |         |   No     | one of 75, 110, 300, 1200, 2400, 4800, 9600, 19200, **38400**, 57600, 115200 |
+| parity   |         |   No     | one of EVEN, ODD, MARK, **NONE**, SPACE |
+
+When using a serial port, you may need to add `-Dgnu.io.rxtx.SerialPorts=/dev/ttyACM0` in your server startup.  Please consult the [forum](https://community.openhab.org) for the latest information.
+
+### CUN Bridge Configuration
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| networkPath   |         |   Yes    | in the form `<device>`, where `<device>` is `<host>:<port>`, where `<host>` is the host name or IP address and `<port>` is the port number. If no `<port>` is provided the default `2323` is assumed |
+
+## Channels
+
+Depending on the thing it supports different Channels
+
+| Channel Type ID | Item Type          | Description                                                                                                                                                                                                                                               | Available on thing                                                    |
+|-----------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| credits         | Number             | This channel indicates the remaining credits. Due to regulatory compliance reasons in Europe, the cul is allowed to send at no more than 1% of the time, which sums up to 36 seconds per hour. Once the threshold has been reached, the cul stops sending commands for the remaining time of the hour.  | cul_max_bridge, cun_max_bridge |
+| led             | Switch             | Turns on / off the led on the CUL. This channel is write only and may indicate false values after restart as it assume the led is always after restart | cul_max_bridge, cun_max_bridge |
+

--- a/bundles/org.openhab.binding.cul/pom.xml
+++ b/bundles/org.openhab.binding.cul/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.cul</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: CUL Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.cul/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.cul/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.cul-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-cul" description="CUL Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-serial</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.cul/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULCommunicationException.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULCommunicationException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul;
+
+/**
+ * An exception which is thrown if communication with a culfw based device
+ * causes an error.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public class CULCommunicationException extends Exception {
+
+    private static final long serialVersionUID = -1861588016496497682L;
+
+    public CULCommunicationException() {
+        super();
+    }
+
+    public CULCommunicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CULCommunicationException(String message) {
+        super(message);
+    }
+
+    public CULCommunicationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULHandler.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULHandler.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul;
+
+/**
+ * An interface representing a culfw based device. Is handled by {@link CulCunBaseBridgeHandler}.
+ * Classes implementing this interface need to have a constructor with a CULConfiguration as a parameter.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public interface CULHandler {
+
+    /**
+     * Send a String representing a culfw command to the CULHandler. Note that
+     * Strings changing the RF mode will be discarded silently.
+     *
+     * @param command
+     * @throws CULCommunicationException
+     */
+    public void send(String command) throws CULCommunicationException;
+
+    /**
+     * Get the number of transmit credits remaining. This
+     * value is updated every time data is RX'd or TX'd
+     *
+     * @return number of 10ms transmit credits remaining
+     */
+    public int getCredit10ms();
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULListener.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/CULListener.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul;
+
+/**
+ * Listen to received events from the CUL. These events can be either received
+ * data or an exception thrown while trying to read data.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public interface CULListener {
+
+    public void dataReceived(String data);
+
+    public void error(Exception e);
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/AbstractCULHandler.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/AbstractCULHandler.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.CULListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract base class for all CULHandler which brings some convenience
+ * regarding registering listeners and detecting forbidden messages.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public abstract class AbstractCULHandler<T extends CULConfig> implements CULHandlerInternal<T> {
+
+    private final static Logger log = LoggerFactory.getLogger(AbstractCULHandler.class);
+
+    /**
+     * Thread which sends all queued commands to the CUL.
+     *
+     * @author Till Klocke
+     * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+     * @since 1.4.0
+     *
+     */
+    private class SendThread extends Thread {
+
+        private final Logger logger = LoggerFactory.getLogger(SendThread.class);
+
+        @Override
+        public void run() {
+            while (!isInterrupted()) {
+                String command = sendQueue.poll();
+                if (command != null) {
+                    if (!command.endsWith("\r\n")) {
+                        command = command + "\r\n";
+                    }
+                    try {
+                        writeMessage(command);
+                    } catch (CULCommunicationException e) {
+                        logger.error("Error while writing command to CUL", e);
+                    }
+                }
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    logger.debug("Error while sleeping in SendThread", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Wrapper class wraps a CULListener and a received Strings and gets
+     * executed by a executor in its own thread.
+     *
+     * @author Till Klocke
+     * @since 1.4.0
+     *
+     */
+    private static class NotifyDataReceivedRunner implements Runnable {
+
+        private String message;
+        private CULListener listener;
+
+        public NotifyDataReceivedRunner(CULListener listener, String message) {
+            this.message = message;
+            this.listener = listener;
+        }
+
+        @Override
+        public void run() {
+            listener.dataReceived(message);
+        }
+    }
+
+    /**
+     * Wrapper class wraps a CULCreditListener and a credit10ms value and gets
+     * executed by a executor in its own thread.
+     *
+     * @author Johannes Goehr (johgoe)
+     *
+     */
+    private static class NotifyCreditChangedRunner implements Runnable {
+
+        private int credit10ms;
+        private CULCreditListener creditListener;
+
+        public NotifyCreditChangedRunner(CULCreditListener creditListener, int credit10ms) {
+            this.credit10ms = credit10ms;
+            this.creditListener = creditListener;
+        }
+
+        @Override
+        public void run() {
+            creditListener.creditChanged(credit10ms);
+        }
+    }
+
+    /**
+     * Executor to handle received messages. Every listern should be called in
+     * its own thread.
+     */
+    protected Executor receiveExecutor = Executors.newCachedThreadPool();
+    protected SendThread sendThread = new SendThread();
+
+    protected T config;
+
+    protected List<CULListener> listeners = new ArrayList<CULListener>();
+    protected List<CULCreditListener> creditListeners = new ArrayList<CULCreditListener>();
+
+    protected Queue<String> sendQueue = new ConcurrentLinkedQueue<String>();
+    protected int credit10ms = 0;
+    protected BufferedReader br;
+    protected BufferedWriter bw;
+
+    protected AbstractCULHandler(T config) {
+        this.config = config;
+    }
+
+    @Override
+    public void registerListener(CULListener listener) {
+        if (listener != null) {
+            listeners.add(listener);
+        }
+    }
+
+    @Override
+    public void unregisterListener(CULListener listener) {
+        if (listener != null) {
+            listeners.remove(listener);
+        }
+    }
+
+    @Override
+    public boolean hasListeners() {
+        return listeners.size() > 0;
+    }
+
+    @Override
+    public void registerCreditListener(CULCreditListener creditListener) {
+        if (creditListeners != null) {
+            creditListeners.add(creditListener);
+        }
+    }
+
+    @Override
+    public void unregisterCreditListener(CULCreditListener creditListener) {
+        if (creditListener != null) {
+            creditListeners.remove(creditListener);
+        }
+    }
+
+    @Override
+    public boolean hasCreditListeners() {
+        return creditListeners.size() > 0;
+    }
+
+    @Override
+    public void open() throws CULDeviceException {
+        openHardware();
+        sendThread.start();
+    }
+
+    @Override
+    public void close() {
+        sendThread.interrupt();
+        closeHardware();
+    }
+
+    /**
+     * initialize the CUL hardware and open the connection
+     *
+     * @throws CULDeviceException
+     */
+    protected abstract void openHardware() throws CULDeviceException;
+
+    /**
+     * Close the connection to the hardware and clean up all resources.
+     */
+    protected abstract void closeHardware();
+
+    @Override
+    public void send(String command) {
+        if (isMessageAllowed(command)) {
+            sendQueue.add(command);
+        }
+    }
+
+    @Override
+    public void sendWithoutCheck(String message) throws CULCommunicationException {
+        sendQueue.add(message);
+    }
+
+    /**
+     * Checks if the message would alter the RF mode of this device.
+     *
+     * @param message
+     *            The message to check
+     * @return true if the message doesn't alter the RF mode, false if it does.
+     */
+    protected boolean isMessageAllowed(String message) {
+        if (message.startsWith("X") || message.startsWith("x")) {
+            return false;
+        }
+        if (message.startsWith("Ar")) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Notifies each CULListener about the received data in its own thread.
+     *
+     * @param data
+     */
+    protected void notifyDataReceived(String data) {
+        for (final CULListener listener : listeners) {
+            receiveExecutor.execute(new NotifyDataReceivedRunner(listener, data));
+        }
+    }
+
+    protected void notifyError(Exception e) {
+        for (CULListener listener : listeners) {
+            listener.error(e);
+        }
+    }
+
+    protected void notifyCreditChanged(int credit10ms) {
+        for (final CULCreditListener creditListener : creditListeners) {
+            receiveExecutor.execute(new NotifyCreditChangedRunner(creditListener, credit10ms));
+        }
+    }
+
+    /**
+     * read and process next line from underlying transport.
+     *
+     * @throws CULCommunicationException
+     *             if
+     */
+    protected void processNextLine() throws CULCommunicationException {
+        String deviceName = config.getDeviceAddress();
+        try {
+            String data = br.readLine();
+            if (data == null) {
+                log.error("EOF encountered for {}", deviceName);
+                throw new CULCommunicationException("EOF encountered for " + deviceName);
+            }
+
+            log.debug("Received raw message from CUL: {}", data);
+            if ("EOB".equals(data)) {
+                log.warn("(EOB) End of Buffer. Last message lost. Try sending less messages per time slot to the CUL");
+                return;
+            } else if ("LOVF".equals(data)) {
+                log.warn(
+                        "(LOVF) Limit Overflow: Last message lost. You are using more than 1% transmitting time. Reduce the number of rf messages");
+                return;
+            } else if (data.matches("^\\d+\\s+\\d+")) {
+                processCreditReport(data);
+                return;
+            }
+            notifyDataReceived(data);
+            requestCreditReport();
+        } catch (SocketException e) {
+            try {
+                this.openHardware();
+            } catch (CULDeviceException e1) {
+                log.error("Exception while reading from CUL port {}", deviceName, e);
+                notifyError(e);
+
+                throw new CULCommunicationException(e);
+            }
+        } catch (IOException e) {
+            log.error("Exception while reading from CUL port {}", deviceName, e);
+            notifyError(e);
+
+            throw new CULCommunicationException(e);
+        }
+    }
+
+    /**
+     * process data received from credit report
+     *
+     * @param data
+     */
+    private void processCreditReport(String data) {
+        // Credit report received
+        String[] report = data.split(" ");
+        credit10ms = Integer.parseInt(report[report.length - 1]);
+        log.debug("credit10ms = {}", credit10ms);
+        notifyCreditChanged(credit10ms);
+    }
+
+    /**
+     * get the remaining send time on channel as seen at the last send/receive
+     * event.
+     *
+     * @return remaining send time in 10ms units
+     */
+    @Override
+    public int getCredit10ms() {
+        return credit10ms;
+    }
+
+    /**
+     * write out request for a credit report directly to CUL
+     */
+    private void requestCreditReport() {
+        /* this requests a report which provides credit10ms */
+        log.debug("Requesting credit report");
+        try {
+            bw.write("X\r\n");
+            bw.flush();
+        } catch (IOException e) {
+            log.error("Can't write report command to CUL", e);
+        }
+    }
+
+    /**
+     * Write a message to the CUL.
+     *
+     * @param message
+     * @throws CULCommunicationException
+     */
+    private void writeMessage(String message) throws CULCommunicationException {
+        String deviceName = config.getDeviceAddress();
+        log.debug("Sending raw message to CUL {}:  '{}'", deviceName, message);
+        if (bw == null) {
+            log.error("Can't write message, BufferedWriter is NULL");
+        }
+        synchronized (bw) {
+            try {
+                bw.write(message);
+                bw.flush();
+            } catch (IOException e) {
+                log.error("Can't write to CUL {}", deviceName, e);
+            }
+
+            requestCreditReport();
+        }
+    }
+
+    @Override
+    public T getConfig() {
+        return config;
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULBindingConstants.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULBindingConstants.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+
+/**
+ * The {@link CULBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Johannes Goehr - Initial contribution
+ */
+@NonNullByDefault
+public class CULBindingConstants {
+
+    private static final String MAX_BINDING_ID = "maxcul";
+    public static final String BRIDGE_CUL_MORIZ = "cul_max_bridge";
+    public static final String BRIDGE_CUN_MORIZ = "cun_max_bridge";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID CULMORIZBRIDGE_THING_TYPE = new ThingTypeUID(MAX_BINDING_ID, BRIDGE_CUL_MORIZ);
+    public static final ThingTypeUID CUNMORIZBRIDGE_THING_TYPE = new ThingTypeUID(MAX_BINDING_ID, BRIDGE_CUN_MORIZ);
+
+    // List of all Channel ids
+    public static final String CHANNEL_CREDITS = "credit10ms";
+    public static final String CHANNEL_LED = "led";
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(
+            Stream.of(CULMORIZBRIDGE_THING_TYPE, CUNMORIZBRIDGE_THING_TYPE).collect(Collectors.toSet()));
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULConfig.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULConfig.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.util.Objects;
+
+/**
+ * Configuration for cul. Can be optained from the {@link CULConfigFactory}.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.9.0
+ */
+public abstract class CULConfig {
+
+    private String deviceType;
+    private CULMode mode;
+    private String deviceAddress;
+
+    public CULConfig(String deviceType, String deviceAddress, CULMode mode) {
+        this.deviceType = deviceType;
+        this.deviceAddress = deviceAddress;
+        this.mode = mode;
+    }
+
+    public String getDeviceType() {
+        return deviceType;
+    }
+
+    public String getDeviceAddress() {
+        return deviceAddress;
+    }
+
+    public CULMode getMode() {
+        return mode;
+    }
+
+    public String getDeviceName() {
+        return deviceType + ":" + deviceAddress;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deviceAddress, deviceType, mode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CULConfig other = (CULConfig) obj;
+        return Objects.equals(deviceAddress, other.deviceAddress) && Objects.equals(deviceType, other.deviceType)
+                && mode == other.mode;
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULConfigFactory.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULConfigFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.util.Dictionary;
+
+import org.osgi.service.cm.ConfigurationException;
+
+/**
+ * Configuration factory for cul handlers.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @since 1.9.0
+ */
+public interface CULConfigFactory {
+
+    /**
+     * Creates a specific CULConfig for a handler implementation.
+     *
+     * @param deviceType type of the device
+     * @param deviceAddress address of the device
+     * @param mode cul mode
+     * @param config additional configurations.
+     * @return CULConfig for the handler implementation
+     * @throws ConfigurationException if configuration is not valid.
+     */
+    CULConfig create(String deviceType, String deviceAddress, CULMode mode, Dictionary<String, ?> config)
+            throws ConfigurationException;
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULCreditListener.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULCreditListener.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public interface CULCreditListener {
+
+    public void creditChanged(int credit10ms);
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULDeviceException.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULDeviceException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+/**
+ * An exception which represents error while opening/connecting to the culfw
+ * based device.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public class CULDeviceException extends Exception {
+
+    private static final long serialVersionUID = 4834148919102194993L;
+
+    public CULDeviceException() {
+        super();
+    }
+
+    public CULDeviceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CULDeviceException(String message) {
+        super(message);
+    }
+
+    public CULDeviceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULHandlerFactory.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULHandlerFactory.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import static org.openhab.binding.cul.internal.CULBindingConstants.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.cul.internal.handler.CulMaxBridgeHandler;
+import org.openhab.binding.cul.internal.handler.CunMaxBridgeHandler;
+import org.openhab.binding.cul.internal.network.CULNetworkConfigFactory;
+import org.openhab.binding.cul.internal.network.CULNetworkHandlerImpl;
+import org.openhab.binding.cul.internal.serial.CULSerialConfigFactory;
+import org.openhab.binding.cul.internal.serial.CULSerialHandlerImpl;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.io.transport.serial.SerialPortManager;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link CULHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Johannes Goehr - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.cul", service = ThingHandlerFactory.class)
+public class CULHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(CULHandlerFactory.class);
+
+    private @NonNullByDefault({}) SerialPortManager serialPortManager;
+
+    @Reference
+    protected void setSerialPortManager(final SerialPortManager serialPortManager) {
+        this.serialPortManager = serialPortManager;
+    }
+
+    protected void unsetSerialPortManager(final SerialPortManager serialPortManager) {
+        this.serialPortManager = null;
+    }
+
+    @Override
+    public @Nullable Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration,
+            @Nullable ThingUID thingUID, @Nullable ThingUID bridgeUID) {
+        if (CULMORIZBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            ThingUID culBridgeUID = getBridgeThingUID(thingTypeUID, thingUID, configuration);
+            return super.createThing(thingTypeUID, configuration, culBridgeUID, null);
+        }
+        if (CUNMORIZBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            ThingUID culBridgeUID = getBridgeThingUID(thingTypeUID, thingUID, configuration);
+            return super.createThing(thingTypeUID, configuration, culBridgeUID, null);
+        }
+        if (supportsThingType(thingTypeUID) && bridgeUID != null) {
+            ThingUID deviceUID = getMaxCulDeviceUID(thingTypeUID, thingUID, configuration, bridgeUID);
+            return super.createThing(thingTypeUID, configuration, deviceUID, bridgeUID);
+        }
+        throw new IllegalArgumentException("The thing type " + thingTypeUID + " is not supported by the binding.");
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    private ThingUID getBridgeThingUID(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID,
+            Configuration configuration) {
+        if (thingUID == null) {
+            String serialNumber = (String) configuration.get(Thing.PROPERTY_SERIAL_NUMBER);
+            return new ThingUID(thingTypeUID, serialNumber);
+        }
+        return thingUID;
+    }
+
+    private ThingUID getMaxCulDeviceUID(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID,
+            Configuration configuration, ThingUID bridgeUID) {
+        if (thingUID == null) {
+            String serialNumber = (String) configuration.get(Thing.PROPERTY_SERIAL_NUMBER);
+            return new ThingUID(thingTypeUID, serialNumber, bridgeUID.getId());
+        }
+        return thingUID;
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+        if (CULMORIZBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            CULManager manager = CULManager.getInstance();
+            manager.registerHandlerClass("serial", CULSerialHandlerImpl.class, new CULSerialConfigFactory(),
+                    new Class[] { SerialPortManager.class }, new Object[] { serialPortManager });
+            return new CulMaxBridgeHandler((Bridge) thing, manager);
+        } else if (CUNMORIZBRIDGE_THING_TYPE.equals(thingTypeUID)) {
+            CULManager manager = CULManager.getInstance();
+            manager.registerHandlerClass("network", CULNetworkHandlerImpl.class, new CULNetworkConfigFactory(),
+                    new Class[0], new Object[0]);
+            return new CunMaxBridgeHandler((Bridge) thing, manager);
+        } else {
+            logger.debug("ThingHandler not found for {}", thingTypeUID);
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULHandlerInternal.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULHandlerInternal.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.CULHandler;
+import org.openhab.binding.cul.CULListener;
+
+/**
+ * Internal interface for the CULManager. CULHandler should always implement this.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public interface CULHandlerInternal<T extends CULConfig> extends CULHandler {
+
+    public void open() throws CULDeviceException;
+
+    public void close();
+
+    void registerListener(CULListener listener);
+
+    void unregisterListener(CULListener listener);
+
+    public boolean hasListeners();
+
+    public void sendWithoutCheck(String message) throws CULCommunicationException;
+
+    public T getConfig();
+
+    public boolean hasCreditListeners();
+
+    void registerCreditListener(CULCreditListener creditListener);
+
+    void unregisterCreditListener(CULCreditListener creditListener);
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULManager.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULManager.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class handles all CULHandler. You can only obtain CULHandlers via this
+ * manager.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public class CULManager {
+
+    private final static Logger logger = LoggerFactory.getLogger(CULManager.class);
+
+    private static CULManager instance = new CULManager();
+
+    private Map<String, DeviceClasses> deviceTypeClasses = new HashMap<String, DeviceClasses>();
+    private Map<String, CULConfigFactory> deviceTypeConfigFactories = new HashMap<String, CULConfigFactory>();
+
+    private Map<String, CULHandlerInternal<?>> openDevices = new HashMap<String, CULHandlerInternal<?>>();
+
+    public static CULManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Retrieve the config factory for a certain device type.
+     *
+     * @param deviceType device type
+     * @return config factory for the device type
+     */
+    public CULConfigFactory getConfigFactory(String deviceType) {
+        return deviceTypeConfigFactories.get(deviceType);
+    }
+
+    /**
+     * Get CULHandler for the given device in the given mode. The same
+     * CULHandler can be returned multiple times if you ask multiple times for
+     * the same device in the same mode. It is not possible to obtain a
+     * CULHandler of an already openend device for another RF mode.
+     *
+     * @param config
+     *            The configuration for the handler.
+     * @return A CULHandler to communicate with the culfw based device.
+     * @throws CULDeviceException
+     */
+    public <T extends CULConfig> CULHandlerInternal<T> getOpenCULHandler(T config) throws CULDeviceException {
+        CULMode mode = config.getMode();
+        String deviceName = config.getDeviceName();
+        logger.debug("Trying to open device {} in mode {}", deviceName, mode.toString());
+        synchronized (openDevices) {
+
+            if (openDevices.containsKey(deviceName)) {
+                @SuppressWarnings("unchecked")
+                CULHandlerInternal<T> handler = (CULHandlerInternal<T>) openDevices.get(deviceName);
+                if (handler.getConfig().equals(config)) {
+                    logger.debug("Device {} is already open in mode {}, returning already openend handler", deviceName,
+                            mode.toString());
+                    return handler;
+                } else {
+                    throw new CULDeviceException(
+                            "The device " + deviceName + " is already open in mode " + mode.toString());
+                }
+            }
+            CULHandlerInternal<T> handler = createNewHandler(config);
+            openDevices.put(deviceName, handler);
+            return handler;
+        }
+    }
+
+    /**
+     * Return a CULHandler to the manager. The CULHandler will only be closed if
+     * there aren't any listeners registered with it. So it is save to call this
+     * methods as soon as you don't need the CULHandler any more.
+     *
+     * @param handler
+     */
+    public void close(CULHandlerInternal<?> handler) {
+        if (handler != null) {
+            synchronized (openDevices) {
+                if (!handler.hasListeners() && !handler.hasCreditListeners()) {
+                    openDevices.remove(handler.getConfig().getDeviceName());
+                    try {
+                        handler.send("X00");
+                    } catch (CULCommunicationException e) {
+                        logger.warn("Couldn't reset rf mode to X00");
+                    }
+                    handler.close();
+                } else {
+                    logger.warn("Can't close device because it still has listeners");
+                }
+            }
+        }
+    }
+
+    static class DeviceClasses {
+        Class<? extends CULHandlerInternal<?>> clazz;
+        Class[] parameterTypes;
+        Object[] parameters;
+
+        public DeviceClasses(Class<? extends CULHandlerInternal<?>> clazz, Class[] parameterTypes,
+                Object[] parameters) {
+            this.clazz = clazz;
+            this.parameterTypes = parameterTypes;
+            this.parameters = parameters;
+        }
+    }
+
+    public void registerHandlerClass(String deviceType, Class<? extends CULHandlerInternal<?>> clazz,
+            CULConfigFactory configFactory, Class[] parameterTypes, Object[] parameters) {
+        logger.debug("Registering class {} for device type {}", clazz.getCanonicalName(), deviceType);
+        deviceTypeClasses.put(deviceType, new DeviceClasses(clazz, parameterTypes, parameters));
+        deviceTypeConfigFactories.put(deviceType, configFactory);
+    }
+
+    private <T extends CULConfig> CULHandlerInternal<T> createNewHandler(T config) throws CULDeviceException {
+        String deviceType = config.getDeviceType();
+        CULMode mode = config.getMode();
+        logger.debug("Searching class for device type {}", deviceType);
+        @SuppressWarnings("unchecked")
+        DeviceClasses culHandlerclass = (DeviceClasses) deviceTypeClasses.get(deviceType);
+        if (culHandlerclass == null) {
+            throw new CULDeviceException("No class for the device type " + deviceType + " is registred");
+        }
+
+        Class<?>[] constructorParametersTypes = add2BeginningOfArray(culHandlerclass.parameterTypes, CULConfig.class);
+        Object[] parameters = add2BeginningOfArray(culHandlerclass.parameters, config);
+
+        try {
+            Constructor<? extends CULHandlerInternal<T>> culHanlderConstructor = ((Class<? extends CULHandlerInternal<T>>) culHandlerclass.clazz)
+                    .getConstructor(constructorParametersTypes);
+
+            CULHandlerInternal<T> culHandler = culHanlderConstructor.newInstance(parameters);
+            List<String> initCommands = mode.getCommands();
+            if (!(culHandler instanceof CULHandlerInternal)) {
+                logger.error("Class {} does not implement the internal interface",
+                        culHandlerclass.clazz.getCanonicalName());
+                throw new CULDeviceException("This CULHandler class does not implement the internal interface: "
+                        + culHandlerclass.clazz.getCanonicalName());
+            }
+            CULHandlerInternal<?> internalHandler = culHandler;
+            internalHandler.open();
+            for (String command : initCommands) {
+                internalHandler.sendWithoutCheck(command);
+            }
+            return culHandler;
+        } catch (SecurityException e1) {
+            throw new CULDeviceException("Not allowed to access the constructor ", e1);
+        } catch (NoSuchMethodException e1) {
+            throw new CULDeviceException("Can't find the constructor to build the CULHandler", e1);
+        } catch (IllegalArgumentException e) {
+            throw new CULDeviceException("Invalid arguments for constructor. CULConfig: " + config, e);
+        } catch (InstantiationException e) {
+            throw new CULDeviceException("Can't instantiate CULHandler object", e);
+        } catch (IllegalAccessException e) {
+            throw new CULDeviceException("Can't instantiate CULHandler object", e);
+        } catch (InvocationTargetException e) {
+            throw new CULDeviceException("Can't instantiate CULHandler object", e);
+        } catch (CULCommunicationException e) {
+            throw new CULDeviceException("Can't initialise RF mode", e);
+        }
+    }
+
+    public static <T> T[] add2BeginningOfArray(T[] elements, T element) {
+        T[] newArray = Arrays.copyOf(elements, elements.length + 1);
+        newArray[0] = element;
+        System.arraycopy(elements, 0, newArray, 1, elements.length);
+
+        return newArray;
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULMode.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/CULMode.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This enum represents the different RF modes in which the CUL can work. Based
+ * on this enum a culfw based device will be configured when openend for the
+ * first time.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public enum CULMode {
+
+    // TODO more research on correct CUL receiption modes
+    /**
+     * Slow RF mode for FS20, FHT etc. Intertechno also works in this mode.
+     */
+    SLOW_RF("X21"),
+    /**
+     * Fast RF mode for Homematic. Intertechno should also work in this mode.
+     */
+    ASK_SIN("X10", "Ar"),
+    /**
+     * Fast RF mode for the Moritz protocol of the Max! heating control system.
+     * Intertechno should also work in this mode.
+     */
+    MAX("X21", "Zr");
+
+    private List<String> commands;
+
+    private CULMode(String... commands) {
+        this.commands = Arrays.asList(commands);
+    }
+
+    public List<String> getCommands() {
+        return commands;
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/config/MaxCULBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/config/MaxCULBridgeConfiguration.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.config;
+
+import org.openhab.binding.cul.internal.CULBindingConstants;
+
+/**
+ * Configuration class for {@link CULBindingConstants} bridge used to connect to the
+ * cul device.
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+
+public class MaxCULBridgeConfiguration {
+
+    /**
+     * Name of the CUL device serial port
+     */
+    public String serialPort;
+
+    /**
+     * Serial port baudrate.
+     */
+    public Integer baudrate;
+
+    /**
+     * Serial port parity.
+     */
+    public String parity;
+
+    /**
+     * Set timezone you want the units to be set to.
+     */
+    public String timezone;
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/config/MaxCUNBridgeConfiguration.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/config/MaxCUNBridgeConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.config;
+
+;
+
+/**
+ * Configuration class for {@link MaxCulBindingConstants} bridge used to connect to the
+ * cul device.
+ *
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class MaxCUNBridgeConfiguration {
+
+    /**
+     * Name of the CUN device
+     */
+    public String networkPath;
+
+    /**
+     * Set timezone you want the units to be set to.
+     */
+    public String timezone;
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CulCunBaseBridgeHandler.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CulCunBaseBridgeHandler.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.handler;
+
+import static org.openhab.binding.cul.internal.CULBindingConstants.CHANNEL_CREDITS;
+import static org.openhab.binding.cul.internal.CULBindingConstants.CHANNEL_LED;
+
+import java.util.stream.Stream;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.CULHandler;
+import org.openhab.binding.cul.CULListener;
+import org.openhab.binding.cul.internal.*;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.*;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public abstract class CulCunBaseBridgeHandler extends BaseBridgeHandler
+        implements CULHandler, CULListener, CULCreditListener {
+
+    private final Logger logger = LoggerFactory.getLogger(CulCunBaseBridgeHandler.class);
+
+    protected CULConfig culConfig;
+    private CULManager manager;
+    private CULHandlerInternal<?> cul;
+
+    public CulCunBaseBridgeHandler(Bridge thing, CULManager manager) {
+        super(thing);
+        this.manager = manager;
+    }
+
+    protected synchronized void connect() {
+        try {
+            cul = manager.getOpenCULHandler(culConfig);
+            cul.registerListener(this);
+            cul.registerCreditListener(this);
+            updateStatus(ThingStatus.ONLINE);
+        } catch (CULDeviceException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            logger.warn("Can't open CUL", e);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (cul != null) {
+            cul.unregisterCreditListener(this);
+            cul.unregisterListener(this);
+            manager.close(cul);
+            cul = null;
+        }
+        super.dispose();
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (ThingStatus.ONLINE != thing.getStatus()) {
+            return;
+        }
+        switch (channelUID.getIdWithoutGroup()) {
+            case CHANNEL_CREDITS:
+                if (command instanceof RefreshType) {
+                    int credit10ms = getCulHandler().getCredit10ms();
+                    creditChanged(credit10ms);
+                    break;
+                } else {
+                    logger.debug("{}: Unhandled command type: {}: {}", getThing().getLabel(), channelUID,
+                            command.getClass());
+                }
+                break;
+            case CHANNEL_LED:
+                if (command instanceof OnOffType) {
+                    setLedMode((command == OnOffType.ON));
+                } else if (command instanceof RefreshType) {
+                    updateState(channelUID, OnOffType.ON);
+                } else {
+                    logger.debug("{}: Unhandled command type: {}: {}", getThing().getLabel(), channelUID,
+                            command.getClass());
+                }
+                break;
+        }
+    }
+
+    public void setLedMode(boolean ledModeOn) {
+        String data = "";
+        if (ledModeOn) {
+            data = "l02";
+        } else {
+            data = "l00";
+        }
+        try {
+            getCulHandler().send(data);
+        } catch (CULCommunicationException e) {
+            logger.error("Unable to send CUL message {} because: {}", data, e.getMessage());
+        }
+    }
+
+    private CULHandler getCulHandler() {
+        if (cul == null) {
+            logger.warn("Cul is not open yet");
+        }
+        return cul;
+    }
+
+    private Stream<CULListener> getCulListenerChildren() {
+        return getThing().getThings().stream().map(Thing::getHandler).filter(CULListener.class::isInstance)
+                .map(CULListener.class::cast);
+    }
+
+    @Override
+    public void send(String command) throws CULCommunicationException {
+        CULHandler culHandler = getCulHandler();
+        if (culHandler != null) {
+            culHandler.send(command);
+        } else {
+            logger.warn("Could not send command {}", command);
+        }
+    }
+
+    @Override
+    public int getCredit10ms() {
+        CULHandler culHandler = getCulHandler();
+        if (culHandler != null) {
+            return culHandler.getCredit10ms();
+        } else {
+            logger.warn("Could not getCredit10ms");
+            return 0;
+        }
+    }
+
+    @Override
+    public void dataReceived(String data) {
+        getCulListenerChildren().forEach(culListener -> culListener.dataReceived(data));
+    }
+
+    @Override
+    public void error(Exception e) {
+        getCulListenerChildren().forEach(culListener -> culListener.error(e));
+    }
+
+    @Override
+    public void creditChanged(int credit10ms) {
+        updateState(new ChannelUID(getThing().getUID(), CHANNEL_CREDITS), new DecimalType(credit10ms));
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CulMaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CulMaxBridgeHandler.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.handler;
+
+import org.openhab.binding.cul.internal.CULManager;
+import org.openhab.binding.cul.internal.CULMode;
+import org.openhab.binding.cul.internal.config.MaxCULBridgeConfiguration;
+import org.openhab.binding.cul.internal.serial.CULSerialConfigFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class CulMaxBridgeHandler extends CulCunBaseBridgeHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CulMaxBridgeHandler.class);
+
+    private MaxCULBridgeConfiguration config;
+
+    public CulMaxBridgeHandler(Bridge thing, CULManager manager) {
+        super(thing, manager);
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(MaxCULBridgeConfiguration.class);
+        if (config.serialPort.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Serial port is not configured.");
+            return;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        culConfig = new CULSerialConfigFactory().create("serial", config.serialPort, CULMode.MAX, config.baudrate,
+                config.parity);
+        logger.debug("Schedule connect to cul");
+        scheduler.submit(this::connect);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CunMaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/handler/CunMaxBridgeHandler.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.handler;
+
+import org.openhab.binding.cul.internal.CULManager;
+import org.openhab.binding.cul.internal.CULMode;
+import org.openhab.binding.cul.internal.config.MaxCUNBridgeConfiguration;
+import org.openhab.binding.cul.internal.network.CULNetworkConfig;
+import org.openhab.binding.cul.internal.network.CULNetworkConfigFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Johannes Goehr (johgoe) - Initial contribution
+ */
+public class CunMaxBridgeHandler extends CulCunBaseBridgeHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CunMaxBridgeHandler.class);
+
+    private MaxCUNBridgeConfiguration config;
+
+    public CunMaxBridgeHandler(Bridge thing, CULManager manager) {
+        super(thing, manager);
+    }
+
+    @Override
+    public void initialize() {
+        config = getConfigAs(MaxCUNBridgeConfiguration.class);
+        if (config.networkPath.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Network Path is not configured.");
+            return;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        culConfig = new CULNetworkConfigFactory().create("network", config.networkPath, CULMode.MAX);
+        culConfig = new CULNetworkConfig("network", config.networkPath, CULMode.MAX);
+        logger.debug("Schedule connect to cun");
+        scheduler.submit(this::connect);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkConfig.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkConfig.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.network;
+
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULMode;
+
+/**
+ * Configuration for network device handler implementation.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.9.0
+ */
+public class CULNetworkConfig extends CULConfig {
+
+    public CULNetworkConfig(String deviceType, String deviceAddress, CULMode mode) {
+        super(deviceType, deviceAddress, mode);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkConfigFactory.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkConfigFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.network;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULConfigFactory;
+import org.openhab.binding.cul.internal.CULMode;
+
+/**
+ * Configuration factory for network device handler implementation.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @since 1.9.0
+ */
+public class CULNetworkConfigFactory implements CULConfigFactory {
+
+    public CULConfig create(String deviceType, String deviceAddress, CULMode mode) {
+        Hashtable<String, String> config = new Hashtable<>();
+        return create(deviceType, deviceAddress, mode, config);
+    }
+
+    @Override
+    public CULConfig create(String deviceType, String deviceAddress, CULMode mode, Dictionary<String, ?> config) {
+        return new CULNetworkConfig(deviceType, deviceAddress, mode);
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkHandlerImpl.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/network/CULNetworkHandlerImpl.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.network;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.internal.AbstractCULHandler;
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULDeviceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation for culfw based devices which communicate via network port
+ * (CUN for example).
+ *
+ * @author Markus Heberling - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.5.0
+ */
+public class CULNetworkHandlerImpl extends AbstractCULHandler<CULNetworkConfig> {
+
+    private static final int CUN_DEFAULT_PORT = 2323;
+
+    /**
+     * Thread which receives all data from the CUL.
+     *
+     * @author Markus Heberling
+     * @since 1.5.0
+     *
+     */
+    private class ReceiveThread extends Thread {
+
+        private final Logger logger = LoggerFactory.getLogger(ReceiveThread.class);
+
+        /**
+         * Mark this thread
+         */
+        ReceiveThread() {
+            super("CUL ReceiveThread");
+        }
+
+        @Override
+        public void run() {
+
+            try {
+                while (!isInterrupted()) {
+                    processNextLine();
+
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        logger.debug("Error while sleeping in ReceiveThread", e);
+                    }
+                }
+                logger.debug("ReceiveThread exiting.");
+            } catch (CULCommunicationException e) {
+                log.error("Connection to CUL broken, terminating receive thread for {}", config.getDeviceAddress());
+            }
+        }
+    }
+
+    final static Logger log = LoggerFactory.getLogger(CULNetworkHandlerImpl.class);
+
+    private ReceiveThread receiveThread;
+
+    private Socket socket;
+    private InputStream is;
+    private OutputStream os;
+
+    /**
+     * Constructor including property map for specific configuration. Just for
+     * compatibility with CulSerialHandlerImpl
+     *
+     * @param config config for the handler
+     */
+    public CULNetworkHandlerImpl(CULConfig config) {
+        super((CULNetworkConfig) config);
+    }
+
+    @Override
+    protected void openHardware() throws CULDeviceException {
+        String deviceName = config.getDeviceAddress();
+        log.debug("Opening network CUL connection for {}", deviceName);
+        try {
+            URI uri = new URI("cul://" + deviceName);
+            String host = uri.getHost();
+            int port = uri.getPort() == -1 ? CUN_DEFAULT_PORT : uri.getPort();
+
+            if (uri.getHost() == null || uri.getPort() == -1) {
+                throw new CULDeviceException("Could not parse host:port from " + deviceName);
+            }
+            log.debug("Opening network CUL connection to {}:{}", host, port);
+            socket = new Socket(host, port);
+            log.info("Connected network CUL connection to {}:{}", host, port);
+            is = socket.getInputStream();
+            os = socket.getOutputStream();
+            br = new BufferedReader(new InputStreamReader(is));
+            bw = new BufferedWriter(new OutputStreamWriter(os));
+
+            log.debug("Starting network listener Thread");
+            receiveThread = new ReceiveThread();
+            receiveThread.start();
+        } catch (IOException e) {
+            throw new CULDeviceException(e);
+        } catch (URISyntaxException e) {
+            throw new CULDeviceException("Could not parse host:port from " + deviceName, e);
+        }
+    }
+
+    @Override
+    protected void closeHardware() {
+        receiveThread.interrupt();
+
+        log.debug("Closing network device {}", config.getDeviceAddress());
+
+        try {
+            if (br != null) {
+                br.close();
+            }
+            if (bw != null) {
+                bw.close();
+            }
+        } catch (IOException e) {
+            log.error("Can't close the input and output streams propberly", e);
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    log.error("Can't close the socket propberly", e);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialConfig.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialConfig.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.serial;
+
+import java.util.Objects;
+
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULMode;
+
+/**
+ * Configuration for serial device handler implementation.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.9.0
+ */
+public class CULSerialConfig extends CULConfig {
+
+    private int baudRate;
+    private int parityMode;
+
+    public CULSerialConfig(String deviceType, String deviceAddress, CULMode mode, int baudRate, int parityMode) {
+        super(deviceType, deviceAddress, mode);
+        this.baudRate = baudRate;
+        this.parityMode = parityMode;
+    }
+
+    public int getBaudRate() {
+        return baudRate;
+    }
+
+    public Integer getParityMode() {
+        return parityMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), baudRate, parityMode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CULSerialConfig other = (CULSerialConfig) obj;
+        return baudRate == other.baudRate && parityMode == other.parityMode;
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialConfigFactory.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialConfigFactory.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.serial;
+
+import java.util.*;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.StringUtils;
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULConfigFactory;
+import org.openhab.binding.cul.internal.CULMode;
+import org.openhab.core.io.transport.serial.SerialPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration factory for serial device handler implementation.
+ *
+ * @author Patrick Ruckstuhl - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.9.0
+ */
+public class CULSerialConfigFactory implements CULConfigFactory {
+    private final static Logger logger = LoggerFactory.getLogger(CULSerialConfigFactory.class);
+    private static final Map<String, Integer> validParitiesMap;
+    private static final List<Integer> validBaudrateMap;
+
+    static {
+        Map<String, Integer> parities = new HashMap<String, Integer>();
+        parities.put("EVEN", SerialPort.PARITY_EVEN);
+        parities.put("ODD", SerialPort.PARITY_ODD);
+        parities.put("MARK", SerialPort.PARITY_MARK);
+        parities.put("NONE", SerialPort.PARITY_NONE);
+        parities.put("SPACE", SerialPort.PARITY_SPACE);
+        validParitiesMap = Collections.unmodifiableMap(parities);
+
+        Integer baudrates[] = { 75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200 };
+        validBaudrateMap = Collections.unmodifiableList(Arrays.asList(baudrates));
+    }
+
+    private final static String KEY_BAUDRATE = "baudrate";
+    private final static String KEY_PARITY = "parity";
+
+    public CULConfig create(String deviceType, String deviceAddress, CULMode mode, Integer configuredBaudRate,
+            String configuredParity) {
+        Hashtable<String, String> config = new Hashtable<>();
+        config.put(KEY_BAUDRATE, configuredBaudRate != null ? Integer.toString(configuredBaudRate) : "");
+        config.put(KEY_PARITY, configuredParity);
+        return create(deviceType, deviceAddress, mode, config);
+    }
+
+    public CULConfig create(String deviceType, String deviceAddress, CULMode mode, Dictionary<String, ?> config) {
+        int baudRate = 9600;
+        final String configuredBaudRate = (String) config.get(KEY_BAUDRATE);
+        Integer tmpBaudRate = baudrateFromConfig(configuredBaudRate);
+        if (tmpBaudRate != null) {
+            baudRate = tmpBaudRate;
+            logger.info("Update config, {} = {}", KEY_BAUDRATE, baudRate);
+        }
+
+        int parityMode = SerialPort.PARITY_EVEN;
+        final String configuredParity = (String) config.get(KEY_PARITY);
+        Integer parsedParityNumber = parityFromConfig(configuredParity);
+        if (parsedParityNumber != null) {
+            parityMode = parsedParityNumber;
+            logger.info("Update config, {} = {} ({})", KEY_PARITY, convertParityModeToString(parityMode), parityMode);
+        }
+
+        return new CULSerialConfig(deviceType, deviceAddress, mode, baudRate, parityMode);
+    }
+
+    private Integer parityFromConfig(final String configuredParity) {
+        if (StringUtils.isNotBlank(configuredParity)) {
+            try {
+                if (isValidParity(configuredParity)) {
+                    return validParitiesMap.get(configuredParity.toUpperCase());
+                } else { // allow literal parity assignment?
+                    int parsedParityNumber = Integer.parseInt(configuredParity);
+                    if (isValidParity(parsedParityNumber)) {
+                        return parsedParityNumber;
+                    } else {
+                        logger.error("The configured '{}' value is invalid. The value '{}' has to be one of {}.",
+                                KEY_PARITY, parsedParityNumber, validParitiesMap.keySet());
+                    }
+                }
+            } catch (NumberFormatException e) {
+                logger.error("Error parsing config key '{}'. Use one of {}.", KEY_PARITY, validParitiesMap.keySet());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * calculate baudrate from config String
+     *
+     * @param configuredBaudRate
+     * @return baud Rate or null if failed
+     */
+    private Integer baudrateFromConfig(final String configuredBaudRate) {
+        if (StringUtils.isNotBlank(configuredBaudRate)) {
+            try {
+                int tmpBaudRate = Integer.parseInt(configuredBaudRate);
+                if (validBaudrateMap.contains(tmpBaudRate)) {
+                    return tmpBaudRate;
+                } else {
+                    logger.error(
+                            "Error parsing config parameter '{}'. Value = {} is not a valid baudrate. Value must be in [75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]",
+                            KEY_BAUDRATE, tmpBaudRate);
+                }
+            } catch (NumberFormatException e) {
+                logger.error("Error parsing config parameter '{}' to integer. Value = {}", KEY_BAUDRATE,
+                        configuredBaudRate);
+            }
+
+        }
+        return null;
+    }
+
+    /**
+     * Checks if mode is a valid input for 'SerialPort' - class
+     *
+     * @param mode
+     * @return true if valid
+     */
+    private boolean isValidParity(int mode) {
+        return validParitiesMap.containsValue(mode);
+    }
+
+    /**
+     * Checks if mode is a valid input for 'SerialPort' - class
+     *
+     * @param mode
+     * @return true if valid
+     */
+    private boolean isValidParity(String mode) {
+        return validParitiesMap.containsKey(mode.toUpperCase());
+    }
+
+    /**
+     * converts modes integer representation into a readable sting
+     *
+     * @param mode
+     * @return text if mode was valid, otherwise "invalid mode"
+     */
+    private String convertParityModeToString(int mode) {
+        if (validParitiesMap.containsValue(mode)) {
+            for (Entry<String, Integer> parity : validParitiesMap.entrySet()) {
+                if (parity.getValue().equals(mode)) {
+                    return parity.getKey();
+                }
+            }
+        }
+        return "invalid mode";
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialHandlerImpl.java
+++ b/bundles/org.openhab.binding.cul/src/main/java/org/openhab/binding/cul/internal/serial/CULSerialHandlerImpl.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.cul.internal.serial;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.TooManyListenersException;
+
+import org.openhab.binding.cul.CULCommunicationException;
+import org.openhab.binding.cul.internal.AbstractCULHandler;
+import org.openhab.binding.cul.internal.CULConfig;
+import org.openhab.binding.cul.internal.CULDeviceException;
+import org.openhab.core.io.transport.serial.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation for culfw based devices which communicate via serial port
+ * (cullite for example). This is based on rxtx and assumes constant parameters
+ * for the serial port.
+ *
+ * @author Till Klocke - Initial contribution
+ * @author Johannes Goehr (johgoe) - Migration to OpenHab 3.0
+ * @since 1.4.0
+ */
+public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig> implements SerialPortEventListener {
+
+    private final static Logger log = LoggerFactory.getLogger(CULSerialHandlerImpl.class);
+    private final SerialPortManager serialPortManager;
+
+    private SerialPort serialPort;
+    private InputStream is;
+    private OutputStream os;
+
+    /**
+     * Constructor including property map for specific configuration.
+     *
+     * @param config
+     *            Configuration for this implementation.
+     */
+    public CULSerialHandlerImpl(CULConfig config, SerialPortManager serialPortManager) {
+        super((CULSerialConfig) config);
+        this.serialPortManager = serialPortManager;
+    }
+
+    @Override
+    public void serialEvent(SerialPortEvent event) {
+        if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
+            try {
+                processNextLine();
+            } catch (CULCommunicationException e) {
+                log.error("Serial CUL connection read failed for {}", config.getDeviceAddress());
+            }
+        }
+    }
+
+    @Override
+    protected void openHardware() throws CULDeviceException {
+        String serialPortName = config.getDeviceAddress();
+        log.debug("Opening serial CUL connection for {}", serialPortName);
+        try {
+            SerialPortIdentifier portIdentifier = serialPortManager.getIdentifier(serialPortName);
+            if (portIdentifier == null) {
+                log.warn("Could not find serial port with name {}", serialPortName);
+                throw new CULDeviceException("Could not find serial port with name " + serialPortName);
+            }
+            serialPort = portIdentifier.open(this.getClass().getName(), 2000);
+            serialPort.setSerialPortParams(config.getBaudRate(), SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
+                    config.getParityMode());
+            is = serialPort.getInputStream();
+            os = serialPort.getOutputStream();
+            br = new BufferedReader(new InputStreamReader(is));
+            bw = new BufferedWriter(new OutputStreamWriter(os));
+
+            serialPort.notifyOnDataAvailable(true);
+            log.debug("Adding serial port event listener");
+            serialPort.addEventListener(this);
+        } catch (PortInUseException e) {
+            throw new CULDeviceException(e);
+        } catch (UnsupportedCommOperationException e) {
+            throw new CULDeviceException(e);
+        } catch (IOException e) {
+            throw new CULDeviceException(e);
+        } catch (TooManyListenersException e) {
+            throw new CULDeviceException(e);
+        }
+    }
+
+    @Override
+    protected void closeHardware() {
+        log.debug("Closing serial device {}", config.getDeviceAddress());
+        if (serialPort != null) {
+            serialPort.removeEventListener();
+        }
+        try {
+            if (br != null) {
+                br.close();
+            }
+            if (bw != null) {
+                bw.close();
+            }
+        } catch (IOException e) {
+            log.error("Can't close the input and output streams propberly", e);
+        } finally {
+            if (serialPort != null) {
+                serialPort.close();
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.cul/src/main/resources/OH-INF/thing/cul_bridge.xml
+++ b/bundles/org.openhab.binding.cul/src/main/resources/OH-INF/thing/cul_bridge.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="maxcul"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="cul_max_bridge">
+		<label>CUL Bridge</label>
+		<description>This bridge is used when using a CUL (serial) in MORIZ mode (MAX!)</description>
+		<channels>
+			<channel id="led" typeId="onoff"/>
+			<channel id="credit10ms" typeId="credits"/>
+		</channels>
+		<config-description>
+			<parameter name="serialPort" type="text" required="true">
+				<label>Serial port</label>
+				<description>Set the device of the CUL device (mandatory)
+					Example CUL with serial port: /dev/ttyACM0 or serial:COM3
+				</description>
+				<limitToOptions>false</limitToOptions>
+				<options>
+					<option value="/dev/ttyACM0">/dev/ttyACM0</option>
+					<option value="COM3">COM3</option>
+				</options>
+			</parameter>
+			<parameter name="baudrate" type="integer" min="1" required="false">
+				<label>Serial port baudrate</label>
+				<description>Serial port baudrate.</description>
+				<limitToOptions>true</limitToOptions>
+				<options>
+					<option value="75">75</option>
+					<option value="110">110</option>
+					<option value="300">300</option>
+					<option value="1200">1200</option>
+					<option value="2400">2400</option>
+					<option value="4800">4800</option>
+					<option value="9600">9600</option>
+					<option value="19200">19200</option>
+					<option value="38400">38400</option>
+					<option value="57600">57600</option>
+					<option value="115200">115200</option>
+				</options>
+				<default>38400</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="parity" type="text" required="false">
+				<label>Serial port parity</label>
+				<description>Serial port parity.</description>
+				<limitToOptions>true</limitToOptions>
+				<options>
+					<option value="EVEN">EVEN</option>
+					<option value="ODD">ODD</option>
+					<option value="MARK">MARK</option>
+					<option value="NONE">NONE</option>
+					<option value="SPACE">SPACE</option>
+				</options>
+				<default>NONE</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</bridge-type>
+	<channel-type id="credits" advanced="true">
+		<item-type>Number</item-type>
+		<label>credits</label>
+		<description>credits of 10ms</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="onoff">
+		<item-type>Switch</item-type>
+		<label>On/Off</label>
+		<category>Switch</category>
+		<tags>
+			<tag>Switchable</tag>
+		</tags>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.cul/src/main/resources/OH-INF/thing/cun_bridge.xml
+++ b/bundles/org.openhab.binding.cul/src/main/resources/OH-INF/thing/cun_bridge.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="maxcul"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="cun_max_bridge">
+		<label>CUN Bridge</label>
+		<description>This bridge is used when using a CUN (network) in MORIZ mode (MAX!)</description>
+		<channels>
+			<channel id="led" typeId="onoff"/>
+			<channel id="credit10ms" typeId="credits"/>
+		</channels>
+		<config-description>
+			<parameter name="networkPath" type="text" required="true">
+				<label>Network Path</label>
+				<description>Set the device of the CUN device (mandatory)
+					Example CUN with default port 2323: 127.0.0.1
+					Example CUN
+					with Port: 127.0.0.1:2323
+				</description>
+				<limitToOptions>false</limitToOptions>
+				<options>
+					<option value="127.0.0.1">127.0.0.1</option>
+					<option value="127.0.0.1:2323">127.0.0.1:2323</option>
+				</options>
+			</parameter>
+		</config-description>
+	</bridge-type>
+	<channel-type id="credits" advanced="true">
+		<item-type>Number</item-type>
+		<label>credits</label>
+		<description>credits of 10ms</description>
+		<state pattern="%d" readOnly="true">
+		</state>
+	</channel-type>
+	<channel-type id="onoff">
+		<item-type>Switch</item-type>
+		<label>On/Off</label>
+		<category>Switch</category>
+		<tags>
+			<tag>Switchable</tag>
+		</tags>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -76,6 +76,8 @@
     <module>org.openhab.binding.comfoair</module>
     <module>org.openhab.binding.coolmasternet</module>
     <module>org.openhab.binding.coronastats</module>
+    <module>org.openhab.binding.cul</module>
+    <module>org.openhab.binding.cul.max</module>
     <module>org.openhab.binding.daikin</module>
     <module>org.openhab.binding.danfossairunit</module>
     <module>org.openhab.binding.darksky</module>


### PR DESCRIPTION
MAX!Cul Binding for OH3

I converted `org.openhab.io.transport.cul` and `org.openhab.binding.maxcul` from OH1 to OH3. 

The new binding `org.openhab.binding.cul` replaces `org.openhab.io.transport.cul` from OH1 
This binding provides just bridges for CUL and CUN for the CUL in Moriz mode. Other modes which where available in OH1 are prepared and can be implemented similar to `maxcul` if also needed for other bindings.

Additionally I added  `org.openhab.binding.cul.max` which replaces `org.openhab.binding.maxcul` from OH1.

For details about things and channels see the README file.
