### PR TITLE
[samsungtv] Fixes device.getIdentity().getDescriptorURL() comparison

### DIFF
--- a/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
+++ b/bundles/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/handler/SamsungTvHandler.java
@@ -325,7 +325,7 @@ public class SamsungTvHandler extends BaseThingHandler implements RegistryListen
     @Override
     public void remoteDeviceAdded(@Nullable Registry registry, @Nullable RemoteDevice device) {
         if (configuration.hostName != null && device != null && device.getIdentity() != null
-                && device.getIdentity().getDescriptorURL() == null
+                && device.getIdentity().getDescriptorURL() != null
                 && configuration.hostName.equals(device.getIdentity().getDescriptorURL().getHost())
                 && device.getType() != null) {
             logger.debug("remoteDeviceAdded: {}, {}", device.getType().getType(),


### PR DESCRIPTION
Fixes #9673 

@kaikreuzer @paulianttila Requesting you review and approve.