### PR TITLE
[onewire] fix absolute humidity channel type

### DIFF
--- a/bundles/org.openhab.binding.onewire/src/main/resources/OH-INF/thing/common.xml
+++ b/bundles/org.openhab.binding.onewire/src/main/resources/OH-INF/thing/common.xml
@@ -92,7 +92,7 @@
 		</config-description>
 	</channel-type>
 	<!-- Absolute Humidity Channel -->
-	<channel-type id="absolutehumidity">
+	<channel-type id="abshumidity">
 		<item-type>Number:Density</item-type>
 		<label>Abs. Humidity</label>
 		<description>absolute humidity (calculated from temperature and relative humidity)</description>


### PR DESCRIPTION
The channel is added dynamically with a channel-type `abshumidity`, but the channel-type definition was names `absolutehumidity`

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>