### PR TITLE
[hue] Implementing "[discovery.upnp] Devices may apply a grace period"

### DIFF
--- a/bundles/org.openhab.binding.hue/README.md
+++ b/bundles/org.openhab.binding.hue/README.md
@@ -373,3 +373,11 @@ if (receivedEvent.getEvent() == "1000.0")) {
     //do stuff
 }       
 ```
+
+### UPnP Discovery: Inbox 'Grace Period'
+
+The Hue Bridge can sometimes be late in sending its UPnP 'ssdp:alive' notifications even though it has not really gone offline.
+This means that the Hue Bridge could be repeatedly removed from, and (re)added to, the InBox.
+Which would lead to confusion in the UI, and repeated logger messages.
+To prevent this, the binding tells the OpenHAB core to wait for a further period of time ('grace period') before actually removing the Bridge from the Inbox.
+The 'grace period' has a default value of 50 seconds, but it can be fine tuned in the main UI via Settings | Bindings | Hue | Configure.

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConstants.java
@@ -83,6 +83,9 @@ public class HueBindingConstants {
     public static final String EVENT_DIMMER_SWITCH = "dimmer_switch_event";
     public static final String EVENT_TAP_SWITCH = "tap_switch_event";
 
+    // Binding configuration properties
+    public static final String REMOVAL_GRACE_PERIOD = "removalGracePeriod";
+
     // Bridge config properties
     public static final String HOST = "ipAddress";
     public static final String PORT = "port";

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -92,4 +92,10 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
         }
         return null;
     }
+
+    @Override
+    public int getRemovalGracePeriodSeconds(RemoteDevice device) {
+        // Hue bridges have maxAge 100 seconds, so apply a grace period of half that
+        return 50;
+    }
 }

--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -121,9 +121,9 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
             Dictionary<String, @Nullable Object> properties = conf.getProperties();
             Object property = properties.get(HueBindingConstants.REMOVAL_GRACE_PERIOD);
             if (property != null) {
-                removalGracePeriodSeconds = Integer.valueOf(property.toString()).longValue();
+                removalGracePeriodSeconds = Long.parseLong(property.toString());
             }
-        } catch (IOException | IllegalStateException | NullPointerException | NumberFormatException e) {
+        } catch (IOException | IllegalStateException | NumberFormatException e) {
             // fall through to pre-initialised (default) value
         }
         logger.trace("getRemovalGracePeriodSeconds={}", removalGracePeriodSeconds);

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/binding/binding.xml
@@ -3,8 +3,16 @@
 	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-	<name>hue Binding</name>
-	<description>The hue Binding integrates the Philips hue system. It
-		allows to control hue bulbs.</description>
+	<name>Hue Binding</name>
+	<description>The Hue Binding integrates the Philips Hue system. It allows to control Hue bulbs.</description>
+
+	<config-description>
+		<parameter name="removalGracePeriod" type="integer">
+			<label>Removal Grace Period</label>
+			<description>Extra grace period (seconds) that UPnP discovery shall wait before removing a lost Bridge from the
+				Inbox. Default is 50 seconds.</description>
+			<default>50</default>
+		</parameter>
+	</config-description>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.hue/src/main/resources/OH-INF/binding/binding.xml
@@ -7,7 +7,7 @@
 	<description>The Hue Binding integrates the Philips Hue system. It allows to control Hue bulbs.</description>
 
 	<config-description>
-		<parameter name="removalGracePeriod" type="integer">
+		<parameter name="removalGracePeriod" type="integer" min="0" step="1" unit="s">
 			<label>Removal Grace Period</label>
 			<description>Extra grace period (seconds) that UPnP discovery shall wait before removing a lost Bridge from the
 				Inbox. Default is 50 seconds.</description>


### PR DESCRIPTION
**BACKGROUND**

The JUPnP library strictly follows the UPnP specification insofar as if a device fails to send its next 'ssdp:alive' notification within its declared 'maxAge' period, it is immediately considered to be gone. The Philips Hue can sometimes be late in sending its 'ssdp:alive' notifications even though it has not really gone offline. This means that the Hue Bridge is repeatedly removed from, and (re)added to, the InBox. There may be up to fifty such removals and (re)addings per day. This leads to confusion in the UI, and repeated logger messages.

**SOLUTION PART A - CORE**

I have made a Pull Request for a change in [discovery.upnp](https://github.com/openhab/openhab-core/pull/2144) that allows bindings to specify an additional grace period that the core UPnP discovery service shall wait before it removes a Thing from the Inbox. The change in [discovery.upnp] comprises an extension to the UpnpDiscoveryParticipant interface adding a new `default int getRemovalGracePeriodSeconds()` method. The change in [discovery.upnp] is implemented so that any existing binding inherits the default method, and its discovery behaviour is thus not changed.

**SOLUTION PART B - HUE BINDING**

This (HUE) binding overrides the `default int getRemovalGracePeriodSeconds()` method, and this asks for an additional grace period, which the core UPnP discovery processes will now honour.

**REFERENCE**
https://github.com/openhab/openhab-core/pull/2144

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
