### PR TITLE
[buienradar] Avoid to much log noise

### DIFF
--- a/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/BuienradarHandler.java
+++ b/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/BuienradarHandler.java
@@ -135,7 +135,7 @@ public class BuienradarHandler extends BaseThingHandler {
                             "Did not get a result from buienradar. Retrying. {} tries remaining, waiting {} seconds.",
                             tries, retryInSeconds);
                 } else {
-                    logger.info(
+                    logger.debug(
                             "Did not get a result from buienradar. Retrying. {} tries remaining, waiting {} seconds.",
                             tries, retryInSeconds);
                 }

--- a/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/BuienradarHandler.java
+++ b/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/BuienradarHandler.java
@@ -76,7 +76,6 @@ public class BuienradarHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    @SuppressWarnings("null")
     @Override
     public void initialize() {
         this.config = getConfigAs(BuienradarConfiguration.class);
@@ -127,12 +126,19 @@ public class BuienradarHandler extends BaseThingHandler {
             return;
         }
         try {
-            @SuppressWarnings("null")
             final Optional<List<Prediction>> predictionsOpt = client.getPredictions(location);
             if (!predictionsOpt.isPresent()) {
                 // Did not get a result, retry the retrieval.
-                logger.warn("Did not get a result from buienradar. Retrying. {} tries remaining, waiting {} seconds.",
-                        tries, retryInSeconds);
+                // Buienradar is not a very stable source and returns nothing quite regular
+                if (tries <= 2) {
+                    logger.warn(
+                            "Did not get a result from buienradar. Retrying. {} tries remaining, waiting {} seconds.",
+                            tries, retryInSeconds);
+                } else {
+                    logger.info(
+                            "Did not get a result from buienradar. Retrying. {} tries remaining, waiting {} seconds.",
+                            tries, retryInSeconds);
+                }
                 scheduler.schedule(() -> refresh(tries - 1, nextRefresh, retryInSeconds * 2), retryInSeconds,
                         TimeUnit.SECONDS);
                 return;
@@ -164,7 +170,6 @@ public class BuienradarHandler extends BaseThingHandler {
         }
     }
 
-    @SuppressWarnings("null")
     @Override
     public void dispose() {
         try {

--- a/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/buienradarapi/BuienradarPredictionAPI.java
+++ b/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/buienradarapi/BuienradarPredictionAPI.java
@@ -143,7 +143,7 @@ public class BuienradarPredictionAPI implements PredictionAPI {
         try {
             result = HttpUtil.executeUrl("GET", address, TIMEOUT_MS);
         } catch (IOException e) {
-            logger.warn("IO Exception when trying to retrieve Buienradar results", e);
+            logger.warn("IO Exception when trying to retrieve Buienradar results");
             return Optional.empty();
         }
 

--- a/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/buienradarapi/BuienradarPredictionAPI.java
+++ b/bundles/org.openhab.binding.buienradar/src/main/java/org/openhab/binding/buienradar/internal/buienradarapi/BuienradarPredictionAPI.java
@@ -143,7 +143,7 @@ public class BuienradarPredictionAPI implements PredictionAPI {
         try {
             result = HttpUtil.executeUrl("GET", address, TIMEOUT_MS);
         } catch (IOException e) {
-            logger.warn("IO Exception when trying to retrieve Buienradar results");
+            logger.debug("IO Exception when trying to retrieve Buienradar results: {}", e.getMessage());
             return Optional.empty();
         }
 

--- a/bundles/org.openhab.binding.buienradar/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.buienradar/src/main/resources/OH-INF/thing/thing-types.xml
@@ -60,10 +60,10 @@
 			</parameter>
 
 			<parameter name="exponentialBackoffRetryBaseInSeconds" type="integer" required="true" min="1" unit="s">
-				<label>Exponential Backoff Base for Retries</label>
-				<description>Exponential back-off base value for retries in seconds. For example, when this is 2 seconds, will retry
-					at 2, 4, 8, 16, 32, 64 seconds.</description>
-				<default>5</default>
+				<label>Doubling Backoff Base for Retries</label>
+				<description>Doubling back-off base value for retries in seconds. For example, when this is 30 seconds, will retry
+					at 30, 60, 120, 240 seconds.</description>
+				<default>30</default>
 			</parameter>
 		</config-description>
 


### PR DESCRIPTION
Buienradar is not the most stable source so the retries create a lot of warn and time outs even provoke (quite regular) stack traces. 

Fixes:  #6698

Signed-off-by: Björn Brings <bjoernbrings@web.de>