### PR TITLE
[konnected] add support for Alarm Panel Pro

### DIFF
--- a/bundles/org.openhab.binding.konnected/README.md
+++ b/bundles/org.openhab.binding.konnected/README.md
@@ -7,7 +7,7 @@ The Konnected hardware is specifically designed for an alarm panel installation,
 
 ## Supported Things
 
-This binding supports one type of thing module, which represents a Konnected Alarm Panel.
+This binding supports two types of thing modules, which represents the wifi version of the Konnected Alarm Panel and the Konnected Alarm Panel Pro.
 
 ## Discovery
 
@@ -28,24 +28,33 @@ The blink setting will disable the transmission LED on the Konnected Alarm Panel
 
 ## Channels
 
-The auto discovered thing adds two default channels.
+Depending on whether the thing type is the wifi version or the pro version the automativally added channels will differ.  
+For the wifi verision the auto discovered thing adds two default channels.
 
 | Channel | Channel Id | Channel Type | Description                                              |
 |---------|------------|--------------|----------------------------------------------------------|
-| 1       | Zone_6     | Switch       | A Switch channel for zone 6                              |
-| 2       | Out        | Actuator     | The Channel for the Out Pin on the Konnected Alarm Panel |
+| 1       | Zone_6     | Switch-wifi       | A Switch channel for zone 6                              |
+| 2       | Out        | Actuator-wifi     | The Channel for the Out Pin on the Konnected Alarm Panel |
 
 One channel for Zone 6 which is a sensor type channel, and one channel for the out pin that is an actuator type channel.
 These channels represent the two pins on the Konnected Alarm Panel whose type cannot be changed.
-For zones 1-5, you will need to add channels for the remaining zones that you have connected and configure them with the appropriate configuration parameters for each channel.
 
+For the Konnected Alarm Panel Pro the auto discovered thing adds three default channels.
+
+| Channel | Channel Id | Channel Type | Description                                              |
+|---------|------------|--------------|----------------------------------------------------------|
+| 1       | Alarm1     | Switch-Pro       | 12v Alarm 1 Output on the Konnected Pro                      |
+| 2       | Output1    | Actuator-Pro     | 3.3v Output 1 on the Konnected Alarm Panel					 |
+| 3       | Alarm2-Output2  | Switch-Pro     | The Selectable 12v Alarm 2 / 3.3v Output 2 on the Konnected Alarm Panel Pro |
+
+For zones 1-5 (wifi version) or zones 1-12 (pro version), you will need to add channels for the remaining zones that you have connected and configure them with the appropriate configuration parameters for each channel.
 
 | Channel Type | Item Type            | Config Parameters                                  | Description                                                                                                                                                                                                                                     |
 |--------------|----------------------|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Switch       | Switch               | Zone Number                                        | This is the channel type for sensors or other read only devices                                                                                                                                                                                 |
-| Actuator     | Switch               | Zone Number, Momentary, Pause, Times               | This is the channel type for devices whose state can be turned on an off by the Konnected Alarm Panel                                                                                                                                           |
-| Temperature  | Number:Temperature   | Zone Number, DHT22, Poll Interval, DS18b20 Address | This is the channel for sensors which measure temperature (DHT22 and DS18B20). The DHT22 setting should be set to true when the channel is monitoring a zone connected to a DHT22 sensor and false if the zone is connected to a DS1820B sensor |
-| Humidity     | Number:Dimensionless | Zone Number                                        | This is the channel type for the humidity sensor on a connected DHT22 sensor                                                                                                                                                                    |
+| Switch-(wifi/pro)       | Switch               | Zone Number                                        | This is the channel type for sensors or other read only devices                                                                                                                                                                                 |
+| Actuator-(wifi/pro)    | Switch               | Zone Number, Momentary, Pause, Times               | This is the channel type for devices whose state can be turned on an off by the Konnected Alarm Panel                                                                                                                                           |
+| Temperature-(wifi/pro)  | Number:Temperature   | Zone Number, DHT22, Poll Interval, DS18b20 Address | This is the channel for sensors which measure temperature (DHT22 and DS18B20). The DHT22 setting should be set to true when the channel is monitoring a zone connected to a DHT22 sensor and false if the zone is connected to a DS1820B sensor |
+| Humidity-(wifi/pro)    | Number:Dimensionless | Zone Number                                        | This is the channel type for the humidity sensor on a connected DHT22 sensor                                                                                                                                                                    |
 
 You will need to configure each channel with the appropriate zone number corresponding to the zone on The Konnected Alarm Panel.
 Then you need to link the corresponding item to the channel.
