### PR TITLE
[icalendar] Ensure DecimalType will be used if no unit given

### DIFF
--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/logic/CommandTag.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/logic/CommandTag.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
@@ -45,9 +46,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class CommandTag {
 
-    private static final List<Class<? extends Command>> otherCommandTypes = Arrays.asList(QuantityType.class,
-            OnOffType.class, OpenClosedType.class, UpDownType.class, HSBType.class, PlayPauseType.class,
-            RewindFastforwardType.class, StringType.class);
+    private static final List<Class<? extends Command>> otherCommandTypes = Arrays.asList(DecimalType.class,
+            QuantityType.class, OnOffType.class, OpenClosedType.class, UpDownType.class, HSBType.class,
+            PlayPauseType.class, RewindFastforwardType.class, StringType.class);
 
     private static final List<Class<? extends Command>> percentCommandType = Arrays.asList(PercentType.class);
 

--- a/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
+++ b/bundles/org.openhab.binding.icalendar/src/test/java/org/openhab/binding/icalendar/internal/logic/BiweeklyPresentableCalendarTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
@@ -290,7 +291,7 @@ public class BiweeklyPresentableCalendarTest {
         // BEGIN:Calendar_Test_Number:12.3:abc
         Command cmd3 = cmdTags.get(3).getCommand();
         assertNotNull(cmd3);
-        assertEquals(QuantityType.class, cmd3.getClass());
+        assertEquals(DecimalType.class, cmd3.getClass());
 
         // BEGIN:Calendar_Test_Temperature:12.3°C:abc
         Command cmd4 = cmdTags.get(4).getCommand();
@@ -353,7 +354,7 @@ public class BiweeklyPresentableCalendarTest {
         // BEGIN:Calendar_Test_Number:-12.3:abc
         cmd3 = cmdTags.get(3).getCommand();
         assertNotNull(cmd3);
-        assertEquals(QuantityType.class, cmd3.getClass());
+        assertEquals(DecimalType.class, cmd3.getClass());
 
         // BEGIN:Calendar_Test_Temperature:-12.3°C:abc
         cmd4 = cmdTags.get(4).getCommand();
@@ -416,7 +417,7 @@ public class BiweeklyPresentableCalendarTest {
         // BEGIN:Calendar_Test_Number:-0:abc
         cmd3 = cmdTags.get(3).getCommand();
         assertNotNull(cmd3);
-        assertEquals(QuantityType.class, cmd3.getClass());
+        assertEquals(DecimalType.class, cmd3.getClass());
 
         // BEGIN:Calendar_Test_Temperature:0K:abc
         cmd4 = cmdTags.get(4).getCommand();
@@ -541,12 +542,12 @@ public class BiweeklyPresentableCalendarTest {
         // </p><p>BEGIN:Calendar_Test_Number:12.3:abc</p>
         cmd6 = cmdTags.get(6).getCommand();
         assertNotNull(cmd6);
-        assertEquals(QuantityType.class, cmd6.getClass());
+        assertEquals(DecimalType.class, cmd6.getClass());
 
         // <p>END:Calendar_Test_Number:23.4:abc</p>
         cmd7 = cmdTags.get(7).getCommand();
         assertNotNull(cmd7);
-        assertEquals(QuantityType.class, cmd7.getClass());
+        assertEquals(DecimalType.class, cmd7.getClass());
     }
 
     @SuppressWarnings("null")


### PR DESCRIPTION
This PR should fix https://github.com/openhab/openhab-addons/issues/9820 by adding `DecimalType` as the first entry in the list of evaluated target command types for calendar events of the icalendar binding.
It has to be an entry before `QuantityType`, because `QuantityType` also returns a valid object for raw decimal types without any unit-of-measurement.