### PR TITLE
[androiddebugbridge] check device awake state and minor fixes

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
@@ -42,6 +42,7 @@ public class AndroidDebugBridgeBindingConstants {
     public static final String STOP_PACKAGE_CHANNEL = "stop-package";
     public static final String STOP_CURRENT_PACKAGE_CHANNEL = "stop-current-package";
     public static final String CURRENT_PACKAGE_CHANNEL = "current-package";
+    public static final String AWAKE_STATE_CHANNEL = "awake-state";
     public static final String WAKE_LOCK_CHANNEL = "wake-lock";
     public static final String SCREEN_STATE_CHANNEL = "screen-state";
     // List of all Parameters

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -120,12 +120,19 @@ public class AndroidDebugBridgeDevice {
         throw new AndroidDebugBridgeDeviceReadException("can read package name");
     }
 
+    public boolean isAwake()
+            throws InterruptedException, AndroidDebugBridgeDeviceException, TimeoutException, ExecutionException {
+        String devicesResp = runAdbShell("dumpsys", "activity", "|", "grep", "mWakefulness");
+        return devicesResp.contains("mWakefulness=Awake");
+    }
+
     public boolean isScreenOn() throws InterruptedException, AndroidDebugBridgeDeviceException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
         String devicesResp = runAdbShell("dumpsys", "power", "|", "grep", "'Display Power'");
         if (devicesResp.contains("=")) {
             try {
-                return devicesResp.split("=")[1].equals("ON");
+                var state = devicesResp.split("=")[1].trim();
+                return state.equals("ON");
             } catch (NumberFormatException e) {
                 logger.debug("Unable to parse device wake lock: {}", e.getMessage());
             }

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -311,7 +311,10 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             logger.warn("Unable to refresh awake state: Timeout");
             return;
         }
-        updateState(new ChannelUID(this.thing.getUID(), AWAKE_STATE_CHANNEL), OnOffType.from(awakeState));
+        var awakeStateChannelUID = new ChannelUID(this.thing.getUID(), AWAKE_STATE_CHANNEL);
+        if (isLinked(awakeStateChannelUID)) {
+            updateState(awakeStateChannelUID, OnOffType.from(awakeState));
+        }
         if (!awakeState && !prevDeviceAwake) {
             logger.debug("device {} is sleeping", config.ip);
             return;

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -59,6 +59,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     private AndroidDebugBridgeConfiguration config = new AndroidDebugBridgeConfiguration();
     private @Nullable ScheduledFuture<?> connectionCheckerSchedule;
     private AndroidDebugBridgeMediaStatePackageConfig @Nullable [] packageConfigs = null;
+    private boolean deviceAwake = false;
 
     public AndroidDebugBridgeHandler(Thing thing) {
         super(thing);
@@ -133,6 +134,12 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 if (command instanceof RefreshType) {
                     int lock = adbConnection.getPowerWakeLock();
                     updateState(channelUID, new DecimalType(lock));
+                }
+                break;
+            case AWAKE_STATE_CHANNEL:
+                if (command instanceof RefreshType) {
+                    boolean awakeState = adbConnection.isAwake();
+                    updateState(channelUID, OnOffType.from(awakeState));
                 }
                 break;
             case SCREEN_STATE_CHANNEL:
@@ -277,6 +284,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 } catch (AndroidDebugBridgeDeviceException e) {
                     logger.debug("Error connecting to device; [{}]: {}", e.getClass().getCanonicalName(),
                             e.getMessage());
+                    adbConnection.disconnect();
                     updateStatus(ThingStatus.OFFLINE);
                     return;
                 }
@@ -294,6 +302,20 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     }
 
     private void refreshStatus() throws InterruptedException, AndroidDebugBridgeDeviceException, ExecutionException {
+        boolean awakeState;
+        boolean prevDeviceAwake = deviceAwake;
+        try {
+            awakeState = adbConnection.isAwake();
+            deviceAwake = awakeState;
+        } catch (TimeoutException e) {
+            logger.warn("Unable to refresh awake state: Timeout");
+            return;
+        }
+        updateState(new ChannelUID(this.thing.getUID(), AWAKE_STATE_CHANNEL), OnOffType.from(awakeState));
+        if (!awakeState && !prevDeviceAwake) {
+            logger.debug("device {} is sleeping", config.ip);
+            return;
+        }
         try {
             handleCommandInternal(new ChannelUID(this.thing.getUID(), MEDIA_VOLUME_CHANNEL), RefreshType.REFRESH);
         } catch (AndroidDebugBridgeDeviceReadException e) {

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
@@ -18,6 +18,7 @@
 			<channel id="current-package" typeId="current-package-channel"/>
 			<channel id="wake-lock" typeId="wake-lock-channel"/>
 			<channel id="screen-state" typeId="screen-state-channel"/>
+			<channel id="awake-state" typeId="awake-state-channel"/>
 		</channels>
 		<representation-property>serial</representation-property>
 		<config-description>
@@ -383,6 +384,13 @@
 		<item-type>Number</item-type>
 		<label>Wake Lock</label>
 		<description>Power Wake Lock State</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="awake-state-channel" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Awake State</label>
+		<description>Awake State</description>
 		<state readOnly="true"/>
 	</channel-type>
 


### PR DESCRIPTION
Signed-off-by: Miguel <miguelwork92@gmail.com>

The binding logs a lot of timeout warnings because it keeps trying to refresh the channels when the android device is not awake, as far as I saw some services stop working when the device go to sleep. This pr aims to fix this by checking that the device is awake before refreshing other channels and also fixes the screen-state channel which was not working correctly.