### PR TITLE
[bluetooth.generic] Enable BLE notification for linked channels

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothCharacteristic.java
@@ -27,7 +27,7 @@ import org.openhab.binding.bluetooth.BluetoothCharacteristic;
  */
 public class BlueGigaBluetoothCharacteristic extends BluetoothCharacteristic {
 
-    private boolean notificationEnabled;
+    private boolean notifying;
 
     public BlueGigaBluetoothCharacteristic(int handle) {
         super(null, handle);
@@ -45,11 +45,11 @@ public class BlueGigaBluetoothCharacteristic extends BluetoothCharacteristic {
         this.uuid = uuid;
     }
 
-    public boolean isNotificationEnabled() {
-        return notificationEnabled;
+    public boolean isNotifying() {
+        return notifying;
     }
 
-    public void setNotificationEnabled(boolean enable) {
-        this.notificationEnabled = enable;
+    public void setNotifying(boolean enable) {
+        this.notifying = enable;
     }
 }

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -289,6 +289,12 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
     }
 
     @Override
+    public boolean isNotifying(BluetoothCharacteristic characteristic) {
+        // TODO will be implemented in a followup PR
+        return false;
+    }
+
+    @Override
     public boolean enableNotifications(BluetoothDescriptor descriptor) {
         // TODO will be implemented in a followup PR
         return false;

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -290,8 +290,8 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
 
     @Override
     public boolean isNotifying(BluetoothCharacteristic characteristic) {
-        // TODO will be implemented in a followup PR
-        return false;
+        BlueGigaBluetoothCharacteristic ch = (BlueGigaBluetoothCharacteristic) characteristic;
+        return ch.isNotificationEnabled();
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -241,12 +241,12 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
     @Override
     public boolean disableNotifications(BluetoothCharacteristic characteristic) {
         if (connection == -1) {
-            logger.debug("Cannot enable notifications, device not connected {}", this);
+            logger.debug("Cannot disable notifications, device not connected {}", this);
             return false;
         }
 
         BlueGigaBluetoothCharacteristic ch = (BlueGigaBluetoothCharacteristic) characteristic;
-        if (ch.isNotificationEnabled()) {
+        if (!ch.isNotificationEnabled()) {
             return true;
         }
 

--- a/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluegiga/src/main/java/org/openhab/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -196,7 +196,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
         }
 
         BlueGigaBluetoothCharacteristic ch = (BlueGigaBluetoothCharacteristic) characteristic;
-        if (ch.isNotificationEnabled()) {
+        if (ch.isNotifying()) {
             return true;
         }
 
@@ -246,7 +246,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
         }
 
         BlueGigaBluetoothCharacteristic ch = (BlueGigaBluetoothCharacteristic) characteristic;
-        if (!ch.isNotificationEnabled()) {
+        if (!ch.isNotifying()) {
             return true;
         }
 
@@ -291,7 +291,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
     @Override
     public boolean isNotifying(BluetoothCharacteristic characteristic) {
         BlueGigaBluetoothCharacteristic ch = (BlueGigaBluetoothCharacteristic) characteristic;
-        return ch.isNotificationEnabled();
+        return ch.isNotifying();
     }
 
     @Override
@@ -619,7 +619,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
                 if (!success) {
                     logger.debug("write to descriptor failed");
                 }
-                ((BlueGigaBluetoothCharacteristic) procedureCharacteristic).setNotificationEnabled(success);
+                ((BlueGigaBluetoothCharacteristic) procedureCharacteristic).setNotifying(success);
                 procedureProgress = BlueGigaProcedure.NONE;
                 procedureCharacteristic = null;
                 break;
@@ -628,7 +628,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
                 if (!success) {
                     logger.debug("write to descriptor failed");
                 }
-                ((BlueGigaBluetoothCharacteristic) procedureCharacteristic).setNotificationEnabled(!success);
+                ((BlueGigaBluetoothCharacteristic) procedureCharacteristic).setNotifying(!success);
                 procedureProgress = BlueGigaProcedure.NONE;
                 procedureCharacteristic = null;
                 break;
@@ -662,7 +662,7 @@ public class BlueGigaBluetoothDevice extends BaseBluetoothDevice implements Blue
         }
 
         for (BlueGigaBluetoothCharacteristic ch : handleToCharacteristic.values()) {
-            ch.setNotificationEnabled(false);
+            ch.setNotifying(false);
         }
 
         cancelTimer(procedureTimer);

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -459,7 +459,8 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                 characteristic.setValue(value);
                 notifyListeners(BluetoothEventType.CHARACTERISTIC_READ_COMPLETE, characteristic,
                         BluetoothCompletionStatus.SUCCESS);
-            } catch (DBusException e) {
+            } catch (DBusException | DBusExecutionException e) {
+                // DBusExecutionException is thrown if the value cannot be read
                 logger.debug("Exception occurred when trying to read characteristic '{}': {}", characteristic.getUuid(),
                         e.getMessage());
                 notifyListeners(BluetoothEventType.CHARACTERISTIC_READ_COMPLETE, characteristic,

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -57,7 +57,7 @@ import com.github.hypfvieh.bluetooth.wrapper.BluetoothGattService;
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Benjamin Lafois - Replaced tinyB with bluezDbus
- * @author Peter Rosenberg - Improve notifications
+ * @author Peter Rosenberg - Improve notifications and properties support
  *
  */
 @NonNullByDefault
@@ -400,6 +400,7 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
                 for (BluetoothGattCharacteristic dBusBlueZCharacteristic : dBusBlueZService.getGattCharacteristics()) {
                     BluetoothCharacteristic characteristic = new BluetoothCharacteristic(
                             UUID.fromString(dBusBlueZCharacteristic.getUuid()), 0);
+                    convertCharacteristicProperties(dBusBlueZCharacteristic, characteristic);
 
                     for (BluetoothGattDescriptor dBusBlueZDescriptor : dBusBlueZCharacteristic.getGattDescriptors()) {
                         BluetoothDescriptor descriptor = new BluetoothDescriptor(characteristic,
@@ -413,6 +414,35 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             notifyListeners(BluetoothEventType.SERVICES_DISCOVERED);
         }
         return true;
+    }
+
+    private void convertCharacteristicProperties(BluetoothGattCharacteristic dBusBlueZCharacteristic, BluetoothCharacteristic characteristic) {
+        int properties = 0;
+
+        for (String property : dBusBlueZCharacteristic.getFlags()) {
+            switch (property) {
+                case "broadcast":
+                    properties |= BluetoothCharacteristic.PROPERTY_BROADCAST;
+                    break;
+                case "read":
+                    properties |= BluetoothCharacteristic.PROPERTY_READ;
+                    break;
+                case "write-without-response":
+                    properties |= BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE;
+                    break;
+                case "write":
+                    properties |= BluetoothCharacteristic.PROPERTY_WRITE;
+                    break;
+                case "notify":
+                    properties |= BluetoothCharacteristic.PROPERTY_NOTIFY;
+                    break;
+                case "indicate":
+                    properties |= BluetoothCharacteristic.PROPERTY_INDICATE;
+                    break;
+            }
+        }
+
+        characteristic.setProperties(properties);
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -57,6 +57,7 @@ import com.github.hypfvieh.bluetooth.wrapper.BluetoothGattService;
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Benjamin Lafois - Replaced tinyB with bluezDbus
+ * @author Peter Rosenberg - Improve notifications
  *
  */
 @NonNullByDefault
@@ -436,6 +437,18 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             }
         });
         return true;
+    }
+
+    @Override
+    public boolean isNotifying(BluetoothCharacteristic characteristic) {
+        BluetoothGattCharacteristic c = getDBusBlueZCharacteristicByUUID(characteristic.getUuid().toString());
+        if (c != null) {
+            Boolean isNotifying = c.isNotifying();
+            return Objects.requireNonNullElse(isNotifying, false);
+        } else {
+            logger.warn("Characteristic '{}' is missing on device '{}'.", characteristic.getUuid(), address);
+            return false;
+        }
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -416,7 +416,8 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
         return true;
     }
 
-    private void convertCharacteristicProperties(BluetoothGattCharacteristic dBusBlueZCharacteristic, BluetoothCharacteristic characteristic) {
+    private void convertCharacteristicProperties(BluetoothGattCharacteristic dBusBlueZCharacteristic,
+            BluetoothCharacteristic characteristic) {
         int properties = 0;
 
         for (String property : dBusBlueZCharacteristic.getFlags()) {

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -416,6 +416,12 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
         return true;
     }
 
+    /**
+     * Convert the flags of BluetoothGattCharacteristic to the int bitset used by BluetoothCharacteristic.
+     *
+     * @param dBusBlueZCharacteristic source characteristic to read the flags from
+     * @param characteristic destination characteristic to write to properties to
+     */
     private void convertCharacteristicProperties(BluetoothGattCharacteristic dBusBlueZCharacteristic,
             BluetoothCharacteristic characteristic) {
         int properties = 0;

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -89,7 +89,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                     this.device.getServices().forEach((service) -> {
                         service.getCharacteristics().forEach((characteristic) -> {
                             CharacteristicHandler charHandler;
-                            if (device.canNotify(characteristic)) {
+                            if (characteristic.canNotify()) {
                                 // If notifications can be enabled, we create the CharacteristicHandler
                                 // if it not exists so that we can register notifications.
                                 charHandler = charHandlers.computeIfAbsent(characteristic, CharacteristicHandler::new);
@@ -114,7 +114,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                                         return;
                                     }
                                 }
-                                if (device.canNotify(characteristic)) {
+                                if (characteristic.canNotify()) {
                                     ChannelUID channelUID = charHandler.getChannelUID(null);
                                     // Enabled/Disable notifications dependent on if the channel is linked.
                                     if (isLinked(channelUID)) {

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -180,8 +180,8 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                     CharacteristicHandler handler = getCharacteristicHandler(characteristic);
                     List<Channel> chans = handler.buildChannels();
                     List<ChannelUID> chanUids = chans.stream().map(Channel::getUID).collect(Collectors.toList());
-                    for (Channel channel : chans) {
-                        channelHandlers.put(channel.getUID(), handler);
+                    for (ChannelUID channel : chanUids) {
+                        channelHandlers.put(channel, handler);
                     }
                     handlerToChannels.put(handler, chanUids);
                     return chans.stream();

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -69,6 +69,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
     private final Map<ChannelUID, CharacteristicHandler> channelHandlers = new ConcurrentHashMap<>();
     private final BluetoothGattParser gattParser = BluetoothGattParserFactory.getDefault();
     private final CharacteristicChannelTypeProvider channelTypeProvider;
+    private final Map<CharacteristicHandler, List<ChannelUID>> handlerToChannels = new ConcurrentHashMap<>();
 
     private @Nullable ScheduledFuture<?> readCharacteristicJob = null;
 
@@ -85,50 +86,34 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
         readCharacteristicJob = scheduler.scheduleWithFixedDelay(() -> {
             if (device.getConnectionState() == ConnectionState.CONNECTED) {
                 if (resolved) {
-                    // go through all characteristics of all services
-                    this.device.getServices().forEach((service) -> {
-                        service.getCharacteristics().forEach((characteristic) -> {
-                            CharacteristicHandler charHandler;
-                            if (characteristic.canNotify()) {
-                                // If notifications can be enabled, we create the CharacteristicHandler
-                                // if it not exists so that we can register notifications.
-                                charHandler = charHandlers.computeIfAbsent(characteristic, CharacteristicHandler::new);
+                    handlerToChannels.forEach((charHandler, channelUids) -> {
+                        // Only read the value manually if notification is not on.
+                        // Also read it the first time before we activate notifications below.
+                        if (!device.isNotifying(charHandler.characteristic) && charHandler.canRead()) {
+                            device.readCharacteristic(charHandler.characteristic);
+                            try {
+                                // TODO the ideal solution would be to use locks/conditions and timeouts
+                                // Kbetween this code and `onCharacteristicReadComplete` but
+                                // that would overcomplicate the code a bit and I plan
+                                // on implementing a better more generalized solution later
+                                Thread.sleep(50);
+                            } catch (InterruptedException e) {
+                                return;
+                            }
+                        }
+                        if (charHandler.characteristic.canNotify()) {
+                            ChannelUID channelUID = charHandler.getChannelUID(null);
+                            // Enabled/Disable notifications dependent on if the channel is linked.
+                            if (isLinked(channelUID)) {
+                                if (!device.isNotifying(charHandler.characteristic)) {
+                                    device.enableNotifications(charHandler.characteristic);
+                                }
                             } else {
-                                // Otherwise we let it being created by getCharacteristicHandler() and do
-                                // nothing here if it is not created yet.
-                                charHandler = charHandlers.get(characteristic);
-                            }
-
-                            if (charHandler != null) {
-                                // Only read the value manually if notification is not on.
-                                // Also read it the first time before we activate notifications below.
-                                if (!device.isNotifying(characteristic) && charHandler.canRead()) {
-                                    device.readCharacteristic(characteristic);
-                                    try {
-                                        // TODO the ideal solution would be to use locks/conditions and timeouts
-                                        // between this code and `onCharacteristicReadComplete` but
-                                        // that would overcomplicate the code a bit and I plan
-                                        // on implementing a better more generalized solution later
-                                        Thread.sleep(50);
-                                    } catch (InterruptedException e) {
-                                        return;
-                                    }
-                                }
-                                if (characteristic.canNotify()) {
-                                    ChannelUID channelUID = charHandler.getChannelUID(null);
-                                    // Enabled/Disable notifications dependent on if the channel is linked.
-                                    if (isLinked(channelUID)) {
-                                        if (!device.isNotifying(characteristic)) {
-                                            device.enableNotifications(characteristic);
-                                        }
-                                    } else {
-                                        if (device.isNotifying(characteristic)) {
-                                            device.disableNotifications(characteristic);
-                                        }
-                                    }
+                                if (device.isNotifying(charHandler.characteristic)) {
+                                    device.disableNotifications(charHandler.characteristic);
                                 }
                             }
-                        });
+                        }
                     });
                 } else {
                     // if we are connected and still haven't been able to resolve the services, try disconnecting and
@@ -149,6 +134,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
 
         charHandlers.clear();
         channelHandlers.clear();
+        handlerToChannels.clear();
     }
 
     @Override
@@ -193,9 +179,11 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                     logger.trace("{} processing characteristic {}", address, characteristic.getUuid());
                     CharacteristicHandler handler = getCharacteristicHandler(characteristic);
                     List<Channel> chans = handler.buildChannels();
+                    List<ChannelUID> chanUids = chans.stream().map(Channel::getUID).collect(Collectors.toList());
                     for (Channel channel : chans) {
                         channelHandlers.put(channel.getUID(), handler);
                     }
+                    handlerToChannels.put(handler, chanUids);
                     return chans.stream();
                 })//
                 .collect(Collectors.toList());

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -361,8 +361,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
             if (gattParser.isKnownCharacteristic(charUUID)) {
                 return gattParser.isValidForRead(charUUID);
             }
-            // TODO: need to evaluate this from characteristic properties, but such properties aren't support yet
-            return true;
+            return characteristic.canRead();
         }
 
         public boolean canWrite() {
@@ -370,8 +369,7 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
             if (gattParser.isKnownCharacteristic(charUUID)) {
                 return gattParser.isValidForWrite(charUUID);
             }
-            // TODO: need to evaluate this from characteristic properties, but such properties aren't support yet
-            return true;
+            return characteristic.canWrite();
         }
 
         private boolean isAdvanced() {

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -102,9 +102,9 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
                             }
                         }
                         if (charHandler.characteristic.canNotify()) {
-                            ChannelUID channelUID = charHandler.getChannelUID(null);
                             // Enabled/Disable notifications dependent on if the channel is linked.
-                            if (isLinked(channelUID)) {
+                            // TODO check why isLinked() is true for not linked channels
+                            if (channelUids.stream().anyMatch(this::isLinked)) {
                                 if (!device.isNotifying(charHandler.characteristic)) {
                                     device.enableNotifications(charHandler.characteristic);
                                 }

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -185,6 +185,25 @@ public class BluetoothCharacteristic {
     }
 
     /**
+     * Returns if the value can be read on this characteristic.
+     *
+     * @return true if the value can be read, false otherwise.
+     */
+    public boolean canRead() {
+        return hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_READ);
+    }
+
+    /**
+     * Returns if the value can be written on this characteristic.
+     *
+     * @return true if the value can be written with of without a response, false otherwise.
+     */
+    public boolean canWrite() {
+        return hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE)
+                || hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE);
+    }
+
+    /**
      * Returns the permissions for this characteristic.
      */
     public int getPermissions() {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -143,6 +143,12 @@ public class BluetoothCharacteristic {
         return instance;
     }
 
+    /**
+     * Set the raw properties. The individual properties are represented as bits inside
+     * of this int value.
+     *
+     * @param properties of this Characteristic
+     */
     public void setProperties(int properties) {
         this.properties = properties;
     }

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Chris Jackson - Initial contribution
  * @author Kai Kreuzer - Cleaned up code
+ * @author Peter Rosenberg - Improve properties support
  */
 public class BluetoothCharacteristic {
     public static final int FORMAT_UINT8 = 0x11;
@@ -142,6 +143,10 @@ public class BluetoothCharacteristic {
         return instance;
     }
 
+    public void setProperties(int properties) {
+        this.properties = properties;
+    }
+
     /**
      * Returns the properties of this characteristic.
      *
@@ -150,6 +155,17 @@ public class BluetoothCharacteristic {
      */
     public int getProperties() {
         return properties;
+    }
+
+    /**
+     * Returns if the given characteristics property is enabled or not.
+     *
+     * @param property one of the Constants BluetoothCharacteristic.PROPERTY_XX
+     * @return true if this characteristic has the given property enabled, false if properties not set or
+     *         the given property is not enabled.
+     */
+    public boolean hasPropertyEnabled(int property) {
+        return (properties & property) != 0;
     }
 
     /**

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothCharacteristic.java
@@ -175,6 +175,16 @@ public class BluetoothCharacteristic {
     }
 
     /**
+     * Returns if notifications can be enabled on this characteristic.
+     *
+     * @return true if notifications can be enabled, false if notifications are not supported, characteristic is missing
+     *         on device or notifications are not supported.
+     */
+    public boolean canNotify() {
+        return hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY);
+    }
+
+    /**
      * Returns the permissions for this characteristic.
      */
     public int getPermissions() {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  * @author Chris Jackson - Initial contribution
  * @author Kai Kreuzer - Refactored class to use Integer instead of int, fixed bugs, diverse improvements
  * @author Connor Petty - Made most of the methods abstract
+ * @author Peter Rosenberg - Improve notifications
  */
 @NonNullByDefault
 public abstract class BluetoothDevice {
@@ -248,6 +249,15 @@ public abstract class BluetoothDevice {
      * @return true if the characteristic write is started successfully
      */
     public abstract boolean writeCharacteristic(BluetoothCharacteristic characteristic);
+
+    /**
+     * Returns if notification is enabled for the given characteristic.
+     *
+     * @param characteristic the {@link BluetoothCharacteristic} to disable notifications for.
+     * @return true if notification is enabled, false if notification is disabled, characteristic missing on device or
+     *         notification not supported.
+     */
+    public abstract boolean isNotifying(BluetoothCharacteristic characteristic);
 
     /**
      * Enables notifications for a characteristic. Only a single read or write operation can be requested at once.

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -251,11 +251,22 @@ public abstract class BluetoothDevice {
     public abstract boolean writeCharacteristic(BluetoothCharacteristic characteristic);
 
     /**
+     * Returns if notifications can be enabled on the given characteristics.
+     *
+     * @param characteristic the {@link BluetoothCharacteristic} to check if notifications can be enabled.
+     * @return true if notifications can be enabled, false if notifications are not supported, characteristic is missing
+     *         on device or notifications are not supported.
+     */
+    public boolean canNotify(BluetoothCharacteristic characteristic) {
+        return characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY);
+    }
+
+    /**
      * Returns if notification is enabled for the given characteristic.
      *
-     * @param characteristic the {@link BluetoothCharacteristic} to disable notifications for.
-     * @return true if notification is enabled, false if notification is disabled, characteristic missing on device or
-     *         notification not supported.
+     * @param characteristic the {@link BluetoothCharacteristic} to check if notifications are enabled.
+     * @return true if notification is enabled, false if notification is disabled, characteristic is missing on device
+     *         or notifications are not supported.
      */
     public abstract boolean isNotifying(BluetoothCharacteristic characteristic);
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BluetoothDevice.java
@@ -251,17 +251,6 @@ public abstract class BluetoothDevice {
     public abstract boolean writeCharacteristic(BluetoothCharacteristic characteristic);
 
     /**
-     * Returns if notifications can be enabled on the given characteristics.
-     *
-     * @param characteristic the {@link BluetoothCharacteristic} to check if notifications can be enabled.
-     * @return true if notifications can be enabled, false if notifications are not supported, characteristic is missing
-     *         on device or notifications are not supported.
-     */
-    public boolean canNotify(BluetoothCharacteristic characteristic) {
-        return characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY);
-    }
-
-    /**
      * Returns if notification is enabled for the given characteristic.
      *
      * @param characteristic the {@link BluetoothCharacteristic} to check if notifications are enabled.

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/DelegateBluetoothDevice.java
@@ -113,6 +113,12 @@ public abstract class DelegateBluetoothDevice extends BluetoothDevice {
     }
 
     @Override
+    public boolean isNotifying(BluetoothCharacteristic characteristic) {
+        BluetoothDevice delegate = getDelegate();
+        return delegate != null ? delegate.isNotifying(characteristic) : false;
+    }
+
+    @Override
     public boolean enableNotifications(BluetoothCharacteristic characteristic) {
         BluetoothDevice delegate = getDelegate();
         return delegate != null ? delegate.enableNotifications(characteristic) : false;

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/CharacteristicPropertiesTest.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/CharacteristicPropertiesTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link BluetoothCharacteristic}.
+ *
+ * @author Peter Rosenberg - Initial contribution
+ */
+public class CharacteristicPropertiesTest {
+    private BluetoothCharacteristic characteristic = new BluetoothCharacteristic(UUID.randomUUID(), 0);
+
+    @Test
+    public void testAllSupportedProperties() {
+        // given
+        // when
+        int properties = 0;
+        properties |= BluetoothCharacteristic.PROPERTY_BROADCAST;
+        properties |= BluetoothCharacteristic.PROPERTY_READ;
+        properties |= BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE;
+        properties |= BluetoothCharacteristic.PROPERTY_WRITE;
+        properties |= BluetoothCharacteristic.PROPERTY_NOTIFY;
+        properties |= BluetoothCharacteristic.PROPERTY_INDICATE;
+        characteristic.setProperties(properties);
+
+        // then
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_BROADCAST), "Broastcast not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_READ), "Read not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE),
+                "Write not response not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE), "Write not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY), "Notify not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_INDICATE), "Indicate not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_SIGNED_WRITE),
+                "Signed write set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_EXTENDED_PROPS),
+                "Extended props set");
+    }
+
+    @Test
+    public void testNoProperties() {
+        // given
+        // when
+        int properties = 0;
+        characteristic.setProperties(properties);
+
+        // then
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_BROADCAST),
+                "Broastcast not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_READ), "Read not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE),
+                "Write not response not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE), "Write not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY), "Notify not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_INDICATE), "Indicate not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_SIGNED_WRITE),
+                "Signed write set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_EXTENDED_PROPS),
+                "Extended props set");
+    }
+
+    @Test
+    public void testSomeSupportedProperties() {
+        // given
+        // when
+        int properties = 0;
+        properties |= BluetoothCharacteristic.PROPERTY_READ;
+        properties |= BluetoothCharacteristic.PROPERTY_NOTIFY;
+        characteristic.setProperties(properties);
+
+        // then
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_BROADCAST),
+                "Broastcast not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_READ), "Read not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE_NO_RESPONSE),
+                "Write not response not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_WRITE), "Write not set");
+        assertTrue(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_NOTIFY), "Notify not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_INDICATE), "Indicate not set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_SIGNED_WRITE),
+                "Signed write set");
+        assertFalse(characteristic.hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_EXTENDED_PROPS),
+                "Extended props set");
+    }
+}

--- a/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/MockBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth/src/test/java/org/openhab/binding/bluetooth/MockBluetoothDevice.java
@@ -103,6 +103,11 @@ public class MockBluetoothDevice extends BaseBluetoothDevice {
     }
 
     @Override
+    public boolean isNotifying(BluetoothCharacteristic characteristic) {
+        return false;
+    }
+
+    @Override
     public boolean disableNotifications(BluetoothCharacteristic characteristic) {
         return false;
     }


### PR DESCRIPTION
Bluetooth low energy (BLE) allows central devices (like openHAB) to subscribe for changes. Whenever a subscribed value changes, the central devices is notified immediately so we don't need to wait until the value is polled next time.
Such a behaviour is useful for applications like push buttons or other devices where immediate action is required.

Changes
- Add Characteristics properties to `BluetoothCharacteristic` to make them accessible
- Add `BluetoothDevice.canNotify()` and `BluetoothDevice.isNotifying()`
- Enabled notifications on linked channels where notifications are supported

This is my first pull request to openHAB, feedback is very welcome.