### PR TITLE
Fix links and NOTICE files

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/NOTICE
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/NOTICE
@@ -1,6 +1,6 @@
-This content is produced and maintained by the Eclipse SmartHome project.
+This content is produced and maintained by the openHAB project.
 
-* Project home: https://openhab.org/
+* Project home: https://www.openhab.org
 
 == Declared Project Licenses
 
@@ -10,15 +10,11 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/eclipse/smarthome
+https://github.com/openhab/openhab-addons
+
+== Third-party Content
 
 Some code of this bundle originates from the Z-Smart Systems Bluegiga Java Library,
-the source of which can be found at -:
+The source code of this library can be found at:
 
 https://github.com/zsmartsystems/com.zsmartsystems.bluetooth.bluegiga
-
-== Copyright Holders
-
-See the NOTICE file distributed with the source code at
-https://github.com/eclipse/smarthome/blob/master/NOTICE
-for detailed information regarding copyright ownership.

--- a/bundles/org.openhab.binding.fsinternetradio/README.md
+++ b/bundles/org.openhab.binding.fsinternetradio/README.md
@@ -34,7 +34,7 @@ If your radio is not discovered, please try to access its API via: `http://<radi
 If you get a 404 error, maybe a different port than the standard port 80 is used by your radio; try scanning the open ports of your radio.<br/>
 If you get a result like `FS_OK 1902014387`, your radio is supported.
 
-If this is the case, please [add your model to this documentation](https://github.com/openhab/openhab-addons/edit/master/bundles/org.openhab.binding.fsinternetradio/README.md) and/or provide discovery information in [this thread](https://community.openhab.org/t/internet-radio-i-need-your-help/2131).
+If this is the case, please [add your model to this documentation](https://github.com/openhab/openhab-addons/edit/main/bundles/org.openhab.binding.fsinternetradio/README.md) and/or provide discovery information in [this thread](https://community.openhab.org/t/internet-radio-i-need-your-help/2131).
 
 ## Binding Configuration
 

--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -55,7 +55,7 @@ Thing coffeemachine coffeemachine [uid="001d63fffe020505#190"]
 
 ## Channels
 
-The definition of the channels in use can best be checked in the [source repository](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing).
+The definition of the channels in use can best be checked in the [source repository](https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing).
 
 ## Example
 

--- a/bundles/org.openhab.binding.mqtt.generic/NOTICE
+++ b/bundles/org.openhab.binding.mqtt.generic/NOTICE
@@ -1,6 +1,6 @@
-This content is produced and maintained by the Eclipse SmartHome project.
+This content is produced and maintained by the openHAB project.
 
-* Project home: https://openhab.org/
+* Project home: https://www.openhab.org
 
 == Declared Project Licenses
 
@@ -8,37 +8,6 @@ This program and the accompanying materials are made available under the terms
 of the Eclipse Public License 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0/.
 
-The MQTT Homie convention is made available under the MIT license, attached at the end of this file.
-
 == Source Code
 
-https://github.com/eclipse/smarthome
-
-== Copyright Holders
-
-See the NOTICE file distributed with the source code at
-https://github.com/eclipse/smarthome/blob/master/NOTICE
-for detailed information regarding copyright ownership.
-
-== MIT license ==
-MIT License
-
-Copyright (c) 2017 Marvin Roger
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.mqtt.homeassistant/NOTICE
+++ b/bundles/org.openhab.binding.mqtt.homeassistant/NOTICE
@@ -1,6 +1,6 @@
-This content is produced and maintained by the Eclipse SmartHome project.
+This content is produced and maintained by the openHAB project.
 
-* Project home: https://openhab.org/
+* Project home: https://www.openhab.org
 
 == Declared Project Licenses
 
@@ -8,37 +8,6 @@ This program and the accompanying materials are made available under the terms
 of the Eclipse Public License 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0/.
 
-The MQTT Homie convention is made available under the MIT license, attached at the end of this file.
-
 == Source Code
 
-https://github.com/eclipse/smarthome
-
-== Copyright Holders
-
-See the NOTICE file distributed with the source code at
-https://github.com/eclipse/smarthome/blob/master/NOTICE
-for detailed information regarding copyright ownership.
-
-== MIT license ==
-MIT License
-
-Copyright (c) 2017 Marvin Roger
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.mqtt.homie/NOTICE
+++ b/bundles/org.openhab.binding.mqtt.homie/NOTICE
@@ -1,6 +1,6 @@
-This content is produced and maintained by the Eclipse SmartHome project.
+This content is produced and maintained by the openHAB project.
 
-* Project home: https://openhab.org/
+* Project home: https://www.openhab.org
 
 == Declared Project Licenses
 
@@ -8,19 +8,18 @@ This program and the accompanying materials are made available under the terms
 of the Eclipse Public License 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0/.
 
-The MQTT Homie convention is made available under the MIT license, attached at the end of this file.
-
 == Source Code
 
-https://github.com/eclipse/smarthome
+https://github.com/openhab/openhab-addons
 
-== Copyright Holders
+== Third-party Content
 
-See the NOTICE file distributed with the source code at
-https://github.com/eclipse/smarthome/blob/master/NOTICE
-for detailed information regarding copyright ownership.
+The MQTT Homie convention is made available under the MIT license, attached at the end of this file.
 
-== MIT license ==
+== Third-party license(s)
+
+=== MIT license
+
 MIT License
 
 Copyright (c) 2017 Marvin Roger

--- a/bundles/org.openhab.binding.nibeheatpump/README.md
+++ b/bundles/org.openhab.binding.nibeheatpump/README.md
@@ -62,7 +62,7 @@ An Arduino-based solution has been tested with Arduino uno + RS485 and Ethernet 
 The [ProDiNo](https://www.kmpelectronics.eu/en-us/products/prodinoethernet.aspx) NetBoards are also supported.
 A ProDiNo has an Ethernet and RS-485 port on the board.
 
-Arduino code is available [here](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
+Arduino code is available [here](https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/Arduino/NibeGW).
 
 Arduino code can be build via Arduino IDE.
 For more details see [www.arduino.cc](https://www.arduino.cc/en/Main/Software). 
@@ -70,7 +70,7 @@ NibeGW configuration (such IP addresses, ports, etc) can be adapted directly by 
 
 ### Raspberry Pi (or other Linux/Unix based boards)
 
-C code is available [here](https://github.com/openhab/openhab-addons/tree/master/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/RasPi).
+C code is available [here](https://github.com/openhab/openhab-addons/tree/main/bundles/org.openhab.binding.nibeheatpump/contrib/NibeGW/RasPi).
 
 To build the C code use: 
 

--- a/bundles/org.openhab.voice.mactts/NOTICE
+++ b/bundles/org.openhab.voice.mactts/NOTICE
@@ -1,6 +1,6 @@
-This content is produced and maintained by the Eclipse SmartHome project.
+This content is produced and maintained by the openHAB project.
 
-* Project home: https://openhab.org/
+* Project home: https://www.openhab.org
 
 == Declared Project Licenses
 
@@ -10,10 +10,4 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 == Source Code
 
-https://github.com/eclipse/smarthome
-
-== Copyright Holders
-
-See the NOTICE file distributed with the source code at
-https://github.com/eclipse/smarthome/blob/master/NOTICE
-for detailed information regarding copyright ownership.
+https://github.com/openhab/openhab-addons


### PR DESCRIPTION
* Updates links to target the openhab-addons 'main' branch instead of the 'master' branch
* Updates some NOTICE files to indicate content is maintained by openHAB instead of Eclipse SmartHome