### PR TITLE
[somfytahoma] Retry command submission when tahoma gateway is busy.

### DIFF
--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/config/SomfyTahomaConfig.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/config/SomfyTahomaConfig.java
@@ -26,6 +26,8 @@ public class SomfyTahomaConfig {
     private String password = "";
     private int refresh = 30;
     private int statusTimeout = 300;
+    private int retries = 10;
+    private int retryDelay = 1000;
 
     public String getEmail() {
         return email;
@@ -43,11 +45,27 @@ public class SomfyTahomaConfig {
         return statusTimeout;
     }
 
+    public int getRetries() {
+        return retries;
+    }
+
+    public int getRetryDelay() {
+        return retryDelay;
+    }
+
     public void setEmail(String email) {
         this.email = email;
     }
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+
+    public void setRetryDelay(int retryDelay) {
+        this.retryDelay = retryDelay;
     }
 }

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
@@ -18,6 +18,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +80,7 @@ public class SomfyTahomaBridgeHandler extends BaseBridgeHandler {
     private @Nullable ScheduledFuture<?> reconciliationFuture;
 
     // List of futures used for command retries
-    private List<ScheduledFuture<?>> retryFutures = new ArrayList<ScheduledFuture<?>>();
+    private Collection<ScheduledFuture<?>> retryFutures = new ConcurrentLinkedQueue<ScheduledFuture<?>>();
 
     /**
      * List of executions

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBridgeHandler.java
@@ -570,18 +570,16 @@ public class SomfyTahomaBridgeHandler extends BaseBridgeHandler {
     }
 
     private void repeatSendCommandInternal(String io, String command, String params, String url, int retries) {
-        logger.info("Retrying command, retries left: {}", retries);
-        Boolean result = sendCommandInternal(io, command, params, url);
-        if (result != null && !result) {
-            if (retries > 0) {
-                scheduler.schedule(() -> {
-                    repeatSendCommandInternal(io, command, params, url, retries - 1);
-                }, thingConfig.getRetryDelay(), TimeUnit.MILLISECONDS);
-            }
+        logger.debug("Retrying command, retries left: {}", retries);
+        boolean result = sendCommandInternal(io, command, params, url);
+        if (!result && (retries > 0)) {
+            scheduler.schedule(() -> {
+                repeatSendCommandInternal(io, command, params, url, retries - 1);
+            }, thingConfig.getRetryDelay(), TimeUnit.MILLISECONDS);
         }
     }
 
-    private Boolean sendCommandInternal(String io, String command, String params, String url) {
+    private boolean sendCommandInternal(String io, String command, String params, String url) {
         String value = params.equals("[]") ? command : params.replace("\"", "");
         String urlParameters = "{\"label\":\"" + getThingLabelByURL(io) + " - " + value
                 + " - OH2\",\"actions\":[{\"deviceURL\":\"" + io + "\",\"commands\":[{\"name\":\"" + command

--- a/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/config/config.xml
@@ -45,5 +45,17 @@
 			<description>Specifies the timeout in seconds after which the status is got from Tahoma cloud</description>
 			<default>300</default>
 		</parameter>
+
+		<parameter name="retries" type="integer" required="false">
+			<label>Retries</label>
+			<description>Specifies the number of retries when command execution</description>
+			<default>10</default>
+		</parameter>
+
+		<parameter name="retryDelay" type="integer" required="false" min="100">
+			<label>Retry delay</label>
+			<description>Specifies the delay in milliseconds between subsequent retries after a command failure</description>
+			<default>1000</default>
+		</parameter>
 	</config-description>
 </config-description:config-descriptions>


### PR DESCRIPTION
Currently, the Tahoma gateway only accepts at most 10 commands. When sending additional commands, the following error message is logged:
2020-10-01 18:02:44.892 [WARN ] [nal.handler.SomfyTahomaBridgeHandler] - Apply command response: {"errorCode":"EXEC_QUEUE_FULL","error":"Execution queue is full on gateway: # 1223-6154-5758 (soft limit: 10)"}
the command will not be carried out by the Tahoma gateway.
This PR is an improvement of the Somfy Tahoma binding. When the gateway responds with an error, the command is retried after a configurable time for a configurable number of retries.