### PR TITLE
[miio] fix printed zone clean command

### DIFF
--- a/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/RoboMapViewer.java
+++ b/bundles/org.openhab.binding.miio/src/test/java/org/openhab/binding/miio/internal/RoboMapViewer.java
@@ -170,7 +170,7 @@ public class RoboMapViewer extends JFrame {
                         double minY = Math.min(fromLocation.getY(), endLocation.getY());
                         double maxY = Math.max(fromLocation.getY(), endLocation.getY());
                         textArea.append(String.format(
-                                "Zone coordinates:\t%s, %s\t\tZone clean command:  app_zone_clean[[ %.0f,%.0f,%.0f,%.0f,1 ]]\r\n",
+                                "Zone coordinates:\t%s, %s\t\tZone clean command:  app_zoned_clean[[ %.0f,%.0f,%.0f,%.0f,1 ]]\r\n",
                                 endLocation, fromLocation, minX, minY, maxX, maxY));
                     } else {
                         final MapPoint pointLocation = MapCoordstoRoboCoords(localCoordtoMapCoords(e.getPoint()));


### PR DESCRIPTION
as per https://community.openhab.org/t/xiaomi-vacuum-map-viewer-to-find-coordinates-for-zone-cleaning/103500/47

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>
