### PR TITLE
[nikobus] added option to reverse rollershutter commands

### DIFF
--- a/bundles/org.openhab.binding.nikobus/README.md
+++ b/bundles/org.openhab.binding.nikobus/README.md
@@ -131,6 +131,8 @@ Defines a `rollershutter-module` with address `4C6C`.
 | output-5  | Rollershutter | Output 5     |
 | output-6  | Rollershutter | Output 6     |
 
+In case rollershutters are moving in the oposite direction when sending `UP` or `DOWN` commands, there is a `reverse` parameter, which can be set to `true` in this case to reverse the rollershutter's direction. Defaults to `false`.
+
 ##### Estimating Position
 
 Nikobus rollershuter module does not provide information about rollershutter's position. In order to bridge this gap, an optional parameter `duration` can be set per channel, describing the amount of time needed by a rollershutter to get from open to closed state (or vice-versa).

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusDimmerModuleHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusDimmerModuleHandler.java
@@ -53,16 +53,16 @@ public class NikobusDimmerModuleHandler extends NikobusSwitchModuleHandler {
     }
 
     @Override
-    protected int valueFromCommand(Command command) {
+    protected int valueFromCommand(String channelId, Command command) {
         if (command instanceof PercentType) {
             return Math.round(((PercentType) command).floatValue() / 100f * 255f);
         }
 
-        return super.valueFromCommand(command);
+        return super.valueFromCommand(channelId, command);
     }
 
     @Override
-    protected State stateFromValue(int value) {
+    protected State stateFromValue(String channelId, int value) {
         int result = Math.round(value * 100f / 255f);
         return new PercentType(result);
     }

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusModuleHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusModuleHandler.java
@@ -182,7 +182,7 @@ abstract class NikobusModuleHandler extends NikobusBaseThingHandler {
         }
 
         if (previousValue == null || previousValue.intValue() != value) {
-            updateState(channelId, stateFromValue(value));
+            updateState(channelId, stateFromValue(channelId, value));
         }
     }
 
@@ -195,7 +195,7 @@ abstract class NikobusModuleHandler extends NikobusBaseThingHandler {
             Integer digits;
 
             if (channelId.equals(channelUID.getId())) {
-                digits = valueFromCommand(command);
+                digits = valueFromCommand(channelId, command);
                 updateStateAndCacheValue(channelId, digits.intValue());
             } else {
                 synchronized (cachedStates) {
@@ -233,7 +233,7 @@ abstract class NikobusModuleHandler extends NikobusBaseThingHandler {
         }
     }
 
-    protected abstract int valueFromCommand(Command command);
+    protected abstract int valueFromCommand(String channelId, Command command);
 
-    protected abstract State stateFromValue(int value);
+    protected abstract State stateFromValue(String channelId, int value);
 }

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusRollershutterModuleHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusRollershutterModuleHandler.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.nikobus.internal.handler;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -47,8 +46,7 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
     private final Logger logger = LoggerFactory.getLogger(NikobusRollershutterModuleHandler.class);
     private final List<PositionEstimator> positionEstimators = new CopyOnWriteArrayList<>();
 
-    private final Map<String, DirectionConfiguration> directionConfigurations = Collections
-            .synchronizedMap(new HashMap<>());
+    private final Map<String, DirectionConfiguration> directionConfigurations = new ConcurrentHashMap<>();
 
     public NikobusRollershutterModuleHandler(Thing thing) {
         super(thing);
@@ -71,8 +69,8 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
                 positionEstimators.add(new PositionEstimator(channel.getUID(), config));
             }
 
-            DirectionConfiguration configuration = config.reverse ? DirectionConfiguration.reversed
-                    : DirectionConfiguration.normal;
+            DirectionConfiguration configuration = config.reverse ? DirectionConfiguration.REVERSED
+                    : DirectionConfiguration.NORMAL;
             directionConfigurations.put(channel.getUID().getId(), configuration);
         }
 
@@ -230,8 +228,8 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
         final int up;
         final int down;
 
-        final static DirectionConfiguration normal = new DirectionConfiguration(1, 2);
-        final static DirectionConfiguration reversed = new DirectionConfiguration(2, 1);
+        final static DirectionConfiguration NORMAL = new DirectionConfiguration(1, 2);
+        final static DirectionConfiguration REVERSED = new DirectionConfiguration(2, 1);
 
         private DirectionConfiguration(int up, int down) {
             this.up = up;

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusRollershutterModuleHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusRollershutterModuleHandler.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.binding.nikobus.internal.handler;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +47,9 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
     private final Logger logger = LoggerFactory.getLogger(NikobusRollershutterModuleHandler.class);
     private final List<PositionEstimator> positionEstimators = new CopyOnWriteArrayList<>();
 
+    private final Map<String, DirectionConfiguration> directionConfigurations = Collections
+            .synchronizedMap(new HashMap<>());
+
     public NikobusRollershutterModuleHandler(Thing thing) {
         super(thing);
     }
@@ -57,43 +63,50 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
         }
 
         positionEstimators.clear();
+        directionConfigurations.clear();
 
         for (Channel channel : thing.getChannels()) {
             PositionEstimatorConfig config = channel.getConfiguration().as(PositionEstimatorConfig.class);
             if (config.delay >= 0 && config.duration > 0) {
                 positionEstimators.add(new PositionEstimator(channel.getUID(), config));
             }
+
+            DirectionConfiguration configuration = config.reverse ? DirectionConfiguration.reversed
+                    : DirectionConfiguration.normal;
+            directionConfigurations.put(channel.getUID().getId(), configuration);
         }
 
         logger.debug("Position estimators for {} = {}", thing.getUID(), positionEstimators);
     }
 
     @Override
