### PR TITLE
[epsonprojector] Set device ready after connecting

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -201,6 +201,7 @@ public class EpsonProjectorDevice {
     public void connect() throws EpsonProjectorException {
         connection.connect();
         connected = true;
+        ready = true;
     }
 
     public void disconnect() throws EpsonProjectorException {


### PR DESCRIPTION
Should fix #9788.

Signed-off-by: Yannick Schaus <github@schaus.net>

