### PR TITLE
[miio] GH-9936 Fixed datatype for brightness of the ambient light

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.ceiling4.json
+++ b/bundles/org.openhab.binding.miio/src/main/resources/database/yeelink.light.ceiling4.json
@@ -55,14 +55,23 @@
 				"property": "bg_bright",
 				"friendlyName": "Ambient Brightness",
 				"channel": "ambientBrightness",
-				"channelType": "ambientBrightness",
-				"type": "Number",
+				"type": "Dimmer",
 				"refresh": true,
 				"ChannelGroup": "actions",
 				"actions": [
 					{
 						"command": "bg_set_bright",
-						"parameterType": "NUMBER"
+						"parameterType": "NUMBER",
+						"condition": {
+							"name": "BrightnessExisting"
+						}
+					},
+					{
+						"command": "set_power",
+						"parameterType": "ONOFF",
+						"condition": {
+							"name": "BrightnessOnOff"
+						}
 					}
 				]
 			},


### PR DESCRIPTION
The ceiling10 Yeelight lamp has 2 dimmer for brightness:
"bright" for the main light and bg_bright for the ambient light.
Both are of type dimmer and accept percentage values between 1 and 100.
This fix changes the datatype of the bg_bright property from Number
to Dimmer in the device mapping database file ceiling4, which is also
the one that is used for the ceiling10 lamp.
