### PR TITLE
[heos] Fix runtime error; Support for new  Denon "Home" speaker added

### DIFF
--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/discovery/HeosDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/discovery/HeosDiscoveryParticipant.java
@@ -79,7 +79,8 @@ public class HeosDiscoveryParticipant implements UpnpDiscoveryParticipant {
         DeviceDetails details = device.getDetails();
         String modelName = details.getModelDetails().getModelName();
         String modelManufacturer = details.getManufacturerDetails().getManufacturer();
-        if ("Denon".equals(modelManufacturer) && (modelName.startsWith("HEOS") || modelName.endsWith("H"))) {
+        if ("Denon".equals(modelManufacturer)
+                && (modelName.startsWith("HEOS") || modelName.endsWith("H") || modelName.contains("Home"))) {
             String deviceType = device.getType().getType();
             if (deviceType.startsWith("ACT") || deviceType.startsWith("Aios")) {
                 return new ThingUID(THING_TYPE_BRIDGE, device.getIdentity().getUdn().getIdentifierString());

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
@@ -179,6 +179,9 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
         String serialNumber = player.serial;
         if (serialNumber != null) {
             prop.put(Thing.PROPERTY_SERIAL_NUMBER, serialNumber);
+        } else {
+            prop.put(Thing.PROPERTY_SERIAL_NUMBER, ""); // If no serial number is provided, write an empty string to
+                                                        // prevent error during runtime
         }
     }
 }

--- a/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
+++ b/bundles/org.openhab.binding.heos/src/main/java/org/openhab/binding/heos/internal/handler/HeosPlayerHandler.java
@@ -180,8 +180,9 @@ public class HeosPlayerHandler extends HeosThingBaseHandler {
         if (serialNumber != null) {
             prop.put(Thing.PROPERTY_SERIAL_NUMBER, serialNumber);
         } else {
-            prop.put(Thing.PROPERTY_SERIAL_NUMBER, ""); // If no serial number is provided, write an empty string to
-                                                        // prevent error during runtime
+            prop.put(Thing.PROPERTY_SERIAL_NUMBER, String.valueOf(player.playerId)); // If no serial number is provided,
+                                                                                     // write an empty string to
+            // prevent error during runtime
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->
<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

- This pull request fixes an runtime issue if no serial number is provided by the HEOS speaker. 
- It also adds the support to use the Denon "Home" speaker series as bridge

The runtime bug was reported within OpenHab [community](https://community.openhab.org/t/heos-denon-support/3449/380).

  
<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
