### PR TITLE
[epsonprojector] Always set ready=true on disconnect and improve documentation

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -1,7 +1,7 @@
 # Epson Projector Binding
 
-This binding is compatible with Epson projectors that support the ESC/VP21 protocol over the built-in ethernet port, serial port or USB to serial adapter.
-If your projector does not have a built-in ethernet port, you can connect to your projector's serial port via a TCP connection using a serial over IP device or by using`ser2net`.
+This binding is compatible with Epson projectors that support the ESC/VP21 protocol over the built-in network (ethernet or Wi-Fi) port, serial port or USB to serial adapter.
+If your projector does not have a built-in networking, you can connect to your projector's serial port via a TCP connection using a serial over IP device or by using`ser2net`.
 
 ## Supported Things
 
@@ -27,7 +27,7 @@ The `projector-serial` thing has the following configuration parameters:
 The `projector-tcp` thing has the following configuration parameters:
 
 - _host_: IP address for the projector or serial over IP device
-- _port_: Port for the projector or serial over IP device; default 3629 for projectors with built-in ethernet connector
+- _port_: Port for the projector or serial over IP device; default 3629 for projectors with built-in ethernet connector or Wi-Fi
 - _pollingInterval_: Polling interval in seconds to update channel states | 5-60 seconds; default 10 seconds
 
 Some notes:

--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -1,7 +1,7 @@
 # Epson Projector Binding
 
 This binding is compatible with Epson projectors that support the ESC/VP21 protocol over the built-in network (ethernet or Wi-Fi) port, serial port or USB to serial adapter.
-If your projector does not have a built-in networking, you can connect to your projector's serial port via a TCP connection using a serial over IP device or by using`ser2net`.
+If your projector does not have built-in networking, you can connect to your projector's serial port via a TCP connection using a serial over IP device or by using`ser2net`.
 
 ## Supported Things
 

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -206,11 +206,11 @@ public class EpsonProjectorDevice {
     public void disconnect() throws EpsonProjectorException {
         connection.disconnect();
         connected = false;
+        ready = true;
         ScheduledFuture<?> timeoutJob = this.timeoutJob;
         if (timeoutJob != null) {
             timeoutJob.cancel(true);
             this.timeoutJob = null;
-            ready = true;
         }
     }
 


### PR DESCRIPTION
Implement the review change from #9770 to always set ready=true on disconnect. Also improved the README to mention projectors with built-in Wi-Fi.