@@ -57,6 +66,11 @@ This is commonly used with a relay module to actuate a garage door opener, or wi
 A beep/blink switch is like a momentary switch that repeats either a specified number of times or indefinitely.
 This is commonly used with a piezo buzzer to make a "beep beep" sound when a door is opened, or to make a repeating beep pattern for an alarm or audible warning.
 It can also be used to blink lights.
+
+A note about the Alarm Panel Pro.
+Zones 1-8 can be configured for any Channel-Types.  
+Zones 9-12 can only be configured for the Switch-Pro type. (binary sensor)
+For More information see: https://help.konnected.io/support/solutions/articles/32000028978-alarm-panel-pro-inputs-and-outputs 
 
 DSB1820 temperature probes.
 These are one wire devices which can all be Konnected to the same "Zone" on the Konnected Alarm Panel.
@@ -71,8 +85,11 @@ A channel should be added for each probe, as indicated above and configured with
 *.items
 
 ```
-Contact Front_Door_Sensor "Front Door" {channel="konnected:module:generic:switch"}
-Switch Siren "Siren" {channel="konnected:module:generic:actuator"}
+Switch Front_Door_Sensor "Front Door" {channel="konnected:wifi-module:generic:switch-wifi"}
+Switch Siren "Siren" {channel="konnected:wifi-module:generic:actuator-wifi"}
+
+Switch Front_Door_Sensor_Pro "Front Door" {channel="konnected:pro-module:generic:switch-pro"}
+Switch Siren_Pro "Siren" {channel="konnected:pro-module:generic:actuator-pro"}
 ```
 
 *.sitemap
@@ -85,12 +102,20 @@ Switch item=Siren label="Alarm Siren" icon="Siren" mappings=[ON="Open", OFF="Clo
 *.things
 
 ```
-Thing konnected:module:generic "Konnected Module" [ipAddress="http://192.168.30.153:9586", macAddress="1586517"]{
-   Type switch      : switch      "Front Door"          [channel_zone=1]
-   Type actuator    : actuator    "Siren"               [channel_zone=1, momentary = 50, times = 2, pause = 50]
-   Type humidity    : humidity    "DHT - Humidity"      [channel_zone=1]
-   Type temperature : temperature "DHT Temperature"     [channel_zone=1, tempsensorType = true, pollinterval = 1]
-   Type temperature : temperature "DS18B20 Temperature" [channel_zone=1, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
+Thing konnected:wifi-module:generic "Konnected Module" [ipAddress="http://192.168.30.153:9586", macAddress="1586517"]{
+   Type switch      : switch-wifi      "Front Door"          [channel_zone=1]
+   Type actuator    : actuator-wifi    "Siren"               [channel_zone=1, momentary = 50, times = 2, pause = 50]
+   Type humidity    : humidity-wifi    "DHT - Humidity"      [channel_zone=1]
+   Type temperature : temperature-wifi "DHT Temperature"     [channel_zone=1, tempsensorType = true, pollinterval = 1]
+   Type temperature : temperature-wifi "DS18B20 Temperature" [channel_zone=1, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
+}
+
+Thing konnected:pro-module:generic "Konnected Module" [ipAddress="http://192.168.30.154:9586", macAddress="1684597"]{
+   Type switch      : switch-pro      "Front Door"          [channel_zone=1]
+   Type actuator    : actuator-pro    "Siren"               [channel_zone=1, momentary = 50, times = 2, pause = 50]
+   Type humidity    : humidity-pro    "DHT - Humidity"      [channel_zone=1]
+   Type temperature : temperature-pro "DHT Temperature"     [channel_zone=1, tempsensorType = true, pollinterval = 1]
+   Type temperature : temperature-pro "DS18B20 Temperature" [channel_zone=1, tempsensorType = false, pollinterval = 1, ds18b20_address = "XX:XX:XX:XX:XX:XX:XX"]
 }
 ```
 

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -25,9 +25,12 @@ import org.openhab.core.thing.ThingTypeUID;
 public class KonnectedBindingConstants {
 
     public static final String BINDING_ID = "konnected";
+    public static final String PRO_MODULE = "pro-module";
+    public static final String WIFI_MODULE = "wifi-module";
 
     // List of all Thing Type UIDs
-    public static final ThingTypeUID THING_TYPE_MODULE = new ThingTypeUID(BINDING_ID, "module");
+    public static final ThingTypeUID THING_TYPE_WIFIMODULE = new ThingTypeUID(BINDING_ID, WIFI_MODULE);
+    public static final ThingTypeUID THING_TYPE_PROMODULE = new ThingTypeUID(BINDING_ID, PRO_MODULE);
 
     // Thing config properties
     public static final String HOST = "ipAddress";
@@ -59,4 +62,8 @@ public class KonnectedBindingConstants {
     public static final String CHANNEL_ACTUATOR_PAUSE = "pause";
 
     public static final String CHANNEL_ONVALUE = "onvalue";
+
+    public static final String PRO_MODULE_ALARM1 = "alarm1";
+    public static final String PRO_MODULE_OUT1 = "out1";
+    public static final String PRO_MODULE_ALARM2_OUT2 = "alarm2_out2";
 }

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedConfiguration.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHTTPUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHandlerFactory.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -17,6 +17,8 @@ import static org.openhab.binding.konnected.internal.KonnectedBindingConstants.*
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.ServletException;
 
@@ -48,7 +50,8 @@ import org.slf4j.LoggerFactory;
 @Component(configurationPid = "binding.konnected", service = ThingHandlerFactory.class)
 public class KonnectedHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(KonnectedHandlerFactory.class);
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_MODULE);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_PROMODULE, THING_TYPE_WIFIMODULE).collect(Collectors.toSet()));
     private static final String alias = "/" + BINDING_ID;
 
     private HttpService httpService;

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHttpRetryExceeded.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/KonnectedHttpRetryExceeded.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/discovery/KonnectedUPnPServer.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/discovery/KonnectedUPnPServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -27,6 +29,7 @@ import org.jupnp.model.meta.RemoteDevice;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.openhab.core.config.discovery.upnp.internal.UpnpDiscoveryService;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
@@ -44,10 +47,12 @@ import org.slf4j.LoggerFactory;
 @Component(service = UpnpDiscoveryParticipant.class)
 public class KonnectedUPnPServer implements UpnpDiscoveryParticipant {
     private Logger logger = LoggerFactory.getLogger(KonnectedUPnPServer.class);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_PROMODULE, THING_TYPE_WIFIMODULE).collect(Collectors.toSet()));
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
-        return Collections.singleton(THING_TYPE_MODULE);
+        return SUPPORTED_THING_TYPES_UIDS;
     }
 
     @Override
