### PR TITLE
Minor README.md update - HTML param formatting value

### DIFF
--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -17,7 +17,7 @@ You are able to create multiple instances of this Thing to broadcast to differen
 | `apikey`                | text    | Your API token / key (APP_TOKEN) to access the Pushover Message API. **mandatory**                                                                   |
 | `user`                  | text    | Your user key or group key (USER_KEY) to which you want to push notifications. **mandatory**                                                         |
 | `title`                 | text    | The default title of a message (default: `openHAB`).                                                                                                 |
-| `format`                | text    | The default format (`none`, `HTML` or `monospace`) of a message (default: `none`).                                                                   |
+| `format`                | text    | The default format (`none`, `html` or `monospace`) of a message (default: `none`).                                                                   |
 | `sound`                 | text    | The default notification sound on target device (default: `default`) (see [supported notification sounds](https://pushover.net/api#sounds)).         |
 | `retry`                 | integer | The retry parameter specifies how often (in seconds) the Pushover servers will send the same notification to the user (default: `300`). **advanced** |
 | `expire`                | integer | The expire parameter specifies how long (in seconds) your notification will continue to be retried (default: `3600`). **advanced**                   |


### PR DESCRIPTION
Pushover: Use "html" for format values in README.md

Using "HTML" seems to have no affect when using sendPriorityMessage, but with "html" used in thing definition, it seems that formatting works as expected.