### PR TITLE
[bluetooth] Increase discovery duration and fix labels

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
@@ -61,7 +61,7 @@ public class BluetoothDiscoveryService extends AbstractDiscoveryService implemen
 
     private final Logger logger = LoggerFactory.getLogger(BluetoothDiscoveryService.class);
 
-    private static final int SEARCH_TIME = 15;
+    private static final int SEARCH_TIME = 60;
 
     private final Set<BluetoothAdapter> adapters = new CopyOnWriteArraySet<>();
     private final Set<BluetoothDiscoveryParticipant> participants = new CopyOnWriteArraySet<>();
@@ -155,10 +155,6 @@ public class BluetoothDiscoveryService extends AbstractDiscoveryService implemen
 
     private static DiscoveryResult copyWithNewBridge(DiscoveryResult result, BluetoothAdapter adapter) {
         String label = result.getLabel();
-        String adapterLabel = adapter.getLabel();
-        if (adapterLabel != null) {
-            label = adapterLabel + " - " + label;
-        }
 
         return DiscoveryResultBuilder.create(createThingUIDWithBridge(result, adapter))//
                 .withBridge(adapter.getUID())//


### PR DESCRIPTION
15 seconds appears far too short - upon every discovery, I have a different set of BT devices in the inbox as all results are cleaned with the next discovery and many devices do not broadcast themselves within the 15 seconds range.

Also, discovery result labels must not contain labels of the bridges, but should only describe the discovered thing itself.
I see the point of hinting the user about what bridge was involved here, but we have this information in the ThingUID already.
@ghys How hard would it be for the inbox to render the id of the bridge (if any) next to the representation property? Have you already thought about such a feature?

Signed-off-by: Kai Kreuzer <kai@openhab.org>