### PR TITLE
[mqtt] Only unsubscribe if we subscribed before

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/TopicSubscribe.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/TopicSubscribe.java
@@ -53,8 +53,9 @@ public class TopicSubscribe implements MqttMessageSubscriber {
     @Override
     public void processMessage(String topic, byte[] payload) {
         final MqttBrokerConnection connection = this.connection;
-        if (connection == null)
+        if (connection == null) {
             return;
+        }
         if (payload.length > 0) {
             topicDiscoveredListener.receivedMessage(thing, connection, topic, payload);
         } else {
@@ -80,7 +81,8 @@ public class TopicSubscribe implements MqttMessageSubscriber {
      * @return Completes with true if successful. Exceptionally otherwise.
      */
     public CompletableFuture<Boolean> stop() {
-        CompletableFuture<Boolean> stopFuture = connection == null ? CompletableFuture.completedFuture(true)
+        CompletableFuture<Boolean> stopFuture = connection == null || !isStarted
+                ? CompletableFuture.completedFuture(true)
                 : connection.unsubscribe(topic, this);
         isStarted = false;
         return stopFuture;


### PR DESCRIPTION
Fixes #9730

During subscription a <code>TopicSubscribe</code> is created (see <code>AbstractBrokerHandler</code>)
But when <code>discoveryEnabled == false</code> the <code>TopicSubscribe</code> is never started.

During tear down, unsubscribe should only be tried, if the subsribe was started before.