### PR TITLE
[mqtt] Remove default for contact/switch alternate on/off message

### DIFF
--- a/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/config/switch-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.generic/src/main/resources/OH-INF/config/switch-channel-config.xml
@@ -83,13 +83,11 @@
 			<label>Custom On/Open Value</label>
 			<description>A number (like 1, 10) or a string (like "enabled") that is additionally recognised as on/open state. You
 				can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
-			<default>1</default>
 		</parameter>
 		<parameter name="off" type="text">
 			<label>Custom Off/Closed Value</label>
 			<description>A number (like 0, -10) or a string (like "disabled") that is additionally recognised as off/closed
 				state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
-			<default>0</default>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>


### PR DESCRIPTION
There is already a default for this : 'ON'/'OFF', 'Open'/'Close'
Why do we need another default?
The code does not honor the default, so the best is, to remove the default from the UI.

Fix for #9710