### PR TITLE
[ftpupload] Add configurable passive port

### DIFF
--- a/bundles/org.openhab.binding.ftpupload/README.md
+++ b/bundles/org.openhab.binding.ftpupload/README.md
@@ -18,10 +18,11 @@ Automatic discovery is not supported.
 
 The binding has the following configuration options:
 
-| Parameter   | Name         | Description                                                                                                            | Required | Default value |
-|-------------|--------------|------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| port        | TCP Port     | TCP port of the FTP server                                                                                             | no       | 2121          |
-| idleTimeout | Idle timeout | The number of seconds before an inactive client is disconnected. If this value is set to 0, the idle time is disabled. | no       | 60            |
+| Parameter    | Name          | Description                                                                                                                                                                                                                                                                                                               | Required | Default value |
+|--------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| port         | TCP Port      | TCP port of the FTP server                                                                                                                                                                                                                                                                                                | no       | 2121          |
+| idleTimeout  | Idle timeout  | The number of seconds before an inactive client is disconnected. If this value is set to 0, the idle time is disabled.                                                                                                                                                                                                    | no       | 60            |
+| passivePorts | Passive Ports | A string of passive ports, can contain a single port (as an integer), multiple ports seperated by commas (e.g. 123,124,125) or ranges of ports, including open ended ranges (e.g. 123-125, 30000-, -1023). Combinations for single ports and ranges is also supported. Empty (default) allows all ports as passive ports. | no       |               |
 
 ## Thing Configuration
 

