### PR TITLE
[epsonprojector] Fix "projector-tcp"-Thing gets stuck after Power-off via TCP

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -210,6 +210,7 @@ public class EpsonProjectorDevice {
         if (timeoutJob != null) {
             timeoutJob.cancel(true);
             this.timeoutJob = null;
+            ready = true;
         }
     }
 


### PR DESCRIPTION
**Issue description:**
When beamer is switched on and gets the "off" command the binding sets a "ready" flag to false. This should prevent sending further commands for 10 seconds. To reset this flag a scheduled task gets fired.
Some how (couldn't figure out why until now) one more command is executed, which shouldn't happen at this moment. This command cannot be executed as expected and predicted in comment of code:

```
EpsonProjectorDevice.java (line: 126)
...
// When PWR OFF command is sent, next command can be sent 10 seconds after the colon is received
...
```

This command raises an error "Couldn't execute command 'Power', No response received" and resets the connection. The `disconnect()-method (EpsonProjectorDevice.java (line: 205)) `deletes the running timeout-job. in this situation the "ready" flag won't get updated to "true" anymore and any following commands are canceled (`EpsonProjectorHandler.java (line: 179) "Refusing command ... while not ready"`).

**Approach to fix this issue:**
When resetting the timeout-job set ready-flag also to "true". This ensures a working new connection when reconnect happens and scheduled job is deleted.

**Sample DEBUG-outpug that shows connection reset after power down**
```
16:27:37.635 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Response: 'PWR=01'
16:27:37.636 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Query: 'SOURCE?'
16:27:37.737 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Response: 'SOURCE=30'
16:27:37.737 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Query: 'CMODE?'
16:27:37.838 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Response: 'CMODE=09'
16:27:45.611 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Query: 'PWR OFF'
16:28:03.738 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Response: ':'
16:28:03.738 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Refusing further commands for 10 seconds to power OFF completion
16:28:03.739 [DEBUG] [ojector.internal.EpsonProjectorDevice] - Query: 'PWR?'
16:28:08.751 [DEBUG] [nternal.handler.EpsonProjectorHandler] - Couldn't execute command 'Power', No response received
16:28:08.752 [DEBUG] [nternal.handler.EpsonProjectorHandler] - Closing connection to device 'epsonprojector:projector-tcp:hometheater'
16:28:08.752 [DEBUG] [.connector.EpsonProjectorTcpConnector] - Close tcp out stream
16:28:08.752 [DEBUG] [.connector.EpsonProjectorTcpConnector] - Close tcp in stream
16:28:08.753 [DEBUG] [.connector.EpsonProjectorTcpConnector] - Closing socket
16:28:08.754 [DEBUG] [.connector.EpsonProjectorTcpConnector] - Closed
16:28:08.754 [DEBUG] [.connector.EpsonProjectorTcpConnector] - Open connection to address'192.168.0.8: 3629'
```