### PR TITLE
[xmppclient] Update Smack library to 4.3.5

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: XMPPClient Binding</name>
 
   <properties>
-    <smack.version>4.3.3</smack.version>
+    <smack.version>4.3.5</smack.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Update the used XMPP client library, Smack, to the latest version of
the 4.3 version series: 4.3.5.
