### PR TITLE
[tr064] Update docs: Manual scan

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -17,7 +17,8 @@ Two kind of Things are supported:
 ## Discovery
 
 The gateway device needs to be added manually.
-After that, sub-devices should be detected automatically. Otherwise go to "Things", click "+" to add a new thing, select the TR-064 binding and click the "Scan" button.
+After that, sub-devices should be detected automatically.
+Otherwise go to "Things", click "+" to add a new thing, select the TR-064 binding and click the "Scan" button.
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -17,7 +17,7 @@ Two kind of Things are supported:
 ## Discovery
 
 The gateway device needs to be added manually.
-After that, sub-devices are detected automatically.
+After that, sub-devices should be detected automatically. Otherwise go to "Things", click "+" to add a new thing, select the TR-064 binding and click the "Scan" button.
 
 ## Thing Configuration
 


### PR DESCRIPTION
Improve the documentation for the case that the sub-devices are not detected automatically.
Happened to me and some other users.
See https://community.openhab.org/t/issues-with-the-new-oh3-tr-064-binding/113926