### PR TITLE
[wundergroundupdatereceiver] Initial contribution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -290,6 +290,7 @@
 /bundles/org.openhab.binding.windcentrale/ @marcelrv
 /bundles/org.openhab.binding.wlanthermo/ @CSchlipp
 /bundles/org.openhab.binding.wled/ @Skinah
+/bundles/org.openhab.binding.wundergroundupdatereceiver/ @danieldemus
 /bundles/org.openhab.binding.xmltv/ @clinique
 /bundles/org.openhab.binding.xmppclient/ @pavel-gololobov
 /bundles/org.openhab.binding.yamahareceiver/ @davidgraeff @zarusz

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1438,6 +1438,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.wundergroundupdatereceiver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.xmltv</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/NOTICE
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/README.md
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/README.md
@@ -1,0 +1,88 @@
+# WundergroundUpdateReceiver Binding
+
+Many personal weather stations are only capable of submitting measurements to the wunderground.com update site.
+
+The request is in itself simple to parse, so by redirecting it to your openhab server you can intercept the values and use them to
+control items in your home. Fx. use measured wind-speed to close an awning or turn on the sprinkler system after some time without rain.
+This binding allows you to mix and match products from various manufacturers that otherwise have a closed system.
+
+It can also be used to submit the same measurements to multiple weather services in rules.
+
+## Supported Things
+
+Any weather station that sends weather measurement updates to the wunderground.com update URLs.
+It is easiest to use with stations that have a configurable target address, but can be made to
+work with any internet-connected weather station, that gets it's dns server via DHCP. 
+
+## Discovery
+
+In the initial version ther is no discovery, but it is planned for a later release. You need to manually add a thing and configure the station id.
+
+## Thing Configuration
+
+The only configurable value is the station id, which should match the one configured on the weather station. If you don't plan on submitting
+measurements to wunderground.com it can be any unique non-empty string value.
+
+## Channels
+
+Each measurement type the wunderground.com update service accepts has a channel. Additionally there is a receipt timestamp and a trigger channel.
+
+State channels:
+
+| channel  | type   | description                  |
+|----------|--------|------------------------------|
+| control  | Switch | This is the control channel  |
+| last-received-datetime | DateTime | The date and time of the last update. |
+| datetime-utc | String | The date and time of the last update in UTC as submitted by the weather station. This can be 'now'. |
+| wind-speed | Number:Speed | Current wind speed, using software specific time period. |
+| wind-speed-avg-2min | Number:Speed | 2 minute average wind speed. |
+| wind-gust-speed-10min | Number:Speed | 10 minute average gust speed. |
+| humidity | Number:Dimensionless | Humidity in %. |
+| indoor-humidity | Number:Dimensionless | Indoor humidity in %. |
+| dew-point | Number:Temperature | Outdoor dew point. |
+| indoor-temperature | Number:Temperature | Indoor temperature. |
+| soil-temperature | Number:Temperature | Soil temperature. |
+| rain | Number:Length | Rain over the past hour. |
+| rain-daily | Number:Length | Rain so far today in local time. |
+| metar | String | METAR formatted weather report |
+| clouds | String | METAR style cloud cover. |
+| soil-moisture | Number:Dimensionless | Soil moisture in %. |
+| leafwetness | Number:Dimensionless | Leaf wetness in %. |
+| solarradiation | Number:Intensity | Solar radiation |
+| uv | Number:Dimensionless | UV index. |
+| visibility | Number:Length | Visibility. |
+| nitric-oxide | Number:Dimensionless | Nitric Oxide ppm. |
+| nitrogen-dioxide-measured | Number:Dimensionless | Nitrogen Dioxide, true measure ppb. |
+| nitrogen-dioxide-nox-no | Number:Dimensionless | NO2 computed, NOx-NO ppb. |
+| nitrogen-dioxide-noy-no | Number:Dimensionless | NO2 computed, NOy-NO ppb. |
+| nitrogen-oxides | Number:Dimensionless | Nitrogen Oxides ppb. |
+| total-reactive-nitrogen | Number:Dimensionless | Total reactive nitrogen. |
+| no3-ion | Number:Density | NO3 ion (nitrate, not adjusted for ammonium ion) µG/m3. |
+| so4-ion | Number:Density | SO4 ion (sulfate, not adjusted for ammonium ion) µG/m3. |
+| sulfur-dioxide | Number:Dimensionless | Sulfur Dioxide, conventional ppb. |
+| sulfur-dioxide-trace-levels | Number:Dimensionless | Sulfur Dioxide, trace levels ppb. |
+| carbon-monoxide | Number:Dimensionless | Carbon Monoxide, conventional ppm. |
+| carbon-monoxide-trace-levels | Number:Dimensionless | Carbon Monoxide, trace levels ppb. |
+| elemental-carbon | Number:Density | Elemental Carbon, PM2.5 µG/m3. |
+| organic-carbon | Number:Density | Organic Carbon, not adjusted for oxygen and hydrogen, PM2.5 µG/m3. |
+| black-carbon | Number:Density | Black Carbon at 880 nm, µG/m3. |
+| aethalometer | Number:Density | second channel of Aethalometer at 370 nm, µG/m3. |
+| pm2_5-mass | Number:Density | PM2.5 mass, µG/m3. |
+| pm10-mass | Number:Density | PM10 mass, µG/m3. |
+| ozone | Number:Dimensionless | Ozone, ppb. |
+| softwaretype | String | A software type string from the weather station |
+|last-query-state|String|The part of the last query after the first unurlencoded ?|
+
+Trigger channels:
+
+| channel  | type   | description                  |
+|----------|--------|------------------------------|
+|last-query-trigger|String|The part of the last query after the first unurlencoded ?|
+
+The trigger channel's payload is the last querystring, so teh following dsl rule script
+would send the measurements on to wunderground.com:
+
+```
+val requestQuery = receivedEvent
+sendHttpGetRequest("https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php?" + requestQuery)
+```

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/pom.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.wundergroundupdatereceiver</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: WundergroundUpdateReceiver Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.wundergroundupdatereceiver-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-wundergroundupdatereceiver" description="Wunderground Update Receiver Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.wundergroundupdatereceiver/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverBindingConstants.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverBindingConstants.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static java.util.Map.entry;
+import static org.openhab.core.library.unit.ImperialUnits.*;
+import static org.openhab.core.library.unit.SIUnits.METRE;
+import static org.openhab.core.library.unit.Units.*;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+import javax.measure.quantity.Length;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
+
+import tec.uom.se.format.SimpleUnitFormat;
+import tec.uom.se.function.MultiplyConverter;
+import tec.uom.se.unit.TransformedUnit;
+
+/**
+ * The {@link WundergroundUpdateReceiverBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@NonNullByDefault
+public class WundergroundUpdateReceiverBindingConstants {
+
+    public static final String BINDING_ID = "wundergroundupdatereceiver";
+
+    public static final String STATION_ID_PARAMETER = "ID";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_UPDATE_RECEIVER = new ThingTypeUID(BINDING_ID,
+            "wundergroundUpdateReceiver");
+
+    public static final String LAST_RECEIVED_DATETIME = "last-received";
+    public static final ChannelTypeUID LAST_RECEIVED_DATETIME_TYPE = new ChannelTypeUID(BINDING_ID,
+            "last-received-datetime");
+    public static final String LAST_QUERY = "last-query";
+
+    // List of all Channel ids without groups
+    public static final String DATEUTC = "dateutc";
+    public static final String SOFTWARE_TYPE = "softwaretype";
+    public static final String WIND_DIRECTION = "winddir";
+    public static final String WIND_SPEED = "windspeedmph";
+    public static final String GUST_SPEED = "windgustmph";
+    public static final String GUST_DIRECTION = "windgustdir";
+    public static final String WIND_SPEED_AVG_2MIN = "windspdmph_avg2m";
+    public static final String WIND_DIRECTION_AVG_2MIN = "winddir_avg2m";
+    public static final String GUST_SPEED_AVG_10MIN = "windgustmph_10m";
+    public static final String GUST_DIRECTION_AVG_10MIN = "windgustdir_10m";
+    public static final String TEMPERATURE = "tempf";
+    public static final String INDOOR_TEMPERATURE = "indoortempf";
+    public static final String SOIL_TEMPERATURE = "soiltempf";
+    public static final String HUMIDITY = "humidity";
+    public static final String INDOOR_HUMIDITY = "indoorhumidity";
+    public static final String DEWPOINT = "dewptf";
+    public static final String SOIL_MOISTURE = "soilmoisture";
+    public static final String LEAF_WETNESS = "leafwetness";
+    public static final String RAIN_IN = "rainin";
+    public static final String DAILY_RAIN_IN = "dailyrainin";
+    public static final String SOLAR_RADIATION = "solarradiation";
+    public static final String UV = "UV";
+    public static final String VISIBILITY = "visibility";
+    public static final String WEATHER = "weather";
+    public static final String CLOUDS = "clouds";
+    public static final String BAROM_IN = "baromin";
+    public static final String AQ_NO = "AqNO";
+    public static final String AQ_NO2T = "AqNO2T";
+    public static final String AQ_NO2 = "AqNO2";
+    public static final String AQ_NO2Y = "AqNO2Y";
+    public static final String AQ_NOX = "AqNOX";
+    public static final String AQ_NOY = "AqNOY";
+    public static final String AQ_NO3 = "AqNO3";
+    public static final String AQ_SO4 = "AqSO4";
+    public static final String AQ_SO2 = "AqSO2";
+    public static final String AQ_SO2T = "AqSO2T";
+    public static final String AQ_CO = "AqCO";
+    public static final String AQ_COT = "AqCOT";
+    public static final String AQ_EC = "AqEC";
+    public static final String AQ_OC = "AqOC";
+    public static final String AQ_BC = "AqBC";
+    public static final String AQ_UV_AETH = "AqUV-AETH";
+    public static final String AQ_PM2_5 = "AqPM2.5";
+    public static final String AQ_PM10 = "AqPM10";
+    public static final String AQ_OZONE = "AqOZONE";
+
+    public static final Unit<Length> NAUTICAL_MILE = addUnit(
+            new TransformedUnit<>("NM", METRE, new MultiplyConverter(1852.0)));
+
+    public static final Set<String> CHANNEL_KEYS = Set.of(DATEUTC, SOFTWARE_TYPE, WIND_DIRECTION, WIND_SPEED,
+            GUST_SPEED, GUST_DIRECTION, WIND_SPEED_AVG_2MIN, WIND_DIRECTION_AVG_2MIN, GUST_SPEED_AVG_10MIN,
+            GUST_DIRECTION_AVG_10MIN, TEMPERATURE, INDOOR_TEMPERATURE, SOIL_TEMPERATURE, HUMIDITY, INDOOR_HUMIDITY,
+            DEWPOINT, SOIL_MOISTURE, LEAF_WETNESS, RAIN_IN, DAILY_RAIN_IN, SOLAR_RADIATION, UV, VISIBILITY, WEATHER,
+            CLOUDS, BAROM_IN, AQ_NO, AQ_NO2, AQ_NO2T, AQ_NO2Y, AQ_NOX, AQ_NOY, AQ_NO3, AQ_SO2, AQ_SO2T, AQ_SO4, AQ_CO,
+            AQ_COT, AQ_EC, AQ_OC, AQ_BC, AQ_UV_AETH, AQ_PM2_5, AQ_PM10, AQ_OZONE);
+
+    public static final Map<String, Unit<? extends Quantity<?>>> CHANNEL_UNIT_MAPPING = Map.ofEntries(
+            entry(TEMPERATURE, FAHRENHEIT), entry(DEWPOINT, FAHRENHEIT), entry(SOIL_TEMPERATURE, FAHRENHEIT),
+            entry(INDOOR_TEMPERATURE, FAHRENHEIT), entry(WIND_SPEED, MILES_PER_HOUR), entry(GUST_SPEED, MILES_PER_HOUR),
+            entry(WIND_SPEED_AVG_2MIN, MILES_PER_HOUR), entry(GUST_SPEED_AVG_10MIN, MILES_PER_HOUR),
+            entry(WIND_DIRECTION, DEGREE_ANGLE), entry(GUST_DIRECTION, DEGREE_ANGLE),
+            entry(WIND_DIRECTION_AVG_2MIN, DEGREE_ANGLE), entry(GUST_DIRECTION_AVG_10MIN, DEGREE_ANGLE),
+            entry(BAROM_IN, INCH_OF_MERCURY), entry(RAIN_IN, INCH), entry(DAILY_RAIN_IN, INCH),
+            entry(SOLAR_RADIATION, IRRADIANCE), entry(AQ_NO, PARTS_PER_BILLION), entry(AQ_NO2, PARTS_PER_BILLION),
+            entry(AQ_NO2T, PARTS_PER_BILLION), entry(AQ_NO2Y, PARTS_PER_BILLION), entry(AQ_NOX, PARTS_PER_BILLION),
+            entry(AQ_NOY, PARTS_PER_BILLION), entry(AQ_SO2, PARTS_PER_BILLION), entry(AQ_SO2T, PARTS_PER_BILLION),
+            entry(AQ_COT, PARTS_PER_BILLION), entry(AQ_OZONE, PARTS_PER_BILLION), entry(AQ_CO, PARTS_PER_MILLION),
+            entry(AQ_NO3, MICROGRAM_PER_CUBICMETRE), entry(AQ_SO4, MICROGRAM_PER_CUBICMETRE),
+            entry(AQ_EC, MICROGRAM_PER_CUBICMETRE), entry(AQ_OC, MICROGRAM_PER_CUBICMETRE),
+            entry(AQ_BC, MICROGRAM_PER_CUBICMETRE), entry(AQ_UV_AETH, MICROGRAM_PER_CUBICMETRE),
+            entry(AQ_PM2_5, MICROGRAM_PER_CUBICMETRE), entry(AQ_PM10, MICROGRAM_PER_CUBICMETRE),
+            entry(HUMIDITY, PERCENT), entry(INDOOR_HUMIDITY, PERCENT), entry(SOIL_MOISTURE, PERCENT),
+            entry(LEAF_WETNESS, PERCENT), entry(VISIBILITY, NAUTICAL_MILE));
+
+    static {
+        SimpleUnitFormat.getInstance().label(NAUTICAL_MILE, "NM");
+    }
+
+    private static <U extends Unit<?>> U addUnit(U unit) {
+        return unit;
+    }
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverConfiguration.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverConfiguration.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link WundergroundUpdateReceiverConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@NonNullByDefault
+public class WundergroundUpdateReceiverConfiguration {
+
+    /**
+     * The station id as registered by wunderground.com or any string if not forwarding data to wunderground.com.
+     * This value will be used as the representation property.
+     */
+    public String stationId = "";
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandler.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandler.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static org.openhab.binding.wundergroundupdatereceiver.internal.WundergroundUpdateReceiverBindingConstants.*;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelGroupUID;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WundergroundUpdateReceiverHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@NonNullByDefault
+public class WundergroundUpdateReceiverHandler extends BaseThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(WundergroundUpdateReceiverHandler.class);
+    private final WundergroundUpdateReceiverServlet wundergroundUpdateReceiverServlet;
+    private final ChannelUID lastReceivedChannel;
+    private final ChannelUID queryStateChannel;
+    private final ChannelUID queryTriggerChannel;
+    private WundergroundUpdateReceiverConfiguration config = new WundergroundUpdateReceiverConfiguration();
+
+    public String getStationId() {
+        return config.stationId;
+    }
+
+    public WundergroundUpdateReceiverHandler(Thing thing,
+            @Nullable WundergroundUpdateReceiverServlet wunderGroundUpdateReceiverServlet) {
+        super(thing);
+        lastReceivedChannel = new ChannelUID(new ChannelGroupUID(getThing().getUID(), "metadata"),
+                LAST_RECEIVED_DATETIME);
+        queryTriggerChannel = new ChannelUID(new ChannelGroupUID(getThing().getUID(), "metadata"),
+                LAST_QUERY + "-trigger");
+        queryStateChannel = new ChannelUID(new ChannelGroupUID(getThing().getUID(), "metadata"), LAST_QUERY + "-state");
+        this.wundergroundUpdateReceiverServlet = Objects.requireNonNull(wunderGroundUpdateReceiverServlet);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.info("Ignoring command {}", command);
+    }
+
+    @Override
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+        super.handleConfigurationUpdate(configurationParameters);
+        this.wundergroundUpdateReceiverServlet.handlerConfigUpdated(this);
+    }
+
+    @Override
+    public void initialize() {
+        this.config = Objects.requireNonNull(getConfigAs(WundergroundUpdateReceiverConfiguration.class));
+        wundergroundUpdateReceiverServlet.addHandler(this);
+        if (wundergroundUpdateReceiverServlet.isActive()) {
+            updateStatus(ThingStatus.ONLINE);
+            logger.info("Wunderground update receiver listening for updates to station id {}", config.stationId);
+            return;
+        }
+        updateStatus(ThingStatus.OFFLINE);
+    }
+
+    @Override
+    public void dispose() {
+        wundergroundUpdateReceiverServlet.removeHandler(this.getStationId());
+        super.dispose();
+        logger.info("Wunderground update receiver stopped listening for updates to station id {}", config.stationId);
+    }
+
+    public void updateChannelStates(WundergroundUpdateReceiverHandler handler, Map<String, String> channelIds) {
+        channelIds.forEach((channelId, state) -> {
+            if (WundergroundUpdateReceiverBindingConstants.CHANNEL_KEYS.contains(channelId)) {
+                updateChannelState(channelId, state);
+            }
+        });
+        updateState(lastReceivedChannel, StringType.valueOf(UUID.randomUUID().toString()));
+        String lastQuery = channelIds.getOrDefault(LAST_QUERY, "");
+        if ("".equals(lastQuery)) {
+            return;
+        }
+        updateState(queryStateChannel, StringType.valueOf(lastQuery));
+        triggerChannel(queryTriggerChannel, lastQuery);
+    }
+
+    public void updateChannelState(String channelId, String[] stateParts) {
+        updateChannelState(channelId, String.join("", stateParts));
+    }
+
+    public void updateChannelState(String channelId, String state) {
+        Optional<Channel> channel = getThing().getChannels().stream()
+                .filter(ch -> channelId.equals(ch.getUID().getIdWithoutGroup())).findFirst();
+        if (channel.isPresent()) {
+            ChannelUID channelUID = channel.get().getUID();
+            @Nullable
+            Float numberValue = null;
+            try {
+                numberValue = Float.valueOf(state);
+            } catch (NumberFormatException ignored) {
+            }
+
+            if (numberValue == null) {
+                updateState(channelUID, StringType.valueOf(state));
+                return;
+            }
+            @Nullable
+            Unit<? extends Quantity<?>> unit = CHANNEL_UNIT_MAPPING.get(channelId);
+            if (unit != null) {
+                updateState(channelUID, new QuantityType<>(numberValue, unit));
+            } else {
+                updateState(channelUID, new DecimalType(numberValue));
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandlerFactory.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverHandlerFactory.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static org.openhab.binding.wundergroundupdatereceiver.internal.WundergroundUpdateReceiverBindingConstants.THING_TYPE_UPDATE_RECEIVER;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.HttpService;
+
+/**
+ * The {@link WundergroundUpdateReceiverHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.wundergroundupdatereceiver", service = ThingHandlerFactory.class)
+public class WundergroundUpdateReceiverHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_UPDATE_RECEIVER);
+    private final HttpService httpService;
+    private @Nullable WundergroundUpdateReceiverServlet wunderGroundUpdateReceiverServlet;
+
+    @Activate
+    public WundergroundUpdateReceiverHandlerFactory(@Reference HttpService httpService) {
+        this.httpService = httpService;
+    }
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (THING_TYPE_UPDATE_RECEIVER.equals(thingTypeUID)) {
+            WundergroundUpdateReceiverServlet servlet = this.wunderGroundUpdateReceiverServlet == null
+                    ? (this.wunderGroundUpdateReceiverServlet = new WundergroundUpdateReceiverServlet(this.httpService))
+                    : this.wunderGroundUpdateReceiverServlet;
+            return new WundergroundUpdateReceiverHandler(thing, servlet);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected void deactivate(ComponentContext componentContext) {
+        @Nullable
+        WundergroundUpdateReceiverServlet servlet = this.wunderGroundUpdateReceiverServlet;
+        if (servlet != null) {
+            servlet.dispose();
+        }
+        this.wunderGroundUpdateReceiverServlet = null;
+        super.deactivate(componentContext);
+    }
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverProfileAdvisor.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverProfileAdvisor.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static org.openhab.binding.wundergroundupdatereceiver.internal.WundergroundUpdateReceiverBindingConstants.BINDING_ID;
+import static org.openhab.binding.wundergroundupdatereceiver.internal.WundergroundUpdateReceiverBindingConstants.LAST_RECEIVED_DATETIME_TYPE;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.profiles.ProfileAdvisor;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.SystemProfiles;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link WundergroundUpdateReceiverProfileAdvisor} suggests the default profile for
+ * all channels except last updated.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@Component
+@NonNullByDefault
+public class WundergroundUpdateReceiverProfileAdvisor implements ProfileAdvisor {
+
+    @Override
+    public @Nullable ProfileTypeUID getSuggestedProfileTypeUID(Channel channel, @Nullable String itemType) {
+        return getSuggestedProfileTypeUID(channel.getChannelTypeUID());
+    }
+
+    @Override
+    public @Nullable ProfileTypeUID getSuggestedProfileTypeUID(ChannelType channelType, @Nullable String itemType) {
+        return getSuggestedProfileTypeUID(channelType.getUID());
+    }
+
+    private @Nullable ProfileTypeUID getSuggestedProfileTypeUID(@Nullable ChannelTypeUID channelTypeUID) {
+        if (channelTypeUID == null || !channelTypeUID.getBindingId().equals(BINDING_ID)) {
+            return null;
+        }
+        if (LAST_RECEIVED_DATETIME_TYPE.equals(channelTypeUID)) {
+            return SystemProfiles.TIMESTAMP_UPDATE;
+        }
+        return SystemProfiles.DEFAULT;
+    }
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServlet.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServlet.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.openhab.binding.wundergroundupdatereceiver.internal.WundergroundUpdateReceiverBindingConstants.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.io.http.servlet.BaseOpenHABServlet;
+import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.HttpService;
+import org.osgi.service.http.NamespaceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WundergroundUpdateReceiverServlet} is responsible for receiving updates,and
+ * updating the matching channels.
+ *
+ * @author Daniel Demus - Initial contribution
+ */
+@NonNullByDefault
+public class WundergroundUpdateReceiverServlet extends BaseOpenHABServlet {
+
+    public static final String SERVLET_URL = "/weatherstation/updateweatherstation.php";
+    private static final long serialVersionUID = -5296703727081438023L;
+
+    private final Logger logger = LoggerFactory.getLogger(WundergroundUpdateReceiverServlet.class);
+    private final Map<String, WundergroundUpdateReceiverHandler> handlers = new HashMap<>();
+
+    private static final Object LOCK = new Object();
+
+    private boolean active = false;
+
+    public WundergroundUpdateReceiverServlet(HttpService httpService) {
+        super(httpService);
+    }
+
+    public boolean isActive() {
+        synchronized (LOCK) {
+            return this.active;
+        }
+    }
+
+    public Set<String> getStationIds() {
+        return this.handlers.keySet();
+    }
+
+    public void activate() {
+        activate(SERVLET_URL, httpService.createDefaultHttpContext());
+    }
+
+    @Override
+    protected void activate(String alias, HttpContext httpContext) {
+        synchronized (LOCK) {
+            try {
+                logger.debug("Starting servlet {} at {}", getClass().getSimpleName(), alias);
+                Dictionary<String, String> props = new Hashtable<>(1, 10);
+                httpService.registerServlet(alias, this, props, httpContext);
+                active = true;
+            } catch (NamespaceException e) {
+                logger.error("Error during servlet registration - alias {} already in use", alias, e);
+            } catch (ServletException e) {
+                logger.error("Error during servlet registration", e);
+            }
+        }
+    }
+
+    public void addHandler(WundergroundUpdateReceiverHandler handler) {
+        synchronized (this.handlers) {
+            if (this.handlers.containsKey(handler.getStationId())) {
+                throw new IllegalArgumentException(String
+                        .format("Handler handling request for stationId %s is already added", handler.getStationId()));
+            }
+            this.handlers.put(handler.getStationId(), handler);
+            if (!isActive()) {
+                activate();
+            }
+        }
+    }
+
+    public void removeHandler(String stationId) {
+        synchronized (this.handlers) {
+            WundergroundUpdateReceiverHandler handler = this.handlers.get(stationId);
+            if (handler != null) {
+                this.handlers.remove(stationId);
+            }
+            if (this.handlers.isEmpty()) {
+                deactivate();
+            }
+        }
+    }
+
+    @Override
+    protected void doGet(@Nullable HttpServletRequest req, @Nullable HttpServletResponse resp) throws IOException {
+        if (!active) {
+            return;
+        }
+        if (req == null) {
+            return;
+        }
+        if (resp == null) {
+            return;
+        }
+        if (req.getRequestURI() == null) {
+            return;
+        }
+        logger.debug("doGet {}", req.getQueryString());
+
+        Optional<WundergroundUpdateReceiverHandler> maybeHandler = Optional
+                .ofNullable(this.handlers.get(req.getParameter(STATION_ID_PARAMETER)));
+        maybeHandler.ifPresent(handler -> {
+            Map<String, String> states = req.getParameterMap().entrySet().stream()
+                    .collect(toMap(Map.Entry::getKey, e -> String.join("", e.getValue())));
+            String queryString = req.getQueryString();
+            if (queryString != null && queryString.length() > 0) {
+                states.put(LAST_QUERY, queryString);
+            }
+            handler.updateChannelStates(handler, states);
+        });
+
+        resp.setStatus(HttpServletResponse.SC_OK);
+        PrintWriter writer = resp.getWriter();
+        writer.write("success");
+        writer.flush();
+        writer.close();
+    }
+
+    public void deactivate() {
+        synchronized (LOCK) {
+            logger.debug("Stopping servlet {} at {}", getClass().getSimpleName(), SERVLET_URL);
+            super.deactivate(SERVLET_URL);
+            active = false;
+        }
+    }
+
+    public void handlerConfigUpdated(WundergroundUpdateReceiverHandler handler) {
+        synchronized (this.handlers) {
+            final Set<Map.Entry<String, WundergroundUpdateReceiverHandler>> changedStationIds = this.handlers.entrySet()
+                    .stream().filter(entry -> handler.getThing().getUID().equals(entry.getValue().getThing().getUID()))
+                    .collect(toSet());
+            changedStationIds.forEach(entry -> {
+                logger.info("Re-assigning listener from station ID {} to station id {}", entry.getKey(),
+                        handler.getStationId());
+                this.removeHandler(entry.getKey());
+                this.addHandler(handler);
+            });
+        }
+    }
+
+    public void dispose() {
+        synchronized (this.handlers) {
+            Set<String> stationIds = new HashSet<>(getStationIds());
+            stationIds.forEach(this::removeHandler);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="wundergroundupdatereceiver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>Wunderground Update Receiver Binding</name>
+	<description><![CDATA[
+		<p>
+		This binding enables acting as a receiver of updates from weather stations that post measurements
+		to https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php. If the hostname is configurable - as on
+		weather stations based on the Fine Offset Electronics WH2600-IP - this is simple, otherwise you have to set up dns
+		such that it resolves the above hostname to your server, without preventing the server from resolving the proper ip if
+		you want to forward the request.
+		</p>
+
+		<p>
+		If you wish to pass the measurements on to rtupdate.wunderground.com, you can use a simple rule that triggers on the
+		wundergroundupdatereceiver:wundergroundUpdateReceiver:&lt;channel-id&gt;:metadata#last-query-trigger running the
+		following simple dsl:
+		</p>
+
+		<p>
+		<code>
+		val requestQuery = receivedEvent
+		sendHttpGetRequest("https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php?" + requestQuery)
+		</code>
+		</p>
+
+		<p>
+		You can also submit the measurements to other services such as OpenWeatherMap by constructing an HTTP request in a rule.
+		</p> ]]></description>
+	<author>Daniel Demus</author>
+</binding:binding>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/i18n/wundergroundupdatereceiver_da.properties
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/i18n/wundergroundupdatereceiver_da.properties
@@ -1,0 +1,139 @@
+binding.wundergroundupdatereceiver.name=Wundergroundopdateringsmodtager Binding
+binding.wundergroundupdatereceiver.description=<![CDATA[ \
+<p>\
+    Denne binding gør det muligt at modtage opdateringer fra vejrstationer som sender målinger til \
+    https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php. \
+    Hvis destinationshostnavnet kan konfigureres - som på Renkforce WH2600 - er det nemt, ellers skal man \
+    pege vejrstationen på en dns server som svarer med serverens adresse når man spørger om ovenstående adresse.\
+</p>\
+<p> \
+Hvis du vil videresende målingerne til rtupdate.wunderground.com, kan man bruge en simpel regel der køres når \
+wundergroundupdatereceiver:wundergroundUpdateReceiver:&lt;channel-id&gt;:metadata#last-query-trigger sker: \
+</p> \
+<p> \
+<code> \
+val requestQuery = receivedEvent \
+sendHttpGetRequest("https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php?" + requestQuery) \
+</code> \
+</p> \
+<p> \
+Man kan også send målinger til andre vejrtjenester i regler der konstruerer et http request fra itemstate. \
+</p> ]]>
+
+thing-type.wundergroundupdatereceiver.description=En endpoint til modtagelse og videreformidling af opdateringer fra vejrstationer, som kan opdatere wunderground.com
+thing-type.wundergroundupdatereceiver.config.label=Stationsid som er konfigureret i vejstationen.
+thing-type.wundergroundupdatereceiver.config.description=<![CDATA[ \
+<p> \
+  wunderground.com api'en kræver en stationsid, som stammer fra WeatherUnderground \
+  kontoen man sender målinger til. \
+<p> \
+</p>\
+  Her bliver den brugt til at skelne mellem ting instanser, så flere vejrstationers opdateringer kan håndteres \
+  eller flere slags måleenheders målinger kan aggregeres. \
+  Hvis man ikke agter at videresende målinger til wunderground.com, kan man sætte dette til en ikke-tom streng. \
+</p>
+
+channel-group-type.wundergroundupdatereceiver.metadata-group.description=Metadata fra den sidste opdatering
+channel-group-type.wundergroundupdatereceiver.wind-group.description=Vindmålinger
+channel-group-type.wundergroundupdatereceiver.wind-group.label=Vind
+channel-group-type.wundergroundupdatereceiver.temperature-group.description=Temperaturmålinger
+channel-group-type.wundergroundupdatereceiver.temperature-group.label=Temperatur
+channel-group-type.wundergroundupdatereceiver.humidity-group.description=Fugtighedsmålinger
+channel-group-type.wundergroundupdatereceiver.humidity-group.label=Fugtighed
+channel-group-type.wundergroundupdatereceiver.rain-group.description=Regnmålinger
+channel-group-type.wundergroundupdatereceiver.rain-group.label=Regn
+channel-group-type.wundergroundupdatereceiver.sunlight-group.description=Lysmålinger
+channel-group-type.wundergroundupdatereceiver.sunlight-group.label=Sollys
+channel-group-type.wundergroundupdatereceiver.pressure-group.description=Barometertrykmålinger
+channel-group-type.wundergroundupdatereceiver.pressure-group.label=Barometertryk
+channel-group-type.wundergroundupdatereceiver.pollution-group.description=Målinger af atmosfærisk forurening
+channel-group-type.wundergroundupdatereceiver.pollution-group.label=Forurening
+
+channel-type.wundergroundupdatereceiver.last-received-datetime.description=Tidspunkt for sidst modtaget opdatering fra stationen
+channel-type.wundergroundupdatereceiver.last-received-datetime.label=Sidst modtaget
+channel-type.wundergroundupdatereceiver.datetime-utc.description=Stationens værdi for sidst opdateringstidspunkt. Kan være 'now'
+channel-type.wundergroundupdatereceiver.datetime-utc.label=Sidst opdateret
+channel-type.wundergroundupdatereceiver.wind-speed.description=Øjeblikkelig vindhastighed i mph
+channel-type.wundergroundupdatereceiver.wind-speed.label=Vindhastighed
+channel-type.wundergroundupdatereceiver.wind-gust-speed.description=Øjeblikkelig vindstødshastighed
+channel-type.wundergroundupdatereceiver.wind-gust-speed.label=Vindstødshastighed
+channel-type.system.wind-direction.description=Øjeblikkelig vindretning som vinkel
+channel-type.system.wind-direction.label=Vindretning
+channel-type.wundergroundupdatereceiver.wind-speed-avg-2min.description=Gennemsnitlig vindhastighed i de sidste 2 minutter
+channel-type.wundergroundupdatereceiver.wind-speed-avg-2min.label=Gns. vindhastighed (2min)
+channel-type.wundergroundupdatereceiver.wind-direction-avg-2min.description=Gennemsnitlig vindretning i de sidste 2 minutter som vinkel
+channel-type.wundergroundupdatereceiver.wind-direction-avg-2min.label=Gns. vindretning (2min)
+channel-type.wundergroundupdatereceiver.wind-gust-speed-10min.description=Gennemsnitlig vindstæshastighed i de sidste 10 minutter
+channel-type.wundergroundupdatereceiver.wind-gust-speed-10min.label=Gns. vindstødshastighed (10min)
+channel-type.wundergroundupdatereceiver.wind-gust-direction-10min.description=Gennemsnitlig vindstødsretning i de sidste 10 minutter som vinkel
+channel-type.wundergroundupdatereceiver.wind-gust-direction-10min.label=Gns. vindstødsretning (10min)
+channel-type.wundergroundupdatereceiver.humidity.description=Udendørs fugtighed i pct
+channel-type.wundergroundupdatereceiver.humidity.label=Udendørs fugtighed
+channel-type.wundergroundupdatereceiver.indoor-humidity.description=Indendørs fugtighed i pct
+channel-type.wundergroundupdatereceiver.indoor-humidity.label=Indendørs fugtighed
+channel-type.wundergroundupdatereceiver.dew-point.description=Dugpunkt
+channel-type.wundergroundupdatereceiver.dew-point.label=Dugpunkt
+channel-type.system.temperature.description=Udendørs temperatur
+channel-type.system.temperature.label=Udendørs temperatur
+channel-type.wundergroundupdatereceiver.indoor-temperature.description=Indendørs temperatur
+channel-type.wundergroundupdatereceiver.indoor-temperature.label=Indendørs temperatur
+channel-type.wundergroundupdatereceiver.soil-temperature.description=Jordtemeperatur
+channel-type.wundergroundupdatereceiver.soil-temperature.label=Jordtemeperatur
+channel-type.wundergroundupdatereceiver.rain.description=Regnmængde i den sidste time
+channel-type.wundergroundupdatereceiver.rain.label=Regn (sidste time)
+channel-type.wundergroundupdatereceiver.rain-daily.description=Regnmængde sidsen starten af dagen
+channel-type.wundergroundupdatereceiver.rain-daily.label=Regn (i dag)
+channel-type.wundergroundupdatereceiver.metar.description=Vejrmelding i METAR format
+channel-type.wundergroundupdatereceiver.metar.label=METAR vejrmelding
+channel-type.wundergroundupdatereceiver.clouds.description=Skydække
+channel-type.wundergroundupdatereceiver.clouds.label=Skydække i METAR format
+channel-type.wundergroundupdatereceiver.soil-moisture.description=Jordfugtighed i pct
+channel-type.wundergroundupdatereceiver.soil-moisture.label=Jordfugtighed
+channel-type.wundergroundupdatereceiver.leafwetness.description=Bladfugtighed i pct
+channel-type.wundergroundupdatereceiver.leafwetness.label=Bladfugtighed
+channel-type.wundergroundupdatereceiver.solarradiation.description=Solstråling i W/m2
+channel-type.wundergroundupdatereceiver.solarradiation.label=Solstråling
+channel-type.wundergroundupdatereceiver.uv.description=UV index
+channel-type.wundergroundupdatereceiver.uv.label=UV index
+channel-type.wundergroundupdatereceiver.visibility.description=Sigtbarhed
+channel-type.wundergroundupdatereceiver.visibility.label=Sigtbarhed
+channel-type.wundergroundupdatereceiver.nitric-oxide.description=
+channel-type.wundergroundupdatereceiver.nitric-oxide.label=Nitrogenoxid
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-measured.description=Målt nitrogendioxid i ppb
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-measured.label=Nitrogendioxid
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-nox-no.description=Beregnet nitrogendioxid i ppb
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-nox-no.label=Beregnet nitrogendioxid
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-noy-no.description=Beregnet nitrogendioxid Y
+channel-type.wundergroundupdatereceiver.nitrogen-dioxide-noy-no.label=Beregnet nitrogendioxid Y
+channel-type.wundergroundupdatereceiver.nitrogen-oxides.description=Nitrogenoxider
+channel-type.wundergroundupdatereceiver.nitrogen-oxides.label=Nitrogenoxid i ppb
+channel-type.wundergroundupdatereceiver.total-reactive-nitrogen.description=Reactive nitrogen ialt
+channel-type.wundergroundupdatereceiver.total-reactive-nitrogen.label=Reactive nitrogen ialt
+channel-type.wundergroundupdatereceiver.no3-ion.description=Nitrat tæthed
+channel-type.wundergroundupdatereceiver.no3-ion.label=Nitrat
+channel-type.wundergroundupdatereceiver.so4-ion.description=Sulfat tæthed
+channel-type.wundergroundupdatereceiver.so4-ion.label=Sulfat
+channel-type.wundergroundupdatereceiver.sulfur-dioxide.description=Svovldioxid i ppb
+channel-type.wundergroundupdatereceiver.sulfur-dioxide.label=Svovldioxid
+channel-type.wundergroundupdatereceiver.sulfur-dioxide-trace-levels.description=Svovldioxid sporelementer
+channel-type.wundergroundupdatereceiver.sulfur-dioxide-trace-levels.label=Svovldioxid sporelementer
+channel-type.wundergroundupdatereceiver.elemental-carbon.description=Kulstofselementer
+channel-type.wundergroundupdatereceiver.elemental-carbon.label=Kulstofselementer
+channel-type.wundergroundupdatereceiver.organic-carbon.description=Organisk kulstof
+channel-type.wundergroundupdatereceiver.organic-carbon.label=Organisk kulstof
+channel-type.wundergroundupdatereceiver.black-carbon.description=Sort kulstof
+channel-type.wundergroundupdatereceiver.black-carbon.label=Sort kulstof
+channel-type.wundergroundupdatereceiver.aethalometer.description=Aethalometer
+channel-type.wundergroundupdatereceiver.aethalometer.label=Aethalometer
+channel-type.wundergroundupdatereceiver.pm2_5-mass.description=PM2.5 massetæthed
+channel-type.wundergroundupdatereceiver.pm2_5-mass.label=PM2.5 massetæthed
+channel-type.wundergroundupdatereceiver.pm10-mass.description=PM10 massetæthed
+channel-type.wundergroundupdatereceiver.pm10-mass.label=PM10 massetæthed
+channel-type.wundergroundupdatereceiver.ozone.description=Ozon
+channel-type.wundergroundupdatereceiver.ozone.label=Ozon
+channel-type.wundergroundupdatereceiver.softwaretype.description=En software type streng fra vejrstationen
+channel-type.wundergroundupdatereceiver.softwaretype.label=Software type
+channel-type.wundergroundupdatereceiver.last-query-state.description=Querystring delen af den sidste query
+channel-type.wundergroundupdatereceiver.last-query-state.label=Den sidste query
+channel-type.wundergroundupdatereceiver.last-query-trigger.description=Querystring delen af den sidste query
+channel-type.wundergroundupdatereceiver.last-query-trigger.label=Den sidste query

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-group-types.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-group-types.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<thing:thing-descriptions bindingId="wundergroundupdatereceiver"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-group-type id="metadata-group">
+		<label>Metadata</label>
+		<description>Metadata regarding the last submission</description>
+		<category>Text</category>
+		<channels>
+			<channel id="last-received" typeId="last-received-datetime"/>
+			<channel id="dateutc" typeId="datetime-utc"/>
+			<channel id="softwaretype" typeId="softwaretype"/>
+			<channel id="last-query-state" typeId="last-query-state"/>
+			<channel id="last-query-trigger" typeId="last-query-trigger"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="wind-group">
+		<label>Wind</label>
+		<description>Wind measurements</description>
+		<category>Wind</category>
+		<channels>
+			<channel id="winddir" typeId="system.wind-direction"/>
+			<channel id="windspeedmph" typeId="wind-speed"/>
+			<channel id="windgustmph" typeId="wind-gust-speed"/>
+			<channel id="windgustdir" typeId="wind-gust-direction"/>
+			<channel id="windspdmph_avg2m" typeId="wind-speed-avg-2min"/>
+			<channel id="winddir_avg2m" typeId="wind-direction-avg-2min"/>
+			<channel id="windgustmph_10m" typeId="wind-gust-speed-10min"/>
+			<channel id="windgustdir_10m" typeId="wind-gust-direction-10min"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="temperature-group">
+		<label>Temperature</label>
+		<description>Temperature measurements</description>
+		<category>Temperature</category>
+		<channels>
+			<channel id="tempf" typeId="system.outdoor-temperature"/>
+			<channel id="indoortempf" typeId="indoor-temperature"/>
+			<channel id="soiltempf" typeId="soil-temperature"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="humidity-group">
+		<label>Moisture</label>
+		<description>Moisture measurements</description>
+		<category>Humidity</category>
+		<channels>
+			<channel id="humidity" typeId="humidity"/>
+			<channel id="indoorhumidity" typeId="indoor-humidity"/>
+			<channel id="dewptf" typeId="dew-point"/>
+			<channel id="soilmoisture" typeId="soil-moisture"/>
+			<channel id="leafwetness" typeId="leafwetness"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="rain-group">
+		<label>Rain</label>
+		<description>Rain measurements</description>
+		<category>Rain</category>
+		<channels>
+			<channel id="rainin" typeId="rain"/>
+			<channel id="dailyrainin" typeId="rain-daily"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="sunlight-group">
+		<label>Sunlight</label>
+		<description>Sunlight measurements</description>
+		<category>Sun_Clouds</category>
+		<channels>
+			<channel id="solarradiation" typeId="solarradiation"/>
+			<channel id="UV" typeId="uv"/>
+			<channel id="visibility" typeId="visibility"/>
+			<channel id="weather" typeId="metar"/>
+			<channel id="clouds" typeId="clouds"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="pressure-group">
+		<label>Pressure</label>
+		<description>Barometric measurements</description>
+		<category>Pressure</category>
+		<channels>
+			<channel id="baromin" typeId="system.barometric-pressure"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="pollution-group">
+		<label>Pollution</label>
+		<description>Pollutant measurements</description>
+		<category>Pollution</category>
+		<channels>
+			<channel id="AqNO" typeId="nitric-oxide"/>
+			<channel id="AqNO2T" typeId="nitrogen-dioxide-measured"/>
+			<channel id="AqNO2" typeId="nitrogen-dioxide-nox-no"/>
+			<channel id="AqNO2Y" typeId="nitrogen-dioxide-noy-no"/>
+			<channel id="AqNOX" typeId="nitrogen-oxides"/>
+			<channel id="AqNOY" typeId="total-reactive-nitrogen"/>
+			<channel id="AqNO3" typeId="no3-ion"/>
+			<channel id="AqSO4" typeId="so4-ion"/>
+			<channel id="AqSO2" typeId="sulfur-dioxide"/>
+			<channel id="AqSO2T" typeId="sulfur-dioxide-trace-levels"/>
+			<channel id="AqCO" typeId="carbon-monoxide"/>
+			<channel id="AqCOT" typeId="carbon-monoxide-trace-levels"/>
+			<channel id="AqEC" typeId="elemental-carbon"/>
+			<channel id="AqOC" typeId="organic-carbon"/>
+			<channel id="AqBC" typeId="black-carbon"/>
+			<channel id="AqUV-AETH" typeId="aethalometer"/>
+			<channel id="AqPM2_5" typeId="pm2_5-mass"/>
+			<channel id="AqPM10" typeId="pm10-mass"/>
+			<channel id="AqOZONE" typeId="ozone"/>
+		</channels>
+	</channel-group-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/channel-types.xml
@@ -1,0 +1,512 @@
+<?xml version="1.0" ?>
+<thing:thing-descriptions bindingId="wundergroundupdatereceiver"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<channel-type id="last-received-datetime">
+		<item-type>DateTime</item-type>
+		<label>Last Received</label>
+		<description>The date and time of the last update.</description>
+		<category>Time</category>
+		<tags>
+			<tag>Point</tag>
+			<tag>Timestamp</tag>
+		</tags>
+		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+	</channel-type>
+
+	<channel-type id="datetime-utc">
+		<item-type>String</item-type>
+		<label>Last Updated</label>
+		<description>The date and time of the last update in UTC as submitted by the weather station. This can be 'now'.</description>
+		<category>Time</category>
+		<tags>
+			<tag>Point</tag>
+			<tag>Timestamp</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="wind-speed">
+		<item-type>Number:Speed</item-type>
+		<label>Current Wind Speed</label>
+		<description>Current wind speed, using software specific time period.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f m/s"/>
+	</channel-type>
+
+	<channel-type id="wind-gust-speed">
+		<item-type>Number:Speed</item-type>
+		<label>Current Gust Speed</label>
+		<description>Current wind gust speed, using software specific time period.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f m/s"/>
+	</channel-type>
+
+	<channel-type id="wind-gust-direction">
+		<item-type>Number:Angle</item-type>
+		<label>Gust Direction</label>
+		<description>Current wind gust direction expressed as an angle using software specific time period.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="wind-speed-avg-2min">
+		<item-type>Number:Speed</item-type>
+		<label>Wind Speed 2min Average</label>
+		<description>2 minute average wind speed.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f m/s"/>
+	</channel-type>
+
+	<channel-type id="wind-direction-avg-2min">
+		<item-type>Number:Angle</item-type>
+		<label>Wind Direction 2min Average</label>
+		<description>2 minute average wind direction.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="wind-gust-speed-10min">
+		<item-type>Number:Speed</item-type>
+		<label>Gust Speed 10min Average</label>
+		<description>10 minute average gust speed.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f m/s"/>
+	</channel-type>
+
+	<channel-type id="wind-gust-direction-10min">
+		<item-type>Number:Angle</item-type>
+		<label>Gust Direction 10min Average</label>
+		<description>10 minute average gust direction.</description>
+		<category>Wind</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Wind</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="humidity">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Humidity</label>
+		<description>Humidity in %.</description>
+		<category>Humidity</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="indoor-humidity">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Indoor Humidity</label>
+		<description>Indoor humidity in %.</description>
+		<category>Humidity</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dew-point">
+		<item-type>Number:Temperature</item-type>
+		<label>Dew Point</label>
+		<description>Outdoor dew point.</description>
+		<category>Humidity</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- for extra outdoor sensors use temp2f, temp3f, and so on -->
+	<channel-type id="indoor-temperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Indoor Temperature</label>
+		<description>Indoor temperature.</description>
+		<category>Temperature</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- for sensors 2,3,4 use soiltemp2f, soiltemp3f, and soiltemp4f -->
+	<channel-type id="soil-temperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Soil Temperature</label>
+		<description>Soil temperature.</description>
+		<category>Temperature</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="rain">
+		<item-type>Number:Length</item-type>
+		<label>Rain in past hour</label>
+		<description>Rain over the past hour.</description>
+		<category>Rain</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Rain</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f mm"/>
+	</channel-type>
+
+	<channel-type id="rain-daily">
+		<item-type>Number:Length</item-type>
+		<label>Rain since start of day</label>
+		<description>Rain so far today in local time.</description>
+		<category>Rain</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Rain</tag>
+		</tags>
+		<state readOnly="true" pattern="%.2f mm"/>
+	</channel-type>
+
+	<channel-type id="metar">
+		<item-type>String</item-type>
+		<label>METAR weather report</label>
+		<description>METAR formatted weather report</description>
+		<category>Sun_Clouds</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="clouds">
+		<item-type>String</item-type>
+		<label>Cloud cover</label>
+		<description>METAR style cloud cover.</description>
+		<category>Sun_Clouds</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- for sensors 2,3,4 use soilmoisture2, soilmoisture3, and soilmoisture4 -->
+	<channel-type id="soil-moisture">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Soil Moisture</label>
+		<description>Soil moisture in %.</description>
+		<category>Moisture</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Water</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- for sensor 2 use leafwetness2 -->
+	<channel-type id="leafwetness">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Leaf wetness</label>
+		<description>Leaf wetness in %.</description>
+		<category>Moisture</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Water</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="solarradiation">
+		<item-type>Number:Intensity</item-type>
+		<label>Solar Radiation</label>
+		<description>Solar radiation</description>
+		<category>Sun</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Light</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="uv">
+		<item-type>Number:Dimensionless</item-type>
+		<label>UV index</label>
+		<description>UV index.</description>
+		<category>Sun</category>
+		<tags>
+			<tag>Measurement</tag>
+			<tag>Ultraviolet</tag>
+		</tags>
+		<state readOnly="true" pattern="%.0f"/>
+	</channel-type>
+
+	<channel-type id="visibility">
+		<item-type>Number:Length</item-type>
+		<label>Visibility</label>
+		<description>Visibility.</description>
+		<category>Sun_Clouds</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<!-- Pollution Fields: -->
+	<channel-type id="nitric-oxide">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Nitric Oxide</label>
+		<description>Nitric Oxide ppm.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="nitrogen-dioxide-measured">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Nitrogen Dioxide</label>
+		<description>Nitrogen Dioxide, true measure ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="nitrogen-dioxide-nox-no">
+		<item-type>Number:Dimensionless</item-type>
+		<label>NO2 X computed</label>
+		<description>NO2 computed, NOx-NO ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="nitrogen-dioxide-noy-no">
+		<item-type>Number:Dimensionless</item-type>
+		<label>NO2 Y computed, NOy-NO ppb</label>
+		<description>NO2 computed, NOy-NO ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="nitrogen-oxides">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Nitrogen Oxides</label>
+		<description>Nitrogen Oxides ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="total-reactive-nitrogen">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Total Reactive Nitrogen</label>
+		<description>Total reactive nitrogen.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="no3-ion">
+		<item-type>Number:Density</item-type>
+		<label>NO3 ion</label>
+		<description>NO3 ion (nitrate, not adjusted for ammonium ion) µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="so4-ion">
+		<item-type>Number:Density</item-type>
+		<label>SO4 ion</label>
+		<description>SO4 ion (sulfate, not adjusted for ammonium ion) µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="sulfur-dioxide">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Sulfur Dioxide</label>
+		<description>Sulfur Dioxide, conventional ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="sulfur-dioxide-trace-levels">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Sulfur Dioxide Trace Levels</label>
+		<description>Sulfur Dioxide, trace levels ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="carbon-monoxide">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Carbon Monoxide</label>
+		<description>Carbon Monoxide, conventional ppm.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="carbon-monoxide-trace-levels">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Carbon Monoxide Trace Levels</label>
+		<description>Carbon Monoxide, trace levels ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="elemental-carbon">
+		<item-type>Number:Density</item-type>
+		<label>Elemental Carbon</label>
+		<description>Elemental Carbon, PM2.5 µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="organic-carbon">
+		<item-type>Number:Density</item-type>
+		<label>Organic Carbon</label>
+		<description>Organic Carbon, not adjusted for oxygen and hydrogen, PM2.5 µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="black-carbon">
+		<item-type>Number:Density</item-type>
+		<label>Black Carbon</label>
+		<description>Black Carbon at 880 nm, µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="aethalometer">
+		<item-type>Number:Density</item-type>
+		<label>Second Channel of Aethalometer</label>
+		<description>second channel of Aethalometer at 370 nm, µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="pm2_5-mass">
+		<item-type>Number:Density</item-type>
+		<label>PM2.5 Mass</label>
+		<description>PM2.5 mass, µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="pm10-mass">
+		<item-type>Number:Density</item-type>
+		<label>PM10 Mass</label>
+		<description>PM10 mass, µG/m3.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="ozone">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Ozone</label>
+		<description>Ozone, ppb.</description>
+		<category>Pollution</category>
+		<tags>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="softwaretype">
+		<item-type>String</item-type>
+		<label>Software Type</label>
+		<description>A software type string from the weather station</description>
+		<category>Text</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-query-state">
+		<item-type>String</item-type>
+		<kind>state</kind>
+		<label>The last query</label>
+		<description>The part of the last query after the first unurlencoded ?</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="last-query-trigger">
+		<item-type>String</item-type>
+		<kind>trigger</kind>
+		<label>The last query</label>
+		<description>The part of the last query after the first unurlencoded ?</description>
+		<event/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="wundergroundupdatereceiver"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Sample Thing Type -->
+	<thing-type id="wundergroundUpdateReceiver">
+		<label>WundergroundUpdateReceiver Binding Thing</label>
+		<description>An endpoint thing that can receive and propagate HTTP GET updates meant for a particular station id at
+			wunderground.com</description>
+
+		<channel-groups>
+			<channel-group id="metadata" typeId="metadata-group"/>
+			<channel-group id="wind" typeId="wind-group"/>
+			<channel-group id="temperature" typeId="temperature-group"/>
+			<channel-group id="humidity" typeId="humidity-group"/>
+			<channel-group id="rain" typeId="rain-group"/>
+			<channel-group id="sunlight" typeId="sunlight-group"/>
+			<channel-group id="pressure" typeId="pressure-group"/>
+			<channel-group id="pollution" typeId="pollution-group"/>
+		</channel-groups>
+
+		<representation-property>stationId</representation-property>
+		<config-description>
+			<parameter name="stationId" type="text" required="true" pattern="\w+">
+				<label>The stationid as configured in the weather station</label>
+				<description><![CDATA[
+				<p>
+					The wunderground.com update api requires a station id, that is defined for the WeatherUnderground
+					account to submit observations to.
+				</p>
+				<p>
+					In this binding it is used to identify a unique thing, so each weather-station or
+					other apparatus submitting measurements can have a separate id, but if you don't set up an HttpBinding to forward
+					the observations to wunderground.com, this value can be any non-blank string.
+				</p> ]]>
+				</description>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.wundergroundupdatereceiver/src/test/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServletTest.java
+++ b/bundles/org.openhab.binding.wundergroundupdatereceiver/src/test/java/org/openhab/binding/wundergroundupdatereceiver/internal/WundergroundUpdateReceiverServletTest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wundergroundupdatereceiver.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsIterableContaining.hasItems;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.ImperialUnits;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+import org.osgi.service.http.HttpService;
+import org.osgi.service.http.NamespaceException;
+
+/**
+ * @author Daniel Demus - Initial contribution
+ */
+class WundergroundUpdateReceiverServletTest {
+
+    private static final String stationId1 = "abcd1234";
+    private static final String stationId2 = "1234abcd";
+    private static final String reqStationId = "dfggger";
+    private static final ThingUID testThindUid = new ThingUID(
+            WundergroundUpdateReceiverBindingConstants.THING_TYPE_UPDATE_RECEIVER, "test-receiver");
+
+    private @Mock HttpService httpService;
+
+    @BeforeEach
+    public void setUp() {
+        openMocks(this);
+    }
+
+    @Test
+    void the_servlet_is_active_after_the_first_handler_is_added() throws ServletException, NamespaceException {
+        // Given
+        WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService);
+        WundergroundUpdateReceiverHandler handler = mock(WundergroundUpdateReceiverHandler.class);
+        when(handler.getStationId()).thenReturn(stationId1);
+
+        // When
+        sut.addHandler(handler);
+
+        // Then
+        verify(httpService).registerServlet(eq(WundergroundUpdateReceiverServlet.SERVLET_URL), eq(sut), any(), any());
+        assertThat(sut.isActive(), is(true));
+    }
+
+    @Test
+    void the_servlet_is_inactive_after_the_last_handler_is_removed() throws ServletException, NamespaceException {
+        // Given
+        WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService);
+        WundergroundUpdateReceiverHandler handler = mock(WundergroundUpdateReceiverHandler.class);
+        when(handler.getStationId()).thenReturn(stationId1);
+
+        // When
+        sut.addHandler(handler);
+
+        // Then
+        verify(httpService).registerServlet(eq(WundergroundUpdateReceiverServlet.SERVLET_URL), eq(sut), any(), any());
+        assertThat(sut.isActive(), is(true));
+
+        // When
+        sut.removeHandler(handler.getStationId());
+
+        // Then
+        verify(httpService).unregister(WundergroundUpdateReceiverServlet.SERVLET_URL);
+        assertThat(sut.isActive(), is(false));
+    }
+
+    @Test
+    void on_dispose_all_handlers_are_removed_and_servlet_is_inactive() throws ServletException, NamespaceException {
+        // Given
+        WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService);
+        WundergroundUpdateReceiverHandler handler1 = mock(WundergroundUpdateReceiverHandler.class);
+        when(handler1.getStationId()).thenReturn(stationId1);
+        WundergroundUpdateReceiverHandler handler2 = mock(WundergroundUpdateReceiverHandler.class);
+        when(handler2.getStationId()).thenReturn(stationId2);
+
+        // When
+        sut.addHandler(handler1);
+        sut.addHandler(handler2);
+
+        // Then
+        verify(httpService).registerServlet(eq(WundergroundUpdateReceiverServlet.SERVLET_URL), eq(sut), any(), any());
+        assertThat(sut.isActive(), is(true));
+
+        // When
+        sut.dispose();
+
+        // Then
+        verify(httpService).unregister(WundergroundUpdateReceiverServlet.SERVLET_URL);
+        assertThat(sut.isActive(), is(false));
+    }
+
+    @Test
+    void changed_station_id_propagates_to_handler_key() throws ServletException, NamespaceException {
+        // Given
+        Thing thing = mock(Thing.class);
+        when(thing.getUID()).thenReturn(testThindUid);
+        when(thing.getConfiguration()).thenReturn(new Configuration(Map.of("stationId", stationId1)));
+        when(thing.getStatus()).thenReturn(ThingStatus.ONLINE);
+        WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService);
+        WundergroundUpdateReceiverHandler handler = new WundergroundUpdateReceiverHandler(thing, sut);
+
+        // When
+        handler.initialize();
+
+        // Then
+        verify(httpService).registerServlet(eq(WundergroundUpdateReceiverServlet.SERVLET_URL), eq(sut), any(), any());
+        assertThat(sut.isActive(), is(true));
+        assertThat(sut.getStationIds(), hasItems(stationId1));
+
+        // When
+        handler.handleConfigurationUpdate(Map.of("stationId", stationId2));
+
+        // Then
+        assertThat(sut.isActive(), is(true));
+        assertThat(sut.getStationIds(), hasItems(stationId2));
+    }
+
+    @Test
+    void a_get_request_is_correctly_parsed() throws IOException {
+        // Given
+        ThingUID testThingUID = new ThingUID(WundergroundUpdateReceiverBindingConstants.THING_TYPE_UPDATE_RECEIVER,
+                "test-receiver");
+        final String queryString = "ID=dfggger&PASSWORD=XXXXXX&tempf=26.1&humidity=74&dewptf=18.9&windchillf=26.1&winddir=14&windspeedmph=1.34&windgustmph=2.46&rainin=0.00&dailyrainin=0.00&weeklyrainin=0.00&monthlyrainin=0.08&yearlyrainin=3.06&solarradiation=42.24&UV=1&indoortempf=69.3&indoorhumidity=32&baromin=30.39&AqNOX=21&dateutc=2021-02-07%2014:04:03&softwaretype=WH2600%20V2.2.8&action=updateraw&realtime=1&rtfreq=5";
+        WundergroundUpdateReceiverServlet sut = new WundergroundUpdateReceiverServlet(httpService);
+        List<Channel> channels = List.of(
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "metadata",
+                                WundergroundUpdateReceiverBindingConstants.DATEUTC), "String")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "wind",
+                                WundergroundUpdateReceiverBindingConstants.WIND_DIRECTION), "Number:Angle")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "wind",
+                                WundergroundUpdateReceiverBindingConstants.WIND_SPEED), "Number:Speed")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "wind",
+                                WundergroundUpdateReceiverBindingConstants.GUST_SPEED), "Number:Speed")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "temperature",
+                                WundergroundUpdateReceiverBindingConstants.TEMPERATURE), "Number:Temperature")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "rain",
+                                WundergroundUpdateReceiverBindingConstants.RAIN_IN), "Number:Length")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "sunlight",
+                                WundergroundUpdateReceiverBindingConstants.SOLAR_RADIATION), "Number:Intensity")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "sunlight", WundergroundUpdateReceiverBindingConstants.UV),
+                                "Number")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "pressure",
+                                WundergroundUpdateReceiverBindingConstants.BAROM_IN), "Number:Pressure")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "humidity",
+                                WundergroundUpdateReceiverBindingConstants.DEWPOINT), "Number:Temperature")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "humidity",
+                                WundergroundUpdateReceiverBindingConstants.HUMIDITY), "Number:Dimensionless")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "pollution",
+                                WundergroundUpdateReceiverBindingConstants.AQ_NOX), "Number:Dimensionless")
+                        .withKind(ChannelKind.STATE).build(),
+                ChannelBuilder
+                        .create(new ChannelUID(testThingUID, "metadata",
+                                WundergroundUpdateReceiverBindingConstants.LAST_QUERY + "-trigger"), "StringType")
+                        .withKind(ChannelKind.TRIGGER).build());
+
+        Configuration config = new Configuration(Map.of("stationId", reqStationId));
+        Thing testThing = ThingBuilder
+                .create(WundergroundUpdateReceiverBindingConstants.THING_TYPE_UPDATE_RECEIVER, testThingUID)
+                .withChannels(channels).withConfiguration(config).build();
+        ThingHandlerCallback callback = mock(ThingHandlerCallback.class);
+        WundergroundUpdateReceiverHandler handler = new WundergroundUpdateReceiverHandler(testThing, sut);
+        handler.setCallback(callback);
+        handler.initialize();
+
+        HttpChannel httpChannel = mock(HttpChannel.class);
+        MetaData.Request request = new MetaData.Request("GET",
+                new HttpURI("http://localhost/" + WundergroundUpdateReceiverServlet.SERVLET_URL + "?" + queryString),
+                HttpVersion.HTTP_1_1, new HttpFields());
+        Request req = new Request(httpChannel, null);
+        req.setMetaData(request);
+
+        // When
+        sut.doGet(req, mock(HttpServletResponse.class, Answers.RETURNS_MOCKS));
+
+        // Then
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "metadata", WundergroundUpdateReceiverBindingConstants.DATEUTC),
+                StringType.valueOf("2021-02-07 14:04:03"));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "wind", WundergroundUpdateReceiverBindingConstants.WIND_DIRECTION),
+                new QuantityType<>(14, Units.DEGREE_ANGLE));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "wind", WundergroundUpdateReceiverBindingConstants.WIND_SPEED),
+                new QuantityType<>(1.34, ImperialUnits.MILES_PER_HOUR));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "wind", WundergroundUpdateReceiverBindingConstants.GUST_SPEED),
+                new QuantityType<>(2.46, ImperialUnits.MILES_PER_HOUR));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "temperature", WundergroundUpdateReceiverBindingConstants.TEMPERATURE),
+                new QuantityType<>(26.1, ImperialUnits.FAHRENHEIT));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "rain", WundergroundUpdateReceiverBindingConstants.RAIN_IN),
+                new QuantityType<>(0, ImperialUnits.INCH));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "sunlight", WundergroundUpdateReceiverBindingConstants.SOLAR_RADIATION),
+                new QuantityType<>(42.24, Units.IRRADIANCE));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "sunlight", WundergroundUpdateReceiverBindingConstants.UV),
+                new DecimalType(1));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "pressure", WundergroundUpdateReceiverBindingConstants.BAROM_IN),
+                new QuantityType<>(30.39, ImperialUnits.INCH_OF_MERCURY));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "humidity", WundergroundUpdateReceiverBindingConstants.DEWPOINT),
+                new QuantityType<>(18.9, ImperialUnits.FAHRENHEIT));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "humidity", WundergroundUpdateReceiverBindingConstants.HUMIDITY),
+                new QuantityType<>(74, Units.PERCENT));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "pollution", WundergroundUpdateReceiverBindingConstants.AQ_NOX),
+                new QuantityType<>(21, Units.PARTS_PER_BILLION));
+        verify(callback, never()).stateUpdated(
+                new ChannelUID(testThindUid, "metadata", WundergroundUpdateReceiverBindingConstants.SOFTWARE_TYPE),
+                StringType.valueOf("WH2600 V2.2.8"));
+        verify(callback)
+                .stateUpdated(
+                        eq(new ChannelUID(testThindUid, "metadata",
+                                WundergroundUpdateReceiverBindingConstants.LAST_RECEIVED_DATETIME)),
+                        any(StringType.class));
+        verify(callback).stateUpdated(
+                new ChannelUID(testThindUid, "metadata",
+                        WundergroundUpdateReceiverBindingConstants.LAST_QUERY + "-state"),
+                StringType.valueOf(queryString));
+        verify(callback).channelTriggered(testThing, new ChannelUID(testThindUid, "metadata",
+                WundergroundUpdateReceiverBindingConstants.LAST_QUERY + "-trigger"), queryString);
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -321,6 +321,7 @@
     <module>org.openhab.binding.windcentrale</module>
     <module>org.openhab.binding.wlanthermo</module>
     <module>org.openhab.binding.wled</module>
+    <module>org.openhab.binding.wundergroundupdatereceiver</module>
     <module>org.openhab.binding.xmltv</module>
     <module>org.openhab.binding.xmppclient</module>
     <module>org.openhab.binding.yamahareceiver</module>


### PR DESCRIPTION
Being the owner of a weather station that is able to submit measurements to wunderground.com via the update URL, I looked for a binding to capture the values and use them locally on my openhab instance to fx. open and close windows or awnings depending on weather conditions, or just to display current weather on a weather page.

I couldn't find any thus this binding. It registers a servlet listening on the wunderground.com update URL path and gathers the submitted values into channels on the thing. Multiple wunderground accounts can be supported by configuring the station id of the thing. The station id must match the ID parameter in the requests from the weather station. Every update is also passed along in a trigger channel, which can then resend the update to wunderground.com in a trivial rule script. In addition you can also submit measurements to other weather services in whatever format they accept.

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
