### PR TITLE
[jablotron] fixed programmable gates channels are not visible in the O…

### DIFF
--- a/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/JablotronBindingConstants.java
+++ b/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/JablotronBindingConstants.java
@@ -28,7 +28,7 @@ import org.openhab.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class JablotronBindingConstants {
 
-    private static final String BINDING_ID = "jablotron";
+    public static final String BINDING_ID = "jablotron";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");

--- a/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronJa100FHandler.java
+++ b/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronJa100FHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.jablotron.internal.handler;
 
+import static org.openhab.binding.jablotron.JablotronBindingConstants.BINDING_ID;
 import static org.openhab.binding.jablotron.JablotronBindingConstants.CACHE_TIMEOUT_MS;
 import static org.openhab.binding.jablotron.JablotronBindingConstants.CHANNEL_LAST_CHECK_TIME;
 
@@ -125,15 +126,16 @@ public class JablotronJa100FHandler extends JablotronAlarmHandler {
     }
 
     private void createPGChannel(String name, String label) {
+        ChannelTypeUID pgmStatus = new ChannelTypeUID(BINDING_ID, "pgm_state");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "Switch").withLabel(label)
-                .build();
+                .withType(pgmStatus).build();
         thingBuilder.withChannel(channel);
         updateThing(thingBuilder.build());
     }
 
     private void createStateChannel(String name, String label) {
-        ChannelTypeUID alarmStatus = new ChannelTypeUID("jablotron", "ja100f_alarm_state");
+        ChannelTypeUID alarmStatus = new ChannelTypeUID(BINDING_ID, "ja100f_alarm_state");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "String").withLabel(label)
                 .withType(alarmStatus).build();

--- a/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronJa100Handler.java
+++ b/bundles/org.openhab.binding.jablotron/src/main/java/org/openhab/binding/jablotron/internal/handler/JablotronJa100Handler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.jablotron.internal.handler;
 
+import static org.openhab.binding.jablotron.JablotronBindingConstants.BINDING_ID;
 import static org.openhab.binding.jablotron.JablotronBindingConstants.CACHE_TIMEOUT_MS;
 import static org.openhab.binding.jablotron.JablotronBindingConstants.CHANNEL_LAST_CHECK_TIME;
 
@@ -98,7 +99,7 @@ public class JablotronJa100Handler extends JablotronAlarmHandler {
     }
 
     private void createTempChannel(String name, String label) {
-        ChannelTypeUID temperature = new ChannelTypeUID("jablotron", "temperature");
+        ChannelTypeUID temperature = new ChannelTypeUID(BINDING_ID, "temperature");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "Number:Temperature")
                 .withLabel(label).withType(temperature).build();
@@ -107,7 +108,7 @@ public class JablotronJa100Handler extends JablotronAlarmHandler {
     }
 
     private void createThermostatChannel(String name, String label) {
-        ChannelTypeUID temperature = new ChannelTypeUID("jablotron", "thermostat");
+        ChannelTypeUID temperature = new ChannelTypeUID(BINDING_ID, "thermostat");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "Number:Temperature")
                 .withLabel(label).withType(temperature).build();
@@ -116,15 +117,16 @@ public class JablotronJa100Handler extends JablotronAlarmHandler {
     }
 
     private void createPGMChannel(String name, String label) {
+        ChannelTypeUID pgmStatus = new ChannelTypeUID(BINDING_ID, "pgm_state");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "Switch").withLabel(label)
-                .build();
+                .withType(pgmStatus).build();
         thingBuilder.withChannel(channel);
         updateThing(thingBuilder.build());
     }
 
     private void createStateChannel(String name, String label) {
-        ChannelTypeUID alarmStatus = new ChannelTypeUID("jablotron", "alarm_state");
+        ChannelTypeUID alarmStatus = new ChannelTypeUID(BINDING_ID, "alarm_state");
         ThingBuilder thingBuilder = editThing();
         Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), "String").withLabel(label)
                 .withType(alarmStatus).build();

--- a/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.jablotron/src/main/resources/OH-INF/thing/channels.xml
@@ -125,6 +125,13 @@
 		<state readOnly="true"/>
 	</channel-type>
 
+	<!-- pgm_state -->
+	<channel-type id="pgm_state">
+		<item-type>Switch</item-type>
+		<label>Programmable Gate State</label>
+		<description>A channel used for controlling the PGM state</description>
+	</channel-type>
+
 	<!-- alarm_state -->
 	<channel-type id="alarm_state">
 		<item-type>String</item-type>


### PR DESCRIPTION
this is a bugfix for a reported problem that channels for programmable gates are missing by the JA100 thing in OH3.
what is interesting, the channels were existing, but they were not visible in the UI channels tab. 
This is a different behaviour from the OH2. After this bugfix they not only exist but they are visible as well ;-)
