### PR TITLE
[bluetooth] Define supported bridge types for generic BT devices

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/thing/generic.xml
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/resources/OH-INF/thing/generic.xml
@@ -5,6 +5,12 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="generic">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="roaming"/>
+			<bridge-type-ref id="bluegiga"/>
+			<bridge-type-ref id="bluez"/>
+		</supported-bridge-type-refs>
+
 		<label>Generic Bluetooth Device</label>
 		<description>A generic bluetooth device that supports GATT characteristics</description>
 


### PR DESCRIPTION
Without this, it is not possible to manually define a generic BT thing in the UI as it is not possible to assign a bridge to it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>