### PR TITLE
[modbus] fix defaults for tcp and serial things and some other minor cleanup

### DIFF
--- a/bundles/org.openhab.binding.modbus/README.md
+++ b/bundles/org.openhab.binding.modbus/README.md
@@ -146,7 +146,7 @@ Basic parameters
 | stopBits  | text    | ✓        |                    | Stop bits. Valid values are: `"1.0"`, `"1.5"`, `"2.0"`.                                                                                                                                                       |     |
 | parity    | text    | ✓        |                    | Parity. Valid values are: `"none"`, `"even"`, `"odd"`.                                                                                                                                                    |     |
 | dataBits  | integer | ✓        |                    | Data bits. Valid values are: `5`, `6`, `7` and `8`.                                                                                                                                                       |     |
-| encoding  | text    | ✓        |                    | Encoding. Valid values are: `"ascii"`, `"rtu"`, `"bin"`.                                                                                                                                                  |     |
+| encoding  | text    |          | `"rtu"`           | Encoding. Valid values are: `"ascii"`, `"rtu"`, `"bin"`.                                                                                                                                                  |     |
 | echo      | boolean |          | `false`            | Flag for setting the RS485 echo mode. This controls whether we should try to read back whatever we send on the line, before reading the response. Valid values are: `true`, `false`.                      |     |
 
 Advanced parameters

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusSerialConfiguration.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusSerialConfiguration.java
@@ -24,16 +24,16 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ModbusSerialConfiguration {
     private @Nullable String port;
-    private int id;
+    private int id = 1;
     private int baud;
     private @Nullable String stopBits;
     private @Nullable String parity;
     private int dataBits;
-    private @Nullable String encoding;
+    private String encoding = "rtu";
     private boolean echo;
     private int receiveTimeoutMillis = 1500;
-    private @Nullable String flowControlIn;
-    private @Nullable String flowControlOut;
+    private String flowControlIn = "none";
+    private String flowControlOut = "none";
     private int timeBetweenTransactionsMillis = 35;
     private int connectMaxTries = 1;
     private int connectTimeoutMillis = 10_000;

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusSerialConfiguration.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusSerialConfiguration.java
@@ -31,12 +31,12 @@ public class ModbusSerialConfiguration {
     private int dataBits;
     private @Nullable String encoding;
     private boolean echo;
-    private int receiveTimeoutMillis;
+    private int receiveTimeoutMillis = 1500;
     private @Nullable String flowControlIn;
     private @Nullable String flowControlOut;
-    private int timeBetweenTransactionsMillis;
-    private int connectMaxTries;
-    private int connectTimeoutMillis;
+    private int timeBetweenTransactionsMillis = 35;
+    private int connectMaxTries = 1;
+    private int connectTimeoutMillis = 10_000;
     private boolean enableDiscovery;
 
     public @Nullable String getPort() {

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusTcpConfiguration.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusTcpConfiguration.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class ModbusTcpConfiguration {
     private @Nullable String host;
     private int port;
-    private int id;
+    private int id = 1;
     private int timeBetweenTransactionsMillis = 60;
     private int timeBetweenReconnectMillis;
     private int connectMaxTries = 1;

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusTcpConfiguration.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/config/ModbusTcpConfiguration.java
@@ -26,11 +26,11 @@ public class ModbusTcpConfiguration {
     private @Nullable String host;
     private int port;
     private int id;
-    private int timeBetweenTransactionsMillis;
+    private int timeBetweenTransactionsMillis = 60;
     private int timeBetweenReconnectMillis;
-    private int connectMaxTries;
+    private int connectMaxTries = 1;
     private int reconnectAfterMillis;
-    private int connectTimeoutMillis;
+    private int connectTimeoutMillis = 10_000;
     private boolean enableDiscovery;
     private boolean rtuEncoded;
 

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
@@ -45,7 +45,7 @@ public abstract class AbstractModbusEndpointThingHandler<E extends ModbusSlaveEn
     protected volatile @Nullable C config;
     protected volatile @Nullable E endpoint;
     protected ModbusManager modbusManager;
-    protected volatile @Nullable EndpointPoolConfiguration poolConfiguration;
+    protected volatile @NonNullByDefault({}) EndpointPoolConfiguration poolConfiguration;
     private final Logger logger = LoggerFactory.getLogger(AbstractModbusEndpointThingHandler.class);
     private @NonNullByDefault({}) ModbusCommunicationInterface comms;
 

--- a/itests/org.openhab.binding.modbus.tests/itest.bndrun
+++ b/itests/org.openhab.binding.modbus.tests/itest.bndrun
@@ -27,8 +27,6 @@ Fragment-Host: org.openhab.binding.modbus
 #
 -runbundles: \
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	org.apache.commons.io;version='[2.2.0,2.2.1)',\
-	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/AbstractModbusOSGiTest.java
@@ -107,13 +107,13 @@ public abstract class AbstractModbusOSGiTest extends JavaOSGiTest {
     private final Logger logger = LoggerFactory.getLogger(AbstractModbusOSGiTest.class);
 
     protected @Mock @NonNullByDefault({}) ModbusManager mockedModbusManager;
+    protected @NonNullByDefault({}) ModbusManager realModbusManager;
     protected @NonNullByDefault({}) ManagedThingProvider thingProvider;
     protected @NonNullByDefault({}) ManagedItemProvider itemProvider;
     protected @NonNullByDefault({}) ManagedItemChannelLinkProvider itemChannelLinkProvider;
     protected @NonNullByDefault({}) ItemRegistry itemRegistry;
     protected @NonNullByDefault({}) CoreItemFactory coreItemFactory;
 
-    private @NonNullByDefault({}) ModbusManager realModbusManager;
     private Set<Item> addedItems = new HashSet<>();
     private Set<Thing> addedThings = new HashSet<>();
     private Set<ItemChannelLink> addedLinks = new HashSet<>();

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
@@ -14,7 +14,7 @@ package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Objects;
 
@@ -98,6 +98,18 @@ public class ModbusTcpThingHandlerTest extends AbstractModbusOSGiTest {
 
             ModbusTcpThingHandler thingHandler = (ModbusTcpThingHandler) thing.getHandler();
             assertNotNull(thingHandler);
+
+            EndpointPoolConfiguration expectedPoolConfiguration = new EndpointPoolConfiguration();
+            expectedPoolConfiguration.setConnectMaxTries(1);
+            expectedPoolConfiguration.setInterTransactionDelayMillis(1);
+
+            // defaults
+            expectedPoolConfiguration.setConnectTimeoutMillis(10_000);
+            expectedPoolConfiguration.setInterConnectDelayMillis(0);
+            expectedPoolConfiguration.setReconnectAfterMillis(0);
+
+            assertEquals(expectedPoolConfiguration, realModbusManager
+                    .getEndpointPoolConfiguration(new ModbusTCPSlaveEndpoint("thisishost", 44, false)));
         }
         {
             Configuration thingConfig = new Configuration();
@@ -147,6 +159,22 @@ public class ModbusTcpThingHandlerTest extends AbstractModbusOSGiTest {
             addThing(thing);
             assertThat(thing.getStatus(), is(equalTo(ThingStatus.OFFLINE)));
             assertThat(thing.getStatusInfo().getStatusDetail(), is(equalTo(ThingStatusDetail.CONFIGURATION_ERROR)));
+        }
+        {
+            //
+            // Ensure the right EndpointPoolConfiguration is still in place
+            //
+            EndpointPoolConfiguration expectedPoolConfiguration = new EndpointPoolConfiguration();
+            expectedPoolConfiguration.setConnectMaxTries(1);
+            expectedPoolConfiguration.setInterTransactionDelayMillis(1); // Note: not 100
+
+            // defaults
+            expectedPoolConfiguration.setConnectTimeoutMillis(10_000);
+            expectedPoolConfiguration.setInterConnectDelayMillis(0);
+            expectedPoolConfiguration.setReconnectAfterMillis(0);
+
+            assertEquals(expectedPoolConfiguration, realModbusManager
+                    .getEndpointPoolConfiguration(new ModbusTCPSlaveEndpoint("thisishost", 44, false)));
         }
     }
 

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusTcpThingHandlerTest.java
@@ -46,6 +46,7 @@ public class ModbusTcpThingHandlerTest extends AbstractModbusOSGiTest {
 
     @Test
     public void testInitializeAndSlaveEndpoint() throws EndpointNotInitializedException {
+        // Using mocked modbus manager
         Configuration thingConfig = new Configuration();
         thingConfig.put("host", "thisishost");
         thingConfig.put("port", 44);
@@ -81,6 +82,8 @@ public class ModbusTcpThingHandlerTest extends AbstractModbusOSGiTest {
 
     @Test
     public void testTwoDifferentEndpointWithDifferentParameters() {
+        // Real implementation needed to validate this behaviour
+        swapModbusManagerToReal();
         // thing1
         {
             Configuration thingConfig = new Configuration();


### PR DESCRIPTION
Small improvements and fixes:
- Resolve modbus itests to remove dependency to apache commons (was removed in https://github.com/openhab/openhab-addons/pull/10002)
- `AbstractModbusEndpointThingHandler` `poolConfiguration` is never null in practice with properly configured `tcp`/`serial` endpoints. Therefore marking with `@NonNullByDefault({})`
- One of the itests did used mocked ModbusManager, leading to no-op test. Fixed now (test still passes)

More significant finding:
- Now utilizing the defaults documented for `tcp` and `serial` configurations. Presumably wrong values were used if one did not explicitly specify the values, e.g. slave id of zero was used instead of 1, or default delay of zero was used between transactions (`timeBetweenTransactionsMillis`) instead something more robust

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