--- a/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/FtpUploadHandlerFactory.java
+++ b/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/FtpUploadHandlerFactory.java
@@ -120,7 +120,7 @@ public class FtpUploadHandlerFactory extends BaseThingHandlerFactory {
 
         if (properties.get("passivePorts") != null) {
             String strPassivePorts = properties.get("passivePorts").toString();
-            if (StringUtils.isNotEmpty(strPassivePorts)) {
+            if (!strPassivePorts.isEmpty()) {
                 try {
                     dataConnectionConfigurationFactory.setPassivePorts(strPassivePorts);
                 } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/FtpUploadHandlerFactory.java
+++ b/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/FtpUploadHandlerFactory.java
@@ -19,6 +19,7 @@ import java.util.Dictionary;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.ftpserver.DataConnectionConfigurationFactory;
 import org.apache.ftpserver.FtpServerConfigurationException;
 import org.apache.ftpserver.ftplet.FtpException;
 import org.openhab.binding.ftpupload.internal.ftp.FtpServer;
@@ -90,6 +91,7 @@ public class FtpUploadHandlerFactory extends BaseThingHandlerFactory {
     protected synchronized void modified(ComponentContext componentContext) {
         stopFtpServer();
         Dictionary<String, Object> properties = componentContext.getProperties();
+        DataConnectionConfigurationFactory dataConnectionConfigurationFactory = new DataConnectionConfigurationFactory();
 
         int port = DEFAULT_PORT;
         int idleTimeout = DEFAULT_IDLE_TIMEOUT;
@@ -116,9 +118,21 @@ public class FtpUploadHandlerFactory extends BaseThingHandlerFactory {
             }
         }
 
+        if (properties.get("passivePorts") != null) {
+            String strPassivePorts = properties.get("passivePorts").toString();
+            if (StringUtils.isNotEmpty(strPassivePorts)) {
+                try {
+                    dataConnectionConfigurationFactory.setPassivePorts(strPassivePorts);
+                } catch (IllegalArgumentException e) {
+                    logger.warn("Invalid passive ports '{}' ({})", strPassivePorts, e.getMessage());
+                }
+            }
+        }
+
         try {
             logger.debug("Starting FTP server, port={}, idleTimeout={}", port, idleTimeout);
-            ftpServer.startServer(port, idleTimeout);
+            ftpServer.startServer(port, idleTimeout,
+                    dataConnectionConfigurationFactory.createDataConnectionConfiguration());
         } catch (FtpException | FtpServerConfigurationException e) {
             logger.warn("FTP server starting failed, reason: {}", e.getMessage());
         }

--- a/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/ftp/FtpServer.java
+++ b/bundles/org.openhab.binding.ftpupload/src/main/java/org/openhab/binding/ftpupload/internal/ftp/FtpServer.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ftpserver.DataConnectionConfiguration;
 import org.apache.ftpserver.FtpServerConfigurationException;
 import org.apache.ftpserver.FtpServerFactory;
 import org.apache.ftpserver.ftplet.DefaultFtplet;
@@ -48,6 +49,7 @@ public class FtpServer {
     private final Logger logger = LoggerFactory.getLogger(FtpServer.class);
 
     private int port;
+    private DataConnectionConfiguration dataConnectionConfiguration;
     int idleTimeout;
 
     private org.apache.ftpserver.FtpServer server;
@@ -61,10 +63,12 @@ public class FtpServer {
         FTPUserManager = new FTPUserManager();
     }
 
-    public void startServer(int port, int idleTimeout) throws FtpException {
+    public void startServer(int port, int idleTimeout, DataConnectionConfiguration dataConnectionConfiguration)
+            throws FtpException {
         stopServer();
         this.port = port;
         this.idleTimeout = idleTimeout;
+        this.dataConnectionConfiguration = dataConnectionConfiguration;
         FTPUserManager.setIdleTimeout(idleTimeout);
         initServer();
     }
@@ -127,8 +131,10 @@ public class FtpServer {
     private void initServer() throws FtpException {
         FtpServerFactory serverFactory = new FtpServerFactory();
         ListenerFactory listenerFactory = new ListenerFactory();
+
         listenerFactory.setPort(port);
         listenerFactory.setIdleTimeout(idleTimeout);
+        listenerFactory.setDataConnectionConfiguration(dataConnectionConfiguration);
 
         Listener listener = listenerFactory.createListener();
 

--- a/bundles/org.openhab.binding.ftpupload/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.ftpupload/src/main/resources/OH-INF/binding/binding.xml
@@ -21,8 +21,10 @@
 		<parameter name="passivePorts" type="text">
 			<label>Passive Port Range</label>
 			<description>A string of passive ports, can contain a single port (as an integer), multiple ports seperated by
-				commas (e.g. 123,124,125) or ranges of ports, including open ended ranges (e.g. 123-125, 30000-, -1023).
-				Combinations for single ports and ranges is also supported. Empty (default) allows all ports as passive ports.</description>
+				commas
+				(e.g. 123,124,125) or ranges of ports, including open ended ranges (e.g. 123-125, 30000-, -1023).
+				Combinations for
+				single ports and ranges is also supported. Empty (default) allows all ports as passive ports.</description>
 			<default></default>
 			<advanced>true</advanced>
 		</parameter>

--- a/bundles/org.openhab.binding.ftpupload/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.ftpupload/src/main/resources/OH-INF/binding/binding.xml
@@ -18,5 +18,13 @@
 				time is disabled.</description>
 			<default>60</default>
 		</parameter>
+		<parameter name="passivePorts" type="text">
+			<label>Passive Port Range</label>
+			<description>A string of passive ports, can contain a single port (as an integer), multiple ports seperated by
+				commas (e.g. 123,124,125) or ranges of ports, including open ended ranges (e.g. 123-125, 30000-, -1023).
+				Combinations for single ports and ranges is also supported. Empty (default) allows all ports as passive ports.</description>
+			<default></default>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 </binding:binding>


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

The PR adds the functionality to optionally configure the passive FTP port range according to org.apache.ftpserver (https://mina.apache.org/ftpserver-project/configuration_passive_ports.html).

This is useful when you want to reduce the attack surface and reduce the number of ports to be allowed in your firewall.

Be aware:
I tried several hours to setup the dev environment with intellij (yes, I followed the docs ;)) - but all I got was building a single binding (this one) with mvn in the console. Testing was also hard because openhab debug always pulled the online version of the binding instead my version from the addon directory. 

So for testing there is help needed. Thanks in advance!