### PR TITLE
[miio] Fix channel type of ambient brightness property for ceiling10 lamp

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.ceiling4.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.ceiling4.json
@@ -56,7 +56,7 @@
 				"friendlyName": "Ambient Brightness",
 				"channel": "ambientBrightness",
 				"channelType": "ambientBrightness",
-				"type": "Number",
+				"type": "Dimmer",
 				"refresh": true,
 				"ChannelGroup": "actions",
 				"actions": [


### PR DESCRIPTION
# [miio] Fix channel type of ambient brightness property for ceiling10 lamp

The ceiling10 Yeelight lamp has 2 dimmer for brightness:
"bright" for the main light and bg_bright for the ambient light.
Both are of type dimmer and accept percentage values between 1 and 100.
This fix changes the datatype of the bg_bright property from Number
to Dimmer in the device mapping database file ceiling4, which is also
the one that is used for the ceiling10 lamp.

This change can easily be tested by dropping the modified JSON file into the
folder /etc/openhab/miio/.
