### PR TITLE
[tesla] Correctly handle floating point numbers for estimatedbatteryrange channel

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.tesla/src/main/resources/OH-INF/thing/channels.xml
@@ -253,7 +253,7 @@
 		<item-type>Number:Length</item-type>
 		<label>Estimated Battery Range</label>
 		<description>Estimated battery range</description>
-		<state pattern="%d %unit%" readOnly="true"></state>
+		<state pattern="%.0f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="estimatedrange" advanced="true">
 		<item-type>Number</item-type>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/9636

Signed-off-by: Kai Kreuzer <kai@openhab.org>