### PR TITLE
[alarmdecoder] Doc update

### DIFF
--- a/bundles/org.openhab.binding.alarmdecoder/README.md
+++ b/bundles/org.openhab.binding.alarmdecoder/README.md
@@ -12,7 +12,7 @@ There are several versions of the adapter available:
 This binding allows openHAB to access the state of wired or wireless contacts and motion detectors connected to supported alarm panels, as well as the state of attached keypads and the messages send to attached LRR devices.
 Support is also available for sending keypad commands, including special/programmable keys supported by your panel.
 
-For those upgrading from the OH1 version of the binding, the [original OH1 README](https://www.openhab.org/v2.5/addons/bindings/alarmdecoder1/) file is available for reference.
+For those upgrading from the OH1 version of the binding, the [original OH1 README](https://github.com/openhab/openhab1-addons/blob/main/bundles/binding/org.openhab.binding.alarmdecoder/README.md) file is available for reference.
 
 ## Supported Things
 
@@ -311,3 +311,7 @@ The alarmdecoder device cannot query the panel for the state of individual zones
 For this reason, the binding puts contacts into the "unknown" state (UNDEF), *until the panel goes into the READY state*.
 At that point, all contacts for which no update messages have arrived are presumed to be in the CLOSED state.
 In other words: to get to a clean slate after an openHAB restart, close all doors/windows such that the panel is READY.
+
+## Reference Information
+
+The protocol used to communicate with the Alarm Decoder is described [here](http://www.alarmdecoder.com/wiki/index.php/Protocol).

--- a/bundles/org.openhab.binding.alarmdecoder/README.md
+++ b/bundles/org.openhab.binding.alarmdecoder/README.md
@@ -12,8 +12,6 @@ There are several versions of the adapter available:
 This binding allows openHAB to access the state of wired or wireless contacts and motion detectors connected to supported alarm panels, as well as the state of attached keypads and the messages send to attached LRR devices.
 Support is also available for sending keypad commands, including special/programmable keys supported by your panel.
 
-For those upgrading from the OH1 version of the binding, the [original OH1 README](https://github.com/openhab/openhab1-addons/blob/main/bundles/binding/org.openhab.binding.alarmdecoder/README.md) file is available for reference.
-
 ## Supported Things
 
 The binding supports the following thing types:
@@ -314,4 +312,4 @@ In other words: to get to a clean slate after an openHAB restart, close all door
 
 ## Reference Information
 
-The protocol used to communicate with the Alarm Decoder is described [here](http://www.alarmdecoder.com/wiki/index.php/Protocol).
+The protocol used to communicate with the Alarm Decoder is described [here](https://www.alarmdecoder.com/wiki/index.php/Protocol).


### PR DESCRIPTION
This PR mainly fixes a broken link in the README.md file. It used to reference the OH1 binding docs at:
https://www.openhab.org/v2.5/addons/bindings/alarmdecoder1/

But the OH1 binding docs don't appear to be available there anymore for some reason, and I was unable to find anywhere they could be accessed on www.openhab.org. I've changed the link to point to the openhab1-addons repo on github instead. If there is a better location to use, please let me know.
