### PR TITLE
[OmniLink] Fix OmniLink temperature/humidity sensors

### DIFF
--- a/bundles/org.openhab.binding.omnilink/pom.xml
+++ b/bundles/org.openhab.binding.omnilink/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.digitaldan</groupId>
       <artifactId>jomnilink</artifactId>
-      <version>1.4.0</version>
+      <version>1.4.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/HumiditySensorHandler.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/HumiditySensorHandler.java
@@ -113,12 +113,12 @@ public class HumiditySensorHandler extends AbstractOmnilinkStatusHandler<Extende
         switch (channelUID.getId()) {
             case CHANNEL_AUX_LOW_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_HEAT_LOW_POINT.getNumber(),
-                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).intValue()),
+                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).floatValue()),
                         thingID);
                 break;
             case CHANNEL_AUX_HIGH_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_COOL_HIGH_POINT.getNumber(),
-                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).intValue()),
+                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).floatValue()),
                         thingID);
                 break;
             default:

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/TempSensorHandler.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/TempSensorHandler.java
@@ -126,12 +126,12 @@ public class TempSensorHandler extends AbstractOmnilinkStatusHandler<ExtendedAux
         switch (channelUID.getId()) {
             case CHANNEL_AUX_LOW_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_HEAT_LOW_POINT.getNumber(),
-                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).intValue()),
+                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).floatValue()),
                         thingID);
                 break;
             case CHANNEL_AUX_HIGH_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_COOL_HIGH_POINT.getNumber(),
-                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).intValue()),
+                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).floatValue()),
                         thingID);
                 break;
             default:

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/TemperatureFormat.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/TemperatureFormat.java
@@ -33,7 +33,7 @@ public enum TemperatureFormat {
         }
 
         @Override
-        public int formatToOmni(int celsius) {
+        public int formatToOmni(float celsius) {
             return MessageUtils.CToOmni(celsius);
         }
     },
@@ -44,7 +44,7 @@ public enum TemperatureFormat {
         }
 
         @Override
-        public int formatToOmni(int fahrenheit) {
+        public int formatToOmni(float fahrenheit) {
             return MessageUtils.FtoOmni(fahrenheit);
         }
     };
@@ -69,7 +69,7 @@ public enum TemperatureFormat {
      * @param format Number in the current format.
      * @return Omni formatted number.
      */
-    public abstract int formatToOmni(int format);
+    public abstract int formatToOmni(float format);
 
     /**
      * Get the number which identifies this format as defined by the omniprotocol.

--- a/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/ThermostatHandler.java
+++ b/bundles/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/handler/ThermostatHandler.java
@@ -157,22 +157,22 @@ public class ThermostatHandler extends AbstractOmnilinkStatusHandler<ExtendedThe
                 break;
             case CHANNEL_THERMO_HEAT_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_HEAT_LOW_POINT.getNumber(),
-                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).intValue()),
+                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).floatValue()),
                         thingID);
                 break;
             case CHANNEL_THERMO_COOL_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_COOL_HIGH_POINT.getNumber(),
-                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).intValue()),
+                        temperatureFormat.get().formatToOmni(((QuantityType<Temperature>) command).floatValue()),
                         thingID);
                 break;
             case CHANNEL_THERMO_HUMIDIFY_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_HUMDIFY_POINT.getNumber(),
-                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).intValue()),
+                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).floatValue()),
                         thingID);
                 break;
             case CHANNEL_THERMO_DEHUMIDIFY_SETPOINT:
                 sendOmnilinkCommand(OmniLinkCmd.CMD_THERMO_SET_DEHUMIDIFY_POINT.getNumber(),
-                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).intValue()),
+                        TemperatureFormat.FAHRENHEIT.formatToOmni(((QuantityType<Dimensionless>) command).floatValue()),
                         thingID);
                 break;
             default:


### PR DESCRIPTION
The upstream code the allows connection to the OmniPro uses float values to convert into Omni values, therefore this change was necessary to allow for proper execution of setting temperature commands. 

Signed-off-by: Ethan Dye <mrtops03@gmail.com>
