### PR TITLE
[tplinksmarthome] Add suppport for the TP-Link Kasa KP115 Smart WiFi Plug with Energy Monitoring

### DIFF
--- a/bundles/org.openhab.binding.tplinksmarthome/README.md
+++ b/bundles/org.openhab.binding.tplinksmarthome/README.md
@@ -105,6 +105,13 @@ Switching, Brightness and Color is done using the `color` channel.
 * LED On/Off
 * Wi-Fi signal strength (RSSI)
 
+### KP115 Kasa Wi-Fi Smart Plug with Energy Monitoring - Slim Edition
+
+* Power On/Off
+* Energy readings
+* LED On/Off
+* Wi-Fi signal strength (RSSI)
+
 ### KP200 Smart Wi-Fi Power Outlet, 2-Sockets
 
 * Power On/Off Group
@@ -291,16 +298,16 @@ All devices support some of the following channels:
 
 | Channel Type ID     | Item Type                | Description                                    | Thing types supporting this channel                                                                |
 |---------------------|--------------------------|------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| switch              | Switch                   | Power the device on or off.                    | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP105, KP200, KP303, KP400, RE270K, RE370K |
+| switch              | Switch                   | Power the device on or off.                    | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS300, KP100, KP105, KP115, KP200, KP303, KP400, RE270K, RE370K |
 | brightness          | Dimmer                   | Set the brightness of device or dimmer.        | HS220, KB100, KL50, KL60, KL110, KL120, LB100, LB110, LB120, LB200                                 |
 | colorTemperature    | Dimmer                   | Set the color temperature in percentage.       | KB130, KL120, KL130, LB120, LB130, LB230                                                           |
 | colorTemperatureAbs | Number                   | Set the color temperature in Kelvin.           | KB130, KL120, KL130, LB120, LB130, LB230                                                           |
 | color               | Color                    | Set the color of the light.                    | KB130, KL130, LB130, LB230                                                                         |
-| power               | Number:Power             | Actual energy usage in Watt.                   | HS110, HS300, KLxxx, LBxxx                                                                         |
-| eneryUsage          | Number:Energy            | Energy Usage in kWh.                           | HS110, HS300                                                                                       |
-| current             | Number:ElectricCurrent   | Actual current usage in Ampere.                | HS110, HS300                                                                                       |
-| voltage             | Number:ElectricPotential | Actual voltage usage in Volt.                  | HS110, HS300                                                                                       |
-| led                 | Switch                   | Switch the status LED on the device on or off. | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS220, HS300, KP100, KP105, KP303, KP200, KP400          |
+| power               | Number:Power             | Actual energy usage in Watt.                   | HS110, HS300, KLxxx, KP115, LBxxx,                                                                 |
+| eneryUsage          | Number:Energy            | Energy Usage in kWh.                           | HS110, HS300, KP115                                                                                |
+| current             | Number:ElectricCurrent   | Actual current usage in Ampere.                | HS110, HS300, KP115                                                                                |
+| voltage             | Number:ElectricPotential | Actual voltage usage in Volt.                  | HS110, HS300, KP115                                                                                |
+| led                 | Switch                   | Switch the status LED on the device on or off. | HS100, HS103, HS105, HS107, HS110, HS200, HS210, HS220, HS300, KP100, KP105, KP115, KP303, KP200, KP400 |
 | rssi                | Number:Power             | Wi-Fi signal strength indicator in dBm.        | All                                                                                                |
 
 The outlet devices (HS107, HS300, KP200, KP400) have group channels.

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeHandlerFactory.java
@@ -75,7 +75,7 @@ public class TPLinkSmartHomeHandlerFactory extends BaseThingHandlerFactory {
                 device = new DimmerDevice();
                 break;
             case PLUG:
-                if (HS110.is(thingTypeUID)) {
+                if (HS110.is(thingTypeUID) || KP115.is(thingTypeUID)) {
                     device = new EnergySwitchDevice();
                 } else {
                     device = new SwitchDevice();

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/java/org/openhab/binding/tplinksmarthome/internal/TPLinkSmartHomeThingType.java
@@ -54,6 +54,7 @@ public enum TPLinkSmartHomeThingType {
     HS110("hs110", DeviceType.PLUG),
     KP100("kp100", DeviceType.PLUG),
     KP105("kp105", DeviceType.PLUG),
+    KP115("kp115", DeviceType.PLUG),
 
     // Switch Thing Type UIDs
     HS200("hs200", DeviceType.SWITCH),

--- a/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KP115.xml
+++ b/bundles/org.openhab.binding.tplinksmarthome/src/main/resources/OH-INF/thing/KP115.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tplinksmarthome"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="kp115">
+		<label>KP115</label>
+		<description>TP-Link KP115 Kasa Wi-Fi Smart Plug with Energy Monitoring - Slim Edition</description>
+		<category>PowerOutlet</category>
+
+		<channels>
+			<channel id="switch" typeId="system.power"/>
+			<channel id="led" typeId="led"/>
+			<channel id="rssi" typeId="rssi"/>
+			<channel id="power" typeId="power"/>
+			<channel id="energyUsage" typeId="energy-usage"/>
+			<channel id="current" typeId="current"/>
+			<channel id="voltage" typeId="voltage"/>
+		</channels>
+
+		<representation-property>deviceId</representation-property>
+
+		<config-description-ref uri="thing-type:device:plug"/>
+	</thing-type>
+</thing:thing-descriptions>


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

[tplinksmarthome] Add suppport for the TP-Link Kasa KP115 Smart WiFi Plug with Energy Monitoring

<!-- DESCRIPTION -->

The KP115 plug is a WiFi smart plug with energy monitoring support. It uses the same API as existing TP-Link smart home devices. This change adds support in the binding for the KP115. All functionality was tested and verified working using OpenHAB 3.0.0 and a retail purchased KP115.