### PR TITLE
[deconz] Fixed wrong channel type for extended color light

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
@@ -116,7 +116,7 @@
 		<category>Lightbulb</category>
 		<channels>
 			<channel typeId="system.color" id="color"/>
-			<channel typeId="system.system.color-temperature-abs" id="color_temperature"/>
+			<channel typeId="ct" id="color_temperature"/>
 			<channel typeId="ontime" id="ontime"/>
 			<channel id="alert" typeId="alert"></channel>
 		</channels>


### PR DESCRIPTION
- Fixed wrong channel type for extended color light

Unfortunately I missed to revert one Color Temperature channel type in #10126 because it was written in a wrong way anyways.

```
2021-02-13 10:33:31.133 [ERROR] [ng.xml.internal.ThingTypeXmlProvider] - Could not register ThingType: deconz:extendedcolorlight
java.lang.IllegalArgumentException: ID segment 'system.color-temperature-abs' contains invalid characters. Each segment of the ID must match the pattern [\w-]*.
	at org.openhab.core.common.AbstractUID.validateSegment(AbstractUID.java:98) ~[bundleFile:?]
	at org.openhab.core.common.AbstractUID.<init>(AbstractUID.java:76) ~[bundleFile:?]
	at org.openhab.core.common.AbstractUID.<init>(AbstractUID.java:49) ~[bundleFile:?]
	at org.openhab.core.thing.UID.<init>(UID.java:48) ~[bundleFile:?]
	at org.openhab.core.thing.type.ChannelTypeUID.<init>(ChannelTypeUID.java:42) ~[bundleFile:?]
	at org.openhab.core.thing.xml.internal.ChannelXmlResult.toChannelDefinition(ChannelXmlResult.java:135) ~[bundleFile:?]
	at org.openhab.core.thing.xml.internal.ThingTypeXmlResult.toChannelDefinitions(ThingTypeXmlResult.java:98) ~[bundleFile:?]
	at org.openhab.core.thing.xml.internal.ThingTypeXmlResult.getBuilder(ThingTypeXmlResult.java:148) ~[bundleFile:?]
	at org.openhab.core.thing.xml.internal.ThingTypeXmlResult.toThingType(ThingTypeXmlResult.java:156) ~[bundleFile:?]
	at org.openhab.core.thing.xml.internal.ThingTypeXmlProvider.addingFinished(ThingTypeXmlProvider.java:137) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.addingFinished(XmlDocumentBundleTracker.java:247) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.parseDocuments(XmlDocumentBundleTracker.java:411) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:382) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:347) [bundleFile:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:?]
	at java.util.concurrent.FutureTask.run(Unknown Source) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
