### PR TITLE
[MAP transformation] Update README.md

### DIFF
--- a/bundles/org.openhab.transform.map/README.md
+++ b/bundles/org.openhab.transform.map/README.md
@@ -1,6 +1,7 @@
 # Map Transformation Service
 
-Transforms the input by mapping it to another string. It expects the mappings to be read from a file which is stored under the `transform` folder. The file name must end with the `.map` extension. 
+Transforms the input by mapping it to another string. It expects the mappings to be read from a file which is stored under the `transform` folder.
+The file name must have the `.map` extension. 
 
 This file should be in property syntax, i.e. simple lines with "key=value" pairs. 
 The file format is documented [here](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).

--- a/bundles/org.openhab.transform.map/README.md
+++ b/bundles/org.openhab.transform.map/README.md
@@ -1,6 +1,6 @@
 # Map Transformation Service
 
-Transforms the input by mapping it to another string. It expects the mappings to be read from a file which is stored under the `transform` folder. 
+Transforms the input by mapping it to another string. It expects the mappings to be read from a file which is stored under the `transform` folder. The file name must end with the `.map` extension. 
 
 This file should be in property syntax, i.e. simple lines with "key=value" pairs. 
 The file format is documented [here](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).


### PR DESCRIPTION
[MAP transformation] Update README.md

Added a note with regards to map file name requirements. Without the .map extension the transformation throws a rather unrelated error into the openhab.log while the transformation fails. See this [post](https://community.openhab.org/t/oh3-rule-and-map-file-name-requirements/114532/2?u=hugob).

Signed-off-by: Stefan Reiner <reiner.stefan@gmx.at>