### PR TITLE
[powermax] Improved error handling for Powermax binding

### DIFF
--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
@@ -106,14 +106,25 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
         }
     }
 
+    /**
+     * Handles a communication failure
+     */
+    public void handleCommunicationFailure() {
+        close();
+
+        for (int i = 0; i < listeners.size(); i++) {
+            listeners.get(i).onCommunicationFailure();
+        }
+    }
+
     @Override
     public void sendMessage(byte[] data) {
         try {
             output.write(data);
             output.flush();
         } catch (IOException e) {
-            logger.debug("sendMessage(): Writing error: {}", e.getMessage(), e);
-            setConnected(false);
+            logger.warn("sendMessage(): Writing error: {}", e.getMessage(), e);
+            handleCommunicationFailure();
         }
     }
 

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
@@ -47,7 +47,7 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
     }
 
     @Override
-    public abstract void open();
+    public abstract void open() throws Exception;
 
     @Override
     public abstract void close();
@@ -109,11 +109,11 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
     /**
      * Handles a communication failure
      */
-    public void handleCommunicationFailure() {
+    public void handleCommunicationFailure(String message) {
         close();
 
         for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onCommunicationFailure();
+            listeners.get(i).onCommunicationFailure(message);
         }
     }
 
@@ -123,8 +123,8 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
             output.write(data);
             output.flush();
         } catch (IOException e) {
-            logger.warn("sendMessage(): Writing error: {}", e.getMessage(), e);
-            handleCommunicationFailure();
+            logger.debug("sendMessage(): Writing error: {}", e.getMessage(), e);
+            handleCommunicationFailure(e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnector.java
@@ -101,9 +101,7 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
                 PowermaxBaseMessage.getMessageHandler(incomingMessage));
 
         // send message to event listeners
-        for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onNewMessageEvent(event);
-        }
+        listeners.forEach(listener -> listener.onNewMessageEvent(event));
     }
 
     /**
@@ -111,10 +109,7 @@ public abstract class PowermaxConnector implements PowermaxConnectorInterface {
      */
     public void handleCommunicationFailure(String message) {
         close();
-
-        for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onCommunicationFailure(message);
-        }
+        listeners.forEach(listener -> listener.onCommunicationFailure(message));
     }
 
     @Override

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnectorInterface.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxConnectorInterface.java
@@ -26,7 +26,7 @@ public interface PowermaxConnectorInterface {
     /**
      * Method for opening a connection to the Visonic alarm panel.
      */
-    public void open();
+    public void open() throws Exception;
 
     /**
      * Method for closing a connection to the Visonic alarm panel.

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxReaderThread.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxReaderThread.java
@@ -50,7 +50,7 @@ public class PowermaxReaderThread extends Thread {
 
     @Override
     public void run() {
-        logger.debug("Data listener started");
+        logger.info("Data listener started");
 
         byte[] readDataBuffer = new byte[READ_BUFFER_SIZE];
         byte[] dataBuffer = new byte[MAX_MSG_SIZE];
@@ -128,10 +128,14 @@ public class PowermaxReaderThread extends Thread {
             Thread.currentThread().interrupt();
             logger.debug("Interrupted via InterruptedIOException");
         } catch (IOException e) {
-            logger.debug("Reading failed: {}", e.getMessage(), e);
+            logger.warn("Reading failed: {}", e.getMessage(), e);
+            connector.handleCommunicationFailure();
+        } catch (Exception e) {
+            logger.warn("Error reading or processing message: {}", e.getMessage(), e);
+            connector.handleCommunicationFailure();
         }
 
-        logger.debug("Data listener stopped");
+        logger.info("Data listener stopped");
     }
 
     /**

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxReaderThread.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxReaderThread.java
@@ -131,8 +131,9 @@ public class PowermaxReaderThread extends Thread {
             logger.debug("Reading failed: {}", e.getMessage(), e);
             connector.handleCommunicationFailure(e.getMessage());
         } catch (Exception e) {
-            logger.debug("Error reading or processing message: {}", e.toString(), e);
-            connector.handleCommunicationFailure(e.toString());
+            String msg = e.getMessage() != null ? e.getMessage() : e.toString();
+            logger.debug("Error reading or processing message: {}", msg, e);
+            connector.handleCommunicationFailure(msg);
         }
 
         logger.info("Data listener stopped");

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxSerialConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxSerialConnector.java
@@ -13,16 +13,12 @@
 package org.openhab.binding.powermax.internal.connector;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.TooManyListenersException;
 
-import org.openhab.core.io.transport.serial.PortInUseException;
 import org.openhab.core.io.transport.serial.SerialPort;
 import org.openhab.core.io.transport.serial.SerialPortEvent;
 import org.openhab.core.io.transport.serial.SerialPortEventListener;
 import org.openhab.core.io.transport.serial.SerialPortIdentifier;
 import org.openhab.core.io.transport.serial.SerialPortManager;
-import org.openhab.core.io.transport.serial.UnsupportedCommOperationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,59 +54,39 @@ public class PowermaxSerialConnector extends PowermaxConnector implements Serial
     }
 
     @Override
-    public void open() {
+    public void open() throws Exception {
         logger.debug("open(): Opening Serial Connection");
 
-        try {
-            SerialPortIdentifier portIdentifier = serialPortManager.getIdentifier(serialPortName);
-            if (portIdentifier != null) {
-                SerialPort commPort = portIdentifier.open(this.getClass().getName(), 2000);
-
-                serialPort = commPort;
-                serialPort.setSerialPortParams(baudRate, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
-                        SerialPort.PARITY_NONE);
-                serialPort.enableReceiveThreshold(1);
-                serialPort.enableReceiveTimeout(250);
-
-                setInput(serialPort.getInputStream());
-                setOutput(serialPort.getOutputStream());
-
-                getOutput().flush();
-                if (getInput().markSupported()) {
-                    getInput().reset();
-                }
-
-                // RXTX serial port library causes high CPU load
-                // Start event listener, which will just sleep and slow down event
-                // loop
-                try {
-                    serialPort.addEventListener(this);
-                    serialPort.notifyOnDataAvailable(true);
-                } catch (TooManyListenersException e) {
-                    logger.warn("Too Many Listeners Exception: {}", e.getMessage(), e);
-                }
-
-                setReaderThread(new PowermaxReaderThread(this, readerThreadName));
-                getReaderThread().start();
-
-                setConnected(true);
-            } else {
-                logger.warn("open(): No Such Port: {}", serialPortName);
-                setConnected(false);
-            }
-        } catch (PortInUseException e) {
-            logger.warn("open(): Port in Use Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (UnsupportedCommOperationException e) {
-            logger.warn("open(): Unsupported Comm Operation Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (UnsupportedEncodingException e) {
-            logger.warn("open(): Unsupported Encoding Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (IOException e) {
-            logger.warn("open(): IO Exception: {}", e.getMessage(), e);
-            setConnected(false);
+        SerialPortIdentifier portIdentifier = serialPortManager.getIdentifier(serialPortName);
+        if (portIdentifier == null) {
+            throw new IOException("No Such Port: " + serialPortName);
         }
+
+        SerialPort commPort = portIdentifier.open(this.getClass().getName(), 2000);
+
+        serialPort = commPort;
+        serialPort.setSerialPortParams(baudRate, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
+        serialPort.enableReceiveThreshold(1);
+        serialPort.enableReceiveTimeout(250);
+
+        setInput(serialPort.getInputStream());
+        setOutput(serialPort.getOutputStream());
+
+        getOutput().flush();
+        if (getInput().markSupported()) {
+            getInput().reset();
+        }
+
+        // RXTX serial port library causes high CPU load
+        // Start event listener, which will just sleep and slow down event
+        // loop
+        serialPort.addEventListener(this);
+        serialPort.notifyOnDataAvailable(true);
+
+        setReaderThread(new PowermaxReaderThread(this, readerThreadName));
+        getReaderThread().start();
+
+        setConnected(true);
     }
 
     @Override

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxSerialConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxSerialConnector.java
@@ -87,7 +87,7 @@ public class PowermaxSerialConnector extends PowermaxConnector implements Serial
                     serialPort.addEventListener(this);
                     serialPort.notifyOnDataAvailable(true);
                 } catch (TooManyListenersException e) {
-                    logger.debug("Too Many Listeners Exception: {}", e.getMessage(), e);
+                    logger.warn("Too Many Listeners Exception: {}", e.getMessage(), e);
                 }
 
                 setReaderThread(new PowermaxReaderThread(this, readerThreadName));
@@ -95,20 +95,20 @@ public class PowermaxSerialConnector extends PowermaxConnector implements Serial
 
                 setConnected(true);
             } else {
-                logger.debug("open(): No Such Port: {}", serialPortName);
+                logger.warn("open(): No Such Port: {}", serialPortName);
                 setConnected(false);
             }
         } catch (PortInUseException e) {
-            logger.debug("open(): Port in Use Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Port in Use Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (UnsupportedCommOperationException e) {
-            logger.debug("open(): Unsupported Comm Operation Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Unsupported Comm Operation Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (UnsupportedEncodingException e) {
-            logger.debug("open(): Unsupported Encoding Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Unsupported Encoding Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (IOException e) {
-            logger.debug("open(): IO Exception: {}", e.getMessage(), e);
+            logger.warn("open(): IO Exception: {}", e.getMessage(), e);
             setConnected(false);
         }
     }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxTcpConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxTcpConnector.java
@@ -16,9 +16,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,35 +51,21 @@ public class PowermaxTcpConnector extends PowermaxConnector {
     }
 
     @Override
-    public void open() {
+    public void open() throws Exception {
         logger.debug("open(): Opening TCP Connection");
 
-        try {
-            tcpSocket = new Socket();
-            tcpSocket.setSoTimeout(250);
-            SocketAddress socketAddress = new InetSocketAddress(ipAddress, tcpPort);
-            tcpSocket.connect(socketAddress, connectTimeout);
+        tcpSocket = new Socket();
+        tcpSocket.setSoTimeout(250);
+        SocketAddress socketAddress = new InetSocketAddress(ipAddress, tcpPort);
+        tcpSocket.connect(socketAddress, connectTimeout);
 
-            setInput(tcpSocket.getInputStream());
-            setOutput(tcpSocket.getOutputStream());
+        setInput(tcpSocket.getInputStream());
+        setOutput(tcpSocket.getOutputStream());
 
-            setReaderThread(new PowermaxReaderThread(this, readerThreadName));
-            getReaderThread().start();
+        setReaderThread(new PowermaxReaderThread(this, readerThreadName));
+        getReaderThread().start();
 
-            setConnected(true);
-        } catch (UnknownHostException e) {
-            logger.warn("open(): Unknown Host Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (SocketException e) {
-            logger.warn("open(): Socket Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (IOException e) {
-            logger.warn("open(): IO Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        } catch (Exception e) {
-            logger.warn("open(): Exception: {}", e.getMessage(), e);
-            setConnected(false);
-        }
+        setConnected(true);
     }
 
     @Override

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxTcpConnector.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/connector/PowermaxTcpConnector.java
@@ -70,16 +70,16 @@ public class PowermaxTcpConnector extends PowermaxConnector {
 
             setConnected(true);
         } catch (UnknownHostException e) {
-            logger.debug("open(): Unknown Host Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Unknown Host Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (SocketException e) {
-            logger.debug("open(): Socket Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Socket Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (IOException e) {
-            logger.debug("open(): IO Exception: {}", e.getMessage(), e);
+            logger.warn("open(): IO Exception: {}", e.getMessage(), e);
             setConnected(false);
         } catch (Exception e) {
-            logger.debug("open(): Exception: {}", e.getMessage(), e);
+            logger.warn("open(): Exception: {}", e.getMessage(), e);
             setConnected(false);
         }
     }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
@@ -166,7 +166,7 @@ public class PowermaxDiscoveryService extends AbstractDiscoveryService
                 name = "Alarm Zone " + zoneNumber;
             }
             name = sensorType + " " + name;
-            logger.debug("Adding new Powermax alarm zone {} ({}) to inbox", thingUID, name);
+            logger.info("Adding new Powermax alarm zone {} ({}) to inbox", thingUID, name);
             Map<String, Object> properties = new HashMap<>(1);
             properties.put(PowermaxZoneConfiguration.ZONE_NUMBER, zoneNumber);
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/discovery/PowermaxDiscoveryService.java
@@ -166,7 +166,7 @@ public class PowermaxDiscoveryService extends AbstractDiscoveryService
                 name = "Alarm Zone " + zoneNumber;
             }
             name = sensorType + " " + name;
-            logger.info("Adding new Powermax alarm zone {} ({}) to inbox", thingUID, name);
+            logger.debug("Adding new Powermax alarm zone {} ({}) to inbox", thingUID, name);
             Map<String, Object> properties = new HashMap<>(1);
             properties.put(PowermaxZoneConfiguration.ZONE_NUMBER, zoneNumber);
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxBridgeHandler.java
@@ -577,11 +577,10 @@ public class PowermaxBridgeHandler extends BaseBridgeHandler implements Powermax
     }
 
     /**
-     * Update all channels to a NULL state to indicate that communication with the panel is offline
+     * Update all channels to an UNDEF state to indicate that communication with the panel is offline
      */
     private synchronized void setAllChannelsOffline() {
-        getThing().getChannels().forEach(c -> updateState(c.getUID(), UnDefType.NULL));
-        getThing().getThings().forEach(t -> t.getChannels().forEach(c -> updateState(c.getUID(), UnDefType.NULL)));
+        getThing().getChannels().forEach(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 
     /**

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxThingHandler.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/handler/PowermaxThingHandler.java
@@ -34,6 +34,7 @@ import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,12 +114,20 @@ public class PowermaxThingHandler extends BaseThingHandler implements PowermaxPa
                 }
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+                setAllChannelsOffline();
                 logger.debug("Set handler status to OFFLINE for thing {} (bridge OFFLINE)", getThing().getUID());
             }
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
             logger.debug("Set handler status to OFFLINE for thing {}", getThing().getUID());
         }
+    }
+
+    /**
+     * Update all channels to an UNDEF state to indicate that the bridge is offline
+     */
+    private synchronized void setAllChannelsOffline() {
+        getThing().getChannels().forEach(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 
     @Override

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
@@ -176,13 +176,12 @@ public class PowermaxCommManager implements PowermaxMessageEventListener {
      *
      * @return true if connected or false if not
      */
-    public boolean open() {
+    public void open() throws Exception {
         if (connector != null) {
             connector.open();
         }
         lastSendMsg = null;
         msgQueue = new ConcurrentLinkedQueue<>();
-        return isConnected();
     }
 
     /**
@@ -285,11 +284,11 @@ public class PowermaxCommManager implements PowermaxMessageEventListener {
     }
 
     @Override
-    public void onCommunicationFailure() {
+    public void onCommunicationFailure(String message) {
         close();
 
         for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onCommunicationFailure();
+            listeners.get(i).onCommunicationFailure(message);
         }
     }
 

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
@@ -255,27 +255,41 @@ public class PowermaxCommManager implements PowermaxMessageEventListener {
         }
 
         PowermaxState updateState = message.handleMessage(this);
-        if (updateState != null) {
-            if (updateState.getUpdateSettings() != null) {
-                panelSettings.updateRawSettings(updateState.getUpdateSettings());
-            }
-            if (!updateState.getUpdatedZoneNames().isEmpty()) {
-                for (Integer zoneIdx : updateState.getUpdatedZoneNames().keySet()) {
-                    panelSettings.updateZoneName(zoneIdx, updateState.getUpdatedZoneNames().get(zoneIdx));
-                }
-            }
-            if (!updateState.getUpdatedZoneInfos().isEmpty()) {
-                for (Integer zoneIdx : updateState.getUpdatedZoneInfos().keySet()) {
-                    panelSettings.updateZoneInfo(zoneIdx, updateState.getUpdatedZoneInfos().get(zoneIdx));
-                }
-            }
 
-            PowermaxStateEvent newEvent = new PowermaxStateEvent(this, updateState);
+        if (updateState == null) {
+            updateState = createNewState();
+        }
 
-            // send message to event listeners
-            for (int i = 0; i < listeners.size(); i++) {
-                listeners.get(i).onNewStateEvent(newEvent);
+        updateState.lastMessageReceived.setValue(System.currentTimeMillis());
+
+        if (updateState.getUpdateSettings() != null) {
+            panelSettings.updateRawSettings(updateState.getUpdateSettings());
+        }
+        if (!updateState.getUpdatedZoneNames().isEmpty()) {
+            for (Integer zoneIdx : updateState.getUpdatedZoneNames().keySet()) {
+                panelSettings.updateZoneName(zoneIdx, updateState.getUpdatedZoneNames().get(zoneIdx));
             }
+        }
+        if (!updateState.getUpdatedZoneInfos().isEmpty()) {
+            for (Integer zoneIdx : updateState.getUpdatedZoneInfos().keySet()) {
+                panelSettings.updateZoneInfo(zoneIdx, updateState.getUpdatedZoneInfos().get(zoneIdx));
+            }
+        }
+
+        PowermaxStateEvent newEvent = new PowermaxStateEvent(this, updateState);
+
+        // send message to event listeners
+        for (int i = 0; i < listeners.size(); i++) {
+            listeners.get(i).onNewStateEvent(newEvent);
+        }
+    }
+
+    @Override
+    public void onCommunicationFailure() {
+        close();
+
+        for (int i = 0; i < listeners.size(); i++) {
+            listeners.get(i).onCommunicationFailure();
         }
     }
 

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxCommManager.java
@@ -278,18 +278,13 @@ public class PowermaxCommManager implements PowermaxMessageEventListener {
         PowermaxStateEvent newEvent = new PowermaxStateEvent(this, updateState);
 
         // send message to event listeners
-        for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onNewStateEvent(newEvent);
-        }
+        listeners.forEach(listener -> listener.onNewStateEvent(newEvent));
     }
 
     @Override
     public void onCommunicationFailure(String message) {
         close();
-
-        for (int i = 0; i < listeners.size(); i++) {
-            listeners.get(i).onCommunicationFailure(message);
-        }
+        listeners.forEach(listener -> listener.onCommunicationFailure(message));
     }
 
     /**

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxMessageEventListener.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxMessageEventListener.java
@@ -28,4 +28,9 @@ public interface PowermaxMessageEventListener extends EventListener {
      * @param event the event object
      */
     public void onNewMessageEvent(EventObject event);
+
+    /**
+     * Event handler method to indicate that communication has been lost
+     */
+    public void onCommunicationFailure();
 }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxMessageEventListener.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/message/PowermaxMessageEventListener.java
@@ -32,5 +32,5 @@ public interface PowermaxMessageEventListener extends EventListener {
     /**
      * Event handler method to indicate that communication has been lost
      */
-    public void onCommunicationFailure();
+    public void onCommunicationFailure(String message);
 }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxPanelSettings.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxPanelSettings.java
@@ -512,16 +512,19 @@ public class PowermaxPanelSettings {
                 result = false;
             }
 
-            // Check if partitions are enabled
-            byte[] partitions = readSettings(PowermaxSendType.DL_PARTITIONS, 0, 0x10 + zoneCnt);
-            if (partitions != null) {
-                partitionsEnabled = (partitions[0] & 0x000000FF) == 1;
-            } else {
-                logger.debug("Cannot get partitions information");
-                result = false;
-            }
-            if (!partitionsEnabled) {
-                partitionCnt = 1;
+            // Check if partitions are enabled (only on panels that support partitions)
+            byte[] partitions = null;
+            if (partitionCnt > 1) {
+                partitions = readSettings(PowermaxSendType.DL_PARTITIONS, 0, 0x10 + zoneCnt);
+                if (partitions != null) {
+                    partitionsEnabled = (partitions[0] & 0x000000FF) == 1;
+                } else {
+                    logger.debug("Cannot get partitions information");
+                    result = false;
+                }
+                if (!partitionsEnabled) {
+                    partitionCnt = 1;
+                }
             }
 
             // Process zone settings

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxState.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxState.java
@@ -47,6 +47,7 @@ public class PowermaxState extends PowermaxStateContainer {
     public StringValue armMode = new StringValue(this, "_arm_mode");
     public BooleanValue downloadSetupRequired = new BooleanValue(this, "_download_setup_required");
     public DateTimeValue lastKeepAlive = new DateTimeValue(this, "_last_keepalive");
+    public DateTimeValue lastMessageReceived = new DateTimeValue(this, "_last_message_received");
     public StringValue panelStatus = new StringValue(this, "_panel_status");
     public StringValue alarmType = new StringValue(this, "_alarm_type");
     public StringValue troubleType = new StringValue(this, "_trouble_type");

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxStateEventListener.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxStateEventListener.java
@@ -32,5 +32,5 @@ public interface PowermaxStateEventListener extends EventListener {
     /**
      * Event handler method to indicate that communication has been lost
      */
-    public void onCommunicationFailure();
+    public void onCommunicationFailure(String message);
 }

--- a/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxStateEventListener.java
+++ b/bundles/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/state/PowermaxStateEventListener.java
@@ -28,4 +28,9 @@ public interface PowermaxStateEventListener extends EventListener {
      * @param event the event object
      */
     public void onNewStateEvent(EventObject event);
+
+    /**
+     * Event handler method to indicate that communication has been lost
+     */
+    public void onCommunicationFailure();
 }


### PR DESCRIPTION
Catch all exceptions, and take all Powermax things offline in the event
of a communication failure. Also adds a 5-minute watchdog for
connections in Standard (non-Powerlink) mode.

Signed-off-by: Ron Isaacson <isaacson.ron@gmail.com>

Closes #9688 