@@ -70,14 +75,16 @@ public class KonnectedUPnPServer implements UpnpDiscoveryParticipant {
         DeviceDetails details = device.getDetails();
         if (details != null) {
             ModelDetails modelDetails = details.getModelDetails();
-
             if (modelDetails != null) {
                 String modelName = modelDetails.getModelName();
                 logger.debug("Model Details: {} Url: {} UDN: {}  Model Number: {}", modelName, details.getBaseURL(),
                         details.getSerialNumber(), modelDetails.getModelNumber());
                 if (modelName != null) {
+                    if (modelName.startsWith("Konnected Pro")) {
+                        return new ThingUID(THING_TYPE_PROMODULE, details.getSerialNumber());
+                    }
                     if (modelName.startsWith("Konnected")) {
-                        return new ThingUID(THING_TYPE_MODULE, details.getSerialNumber());
+                        return new ThingUID(THING_TYPE_WIFIMODULE, details.getSerialNumber());
                     }
                 }
             }

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModuleGson.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModuleGson.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -11,6 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.konnected.internal.gson;
+
+import static org.openhab.binding.konnected.internal.KonnectedBindingConstants.*;
+
+import java.util.Arrays;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -24,6 +28,7 @@ import com.google.gson.annotations.SerializedName;
 public class KonnectedModuleGson {
 
     private Integer pin;
+    private String zone;
     private String temp;
     private String humi;
     private String state;
@@ -36,12 +41,50 @@ public class KonnectedModuleGson {
     private Integer pollInterval;
     private String addr;
 
-    public Integer getPin() {
-        return pin;
+    private Integer getPin() {
+
+        return Arrays.asList(PIN_TO_ZONE).indexOf(pin);
     }
 
-    public void setPin(Integer setPin) {
-        this.pin = setPin;
+    private void setPin(Integer setPin) {
+
+        this.pin = Arrays.asList(PIN_TO_ZONE).get(setPin);
+    }
+
+    private Integer getZone() {
+
+        switch (zone) {
+            case PRO_MODULE_ALARM1:
+                return Integer.decode("13");
+
+            case PRO_MODULE_OUT1:
+                return Integer.decode("14");
+
+            case PRO_MODULE_ALARM2_OUT2:
+                return Integer.decode("15");
+            default:
+                return Integer.decode(zone);
+        }
+    }
+
+    private void setZone(Integer setZone) {
+
+        switch (setZone) {
+            case 13:
+                this.zone = PRO_MODULE_ALARM1;
+                break;
+            case 14:
+                this.zone = PRO_MODULE_OUT1;
+                break;
+            case 15:
+                this.zone = PRO_MODULE_ALARM2_OUT2;
+                break;
+            default:
+                this.zone = Integer.toString(setZone);
+
+        }
+
+        ;
     }
 
     public Integer getPollInterval() {
@@ -110,5 +153,28 @@ public class KonnectedModuleGson {
 
     public void setAddr(String setAddr) {
         this.addr = setAddr;
+    }
+
+    public void setPinZone(String ThingID, Integer sentZone) {
+        switch (ThingID) {
+            case PRO_MODULE:
+                this.setZone(sentZone);
+                break;
+            case WIFI_MODULE:
+                this.setPin(sentZone);
+                break;
+        }
+    }
+
+    public Integer getPinZone(String ThingID) {
+
+        switch (ThingID) {
+            case PRO_MODULE:
+                return this.getZone();
+
+            default:
+                return this.getPin();
+
+        }
     }
 }

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModulePayload.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/gson/KonnectedModulePayload.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/handler/KonnectedHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -15,7 +15,6 @@ package org.openhab.binding.konnected.internal.handler;
 import static org.openhab.binding.konnected.internal.KonnectedBindingConstants.*;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -54,13 +53,14 @@ import com.google.gson.GsonBuilder;
 public class KonnectedHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(KonnectedHandler.class);
     private KonnectedConfiguration config;
-
     private final String konnectedServletPath;
     private final KonnectedHTTPUtils http = new KonnectedHTTPUtils(30);
     private String callbackIpAddress = null;
     private String moduleIpAddress;
     private Gson gson = new GsonBuilder().create();
     private int retryCount;
+    private String thingID;
+    public String authToken;
 
     /**
      * This is the constructor of the Konnected Handler.
@@ -73,11 +73,12 @@ public class KonnectedHandler extends BaseThingHandler {
      */
     public KonnectedHandler(Thing thing, String path, String hostAddress, String port) {
         super(thing);
-
         this.konnectedServletPath = path;
         callbackIpAddress = hostAddress + ":" + port;
         logger.debug("The callback ip address is: {}", callbackIpAddress);
         retryCount = 2;
+        thingID = this.getThing().getThingTypeUID().getId();
+        authToken = getThing().getUID().getAsString();
     }
 
     @Override
@@ -88,22 +89,20 @@ public class KonnectedHandler extends BaseThingHandler {
         String zoneNumber = (String) channel.getConfiguration().get(CHANNEL_ZONE);
         Integer zone = Integer.parseInt(zoneNumber);
         logger.debug("The channelUID is: {} and the zone is : {}", channelUID.getAsString(), zone);
-        // convert the zone to the pin based on value at index of zone
-        Integer pin = Arrays.asList(PIN_TO_ZONE).get(zone);
         // if the command is OnOfftype
         if (command instanceof OnOffType) {
-            if (channelType.equalsIgnoreCase(CHANNEL_SWITCH)) {
+            if (channelType.contains(CHANNEL_SWITCH)) {
                 logger.debug("A command was sent to a sensor type so we are ignoring the command");
             } else {
                 int sendCommand = (OnOffType.OFF.compareTo((OnOffType) command));
-                logger.debug("The command being sent to pin {} for channel:{}  is {}", pin, channelUID.getAsString(),
+                logger.debug("The command being sent to zone {} for channel:{}  is {}", zone, channelUID.getAsString(),
                         sendCommand);
-                sendActuatorCommand(Integer.toString(sendCommand), pin, channelUID);
+                sendActuatorCommand(Integer.toString(sendCommand), zone, channelUID);
             }
         } else if (command instanceof RefreshType) {
             // check to see if handler has been initialized before attempting to get state of pin, else wait one minute
             if (this.isInitialized()) {
-                getSwitchState(pin, channelUID);
+                getSwitchState(zone, channelUID);
             } else {
                 scheduler.schedule(() -> {
                     handleCommand(channelUID, command);
@@ -119,13 +118,14 @@ public class KonnectedHandler extends BaseThingHandler {
      * @param event the {@link KonnectedModuleGson} event that contains the state and pin information to be processed
      */
     public void handleWebHookEvent(KonnectedModuleGson event) {
-        // if we receive a command upteate the thing status to being online
+        // if we receive a command update the thing status to being online
         updateStatus(ThingStatus.ONLINE);
         // get the zone number based off of the index location of the pin value
-        String sentZone = Integer.toString(Arrays.asList(PIN_TO_ZONE).indexOf(event.getPin()));
+        // String sentZone = Integer.toString(Arrays.asList(PIN_TO_ZONE).indexOf(event.getPin()));
+        String sentZone = Integer.toString(event.getPinZone(thingID));
         // check that the zone number is in one of the channelUID definitions
         logger.debug("Looping Through all channels on thing: {} to find a match for {}", thing.getUID().getAsString(),
-                event.getAuthToken());
+                sentZone);
         getThing().getChannels().forEach(channel -> {
             ChannelUID channelId = channel.getUID();
             String zoneNumber = (String) channel.getConfiguration().get(CHANNEL_ZONE);
@@ -139,14 +139,14 @@ public class KonnectedHandler extends BaseThingHandler {
                 logger.debug("The channeltypeID is: {}", channelType);
                 // check if the itemType has been defined for the zone received
                 // check the itemType of the Zone, if Contact, send the State if Temp send Temp, etc.
-                if (channelType.equalsIgnoreCase(CHANNEL_SWITCH) || channelType.equalsIgnoreCase(CHANNEL_ACTUATOR)) {
+                if (channelType.contains(CHANNEL_SWITCH) || channelType.contains(CHANNEL_ACTUATOR)) {
                     OnOffType onOffType = event.getState().equalsIgnoreCase(getOnState(channel)) ? OnOffType.ON
                             : OnOffType.OFF;
                     updateState(channelId, onOffType);
-                } else if (channelType.equalsIgnoreCase(CHANNEL_HUMIDITY)) {
+                } else if (channelType.contains(CHANNEL_HUMIDITY)) {
                     // if the state is of type number then this means it is the humidity channel of the dht22
                     updateState(channelId, new QuantityType<>(Double.parseDouble(event.getHumi()), Units.PERCENT));
-                } else if (channelType.equalsIgnoreCase(CHANNEL_TEMPERATURE)) {
+                } else if (channelType.contains(CHANNEL_TEMPERATURE)) {
                     Configuration configuration = channel.getConfiguration();
                     if (((Boolean) configuration.get(CHANNEL_TEMPERATURE_TYPE))) {
                         updateState(channelId,
@@ -324,7 +324,6 @@ public class KonnectedHandler extends BaseThingHandler {
     private String constructSettingsPayload() {
         String hostPath = "";
         hostPath = callbackIpAddress + this.konnectedServletPath;
-        String authToken = getThing().getUID().getAsString();
         logger.debug("The Auth_Token is: {}", authToken);
         KonnectedModulePayload payload = new KonnectedModulePayload(authToken, "http://" + hostPath);
         payload.setBlink(config.blink);
@@ -337,8 +336,6 @@ public class KonnectedHandler extends BaseThingHandler {
                 // get the zone number in integer form
                 String zoneNumber = (String) channel.getConfiguration().get(CHANNEL_ZONE);
                 Integer zone = Integer.parseInt(zoneNumber);
-                // convert the zone to the pin based on value at index of zone
-                Integer pin = Arrays.asList(PIN_TO_ZONE).get(zone);
                 // if the pin is an actuator add to actuator string
                 // else add to sensor string
                 // This is determined based off of the accepted item type, contact types are sensors
@@ -346,20 +343,20 @@ public class KonnectedHandler extends BaseThingHandler {
                 String channelType = channel.getChannelTypeUID().getAsString();
                 logger.debug("The channeltypeID is: {}", channelType);
                 KonnectedModuleGson module = new KonnectedModuleGson();
-                module.setPin(pin);
-                if (channelType.equalsIgnoreCase(CHANNEL_SWITCH)) {
+                module.setPinZone(thingID, zone);
+                if (channelType.contains(CHANNEL_SWITCH)) {
                     payload.addSensor(module);
                     logger.trace("Channel {} will be configured on the konnected alarm panel as a switch",
                             channel.toString());
-                } else if (channelType.equalsIgnoreCase(CHANNEL_ACTUATOR)) {
+                } else if (channelType.contains(CHANNEL_ACTUATOR)) {
                     payload.addActuators(module);
                     logger.trace("Channel {} will be configured on the konnected alarm panel as an actuator",
                             channel.toString());
-                } else if (channelType.equalsIgnoreCase(CHANNEL_HUMIDITY)) {
+                } else if (channelType.contains(CHANNEL_HUMIDITY)) {
                     // the humidity channels do not need to be added because the supported sensor (dht22) is added under
                     // the temp sensor
                     logger.trace("Channel {} is a humidity channel.", channel.toString());
-                } else if (channelType.equalsIgnoreCase(CHANNEL_TEMPERATURE)) {
+                } else if (channelType.contains(CHANNEL_TEMPERATURE)) {
                     logger.trace("Channel {} will be configured on the konnected alarm panel as a temperature sensor",
                             channel.toString());
                     Configuration configuration = channel.getConfiguration();
@@ -416,9 +413,9 @@ public class KonnectedHandler extends BaseThingHandler {
      * Sends a command to the module via {@link KonnectedHTTPUtils}
      *
      * @param scommand the string command, either 0 or 1 to send to the actutor pin on the Konnected module
-     * @param pin the pin to send the command to on the Konnected Module
+     * @param zone the zone to send the command to on the Konnected Module
      */
-    private void sendActuatorCommand(String scommand, Integer pin, ChannelUID channelId) {
+    private void sendActuatorCommand(String scommand, Integer zone, ChannelUID channelId) {
         try {
             Channel channel = getThing().getChannel(channelId.getId());
             if (!(channel == null)) {
@@ -427,7 +424,9 @@ public class KonnectedHandler extends BaseThingHandler {
                 Configuration configuration = channel.getConfiguration();
                 KonnectedModuleGson payload = new KonnectedModuleGson();
                 payload.setState(scommand);
-                payload.setPin(pin);
+
+                payload.setPinZone(thingID, zone);
+
                 // check to see if this is an On Command type, if so add the momentary, pause, times to the payload if
                 // they exist on the configuration.
                 if (scommand.equals(getOnState(channel))) {
@@ -461,7 +460,16 @@ public class KonnectedHandler extends BaseThingHandler {
                 }
                 String payloadString = gson.toJson(payload);
                 logger.debug("The command payload  is: {}", payloadString);
-                http.doPut(moduleIpAddress + "/device", payloadString, retryCount);
+                String path = "";
+                switch (this.thingID) {
+                    case PRO_MODULE:
+                        path = "/zone";
+                        break;
+                    case WIFI_MODULE:
+                        path = "/device";
+                        break;
+                }
+                http.doPut(moduleIpAddress + path, payloadString, retryCount);
             } else {
                 logger.debug("The channel {} returned null for channelId.getID(): {}", channelId.toString(),
                         channelId.getId());
@@ -474,13 +482,13 @@ public class KonnectedHandler extends BaseThingHandler {
         }
     }
 
-    private void getSwitchState(Integer pin, ChannelUID channelId) {
+    private void getSwitchState(Integer zone, ChannelUID channelId) {
         Channel channel = getThing().getChannel(channelId.getId());
         if (!(channel == null)) {
             logger.debug("getasstring: {} getID: {} getGroupId: {} toString:{}", channelId.getAsString(),
                     channelId.getId(), channelId.getGroupId(), channelId.toString());
             KonnectedModuleGson payload = new KonnectedModuleGson();
-            payload.setPin(pin);
+            payload.setPinZone(thingID, zone);
             String payloadString = gson.toJson(payload);
             logger.debug("The command payload  is: {}", payloadString);
             try {

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedHTTPServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedWebHookFail.java
+++ b/bundles/org.openhab.binding.konnected/src/main/java/org/openhab/binding/konnected/internal/servlet/KonnectedWebHookFail.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/binding/binding.xml
@@ -4,4 +4,5 @@
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 	<name>Konnected Binding</name>
 	<description>This is the binding for Konnected.</description>
+	<author>Zachary Christiansen</author>
 </binding:binding>

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -3,23 +3,35 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
-	<!-- This is the Konnected Thing-Type -->
-	<thing-type id="module" extensible="switch,actuator,temperature,humidity">
+	<!-- This is the Konnected Wifi Thing-Type -->
+	<thing-type id="wifi-module" extensible="switch-wifi,actuator-wifi,temperature-wifi,humidity-wifi">
 		<label>The Konnected Alarm Panel</label>
-		<description>The Konnected Module</description>
+		<description>The Konnected Wifi Alarm Panel</description>
 		<channels>
-			<channel id="Zone_6" typeId="switch">
+			<channel id="Zone_6" typeId="switch-wifi">
 				<label>Zone 6</label>
 				<description>Zone 6 Sensor</description>
 			</channel>
-			<channel id="Out" typeId="actuator">
+			<channel id="Out" typeId="actuator-wifi">
 				<label>The out Pin</label>
 			</channel>
 		</channels>
 		<config-description-ref uri="thing-type:konnected:module"/>
 	</thing-type>
+	<!-- This is the Konnected Alarm Panel Pro Thing-Type -->
+	<thing-type id="pro-module" extensible="switch-pro,actuator-pro,temperature-pro,humidity-pro">
+		<label>The Konnected Alarm Panel Pro</label>
+		<description>The Konnected Wifi Alarm Panel Pro</description>
+		<channels>
+			<channel id="Alarm1" typeId="actuator-pro-alarm1"></channel>
+			<channel id="Output1" typeId="actuator-pro-out1"></channel>
+			<channel id="Alarm2-Output2" typeId="actuator-pro-alarm2"></channel>
+		</channels>
+		<config-description-ref uri="thing-type:konnected:module"/>
+	</thing-type>
+
 	<!-- Zone Channel Type -->
-	<channel-type id="switch">
+	<channel-type id="switch-wifi">
 		<item-type>Switch</item-type>
 		<label>Switch</label>
 		<description>This zone is a read only switch type zone</description>
@@ -51,7 +63,7 @@
 			</parameter>
 		</config-description>
 	</channel-type>
-	<channel-type id="temperature">
+	<channel-type id="temperature-wifi">
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
 		<description>This zone measures temperature</description>
@@ -84,7 +96,7 @@
 			</parameter>
 		</config-description>
 	</channel-type>
-	<channel-type id="humidity">
+	<channel-type id="humidity-wifi">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<description>This zone measures humidity</description>
@@ -105,7 +117,7 @@
 			</parameter>
 		</config-description>
 	</channel-type>
-	<channel-type id="actuator">
+	<channel-type id="actuator-wifi">
 		<item-type>Switch</item-type>
 		<label>Actuator</label>
 		<description>This zone is an actuator</description>
@@ -122,6 +134,254 @@
 					<option value="5">5</option>
 					<option value="6">6</option>
 					<option value="7">Out</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
+					command set to 1 and actuators that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
+			<parameter name="momentary" type="integer">
+				<label>Momentary</label>
+				<description>The duration of the pulse in millisecods</description>
+			</parameter>
+			<parameter name="pause" type="integer">
+				<label>Pause</label>
+				<description>The time between pulses in millisecods</description>
+			</parameter>
+			<parameter name="times" type="integer">
+				<label>Times</label>
+				<description>is the number of times to repeat or `-1` for an infinitely repeating pulse</description>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="switch-pro">
+		<item-type>Switch</item-type>
+		<label>Switch</label>
+		<description>This zone is a read only switch type zone</description>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<default>4</default>
+				<options>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+					<option value="9">9</option>
+					<option value="10">10</option>
+					<option value="11">11</option>
+					<option value="12">12</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as the on value. For sensors that activate with a high
+					value leave at the default of 1 and sensors that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="actuator-pro">
+		<item-type>Switch</item-type>
+		<label>Actuator</label>
+		<description>This zone is an actuator</description>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<default>2</default>
+				<options>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
+					command set to 1 and actuators that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
+			<parameter name="momentary" type="integer">
+				<label>Momentary</label>
+				<description>The duration of the pulse in millisecods</description>
+			</parameter>
+			<parameter name="pause" type="integer">
+				<label>Pause</label>
+				<description>The time between pulses in millisecods</description>
+			</parameter>
+			<parameter name="times" type="integer">
+				<label>Times</label>
+				<description>is the number of times to repeat or `-1` for an infinitely repeating pulse</description>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="temperature-pro">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature</label>
+		<description>This zone measures temperature</description>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="zone" type="text">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<options>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+				</options>
+			</parameter>
+			<parameter name="tempsensorType" type="boolean">
+				<label>DHT22</label>
+				<description>Is the sensor a dht22 or a ds18b20? Set to true for dht22 sensor</description>
+			</parameter>
+			<parameter name="pollinterval" type="integer">
+				<label>Poll Interval</label>
+				<description>The interval in minutes to poll the sensor.</description>
+			</parameter>
+			<parameter name="ds18b20_address" type="text">
+				<label>DS18b20 Address</label>
+				<description>This is the unique address of the sensor on the one wire bus.</description>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="humidity-pro">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Humidity</label>
+		<description>This zone measures humidity</description>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<options>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+				</options>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="actuator-pro-alarm1">
+		<item-type>Switch</item-type>
+		<label>Alarm 1</label>
+		<description>The Alarm 1 Output on the Konnected Pro</description>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<default>13</default>
+				<options>
+					<option value="13">Output1</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
+					command set to 1 and actuators that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
+			<parameter name="momentary" type="integer">
+				<label>Momentary</label>
+				<description>The duration of the pulse in millisecods</description>
+			</parameter>
+			<parameter name="pause" type="integer">
+				<label>Pause</label>
+				<description>The time between pulses in millisecods</description>
+			</parameter>
+			<parameter name="times" type="integer">
+				<label>Times</label>
+				<description>is the number of times to repeat or `-1` for an infinitely repeating pulse</description>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="actuator-pro-out1">
+		<item-type>Switch</item-type>
+		<label>Output 1</label>
+		<description>Output 1 on the Konnected Pro</description>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<default>14</default>
+				<options>
+					<option value="14">Alarm1</option>
+				</options>
+			</parameter>
+			<parameter name="onvalue" type="text">
+				<label>On Value</label>
+				<description>The value that will be treated by the binding as an on command. For actuators that activate with a high
+					command set to 1 and actuators that activate with a low value set to 0.</description>
+				<default>1</default>
+				<options>
+					<option value="0">0</option>
+					<option value="1">1</option>
+				</options>
+			</parameter>
+			<parameter name="momentary" type="integer">
+				<label>Momentary</label>
+				<description>The duration of the pulse in millisecods</description>
+			</parameter>
+			<parameter name="pause" type="integer">
+				<label>Pause</label>
+				<description>The time between pulses in millisecods</description>
+			</parameter>
+			<parameter name="times" type="integer">
+				<label>Times</label>
+				<description>is the number of times to repeat or `-1` for an infinitely repeating pulse</description>
+			</parameter>
+		</config-description>
+	</channel-type>
+	<channel-type id="actuator-pro-alarm2">
+		<item-type>Switch</item-type>
+		<label>Alarm 2/ Output 2</label>
+		<description>The Selectable Alarm 2 / Output 2 on the Konnected Alarm Panel Pro</description>
+		<config-description>
+			<parameter name="zone" type="text" required="true">
+				<label>Zone Number</label>
+				<description>The Zone Number of the channel.</description>
+				<default>15</default>
+				<options>
+					<option value="15">Alarm2/Output2</option>
 				</options>
 			</parameter>
 			<parameter name="onvalue" type="text">

--- a/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.konnected/src/main/resources/OH-INF/thing/thing-types.xml
@@ -21,7 +21,7 @@
 	<!-- This is the Konnected Alarm Panel Pro Thing-Type -->
 	<thing-type id="pro-module" extensible="switch-pro,actuator-pro,temperature-pro,humidity-pro">
 		<label>The Konnected Alarm Panel Pro</label>
-		<description>The Konnected Wifi Alarm Panel Pro</description>
+		<description>The Konnected Alarm Panel Pro</description>
 		<channels>
 			<channel id="Alarm1" typeId="actuator-pro-alarm1"></channel>
 			<channel id="Output1" typeId="actuator-pro-out1"></channel>


### PR DESCRIPTION

This binding is a re-work of the binding to add support for the Alarm Panel Pro.  Here is an overview of this device. https://help.konnected.io/support/solutions/articles/32000028978-alarm-panel-pro-inputs-and-outputs

The device utilizes many of the same calls as the wifi version however there are some differences so in addition to the new thing-types re-works to the hander were needed to correctly format and process the api calls between the existing esp8266 based wifi devices and the esp32 based alarm panel pro running the konnected firmware.

The code was originally built and tested under 2.5.x and this forum post has more information regarding that testing.

https://community.openhab.org/t/konnected-beta-add-support-for-alarm-panel-pro/107996/33

Links to updated jars for both 2.5.x and 3.0.x can be found at the top of that forum post.

This is a breaking change that will require previous users to delete and re-create things given the re-work needed to the Things-Types.
