### PR TITLE
[sunspec] Handle fp numbers for voltage types

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/OH-INF/thing/meter-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/resources/OH-INF/thing/meter-channel-types.xml
@@ -7,12 +7,12 @@
 	<channel-type id="ac-average-voltage-to-n-type">
 		<item-type>Number:ElectricPotential</item-type>
 		<label>Average Line To Neutral AC Voltage</label>
-		<state readOnly="true" pattern="%d %unit%"/>
+		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="ac-average-voltage-to-next-type">
 		<item-type>Number:ElectricPotential</item-type>
 		<label>Average Line To Line AC Voltage</label>
-		<state readOnly="true" pattern="%d %unit%"/>
+		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 	<channel-type id="ac-total-real-power-type">
 		<item-type>Number:Power</item-type>


### PR DESCRIPTION
Fixes #9269 
Signed-off-by: Jan Philipp Giel <mail@philsown.de>

Sunspec defined voltage types throw an exception when formatting for the UI, the pattern %d %unit% has to be replaced with %.0f %unit% as already done for #9636, #9596 and #9597 