### PR TITLE
[homekit] fix for 9746: use item name as accessory serial

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/accessories/AbstractHomekitAccessoryImpl.java
@@ -96,7 +96,7 @@ abstract class AbstractHomekitAccessoryImpl implements HomekitAccessory {
 
     @Override
     public CompletableFuture<String> getSerialNumber() {
-        return CompletableFuture.completedFuture("none");
+        return CompletableFuture.completedFuture(accessory.getItem().getName());
     }
 
     @Override


### PR DESCRIPTION
fixes the issue with controller app by using item name as accessory serial

#9746 

Signed-off-by: Eugen Freiter <freiter@gmx.de>