-    protected int valueFromCommand(Command command) {
-        if (command == UpDownType.DOWN || command == StopMoveType.MOVE) {
-            return 0x02;
-        }
-        if (command == UpDownType.UP) {
-            return 0x01;
-        }
+    protected int valueFromCommand(String channelId, Command command) {
         if (command == StopMoveType.STOP) {
             return 0x00;
         }
-
+        if (command == UpDownType.DOWN || command == StopMoveType.MOVE) {
+            return getDirectionConfiguration(channelId).down;
+        }
+        if (command == UpDownType.UP) {
+            return getDirectionConfiguration(channelId).up;
+        }
         throw new IllegalArgumentException("Command '" + command + "' not supported");
     }
 
     @Override
-    protected State stateFromValue(int value) {
+    protected State stateFromValue(String channelId, int value) {
         if (value == 0x00) {
             return OnOffType.OFF;
         }
-        if (value == 0x01) {
+
+        DirectionConfiguration configuration = getDirectionConfiguration(channelId);
+        if (value == configuration.up) {
             return UpDownType.UP;
         }
-        if (value == 0x02) {
+        if (value == configuration.down) {
             return UpDownType.DOWN;
         }
+
         throw new IllegalArgumentException("Unexpected value " + value + " received");
     }
 
@@ -119,9 +132,18 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
         super.updateState(channelUID, new PercentType(percent));
     }
 
+    private DirectionConfiguration getDirectionConfiguration(String channelId) {
+        DirectionConfiguration configuration = directionConfigurations.get(channelId);
+        if (configuration == null) {
+            throw new IllegalArgumentException("Direction configuration not found for " + channelId);
+        }
+        return configuration;
+    }
+
     public static class PositionEstimatorConfig {
         public int duration = -1;
         public int delay = 5;
+        public boolean reverse = false;
     }
 
     private class PositionEstimator {
@@ -201,6 +223,19 @@ public class NikobusRollershutterModuleHandler extends NikobusModuleHandler {
         public String toString() {
             return "PositionEstimator('" + channelUID + "', duration = " + durationInMillis + "ms, delay = "
                     + delayInMillis + "ms)";
+        }
+    }
+
+    private static class DirectionConfiguration {
+        final int up;
+        final int down;
+
+        final static DirectionConfiguration normal = new DirectionConfiguration(1, 2);
+        final static DirectionConfiguration reversed = new DirectionConfiguration(2, 1);
+
+        private DirectionConfiguration(int up, int down) {
+            this.up = up;
+            this.down = down;
         }
     }
 }

--- a/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusSwitchModuleHandler.java
+++ b/bundles/org.openhab.binding.nikobus/src/main/java/org/openhab/binding/nikobus/internal/handler/NikobusSwitchModuleHandler.java
@@ -30,7 +30,7 @@ public class NikobusSwitchModuleHandler extends NikobusModuleHandler {
     }
 
     @Override
-    protected int valueFromCommand(Command command) {
+    protected int valueFromCommand(String channelId, Command command) {
         if (command == OnOffType.ON) {
             return 0xff;
         }
@@ -43,7 +43,7 @@ public class NikobusSwitchModuleHandler extends NikobusModuleHandler {
     }
 
     @Override
-    protected State stateFromValue(int value) {
+    protected State stateFromValue(String channelId, int value) {
         return value != 0 ? OnOffType.ON : OnOffType.OFF;
     }
 }

--- a/bundles/org.openhab.binding.nikobus/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.nikobus/src/main/resources/OH-INF/config/config.xml
@@ -44,6 +44,10 @@
 			<label>Delay</label>
 			<description>Delay specifying how many seconds after duration module's output is set to OFF. Defaults to 5 seconds</description>
 		</parameter>
+		<parameter name="reverse" type="boolean">
+			<label>Reverse Direction</label>
+			<description>Reverse direction of rollershutters. Defaults to false</description>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>


### PR DESCRIPTION
New option introduced - reverses command UP -> DOWN and DOWN -> UP for rollershutter - might happen if rollershuter module's output is wired differently, reported by user.

Signed-off-by: Boris Krivonog <boris.krivonog@inova.si>
