### PR TITLE
[tr064] fix wrong unit in TotalBytes

### DIFF
--- a/bundles/org.openhab.binding.tr064/README.md
+++ b/bundles/org.openhab.binding.tr064/README.md
@@ -158,6 +158,8 @@ In this case you have to use the `wifi5GHzEnable` channel for switching the gues
 | `wanTotalBytesReceived`    | `Number:DataAmount`       |     x    | Total Bytes Received                                           |
 | `wanTotalBytesSent`        | `Number:DataAmount`       |     x    | Total Bytes Sent                                               |
  
+**Note:** AVM Fritzbox devices use 4-byte-unsigned-integers for `wanTotalBytesReceived` and `wanTotalBytesSent`, because of that the counters are reset after around 4GB data.
+
 ## `PHONEBOOK` Profile
 
 The binding provides a profile for using the FritzBox phonebooks for resolving numbers to names.

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -173,13 +173,13 @@
 		<getAction name="GetCommonLinkProperties" argument="NewLayer1UpstreamMaxBitRate"/>
 	</channel>
 	<channel name="wanTotalBytesReceived" label="Total Bytes Received">
-		<item type="Number:DataAmount" unit="B" statePattern="%.3f Gio"/>
+		<item type="Number:DataAmount" unit="B" statePattern="%.3f GB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1"/>
 		<getAction name="GetTotalBytesReceived" argument="NewTotalBytesReceived"/>
 	</channel>
 	<channel name="wanTotalBytesSent" label="Total Bytes Sent">
-		<item type="Number:DataAmount" unit="B" statePattern="%.3f Gio"/>
+		<item type="Number:DataAmount" unit="B" statePattern="%.3f GB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1"/>
 		<getAction name="GetTotalBytesSent" argument="NewTotalBytesSent"/>


### PR DESCRIPTION
The change to GB war forgotten before the binding was merged. Also clarify why counters are different from what is shown in the online counter in fritzbox devices.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>
