### PR TITLE
[homekit] fix pairing after addon update

### DIFF
--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -173,7 +173,7 @@ public class HomekitImpl implements Homekit {
             changeListener.setBridge(bridge);
             this.bridge = bridge;
             bridge.setConfigurationIndex(changeListener.getConfigurationRevision());
-
+            bridge.refreshAuthInfo();
             final int lastAccessoryCount = changeListener.getLastAccessoryCount();
             int currentAccessoryCount = changeListener.getAccessories().size();
             if (currentAccessoryCount < lastAccessoryCount) {


### PR DESCRIPTION
as described here https://github.com/openhab/openhab-core/issues/2098
homekit addon does not set pairing status correctly after an update. this PR fix it - on bridge start it will check whether a pairing/user exists and set the discoverability at HAP level accordantly.


Signed-off-by: Eugen Freiter <freiter@gmx.de>
