### PR TITLE
[draytonwiser] MDNS Fixes

### DIFF
--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserMDNSDiscoveryParticipant.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.jmdns.ServiceInfo;
 
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant {
 
     private final Logger logger = LoggerFactory.getLogger(DraytonWiserMDNSDiscoveryParticipant.class);
+    private final Pattern findIllegalChars = Pattern.compile("[^A-Za-z0-9_-]");
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
@@ -69,10 +71,12 @@ public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryPartic
                 if (addresses.length > 0 && addresses[0] != null) {
                     properties.put(PROP_ADDRESS, addresses[0].getHostAddress());
                     properties.put(REFRESH_INTERVAL, DEFAULT_REFRESH_SECONDS);
+
+                    return DiscoveryResultBuilder.create(uid).withProperties(properties)
+                            .withRepresentationProperty(PROP_ADDRESS).withLabel("Heat Hub - " + service.getName())
+                            .build();
                 }
 
-                return DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withRepresentationProperty(PROP_ADDRESS).withLabel("Heat Hub - " + service.getName()).build();
             }
         }
         return null;
@@ -83,7 +87,7 @@ public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryPartic
         if (service.getType() != null && service.getType().equals(getServiceType())
                 && service.getName().contains("WiserHeat")) {
             logger.trace("Discovered a Drayton Wiser Heat Hub thing with name '{}'", service.getName());
-            return new ThingUID(THING_TYPE_BRIDGE, service.getName());
+            return new ThingUID(THING_TYPE_BRIDGE, findIllegalChars.matcher(service.getName()).replaceAll(""));
         }
         return null;
     }


### PR DESCRIPTION
Small bugfixes for MDNS discovery functionality:

1. Fixes #8786 invalid uid on discovered hub
2. Resolve issue on startup in OH3 for discovery result without address, reported here https://community.openhab.org/t/drayton-wiser-thermostat-binding/35640/402