### PR TITLE
[tivo] Add IR code commands to dropdown and documentation

### DIFF
--- a/bundles/org.openhab.binding.tivo/README.md
+++ b/bundles/org.openhab.binding.tivo/README.md
@@ -121,7 +121,7 @@ VIDEO_MODE_NATIVE
 
 **tivo.things**
 
-````java
+```java
 tivo:sckt:Living_Room "Living Room TiVo" [ host="192.168.0.19" ]
 ```
 
@@ -142,6 +142,7 @@ Switch      TiVo_Search         "Search Demo"
 ```
 
 * The item `TiVo_SetChannelName` depends upon a valid `tivo.map` file to translate channel numbers to channel names. The openHAB **MAP** transformation service must also be installed.
+* See [this discussion thread] (https://community.openhab.org/t/bogob-big-ol-grid-o-buttons-is-this-even-possible-yes-yes-it-is/115343) for an example of setting up an advanced UI to simulate the look of the TiVo remote.
 
 **tivo.sitemap:**
 

--- a/bundles/org.openhab.binding.tivo/README.md
+++ b/bundles/org.openhab.binding.tivo/README.md
@@ -52,8 +52,8 @@ All devices support the following channels:
 |-----------------|-----------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | channelSet      | Number (1-9999) | Current Channel - Request (SETCH)     | Displays the current channel number. When changed, tunes the DVR to the specified channel (unless a recording is in progress on all available tuners). The TiVo must be in Live TV mode for this command to work.                                                 |
 | channelForce    | Number (1-9999) | Current Channel - Forced (FORCECH)    | Displays the current channel number. When changed, tunes the DVR to the specified channel, **cancelling any recordings in progress if necessary** i.e. when all tuners are already in use / recording. The TiVo must be in Live TV mode for this command to work. |
-| menuTeleport    | String          | Change Special/Menu Screen (TELEPORT) | Change to one of the following TiVo menu screens: TIVO (Home), LIVETV, GUIDE, NOWPLAYING (My Shows), SEARCH, NETFLIX.                                                                                                                                                   |
-| irCommand       | String          | Remote Control Button (IRCOMMAND)     | Send a simulated button push from the remote control to the TiVo. See Appendix A in document TCP Remote Protocol 1.1 for supported codes.                                                                                                                         |
+| menuTeleport    | String          | Change Special/Menu Screen (TELEPORT) | Change to one of the following TiVo menu screens: TIVO (Home), LIVETV, GUIDE, NOWPLAYING (My Shows), SEARCH, NETFLIX.                                                                                                                                             |
+| irCommand       | String          | Remote Control Button (IRCOMMAND)     | Send a simulated button push from the remote control to the TiVo. See below for available IR COMMANDS.                                                                                                                                                            |
 | kbdCommand      | String          | Keyboard Command (KEYBOARD)           | Sends a code corresponding to a keyboard key press to the TiVo e.g. A-Z. See Appendix A in document TCP Remote Protocol 1.1 for supported characters and special character codes.                                                                                 |
 | dvrStatus       | String          | TiVo Status                           | Action return code / channel information returned by the TiVo.                                                                                                                                                                                                    |
 
@@ -61,6 +61,61 @@ All devices support the following channels:
 * Keyboard commands must currently be issued one character at a time to the item (this is how the TiVo natively supports this command).
 * To send multiple copies of the same keyboard command, append an asterisk with the number of repeats required e.g. NUM2*4 would send the number 2 four times. This is useful for performing searches where the number characters can only be accessed by pressing the keys multiple times in rapid succession i.e. each key press cycles through characters A, B, C, 2.
 * Special characters must also be changed to the appropriate command e.g. the comma symbol(`,`) must not be sent it should be replaced by 'COMMA'.
+
+Available IR Commands to use with `irCommand` channel:  
+UP  
+DOWN  
+LEFT  
+RIGHT  
+SELECT  
+TIVO  
+LIVETV  
+GUIDE  
+INFO  
+EXIT  
+THUMBSUP  
+THUMBSDOWN  
+CHANNELUP  
+CHANNELDOWN  
+PLAY  
+FORWARD  
+REVERSE  
+PAUSE  
+SLOW  
+REPLAY  
+ADVANCE  
+RECORD  
+NUM0  
+NUM1  
+NUM2  
+NUM3  
+NUM4  
+NUM5  
+NUM6  
+NUM7  
+NUM8  
+NUM9  
+ENTER  
+CLEAR  
+ACTION_A  
+ACTION_B  
+ACTION_C  
+ACTION_D  
+CC_ON  
+CC_OFF  
+FIND_REMOTE  
+ASPECT_CORRECTION_FULL  
+ASPECT_CORRECTION_PANEL  
+ASPECT_CORRECTION_ZOOM  
+ASPECT_CORRECTION_WIDE_ZOOM  
+VIDEO_MODE_FIXED_480i  
+VIDEO_MODE_FIXED_480p  
+VIDEO_MODE_FIXED_720p  
+VIDEO_MODE_FIXED_1080i  
+VIDEO_MODE_HYBRID  
+VIDEO_MODE_HYBRID_720p  
+VIDEO_MODE_HYBRID_1080i  
+VIDEO_MODE_NATIVE  
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.tivo/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tivo/src/main/resources/OH-INF/thing/thing-types.xml
@@ -105,13 +105,14 @@
 		<item-type>String</item-type>
 		<label>Change Menu Screen</label>
 		<description>Change(TELEPORT) to one of the following TiVo menu screens: TIVO (Home), LIVE TV, GUIDE, NOW PLAYING (My
-			Shows), NETFLIX. Type: String</description>
+			Shows), SEARCH, NETFLIX. Type: String</description>
 		<state readOnly="false">
 			<options>
 				<option value="TIVO">TIVO</option>
 				<option value="LIVETV">LIVETV</option>
 				<option value="GUIDE">GUIDE</option>
 				<option value="NOWPLAYING">NOWPLAYING</option>
+				<option value="SEARCH">SEARCH</option>
 				<option value="NETFLIX">NETFLIX</option>
 			</options>
 		</state>
@@ -119,9 +120,65 @@
 	<channel-type id="irCommand">
 		<item-type>String</item-type>
 		<label>Remote Control Button</label>
-		<description>Send a simulated button push (IRCODE) from the remote control to the TiVo. See Appendix A in document TCP
-			Remote Protocol 1.1 for supported codes. Type: String</description>
-		<state readOnly="false"/>
+		<description>Send a simulated button push (IRCODE) from the remote control to the TiVo. See README.md for supported
+			codes. Type: String</description>
+		<state readOnly="false">
+			<options>
+				<option value="UP">UP</option>
+				<option value="DOWN">DOWN</option>
+				<option value="LEFT">LEFT</option>
+				<option value="RIGHT">RIGHT</option>
+				<option value="SELECT">SELECT</option>
+				<option value="TIVO">TIVO</option>
+				<option value="LIVETV">LIVETV</option>
+				<option value="GUIDE">GUIDE</option>
+				<option value="INFO">INFO</option>
+				<option value="EXIT">EXIT</option>
+				<option value="THUMBSUP">THUMBSUP</option>
+				<option value="THUMBSDOWN">THUMBSDOWN</option>
+				<option value="CHANNELUP">CHANNELUP</option>
+				<option value="CHANNELDOWN">CHANNELDOWN</option>
+				<option value="PLAY">PLAY</option>
+				<option value="FORWARD">FORWARD</option>
+				<option value="REVERSE">REVERSE</option>
+				<option value="PAUSE">PAUSE</option>
+				<option value="SLOW">SLOW</option>
+				<option value="REPLAY">REPLAY</option>
+				<option value="ADVANCE">ADVANCE</option>
+				<option value="RECORD">RECORD</option>
+				<option value="NUM0">NUM0</option>
+				<option value="NUM1">NUM1</option>
+				<option value="NUM2">NUM2</option>
+				<option value="NUM3">NUM3</option>
+				<option value="NUM4">NUM4</option>
+				<option value="NUM5">NUM5</option>
+				<option value="NUM6">NUM6</option>
+				<option value="NUM7">NUM7</option>
+				<option value="NUM8">NUM8</option>
+				<option value="NUM9">NUM9</option>
+				<option value="ENTER">ENTER</option>
+				<option value="CLEAR">CLEAR</option>
+				<option value="ACTION_A">ACTION_A</option>
+				<option value="ACTION_B">ACTION_B</option>
+				<option value="ACTION_C">ACTION_C</option>
+				<option value="ACTION_D">ACTION_D</option>
+				<option value="CC_ON">CC_ON</option>
+				<option value="CC_OFF">CC_OFF</option>
+				<option value="FIND_REMOTE">FIND_REMOTE</option>
+				<option value="ASPECT_CORRECTION_FULL">ASPECT_CORRECTION_FULL</option>
+				<option value="ASPECT_CORRECTION_PANEL">ASPECT_CORRECTION_PANEL</option>
+				<option value="ASPECT_CORRECTION_ZOOM">ASPECT_CORRECTION_ZOOM</option>
+				<option value="ASPECT_CORRECTION_WIDE_ZOOM">ASPECT_CORRECTION_WIDE_ZOOM</option>
+				<option value="VIDEO_MODE_FIXED_480i">VIDEO_MODE_FIXED_480i</option>
+				<option value="VIDEO_MODE_FIXED_480p">VIDEO_MODE_FIXED_480p</option>
+				<option value="VIDEO_MODE_FIXED_720p">VIDEO_MODE_FIXED_720p</option>
+				<option value="VIDEO_MODE_FIXED_1080i">VIDEO_MODE_FIXED_1080i</option>
+				<option value="VIDEO_MODE_HYBRID">VIDEO_MODE_HYBRID</option>
+				<option value="VIDEO_MODE_HYBRID_720p">VIDEO_MODE_HYBRID_720p</option>
+				<option value="VIDEO_MODE_HYBRID_1080i">VIDEO_MODE_HYBRID_1080i</option>
+				<option value="VIDEO_MODE_NATIVE">VIDEO_MODE_NATIVE</option>
+			</options>
+		</state>
 	</channel-type>
 	<channel-type id="kbdCommand">
 		<item-type>String</item-type>


### PR DESCRIPTION
Additional refinement to the revamped Tivo binding. All available IR commands were added to the default drop down for the irCommand channel and to the README. Previously the user was directed to find this info in the protocol PDF which has become harder to find as of late.

@AndyXMB