### PR TITLE
[siemensrds]  Hide already instantiated Things in the InBox

### DIFF
--- a/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
+++ b/bundles/org.openhab.binding.siemensrds/src/main/java/org/openhab/binding/siemensrds/internal/RdsDataPoints.java
@@ -299,7 +299,7 @@ public class RdsDataPoints {
             @Nullable
             RdsDataPoints newPoints = GSON.fromJson(json, RdsDataPoints.class);
 
-            Map<String, @Nullable BasePoint> newPointsMap = newPoints.points;
+            Map<String, @Nullable BasePoint> newPointsMap = newPoints != null ? newPoints.points : null;
 
             if (newPointsMap == null) {
                 throw new RdsCloudException("new points map empty");

--- a/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.siemensrds/src/main/resources/OH-INF/thing/thing-types.xml
@@ -113,6 +113,7 @@
 			<property name="vendor">Siemens</property>
 			<property name="modelId">RDS</property>
 		</properties>
+		<representation-property>plantId</representation-property>
 
 		<config-description>
 			<parameter name="plantId" type="text" required="true">


### PR DESCRIPTION
Signed-off-by: Andrew Fiddian-Green software@whitebear.ch

Added Representation Property so that already instantiated Things will be hidden in the InBox.

Also fixed a potential null pointer issue.