### PR TITLE
[octopusenergy] New binding to support Octopus Energy API (agile energy tariffs in the UK)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ features/**/src/main/feature
 .vscode
 .factorypath
 pom.xml.versionsBackup
+
+bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelperLiveTest.java

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,6 +190,7 @@
 /bundles/org.openhab.binding.nuvo/ @mlobstein
 /bundles/org.openhab.binding.nzwateralerts/ @cossey
 /bundles/org.openhab.binding.oceanic/ @kgoderis
+/bundles/org.openhab.binding.octopusenergy/ @renescherer
 /bundles/org.openhab.binding.ojelectronics/ @EvilPingu
 /bundles/org.openhab.binding.omnikinverter/ @hansbogert
 /bundles/org.openhab.binding.omnilink/ @ecdye

--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -938,6 +938,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.octopusenergy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.ojelectronics</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.octopusenergy/NOTICE
+++ b/bundles/org.openhab.binding.octopusenergy/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-addons

--- a/bundles/org.openhab.binding.octopusenergy/README.md
+++ b/bundles/org.openhab.binding.octopusenergy/README.md
@@ -1,16 +1,13 @@
 # Octopus Energy Binding
 
-This binding allows OpenHAB to communicate with the public API from Octopus Energy (https://octopus.energy), an energy provider in the UK.
+This binding allows openHAB to communicate with the public API from Octopus Energy (https://octopus.energy), an energy provider in the UK.
 The following features are provided by the binding:
 
-- retrieval of latest meter readings (consumption)
-- retrieval of tariff schedule / unit rates (if on an agile tariff, half-hourly future rates are provided based on availability)
-- calculation of forward looking least cost window based on given energy consumption. I.e. when is the cheapest time to run my dishwasher? This is available as a single pair of channels (cheapestSlotDuration, cheapestSlotStart) and also as an action for the use in scripts/rules.
+- Retrieval of latest meter readings (consumption)
+- Retrieval of tariff schedule / unit rates (if on an agile tariff, half-hourly future rates are provided based on availability)
+- Calculation of forward looking least cost window based on given energy consumption. I.e. when is the cheapest time to run my dishwasher? This is available as a single pair of channels (cheapestSlotDuration, cheapestSlotStart) and also as an action for the use in scripts/rules.
 
-#### Current Limitations / Work in Progress
-
-- only tested with Octopus "Agile" electricity tariff. I would welcome users of "Go" or "Go Faster" for testing.
-- doesn't do very much with historical data
+So far, this binding has only been tested with Octopus "Agile" electricity tariff. I would welcome users of "Go" or "Go Faster" for testing.
 
 ## Supported Things
 
@@ -18,9 +15,9 @@ This binding supports the following thing types
 
 | Thing                 | Thing Type | Discovery | Description                                    |
 |-----------------------|------------|-----------|------------------------------------------------|
-| Bridge                | Bridge     | Manual    |  A single connection to the Octopus Energy API |
-| ElectricityMeterPoint | Thing      | Automatic |  An electricity meter point                    |
-| GasMeterPoint         | Thing      | Automatic |  An gas meter point                            |
+| bridge                | Bridge     | Manual    |  A single connection to the Octopus Energy API |
+| electricityMeterPoint | Thing      | Automatic |  An electricity meter point                    |
+| gasMeterPoint         | Thing      | Automatic |  An gas meter point                            |
 
 
 ## Discovery
@@ -76,10 +73,11 @@ The following channels are defined. Except for the bridge refresh channel, all a
 ## Actions
 
 The key feature of this binding is a number of actions which can be invoked against an electricity meter point to calculate the optimal time and cost for running a certain appliance (e.g. Dishwasher). This can be used in a variety of ways, such as:
-- display the recommended Dishwasher or Washing machine start time on a wall panel
-- schedule a nightly EV charging session if your EVSE or car allows automated scheduling
-- switching of storage heaters overnight
-- schedule wake up time for a server to run nightly backups
+
+- Display the recommended Dishwasher or Washing machine start time on a wall panel
+- Schedule a nightly EV charging session if your EVSE or car allows automated scheduling
+- Switching of storage heaters overnight
+- Schedule wake up time for a server to run nightly backups
 
 ####  Electricity Meter Point
 

--- a/bundles/org.openhab.binding.octopusenergy/README.md
+++ b/bundles/org.openhab.binding.octopusenergy/README.md
@@ -1,0 +1,167 @@
+# Octopus Energy Binding
+
+This binding allows OpenHAB to communicate with the public API from Octopus Energy (https://octopus.energy), an energy provider in the UK.
+The following features are provided by the binding:
+
+- retrieval of latest meter readings (consumption)
+- retrieval of tariff schedule / unit rates (if on an agile tariff, half-hourly future rates are provided based on availability)
+- calculation of forward looking least cost window based on given energy consumption. I.e. when is the cheapest time to run my dishwasher? This is available as a single pair of channels (cheapestSlotDuration, cheapestSlotStart) and also as an action for the use in scripts/rules.
+
+#### Current Limitations / Work in Progress
+
+- only tested with Octopus "Agile" electricity tariff. I would welcome users of "Go" or "Go Faster" for testing.
+- doesn't do very much with historical data
+
+## Supported Things
+
+This binding supports the following thing types
+
+| Thing                 | Thing Type | Discovery | Description                                    |
+|-----------------------|------------|-----------|------------------------------------------------|
+| Bridge                | Bridge     | Manual    |  A single connection to the Octopus Energy API |
+| ElectricityMeterPoint | Thing      | Automatic |  An electricity meter point                    |
+| GasMeterPoint         | Thing      | Automatic |  An gas meter point                            |
+
+
+## Discovery
+
+Once the bridge is configured with Octopus Energy account number and API key, the various meter points will be discovered automatically and added to the Inbox.
+ 
+## Thing Configuration
+
+#### Manual configuration
+
+For the identifier of the meter points, the corresponding MPAN or MPRN is used.
+
+```
+Bridge octopusenergy:bridge:api "Demo Octopus Energy Bridge" [ accountNumber="<Account Number>", apiKey="<API Key>", refreshInterval=15 ]
+{
+  Thing electricityMeterPoint 1679122486235 "My Electricy Meter Point with MPAN 1679122486235"
+  Thing gasMeterPoint            3046829404 "My Gas Meter Point with MPRN 3046829404"
+}
+```
+
+## Channels
+
+The following channels are defined. Except for the bridge refresh channel, all are read-only.
+
+####  Bridge
+
+| channel                        | type          | description                                                                                  |
+|--------------------------------|---------------|----------------------------------------------------------------------------------------------|
+| refresh                        | Switch        | Allows a manual refresh of the API data when sent an ON command                              |
+| lastRefreshTime                | DateTime      | The time consumption and tariff information was last refreshed                               |
+
+####  Electricity Meter Point
+
+| channel                        | type          | description                                                                                  |
+|--------------------------------|---------------|----------------------------------------------------------------------------------------------|
+| mpan                           | String        | Meter Point Administration Number                                                            |
+| currentTariff                  | String        | The currently applicable tariff                                                              |
+| mostRecentConsumptionAmount    | Number:Energy | The amount of energy consumed during the given time window                                   |
+| mostRecentConsumptionStartTime | DateTime      | The start time of the most recent consumption window                                         |
+| mostRecentConsumptionEndTime   | DateTime      | The end time of the most recent consumption window                                           |
+| unitPriceWindowStartTime       | Number        | The start time of the unit price window                                                      |
+| unitPriceWindowEndTime         | DateTime      | The end time of the unit price window                                                        |
+| unitPriceWindowMinAmount       | Number        | The minimum unit price of energy in GBp per Kilowatt Hour over the available forecast period |
+| unitPriceWindowMaxAmount       | DateTime      | The maximum unit price of energy in GBp per Kilowatt Hour over the available forecast period |
+
+####  Gas Meter Point
+
+| channel                        | type          | description                                                                                  |
+|--------------------------------|---------------|----------------------------------------------------------------------------------------------|
+| mprn                           | String        | Meter Point Reference Number                                                                 |
+| currentTariff                  | String        | The currently applicable tariff                                                              |
+
+## Actions
+
+The key feature of this binding is a number of actions which can be invoked against an electricity meter point to calculate the optimal time and cost for running a certain appliance (e.g. Dishwasher). This can be used in a variety of ways, such as:
+- display the recommended Dishwasher or Washing machine start time on a wall panel
+- schedule a nightly EV charging session if your EVSE or car allows automated scheduling
+- switching of storage heaters overnight
+- schedule wake up time for a server to run nightly backups
+
+####  Electricity Meter Point
+
+| action                         | parameters                                                        | description                                                                                                |
+|--------------------------------|-------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| optimise                       | Duration duration                                                 | Calculates the optimal time and cost for an activity with a given duration.                                |
+| optimiseWithRecurringEndTime   | Duration duration, int latestEndHour, int latestEndMinute         | Calculates the optimal time for an activity with a given duration and a latest end time (hour/minute)      |
+| optimiseWithRecurringStartTime | Duration duration, int earliestStartHour, int earliestStartMinute | Calculates the optimal time for an activity with a given duration and an earliest start time (hour/minute) |
+| optimiseWithAbsoluteStartTime  | Duration duration, ZonedDateTime earliestStartTime                | Calculates the optimal time for an activity with a given duration and an earliest absolute start time      |
+
+
+## Examples
+
+octopusenergy.things
+
+```
+Bridge octopusenergy:bridge:api "Demo Octopus Energy Bridge" [ accountNumber="A_123456", apiKey="sk_live_MGlrHJ67GKd93Sle9IO", refreshInterval=15 ]
+{
+  Thing electricityMeterPoint 1679122486235 "My Electricy Meter Point with MPAN 1679122486235"
+  Thing gasMeterPoint            7048462901 "My Gas Meter Point with MPRN 7048462901"
+}
+```
+
+octopusenergy.items
+
+```
+// Bridge Items
+Switch   Refresh          "Refresh the data"                { channel="octopusenergy:bridge:api:refresh" }
+DateTime LastRefreshTime  "Last Refresh Time [%1$td.%1$tm.%1$tY %1$tH:%1$tM:%1$tS]"      <time>  { channel="octopusenergy:bridge:api:lastRefreshTime" }
+
+// Electricity Meter Point Items
+String   MPAN             "MPAN [%s]"                                                            { channel="octopusenergy:electricityMeterPoint:api:1679122486235:mpan" }  
+String   CurrentTariff    "Current Tariff [%s]"                                                  { channel="octopusenergy:electricityMeterPoint:api:1679122486235:currentTariff" }  
+DateTime PriceWindowStart "Prices available from [%1$td.%1$tm.%1$tY %1$tH:%1$tM:%1$tS]"  <time>  { channel="octopusenergy:electricityMeterPoint:api:1679122486235:unitPriceWindowStartTime" }
+DateTime PriceWindowEnd   "Prices available until [%1$td.%1$tm.%1$tY %1$tH:%1$tM:%1$tS]" <time>  { channel="octopusenergy:electricityMeterPoint:api:1679122486235:unitPriceWindowEndTime" }
+Number   PriceMin         "Lowest Unit Price [%.2f p/kWh]"                                       { channel="octopusenergy:electricityMeterPoint:api:1679122486235:unitPriceWindowMinAmount" }
+Number   PriceMax         "Highest Unit Price [%.2f p/kWh]"                                      { channel="octopusenergy:electricityMeterPoint:api:1679122486235:unitPriceWindowMaxAmount" }
+
+// Wall Panel Items (e.g. HABPanel)
+// - connect DishwasherDuration to a slider (0-300, step 5)
+// - connect DishwasherEndHour to a slider (0-23, step 1)
+// - connect DishwasherEndMinute to a slider (0-55, step 5)
+//
+Number:Time DishwasherDuration         "Dishwasher Program Duration [%d mins]"
+Number      DishwasherEndHour          "Dishwasher must finish before [%d hour]"
+Number      DishwasherEndMinute        "Dishwasher must finish before [%d min]"
+DateTime    DishwasherOptimalStartTime "Dishwasher optimal start time [%1$td.%1$tm.%1$tY %1$tH:%1$tM:%1$tS]" <time> 
+Number      DishwasherAvgUnitPrice     "Dishwasher average unit price [%.2f p/kWh]" <time> 
+
+```
+
+octopusenergy.rules
+
+```
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.util.Map
+
+rule "calculateDishwasherEndTime"
+when
+  Item LastRefreshTime changed
+  or Item DishwasherDuration changed
+  or Item DishwasherEndHour changed
+  or Item DishwasherEndMinute changed
+then
+  val octopusAction = getActions("octopusenergy","octopusenergy:electricityMeterPoint:api:1679122486235")
+
+  var Duration duration = Duration.ofMinutes((DishwasherDuration.state as Number).longValue())
+  var int endHour = (DishwasherEndHour.state as Number).intValue()
+  var int endMinute = (DishwasherEndMinute.state as Number).intValue()
+
+  var Map<String,Object> result = octopusAction.optimiseWithRecurringEndTime(duration,endHour,endMinute);
+  
+  var ZonedDateTime optimisedStartTime = (result.get("optimisedStartTime") as ZonedDateTime)
+  var BigDecimal optimisedAverageUnitCost = (result.get("optimisedAverageUnitCost") as BigDecimal)
+
+  postUpdate(DishwasherOptimalStartTime, new DateTimeType(optimisedStartTime))
+  postUpdate(DishwasherAvgUnitPrice, new DecimalType(optimisedAverageUnitCost))
+end
+```
+
+
+
+

--- a/bundles/org.openhab.binding.octopusenergy/pom.xml
+++ b/bundles/org.openhab.binding.octopusenergy/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.octopusenergy</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: OctopusEnergy Binding</name>
+
+</project>

--- a/bundles/org.openhab.binding.octopusenergy/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.openhab.binding.octopusenergy-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+
+	<feature name="openhab-binding-octopusenergy" description="OctopusEnergy Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.octopusenergy/${project.version}</bundle>
+	</feature>
+</features>

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelper.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelper.java
@@ -249,7 +249,7 @@ public class OctopusEnergyApiHelper {
                         "Unexpected Http response: " + response.getStatus() + " - " + response.getReason());
             }
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            throw new ApiException("Exception caught during API execution." + e);
+            throw new ApiException("Exception caught during API execution.", e);
         }
     }
 }

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelper.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelper.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Authentication;
+import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.BasicAuthentication;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.octopusenergy.internal.dto.Accounts;
+import org.openhab.binding.octopusenergy.internal.dto.Consumption;
+import org.openhab.binding.octopusenergy.internal.dto.ElectricityMeterPoint;
+import org.openhab.binding.octopusenergy.internal.dto.Meter;
+import org.openhab.binding.octopusenergy.internal.dto.PagedResultSet;
+import org.openhab.binding.octopusenergy.internal.dto.Price;
+import org.openhab.binding.octopusenergy.internal.exception.ApiException;
+import org.openhab.binding.octopusenergy.internal.exception.AuthenticationException;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * The {@link OctopusEnergyApiHelper} is a helper class to abstract the Octopus Energy API. It handles authentication
+ * and
+ * all JSON API calls.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyApiHelper {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyApiHelper.class);
+
+    private static final String API_USER_AGENT = "Mozilla/5.0 (Linux; Android 7.0; SM-G930F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36";
+
+    private static final String API_URL = "https://api.octopus.energy/v1/";
+    private static final String ACCOUNTS_URL = API_URL + "accounts/";
+    private static final String ELECTRICITY_METER_POINT_URL = API_URL + "electricity-meter-points/";
+    private static final String PRODUCT_POINT_URL = API_URL + "products/";
+    private static final int DEFAULT_QUERY_PAGE_SIZE = 10; // Query a maximum of 10 results
+    private static final int DEFAULT_PRICE_QUERY_PAGE_SIZE = 100; // We want up to 48h half-hourly readings
+    private static final int DEFAULT_QUERY_WINDOW = 48; // Most smart meters only communicate sporadically. 48 hours
+                                                        // should provide enough time to have at least a small number of
+                                                        // readings.
+
+    private static final DateTimeFormatter ZULU_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    private String accountNumber = "";
+    private String apiKey = "";
+
+    private boolean authenticated = false;
+
+    private @NonNullByDefault({}) HttpClient httpClient;
+    private Accounts accounts = new Accounts();
+
+    /**
+     * Sets the httpClient object to be used for API calls.
+     *
+     * @param httpClient the client to be used.
+     */
+    public void setHttpClient(@Nullable HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Sets the account number to be used for API calls.
+     *
+     * @param accountNumber the user's account number.
+     */
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    /**
+     * Sets the API key to be used for API calls.
+     *
+     * @param apiKey the user's API key.
+     */
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Returns the accounts.
+     *
+     * @return the topology
+     */
+    public final Accounts getAccounts() {
+        return accounts;
+    }
+
+    /**
+     * Refreshes the accounts, i.e. all meter points, through a call to the Octopus Energy API.
+     */
+    public synchronized void updateAccounts() throws ApiException {
+        try {
+            String url = ACCOUNTS_URL + accountNumber + "/";
+            Accounts cache = OctopusEnergyBindingConstants.GSON.fromJson(getDataFromApi(url), Accounts.class);
+            if (cache != null) {
+                accounts = cache;
+            }
+        } catch (JsonSyntaxException e) {
+            throw new ApiException("Exception caught during accounts cache update: {}", e);
+        }
+    }
+
+    /**
+     * Refreshes the consumption for each meter point
+     */
+    public synchronized void updateElectricityConsumption() throws ApiException {
+        try {
+            ZonedDateTime endTime = ZonedDateTime.now();
+            ZonedDateTime startTime = endTime.minus(DEFAULT_QUERY_WINDOW, ChronoUnit.HOURS);
+            for (ElectricityMeterPoint emp : accounts.getElectricityMeterPoints()) {
+                emp.consumptionList = new ArrayList<Consumption>();
+                for (Meter m : emp.meters) {
+                    StringBuilder url = new StringBuilder(ELECTRICITY_METER_POINT_URL);
+                    url.append(emp.mpan);
+                    url.append("/meters/");
+                    url.append(m.serialNumber);
+                    url.append("/consumption/?page_size=");
+                    url.append(DEFAULT_QUERY_PAGE_SIZE);
+                    url.append("&period_from=");
+                    url.append(ZULU_TIME_FORMATTER.format(startTime));
+                    url.append("&period_to=");
+                    url.append(ZULU_TIME_FORMATTER.format(endTime));
+                    url.append("&order_by=-period");
+                    Type collectionType = new TypeToken<PagedResultSet<Consumption>>() {
+                    }.getType();
+                    PagedResultSet<Consumption> cache = OctopusEnergyBindingConstants.GSON
+                            .fromJson(getDataFromApi(url.toString()), collectionType);
+                    if (cache != null) {
+                        m.consumptionList = cache.results;
+                        // in most cases, we only have 1 active meter per meter point, but the model allows for having
+                        // more than one meter, we therefore aggregate the consumption results by meter point
+                        emp.consumptionList = Consumption.aggregate(emp.consumptionList, m.consumptionList);
+                    }
+                }
+                logger.debug("# of consumptions: {}, most recent: {}", emp.consumptionList.size(),
+                        emp.consumptionList.get(emp.consumptionList.size() - 1));
+            }
+        } catch (JsonSyntaxException e) {
+            throw new ApiException("Exception caught during accounts cache update: {}", e);
+        }
+    }
+
+    /**
+     * Refreshes the consumption for each meter point
+     */
+    public synchronized void updateElectricityPrices() throws ApiException {
+        try {
+            ZonedDateTime endTime = ZonedDateTime.now().plus(DEFAULT_QUERY_WINDOW, ChronoUnit.HOURS);
+            ZonedDateTime startTime = ZonedDateTime.now();
+            for (ElectricityMeterPoint emp : accounts.getElectricityMeterPoints()) {
+                StringBuilder url = new StringBuilder(PRODUCT_POINT_URL);
+                url.append(emp.getProductAsOf(startTime));
+                url.append("/electricity-tariffs/");
+                url.append(emp.getAgreementAsOf(startTime).tariffCode);
+                url.append("/standard-unit-rates/?page_size=");
+                url.append(DEFAULT_PRICE_QUERY_PAGE_SIZE);
+                url.append("&period_from=");
+                url.append(ZULU_TIME_FORMATTER.format(startTime));
+                url.append("&period_to=");
+                url.append(ZULU_TIME_FORMATTER.format(endTime));
+                Type collectionType = new TypeToken<PagedResultSet<Price>>() {
+                }.getType();
+                PagedResultSet<Price> cache = OctopusEnergyBindingConstants.GSON
+                        .fromJson(getDataFromApi(url.toString()), collectionType);
+                if (cache != null) {
+                    emp.priceList = cache.results;
+                    Collections.sort(emp.priceList, Price.INTERVAL_START_ORDER_ASC);
+                    logger.debug("# of prices: {}, furthest: {}", emp.priceList.size(),
+                            emp.priceList.get(emp.priceList.size() - 1));
+                }
+            }
+        } catch (JsonSyntaxException | RecordNotFoundException e) {
+            throw new ApiException("Exception caught during accounts cache update: {}", e);
+        }
+    }
+
+    /**
+     * Return the "data" element of the API result as a JsonElement.
+     *
+     * @param url The URL of the API call.
+     * @return The "data" element of the API result.
+     * @throws ApiException
+     */
+    private JsonElement getDataFromApi(String url) throws ApiException {
+        logger.debug("getting data for URL: {}", url);
+        if (!authenticated) {
+            AuthenticationStore authenticationStore = httpClient.getAuthenticationStore();
+            logger.debug("creating BASIC authentication: '{}:'", apiKey);
+            BasicAuthentication authentication = new BasicAuthentication(URI.create(API_URL), Authentication.ANY_REALM,
+                    apiKey, "");
+            authenticationStore.addAuthentication(authentication);
+            authenticated = true;
+        }
+        Request request = httpClient.newRequest(url).method(HttpMethod.GET);
+        try {
+            request.header(HttpHeader.ACCEPT, "application/json, text/plain, */*");
+            request.header(HttpHeader.ACCEPT_ENCODING, "gzip, deflate");
+            request.header(HttpHeader.CONTENT_TYPE, "application/json; utf-8");
+            request.header(HttpHeader.USER_AGENT, API_USER_AGENT);
+            ContentResponse response = request.send();
+            if (response.getStatus() == HttpURLConnection.HTTP_OK) {
+                String responseData = response.getContentAsString();
+                logger.debug("API execution successful, response: {}", responseData);
+
+                JsonParser parser = new JsonParser();
+                JsonElement object = parser.parse(responseData);
+                return object;
+            } else if (response.getStatus() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new AuthenticationException("Invalid account number/API key combination");
+            } else {
+                logger.debug("HTTP Response: {} - {}", response.getStatus(), response.getReason());
+                throw new ApiException(
+                        "Unexpected Http response: " + response.getStatus() + " - " + response.getReason());
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ApiException("Exception caught during API execution." + e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyBindingConstants.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyBindingConstants.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.util.GsonDurationTypeAdapter;
+import org.openhab.binding.octopusenergy.internal.util.GsonLocalDateTypeAdapter;
+import org.openhab.binding.octopusenergy.internal.util.GsonLocalTimeTypeAdapter;
+import org.openhab.binding.octopusenergy.internal.util.GsonZonedDateTimeTypeAdapter;
+import org.openhab.core.thing.ThingTypeUID;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * The {@link OctopusEnergyBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyBindingConstants {
+
+    private static final String BINDING_ID = "octopusenergy";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
+    public static final ThingTypeUID THING_TYPE_ELECTRICITY_METER_POINT = new ThingTypeUID(BINDING_ID,
+            "electricityMeterPoint");
+    public static final ThingTypeUID THING_TYPE_GAS_METER_POINT = new ThingTypeUID(BINDING_ID, "gasMeterPoint");
+
+    public static final Set<ThingTypeUID> BRIDGE_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_BRIDGE);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(
+            Arrays.asList(THING_TYPE_ELECTRICITY_METER_POINT, THING_TYPE_GAS_METER_POINT));
+
+    // List of all Channel ids
+    public static final String CHANNEL_BRIDGE_REFRESH = "refresh";
+    public static final String CHANNEL_BRIDGE_LAST_REFRESH_TIME = "lastRefreshTime";
+
+    public static final String CHANNEL_METERPOINT_MPAN = "mpan";
+    public static final String CHANNEL_METERPOINT_MPRN = "mprn";
+    public static final String CHANNEL_METERPOINT_CURRENT_TARIFF = "currentTariff";
+    public static final String CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_AMOUNT = "mostRecentConsumptionAmount";
+    public static final String CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_START_TIME = "mostRecentConsumptionStartTime";
+    public static final String CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_END_TIME = "mostRecentConsumptionEndTime";
+    public static final String CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_START_TIME = "unitPriceWindowStartTime";
+    public static final String CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_END_TIME = "unitPriceWindowEndTime";
+    public static final String CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MIN_AMOUNT = "unitPriceWindowMinAmount";
+    public static final String CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MAX_AMOUNT = "unitPriceWindowMaxAmount";
+
+    // Other Binding constants
+
+    public static final String PROPERTY_NAME_MPAN = "mpan";
+    public static final String PROPERTY_NAME_MPRN = "mprn";
+
+    public static final long DEFAULT_REFRESH_INTERVAL_MINS = 15;
+
+    public static final String UNDEFINED_STRING = "UNDEFINED";
+    public static final ZonedDateTime UNDEFINED_TIME = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
+
+    public static final Gson GSON = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .registerTypeAdapter(Duration.class, new GsonDurationTypeAdapter())
+            .registerTypeAdapter(ZonedDateTime.class, new GsonZonedDateTimeTypeAdapter())
+            .registerTypeAdapter(LocalDate.class, new GsonLocalDateTypeAdapter())
+            .registerTypeAdapter(LocalTime.class, new GsonLocalTimeTypeAdapter()).create();
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyConfiguration.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyConfiguration.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link OctopusEnergyConfiguration} class contains fields mapping thing configuration parameters.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyConfiguration {
+
+    /**
+     * The Octopus Energy account number.
+     */
+    public String accountNumber = "";
+
+    /**
+     * The Octopus Energy API key.
+     */
+    public String apiKey = "";
+
+    /**
+     * The Octopus Energy query interval (in minutes) for consumption and price updates.
+     */
+    public long refreshInterval = OctopusEnergyBindingConstants.DEFAULT_REFRESH_INTERVAL_MINS;
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyDiscoveryService.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyDiscoveryService.java
@@ -132,7 +132,7 @@ public class OctopusEnergyDiscoveryService extends AbstractDiscoveryService
     private void electricityMeterPointDiscovered(ElectricityMeterPoint meterPoint) {
         logger.debug("Discovered meter point: {}", meterPoint.mpan);
         ThingUID thingsUID = new ThingUID(THING_TYPE_ELECTRICITY_METER_POINT, bridgeUID, meterPoint.mpan);
-        Map<String, Object> properties = new HashMap<String, Object>(meterPoint.getThingProperties());
+        Map<String, Object> properties = new HashMap<>(meterPoint.getThingProperties());
         thingDiscovered(DiscoveryResultBuilder.create(thingsUID)
                 .withLabel("Octopus Energy Electricity Meter Point " + meterPoint.mpan).withProperties(properties)
                 .withRepresentationProperty(PROPERTY_NAME_MPAN).withBridge(bridgeUID).build());
@@ -141,7 +141,7 @@ public class OctopusEnergyDiscoveryService extends AbstractDiscoveryService
     private void gasMeterPointDiscovered(GasMeterPoint meterPoint) {
         logger.debug("Discovered meter point: {}", meterPoint.mprn);
         ThingUID thingsUID = new ThingUID(THING_TYPE_GAS_METER_POINT, bridgeUID, meterPoint.mprn);
-        Map<String, Object> properties = new HashMap<String, Object>(meterPoint.getThingProperties());
+        Map<String, Object> properties = new HashMap<>(meterPoint.getThingProperties());
         thingDiscovered(DiscoveryResultBuilder.create(thingsUID)
                 .withLabel("Octopus Gas Electricity Meter Point " + meterPoint.mprn).withProperties(properties)
                 .withRepresentationProperty(PROPERTY_NAME_MPRN).withBridge(bridgeUID).build());

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyDiscoveryService.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyDiscoveryService.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import static org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.dto.ElectricityMeterPoint;
+import org.openhab.binding.octopusenergy.internal.dto.GasMeterPoint;
+import org.openhab.binding.octopusenergy.internal.handler.OctopusEnergyBridgeHandler;
+import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyDiscoveryService} is an implementation of a discovery service for Octopus Energy meter
+ * points.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyDiscoveryService extends AbstractDiscoveryService
+        implements DiscoveryService, ThingHandlerService {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyDiscoveryService.class);
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_BRIDGE);
+
+    private static final int DISCOVER_TIMEOUT_SECONDS = 5;
+    private static final int DISCOVERY_SCAN_DELAY_MINUTES = 1;
+    private static final int DISCOVERY_REFRESH_INTERVAL_HOURS = 12;
+
+    private @Nullable ScheduledFuture<?> discoveryJob;
+
+    private @NonNullByDefault({}) OctopusEnergyBridgeHandler bridgeHandler;
+    private @NonNullByDefault({}) ThingUID bridgeUID;
+
+    /**
+     * Creates a OctopusEnergyDiscoveryService with enabled autostart.
+     */
+    public OctopusEnergyDiscoveryService() {
+        super(SUPPORTED_THING_TYPES, DISCOVER_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypes() {
+        return SUPPORTED_THING_TYPES;
+    }
+
+    @Override
+    public void activate() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY, Boolean.TRUE);
+        super.activate(properties);
+    }
+
+    /* We override this method to allow a call from the thing handler factory */
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        if (handler instanceof OctopusEnergyBridgeHandler) {
+            bridgeHandler = (OctopusEnergyBridgeHandler) handler;
+            bridgeUID = bridgeHandler.getUID();
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return bridgeHandler;
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        logger.debug("Starting Octopus Energy account discovery");
+        stopBackgroundDiscovery();
+        discoveryJob = scheduler.scheduleWithFixedDelay(this::startScan, DISCOVERY_SCAN_DELAY_MINUTES,
+                DISCOVERY_REFRESH_INTERVAL_HOURS * 60, TimeUnit.MINUTES);
+        logger.debug("Scheduled topology-changed job every {} hours", DISCOVERY_REFRESH_INTERVAL_HOURS);
+    }
+
+    @Override
+    protected void stopBackgroundDiscovery() {
+        ScheduledFuture<?> job = discoveryJob;
+        if (job != null) {
+            job.cancel(true);
+            discoveryJob = null;
+            logger.debug("Stopped Octopus Energy background discovery");
+        }
+    }
+
+    @Override
+    protected void startScan() {
+        logger.debug("Starting Octopus Energy account discovery scan");
+        // If the bridge is not online no other thing devices can be found, so no reason to scan at this moment.
+        removeOlderResults(getTimestampOfLastScan());
+        if (bridgeHandler.getThing().getStatus() == ThingStatus.ONLINE) {
+            logger.debug("Starting device discovery for bridge {}", bridgeUID);
+            bridgeHandler.listElectricityMeterPoints().forEach(this::electricityMeterPointDiscovered);
+            bridgeHandler.listGasMeterPoints().forEach(this::gasMeterPointDiscovered);
+        }
+    }
+
+    private void electricityMeterPointDiscovered(ElectricityMeterPoint meterPoint) {
+        logger.debug("Discovered meter point: {}", meterPoint.mpan);
+        ThingUID thingsUID = new ThingUID(THING_TYPE_ELECTRICITY_METER_POINT, bridgeUID, meterPoint.mpan);
+        Map<String, Object> properties = new HashMap<String, Object>(meterPoint.getThingProperties());
+        thingDiscovered(DiscoveryResultBuilder.create(thingsUID)
+                .withLabel("Octopus Energy Electricity Meter Point " + meterPoint.mpan).withProperties(properties)
+                .withRepresentationProperty(PROPERTY_NAME_MPAN).withBridge(bridgeUID).build());
+    }
+
+    private void gasMeterPointDiscovered(GasMeterPoint meterPoint) {
+        logger.debug("Discovered meter point: {}", meterPoint.mprn);
+        ThingUID thingsUID = new ThingUID(THING_TYPE_GAS_METER_POINT, bridgeUID, meterPoint.mprn);
+        Map<String, Object> properties = new HashMap<String, Object>(meterPoint.getThingProperties());
+        thingDiscovered(DiscoveryResultBuilder.create(thingsUID)
+                .withLabel("Octopus Gas Electricity Meter Point " + meterPoint.mprn).withProperties(properties)
+                .withRepresentationProperty(PROPERTY_NAME_MPRN).withBridge(bridgeUID).build());
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyHandlerFactory.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyHandlerFactory.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import static org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants.*;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.handler.OctopusEnergyBridgeHandler;
+import org.openhab.binding.octopusenergy.internal.handler.OctopusEnergyElectricityMeterPointHandler;
+import org.openhab.binding.octopusenergy.internal.handler.OctopusEnergyGasMeterPointHandler;
+import org.openhab.core.io.net.http.HttpClientFactory;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+@Component(configurationPid = "binding.octopusenergy", service = ThingHandlerFactory.class)
+public class OctopusEnergyHandlerFactory extends BaseThingHandlerFactory {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyHandlerFactory.class);
+
+    private OctopusEnergyApiHelper apiHelper = new OctopusEnergyApiHelper();
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .of(BRIDGE_THING_TYPES_UIDS, OctopusEnergyBindingConstants.SUPPORTED_THING_TYPES_UIDS)
+            .flatMap(Collection::stream).collect(Collectors.toSet());
+
+    /**
+     * Returns true if the factory supports the given thing type.
+     */
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    /**
+     * Returns a newly created thing handler for the given thing.
+     */
+    @Override
+    protected @Nullable ThingHandler createHandler(Thing thing) {
+        logger.debug("createHandler - create handler for {}", thing);
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(THING_TYPE_ELECTRICITY_METER_POINT)) {
+            return new OctopusEnergyElectricityMeterPointHandler(thing, apiHelper);
+        } else if (thingTypeUID.equals(THING_TYPE_GAS_METER_POINT)) {
+            return new OctopusEnergyGasMeterPointHandler(thing, apiHelper);
+        } else if (thingTypeUID.equals(THING_TYPE_BRIDGE)) {
+            return new OctopusEnergyBridgeHandler((Bridge) thing, apiHelper);
+        }
+        return null;
+    }
+
+    @Reference
+    protected void setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        apiHelper.setHttpClient(httpClientFactory.getCommonHttpClient());
+    }
+
+    protected void unsetHttpClientFactory(HttpClientFactory httpClientFactory) {
+        apiHelper.setHttpClient(null);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/AccountProperty.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/AccountProperty.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link AccountProperty} is a DTO class representing a physical building/location (e.g. a private house).
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class AccountProperty {
+
+    // {
+    // "id":2305833,
+    // "moved_in_at":"2020-10-09T00:00:00+01:00",
+    // "moved_out_at":null,
+    // "address_line_1":"99 MyStreet",
+    // "address_line_2":"",
+    // "address_line_3":"My Hamlet",
+    // "town":"MyTown",
+    // "county":"MyCounty",
+    // "postcode":"MyPostcode",
+    // "electricity_meter_points":[
+    // ],
+    // "gas_meter_points":[
+    // ]
+    // }
+
+    /**
+     * An Octopus Energy generated unique property identifier.
+     */
+    public long id;
+
+    /**
+     * Time when the user moved into the property.
+     */
+    @Nullable
+    public ZonedDateTime movedInAt;
+    /**
+     * Time when the user moved out of the property.
+     */
+    @Nullable
+    public ZonedDateTime movedOutAt;
+
+    @SerializedName("address_line_1")
+    @Nullable
+    public String addressLine1;
+
+    @SerializedName("address_line_2")
+    @Nullable
+    public String addressLine2;
+
+    @SerializedName("address_line_3")
+
+    @Nullable
+    public String addressLine3;
+
+    @Nullable
+    public String town;
+
+    @Nullable
+    public String county;
+
+    @Nullable
+    public String postcode;
+
+    ArrayList<ElectricityMeterPoint> electricityMeterPoints = new ArrayList<>();
+    ArrayList<GasMeterPoint> gasMeterPoints = new ArrayList<>();
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Accounts.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Accounts.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+
+/**
+ * The {@link Accounts} class is a DTO to hold an API response to a 'accounts' call.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Accounts {
+
+    // {
+    // "number":"A-E653DBA",
+    // "properties":[
+    // ]
+    // }
+
+    /**
+     * The account number of the Octopus Energy account.
+     */
+    public String number = "";
+
+    /**
+     * A list of account properties (i.e. houses)
+     */
+    public ArrayList<AccountProperty> properties = new ArrayList<>();
+
+    /**
+     * @return a list of electricity meter points across all properties in this account.
+     */
+    public List<ElectricityMeterPoint> getElectricityMeterPoints() {
+        ArrayList<ElectricityMeterPoint> combined = new ArrayList<>();
+        for (AccountProperty ap : properties) {
+            combined.addAll(ap.electricityMeterPoints);
+        }
+        return combined;
+    }
+
+    /**
+     * @return a list of gas meter points across all properties in this account.
+     */
+    public List<GasMeterPoint> getGasMeterPoints() {
+        ArrayList<GasMeterPoint> combined = new ArrayList<>();
+        for (AccountProperty ap : properties) {
+            combined.addAll(ap.gasMeterPoints);
+        }
+        return combined;
+    }
+
+    /**
+     * finds the meter point with the given identifier.
+     *
+     * @param identifier
+     * @return
+     *         the meter point or null if no meter point with the given identifier is found.
+     */
+    public ElectricityMeterPoint getElectricityMeterPoint(String identifier) throws RecordNotFoundException {
+        for (AccountProperty ap : properties) {
+            for (ElectricityMeterPoint mp : ap.electricityMeterPoints) {
+                if (mp.mpan.equals(identifier)) {
+                    return mp;
+                }
+            }
+        }
+        throw new RecordNotFoundException("No Meter Point wuth MPAN: " + identifier + " exists");
+    }
+
+    /**
+     * finds the meter point with the given identifier.
+     *
+     * @param identifier
+     * @return
+     *         the meter point or null if no meter point with the given identifier is found.
+     */
+    public GasMeterPoint getGasMeterPoint(String identifier) throws RecordNotFoundException {
+        for (AccountProperty ap : properties) {
+            for (GasMeterPoint mp : ap.gasMeterPoints) {
+                if (mp.mprn.equals(identifier)) {
+                    return mp;
+                }
+            }
+        }
+        throw new RecordNotFoundException("No Meter Point wuth MPRN: " + identifier + " exists");
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Agreement.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Agreement.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+
+/**
+ * The {@link Agreement} is a DTO class representing an agreement or contract.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Agreement {
+    // {
+    // "tariff_code":"E-1R-SUPER-GREEN-12M-20-09-22-A",
+    // "valid_from":"2020-11-01T00:00:00Z",
+    // "valid_to":"2020-12-11T00:00:00Z"
+    // },
+
+    public String tariffCode = OctopusEnergyBindingConstants.UNDEFINED_STRING;
+    public ZonedDateTime validFrom = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public ZonedDateTime validTo = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    public Agreement(String tariffCode, ZonedDateTime validFrom, ZonedDateTime validTo) {
+        super();
+        this.tariffCode = tariffCode;
+        this.validFrom = validFrom;
+        this.validTo = validTo;
+    }
+
+    public String getProduct() throws RecordNotFoundException {
+        String product = tariffCode;
+        try {
+            // find index of the char after the second hyphen
+            int hyphenIndex = product.indexOf('-', product.indexOf('-') + 1) + 1;
+            product = product.substring(hyphenIndex);
+            hyphenIndex = product.lastIndexOf('-');
+            return product.substring(0, hyphenIndex);
+        } catch (IndexOutOfBoundsException e) {
+            throw new RecordNotFoundException("Can't determine product from tariff - " + tariffCode, e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Consumption.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Consumption.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link Consumption} is a DTO class representing an agreement or contract.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Consumption {
+    // {
+    // "consumption":0.283,
+    // "interval_start":"2021-01-17T20:30:00Z",
+    // "interval_end":"2021-01-17T21:00:00Z"
+    // }
+
+    public static final Comparator<Consumption> CONSUMPTION_ORDER_ASC = new Comparator<Consumption>() {
+        @Override
+        public int compare(Consumption c1, Consumption c2) {
+            return c1.consumption.compareTo(c2.consumption);
+        }
+    };
+    public static final Comparator<Consumption> INTERVAL_START_ORDER_ASC = new Comparator<Consumption>() {
+        @Override
+        public int compare(Consumption c1, Consumption c2) {
+            return c1.intervalStart.compareTo(c2.intervalStart);
+        }
+    };
+
+    /**
+     * Aggregates two lists of consumption data into a single list. If energy data is available in both lists for the
+     * same interval, this will be added together for the result list.
+     *
+     * The code assumes that there are no duplicate intervals within a single list and all intervals are the same size.
+     *
+     * @param list1
+     * @param list2
+     * @return
+     *         the aggregated list.
+     */
+    public static final List<Consumption> aggregate(List<Consumption> list1, List<Consumption> list2) {
+        List<Consumption> slist = new ArrayList<>(list1);
+        slist.addAll(list2);
+        Collections.sort(slist, INTERVAL_START_ORDER_ASC);
+        List<Consumption> result = new ArrayList<>();
+        int i;
+        for (i = 0; i < (slist.size() - 1); i++) {
+            Consumption c1 = slist.get(i);
+            Consumption c2 = slist.get(i + 1);
+            if (c1.intervalStart.equals(c2.intervalStart)) {
+                c1.consumption = c1.consumption.add(c2.consumption);
+                i++;
+            }
+            result.add(c1);
+        }
+        if (i < slist.size()) {
+            result.add(slist.get(i));
+        }
+        return result;
+    }
+
+    public Consumption(BigDecimal consumption, ZonedDateTime intervalStart, ZonedDateTime intervalEnd) {
+        this.consumption = consumption;
+        this.intervalStart = intervalStart;
+        this.intervalEnd = intervalEnd;
+    }
+
+    public BigDecimal consumption = BigDecimal.ZERO;
+    public ZonedDateTime intervalStart = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public ZonedDateTime intervalEnd = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    @Override
+    public String toString() {
+        return "Consumption(" + intervalStart + "," + intervalEnd + "," + consumption + ")";
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/ElectricityMeterPoint.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/ElectricityMeterPoint.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.openhab.binding.octopusenergy.internal.util.PriceOptimiser;
+
+/**
+ * The {@link ElectricityMeterPoint} is a DTO class representing an electricity meter point.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class ElectricityMeterPoint {
+
+    // {
+    // "mpan":"1012493048237",
+    // "profile_class":1,
+    // "consumption_standard":4514,
+    // "meters":[
+    // ],
+    // "agreements":[
+    // ],
+    // "is_export":false
+    // }
+
+    /**
+     * The Meter Point Administration Number, a unique identifier of each meter point.
+     */
+    public String mpan = OctopusEnergyBindingConstants.UNDEFINED_STRING;
+
+    public @Nullable Integer profileClass;
+    public @Nullable Long consumptionStandard;
+
+    public List<Meter> meters = new ArrayList<>();
+    public List<Agreement> agreements = new ArrayList<>();
+
+    public @Nullable Boolean isExport;
+
+    public List<Consumption> consumptionList = new ArrayList<>();
+
+    /**
+     * a list of price slots, ordered from earliest to latest
+     */
+    public List<Price> priceList = new ArrayList<>();
+
+    public PriceOptimiser optimizer = new PriceOptimiser();
+
+    public Map<String, String> getThingProperties() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("mpan", mpan);
+        Integer pc = profileClass;
+        if (pc != null) {
+            properties.put("profileClass", pc.toString());
+        }
+        Long cs = consumptionStandard;
+        if (cs != null) {
+            properties.put("consumptionStandard", cs.toString());
+        }
+        Boolean ie = isExport;
+        if (ie != null) {
+            properties.put("isExport", ie.toString());
+        }
+        return properties;
+    }
+
+    public Agreement getAgreementAsOf(ZonedDateTime startTime) throws RecordNotFoundException {
+        for (Agreement agr : agreements) {
+            if ((startTime.isEqual(agr.validFrom) || startTime.isAfter(agr.validFrom))
+                    && (startTime.isBefore(agr.validTo))) {
+                return agr;
+            }
+        }
+        throw new RecordNotFoundException("No agreement found for time - " + startTime.toString());
+    }
+
+    public String getProductAsOf(ZonedDateTime startTime) throws RecordNotFoundException {
+        return getAgreementAsOf(startTime).getProduct();
+    }
+
+    public Consumption getMostRecentConsumption() throws RecordNotFoundException {
+        if (consumptionList.size() > 0) {
+            return Collections.max(consumptionList, Consumption.INTERVAL_START_ORDER_ASC);
+        }
+        throw new RecordNotFoundException();
+    }
+
+    public BigDecimal getMaxPrice(boolean includeVat) throws RecordNotFoundException {
+        if (priceList.size() > 0) {
+            Price p = Collections.max(priceList, Price.PRICE_ORDER_ASC);
+            return includeVat ? p.valueIncVat : p.valueExcVat;
+        }
+        throw new RecordNotFoundException();
+    }
+
+    public BigDecimal getMinPrice(boolean includeVat) throws RecordNotFoundException {
+        if (priceList.size() > 0) {
+            Price p = Collections.min(priceList, Price.PRICE_ORDER_ASC);
+            return includeVat ? p.valueIncVat : p.valueExcVat;
+        }
+        throw new RecordNotFoundException();
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/GasMeterPoint.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/GasMeterPoint.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+
+/**
+ * The {@link GasMeterPoint} is a DTO class representing a gas meter point.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class GasMeterPoint {
+
+    // {
+    // "mprn":"3029115504",
+    // "consumption_standard":23882,
+    // "meters":[
+    // ],
+    // "agreements":[
+    // ]
+    // }
+
+    /**
+     * The Meter Point Reference Number, a unique identifier of each meter point.
+     */
+    public String mprn = OctopusEnergyBindingConstants.UNDEFINED_STRING;
+
+    public @Nullable Long consumptionStandard;
+
+    public ArrayList<Meter> meters = new ArrayList<>();
+    public ArrayList<Agreement> agreements = new ArrayList<>();
+
+    public Map<String, String> getThingProperties() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("mprn", mprn);
+        Long cs = consumptionStandard;
+        if (cs != null) {
+            properties.put("consumptionStandard", cs.toString());
+        }
+        return properties;
+    }
+
+    public Agreement getAgreementAsOf(ZonedDateTime startTime) throws RecordNotFoundException {
+        for (Agreement agr : agreements) {
+            if ((startTime.isEqual(agr.validFrom) || startTime.isAfter(agr.validFrom))
+                    && (startTime.isBefore(agr.validTo))) {
+                return agr;
+            }
+        }
+        throw new RecordNotFoundException("No agreement found for time - " + startTime.toString());
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Meter.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Meter.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link ElectricityMeterPoint} is a DTO class representing a physical meter.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Meter {
+
+    // {
+    // "serial_number":"S81E028343",
+    // "registers":[
+    // ]
+    // }
+
+    public String serialNumber = OctopusEnergyBindingConstants.UNDEFINED_STRING;
+
+    public ArrayList<Register> registers = new ArrayList<>();
+
+    public List<Consumption> consumptionList = new ArrayList<>();
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/PagedResultSet.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/PagedResultSet.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.util.ArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link PagedResultSet} is a DTO generic class representing a set of paged results.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class PagedResultSet<T> {
+    // {
+    // "count":6,
+    // "next":null,
+    // "previous":null,
+    // "results":[
+    // ]
+    // }
+
+    public int count;
+    public String next = "null";
+    public String previous = "null";
+    public ArrayList<T> results = new ArrayList<>();
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Price.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Price.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link Price} is a DTO class representing a price.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Price {
+
+    public static final Comparator<Price> PRICE_ORDER_ASC = new Comparator<Price>() {
+        @Override
+        public int compare(Price c1, Price c2) {
+            return c1.valueExcVat.compareTo(c2.valueExcVat);
+        }
+    };
+
+    public static final Comparator<Price> INTERVAL_START_ORDER_ASC = new Comparator<Price>() {
+        @Override
+        public int compare(Price c1, Price c2) {
+            return c1.validFrom.compareTo(c2.validFrom);
+        }
+    };
+
+    public BigDecimal valueExcVat = BigDecimal.ZERO;
+    public BigDecimal valueIncVat = BigDecimal.ZERO;
+    public ZonedDateTime validFrom = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public ZonedDateTime validTo = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    public Price(BigDecimal valueExcVat, BigDecimal valueIncVat, ZonedDateTime validFrom, ZonedDateTime validTo) {
+        super();
+        this.valueExcVat = valueExcVat;
+        this.valueIncVat = valueIncVat;
+        this.validFrom = validFrom;
+        this.validTo = validTo;
+    }
+
+    public Price(double valueExcVat, double valueIncVat, ZonedDateTime validFrom, ZonedDateTime validTo) {
+        super();
+        this.valueExcVat = BigDecimal.valueOf(valueExcVat);
+        this.valueIncVat = BigDecimal.valueOf(valueIncVat);
+        this.validFrom = validFrom;
+        this.validTo = validTo;
+    }
+
+    @Override
+    public String toString() {
+        return "Price [valueExcVat=" + valueExcVat + ", valueIncVat=" + valueIncVat + ", validFrom=" + validFrom
+                + ", validTo=" + validTo + "]";
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/PriceOptimiserResult.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/PriceOptimiserResult.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link PriceOptimiserResult} is a DTO class representing the results of a price optimiser run.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class PriceOptimiserResult {
+    // optimiser inputs
+    public ZonedDateTime requestedStartTime = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public ZonedDateTime requestedEndTime = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public Duration requestedDuration = Duration.ZERO;
+
+    // optimiser outputs
+    public ZonedDateTime optimisedStartTime = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+    public BigDecimal optimisedAverageUnitCost = BigDecimal.ZERO;
+
+    public ZonedDateTime lastUpdatedTime = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    public PriceOptimiserResult(ZonedDateTime requestedStartTime, ZonedDateTime requestedEndTime,
+            Duration requestedDuration, ZonedDateTime optimisedStartTime, BigDecimal optimisedAverageUnitCost,
+            ZonedDateTime lastUpdatedTime) {
+        super();
+        this.requestedStartTime = requestedStartTime;
+        this.requestedEndTime = requestedEndTime;
+        this.requestedDuration = requestedDuration;
+        this.optimisedStartTime = optimisedStartTime;
+        this.optimisedAverageUnitCost = optimisedAverageUnitCost;
+        this.lastUpdatedTime = lastUpdatedTime;
+    }
+
+    @Override
+    public String toString() {
+        return "PriceOptimizerResult [requestedStartTime=" + requestedStartTime + ", requestedEndTime="
+                + requestedEndTime + ", requestedDuration=" + requestedDuration + ", optimisedStartTime="
+                + optimisedStartTime + ", optimisedAverageUnitCost=" + optimisedAverageUnitCost + ", lastUpdatedTime="
+                + lastUpdatedTime + "]";
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Register.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/dto/Register.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link Register} is a DTO class representing a register entry of a meter.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class Register {
+
+    // {
+    // "identifier":"01",
+    // "rate":"STANDARD",
+    // "is_settlement_register":true
+    // }
+
+    public String identifer = OctopusEnergyBindingConstants.UNDEFINED_STRING;
+
+    @Nullable
+    public String rate;
+
+    @Nullable
+    public Boolean isSettlementRegister;
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/ApiException.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/ApiException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link ApiException} is thrown during API interactions.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class ApiException extends OctopusEnergyException {
+
+    private static final long serialVersionUID = -7851429815604230535L;
+
+    public ApiException() {
+        super();
+    }
+
+    public ApiException(String message) {
+        super(message);
+    }
+
+    public ApiException(Throwable cause) {
+        super(cause);
+    }
+
+    public ApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/AuthenticationException.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/AuthenticationException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link AuthenticationException} is thrown during API interactions if the given account number / API
+ * key combination is invalid.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class AuthenticationException extends ApiException {
+
+    private static final long serialVersionUID = 4808759343110862340L;
+
+    public AuthenticationException() {
+        super();
+    }
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
+    public AuthenticationException(Throwable cause) {
+        super(cause);
+    }
+
+    public AuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/NotEnoughDataException.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/NotEnoughDataException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link NotEnoughDataException} is thrown if not enough data is available for the function to be performed.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class NotEnoughDataException extends OctopusEnergyException {
+
+    private static final long serialVersionUID = 4808345987650248340L;
+
+    public NotEnoughDataException() {
+        super();
+    }
+
+    public NotEnoughDataException(String message) {
+        super(message);
+    }
+
+    public NotEnoughDataException(Throwable cause) {
+        super(cause);
+    }
+
+    public NotEnoughDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/OctopusEnergyException.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/OctopusEnergyException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link OctopusEnergyException} class is the parent of all Octopus Energy binding exceptions.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyException extends Exception {
+
+    private static final long serialVersionUID = -7893729815604230535L;
+
+    public OctopusEnergyException() {
+        super();
+    }
+
+    public OctopusEnergyException(String message) {
+        super(message);
+    }
+
+    public OctopusEnergyException(Throwable cause) {
+        super(cause);
+    }
+
+    public OctopusEnergyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/RecordNotFoundException.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/exception/RecordNotFoundException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.exception;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link RecordNotFoundException} is thrown if a record is not found during a search.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class RecordNotFoundException extends OctopusEnergyException {
+
+    private static final long serialVersionUID = 4808759343110248340L;
+
+    public RecordNotFoundException() {
+        super();
+    }
+
+    public RecordNotFoundException(String message) {
+        super(message);
+    }
+
+    public RecordNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public RecordNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBaseMeterPointHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBaseMeterPointHandler.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import static org.openhab.core.thing.ThingStatus.ONLINE;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyApiHelper;
+import org.openhab.core.cache.ExpiringCache;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyBaseMeterPointHandler} is a base class responsible for handling commands, which are sent to
+ * one of the channels.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public abstract class OctopusEnergyBaseMeterPointHandler extends BaseThingHandler {
+
+    private static final int CACHE_TIMEOUT_SECOND = 3;
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyBaseMeterPointHandler.class);
+
+    protected final ExpiringCache<Integer> updateThingCache = new ExpiringCache<>(
+            Duration.ofSeconds(CACHE_TIMEOUT_SECOND), this::refreshCache);
+
+    protected final OctopusEnergyApiHelper apiHelper;
+
+    public OctopusEnergyBaseMeterPointHandler(Thing thing, OctopusEnergyApiHelper apiHelper) {
+        super(thing);
+        this.apiHelper = apiHelper;
+    }
+
+    @Override
+    public void initialize() {
+        updateStatus(ONLINE);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            synchronized (updateThingCache) {
+                updateThingCache.getValue();
+            }
+        }
+    }
+
+    @Override
+    public void updateProperties(Map<String, String> properties) {
+        super.updateProperties(properties);
+    }
+
+    protected abstract void updateThing();
+
+    private @Nullable Integer refreshCache() {
+        logger.debug("cache has expired, we refresh the values in the thing");
+        updateThing();
+        return Integer.MIN_VALUE;
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeActions.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeActions.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.exception.ApiException;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyBridgeActions} class implements a actions for the Octopus Energy bridge.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@ThingActionsScope(name = "octopusenergy")
+@NonNullByDefault
+public class OctopusEnergyBridgeActions implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyBridgeActions.class);
+
+    private @Nullable OctopusEnergyBridgeHandler handler;
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        this.handler = (OctopusEnergyBridgeHandler) handler;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "refresh", description = "Refreshes cached data from Octopus Energy.")
+    public void refresh() {
+        OctopusEnergyBridgeHandler handler = this.handler;
+        if (handler != null) {
+            try {
+                handler.refresh();
+            } catch (ApiException e) {
+                logger.warn("Could not refresh data from API - {}", e.getMessage());
+            }
+        }
+    }
+
+    public static void refresh(@Nullable ThingActions actions) {
+        if (actions instanceof OctopusEnergyBridgeActions) {
+            ((OctopusEnergyBridgeActions) actions).refresh();
+        } else {
+            throw new IllegalArgumentException("Instance is not an OctopusEnergyElectricityMeterPointActions class.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
@@ -77,8 +77,6 @@ public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
         OctopusEnergyConfiguration config = getConfigAs(OctopusEnergyConfiguration.class);
 
         if (config.accountNumber.equals("") || config.apiKey.equals("")) {
-            logger.warn("Setting thing '{}' to OFFLINE: Parameter 'accountNumber' and 'apiKey' must be configured.",
-                    getThing().getUID());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-missing-account-number-or-api-key");
             return;
@@ -89,7 +87,6 @@ public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
                 apiHelper.setAccountNumber(config.accountNumber);
                 apiHelper.setApiKey(config.apiKey);
                 refresh();
-                logger.debug("Accounts update successful, setting bridge status to ONLINE");
                 updateStatus(ThingStatus.ONLINE);
             } catch (AuthenticationException e) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -112,8 +109,7 @@ public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
                         updateStatus(ThingStatus.ONLINE);
                     }
                 } catch (ApiException e) {
-                    logger.warn("Setting thing '{}' to OFFLINE: Exception from API - {}", getThing().getUID(),
-                            e.getMessage());
+                    logger.warn("Exception from API - {}, {}", getThing().getUID(), e.getMessage());
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "@text/offline.comm-error-general");
                 }
@@ -152,8 +148,7 @@ public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
                                     "@text/offline.conf-error-authentication");
                             return;
                         } catch (ApiException e) {
-                            logger.warn("Setting thing '{}' to OFFLINE: Exception from API - {}", getThing().getUID(),
-                                    e.getMessage());
+                            logger.warn("Exception from API - {}, {}", getThing().getUID(), e.getMessage());
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                     "@text/offline.comm-error-general");
                         }

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
@@ -109,7 +109,7 @@ public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
                         updateStatus(ThingStatus.ONLINE);
                     }
                 } catch (ApiException e) {
-                    logger.warn("Exception from API - {}, {}", getThing().getUID(), e.getMessage());
+                    logger.warn("Exception from API - {}", getThing().getUID(), e);
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             "@text/offline.comm-error-general");
                 }

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyBridgeHandler.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import static org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants.*;
+
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyApiHelper;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyConfiguration;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyDiscoveryService;
+import org.openhab.binding.octopusenergy.internal.dto.ElectricityMeterPoint;
+import org.openhab.binding.octopusenergy.internal.dto.GasMeterPoint;
+import org.openhab.binding.octopusenergy.internal.exception.ApiException;
+import org.openhab.binding.octopusenergy.internal.exception.AuthenticationException;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseBridgeHandler;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyBridgeHandler} is responsible for handling the bridge things created to use the Octopus
+ * Energy API.
+ *
+ * It also spawns a background polling thread to update the data at a specified time interval.
+ *
+ * @author Rene Scherer - Initial Contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyBridgeHandler extends BaseBridgeHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyBridgeHandler.class);
+
+    private final OctopusEnergyApiHelper apiHelper;
+    private @Nullable ScheduledFuture<?> pollingJob;
+
+    private ZonedDateTime lastRefreshTime = UNDEFINED_TIME;
+
+    public OctopusEnergyBridgeHandler(Bridge bridge, OctopusEnergyApiHelper apiHelper) {
+        super(bridge);
+        this.apiHelper = apiHelper;
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Initializing Octopus Energy bridge handler.");
+        OctopusEnergyConfiguration config = getConfigAs(OctopusEnergyConfiguration.class);
+
+        if (config.accountNumber.equals("") || config.apiKey.equals("")) {
+            logger.warn("Setting thing '{}' to OFFLINE: Parameter 'accountNumber' and 'apiKey' must be configured.",
+                    getThing().getUID());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "@text/offline.conf-error-missing-account-number-or-api-key");
+            return;
+        } else {
+            updateStatus(ThingStatus.UNKNOWN);
+            try {
+                logger.debug("Login to API with account number: {}", config.accountNumber);
+                apiHelper.setAccountNumber(config.accountNumber);
+                apiHelper.setApiKey(config.apiKey);
+                refresh();
+                logger.debug("Accounts update successful, setting bridge status to ONLINE");
+                updateStatus(ThingStatus.ONLINE);
+            } catch (AuthenticationException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "@text/offline.conf-error-authentication");
+                return;
+            } catch (ApiException e) {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        "@text/offline.comm-error-general");
+            }
+        }
+
+        ScheduledFuture<?> job = pollingJob;
+        if (job == null || job.isCancelled()) {
+            pollingJob = scheduler.scheduleWithFixedDelay(() -> {
+                try {
+                    refresh();
+                    if ((getThing().getStatus() == ThingStatus.OFFLINE) && (getThing().getStatusInfo()
+                            .getStatusDetail() == ThingStatusDetail.COMMUNICATION_ERROR)) {
+                        // if previous status was COMMUNICATION_ERROR, we now reestablished the comms
+                        updateStatus(ThingStatus.ONLINE);
+                    }
+                } catch (ApiException e) {
+                    logger.warn("Setting thing '{}' to OFFLINE: Exception from API - {}", getThing().getUID(),
+                            e.getMessage());
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                            "@text/offline.comm-error-general");
+                }
+            }, config.refreshInterval, config.refreshInterval, TimeUnit.MINUTES);
+            logger.debug("Bridge topology polling job every {} minutes", config.refreshInterval);
+        }
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(OctopusEnergyDiscoveryService.class);
+    }
+
+    @Override
+    public void dispose() {
+        ScheduledFuture<?> job = pollingJob;
+        if (job != null && !job.isCancelled()) {
+            job.cancel(true);
+            pollingJob = null;
+            logger.debug("Stopped topology background polling process");
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            updateThing();
+        } else {
+            switch (channelUID.getId()) {
+                case CHANNEL_BRIDGE_REFRESH:
+                    if (OnOffType.ON.equals(command)) {
+                        try {
+                            refresh();
+                        } catch (AuthenticationException e) {
+                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                                    "@text/offline.conf-error-authentication");
+                            return;
+                        } catch (ApiException e) {
+                            logger.warn("Setting thing '{}' to OFFLINE: Exception from API - {}", getThing().getUID(),
+                                    e.getMessage());
+                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                    "@text/offline.comm-error-general");
+                        }
+                        updateState(CHANNEL_BRIDGE_REFRESH, OnOffType.OFF);
+                    }
+                    break;
+            }
+        }
+    }
+
+    public ThingUID getUID() {
+        return thing.getUID();
+    }
+
+    public Iterable<ElectricityMeterPoint> listElectricityMeterPoints() {
+        return apiHelper.getAccounts().getElectricityMeterPoints();
+    }
+
+    public Iterable<GasMeterPoint> listGasMeterPoints() {
+        return apiHelper.getAccounts().getGasMeterPoints();
+    }
+
+    protected void updateThing() {
+        if (lastRefreshTime.isEqual(UNDEFINED_TIME)) {
+            updateState(CHANNEL_BRIDGE_LAST_REFRESH_TIME, UnDefType.UNDEF);
+        } else {
+            updateState(CHANNEL_BRIDGE_LAST_REFRESH_TIME, new DateTimeType(lastRefreshTime));
+        }
+        updateState(CHANNEL_BRIDGE_REFRESH, OnOffType.OFF);
+    }
+
+    protected synchronized void refresh() throws ApiException {
+        logger.debug("Refreshing cache from API");
+        apiHelper.updateAccounts();
+        apiHelper.updateElectricityConsumption();
+        apiHelper.updateElectricityPrices();
+        lastRefreshTime = ZonedDateTime.now();
+        updateState(CHANNEL_BRIDGE_LAST_REFRESH_TIME, new DateTimeType(lastRefreshTime));
+
+        logger.debug("Updating {} connected things", getThing().getThings().size());
+        for (Thing th : getThing().getThings()) {
+            String identifier = th.getUID().getId();
+            Map<String, String> properties = null;
+            ThingHandler handler = th.getHandler();
+            if (handler instanceof OctopusEnergyElectricityMeterPointHandler) {
+                ((OctopusEnergyElectricityMeterPointHandler) handler).updateThing();
+                ElectricityMeterPoint mp;
+                try {
+                    mp = apiHelper.getAccounts().getElectricityMeterPoint(identifier);
+                    properties = mp.getThingProperties();
+                    ((OctopusEnergyElectricityMeterPointHandler) handler).updateProperties(properties);
+                } catch (RecordNotFoundException e) {
+                    logger.warn("No Meter Point found with MPAN - {}", identifier);
+                }
+            }
+            if (handler instanceof OctopusEnergyGasMeterPointHandler) {
+                ((OctopusEnergyGasMeterPointHandler) handler).updateThing();
+                GasMeterPoint mp;
+                try {
+                    mp = apiHelper.getAccounts().getGasMeterPoint(identifier);
+                    properties = mp.getThingProperties();
+                    ((OctopusEnergyGasMeterPointHandler) handler).updateProperties(properties);
+                } catch (RecordNotFoundException e) {
+                    logger.warn("No Meter Point found with MPRN - {}", identifier);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyElectricityMeterPointActions.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyElectricityMeterPointActions.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.octopusenergy.internal.dto.Price;
+import org.openhab.binding.octopusenergy.internal.dto.PriceOptimiserResult;
+import org.openhab.binding.octopusenergy.internal.exception.NotEnoughDataException;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.openhab.binding.octopusenergy.internal.util.PriceOptimiser;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyElectricityMeterPointActions} class implements actions for Electricity Meter Points.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@ThingActionsScope(name = "octopusenergy")
+@NonNullByDefault
+public class OctopusEnergyElectricityMeterPointActions implements ThingActions {
+
+    private static final PriceOptimiser PO = PriceOptimiser.getInstance();
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyElectricityMeterPointActions.class);
+
+    private @Nullable OctopusEnergyElectricityMeterPointHandler handler;
+
+    @Override
+    public void setThingHandler(ThingHandler handler) {
+        this.handler = (OctopusEnergyElectricityMeterPointHandler) handler;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return handler;
+    }
+
+    @RuleAction(label = "optimise", description = "Calculates the optimal time and cost for an activity.")
+    public @Nullable @ActionOutput(name = "lastUpdatedTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedStartTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedAverageUnitCost", type = "java.math.BigDecimal") @ActionOutput(name = "requestedDuration", type = "java.time.Duration") @ActionOutput(name = "requestedEndTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "requestedStartTime", type = "java.time.ZonedDateTime") Map<String, Object> optimise(
+            @ActionInput(name = "duration", label = "duration", description = "The duration of the activity.") Duration duration) {
+        try {
+            return toResultMap(PO.optimiseWithAbsoluteStartTime(duration, ZonedDateTime.now(), getPriceList()));
+        } catch (NotEnoughDataException e) {
+            logger.warn("Not enough data available for optimizer - {}", e.getMessage());
+        } catch (RecordNotFoundException e) {
+            logger.warn("No Meter Point found for optimizer - {}", e.getMessage());
+        }
+        return new HashMap<String, Object>();
+    }
+
+    public static @Nullable Map<String, Object> optimise(@Nullable ThingActions actions, Duration duration) {
+        if (actions instanceof OctopusEnergyElectricityMeterPointActions) {
+            return ((OctopusEnergyElectricityMeterPointActions) actions).optimise(duration);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OctopusEnergyElectricityMeterPointActions class.");
+        }
+    }
+
+    @RuleAction(label = "optimiseWithRecurringEndTime", description = "Calculates the optimal time and cost for an activity.")
+    public @Nullable @ActionOutput(name = "lastUpdatedTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedStartTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedAverageUnitCost", type = "java.math.BigDecimal") @ActionOutput(name = "requestedDuration", type = "java.time.Duration") @ActionOutput(name = "requestedEndTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "requestedStartTime", type = "java.time.ZonedDateTime") Map<String, Object> optimiseWithRecurringEndTime(
+            @ActionInput(name = "duration", label = "duration", description = "The duration of the activity.") Duration duration,
+            @ActionInput(name = "latestEndHour", label = "latestEndHour", description = "The latest hour the activity must finish.") int latestEndHour,
+            @ActionInput(name = "latestEndMinute", label = "latestEndMinute", description = "The latest minute the activity must finish.") int latestEndMinute) {
+        try {
+            return toResultMap(PO.optimiseWithRecurringEndTime(duration, ZonedDateTime.now(), latestEndHour,
+                    latestEndMinute, getPriceList()));
+        } catch (NotEnoughDataException e) {
+            logger.warn("Not enough data available for optimizer - {}", e.getMessage());
+        } catch (RecordNotFoundException e) {
+            logger.warn("No Meter Point found for optimizer - {}", e.getMessage());
+        }
+        return new HashMap<String, Object>();
+    }
+
+    public static @Nullable Map<String, Object> optimiseWithRecurringEndTime(@Nullable ThingActions actions,
+            Duration duration, int latestEndHour, int latestEndMinute) {
+        if (actions instanceof OctopusEnergyElectricityMeterPointActions) {
+            return ((OctopusEnergyElectricityMeterPointActions) actions).optimiseWithRecurringEndTime(duration,
+                    latestEndHour, latestEndMinute);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OctopusEnergyElectricityMeterPointActions class.");
+        }
+    }
+
+    @RuleAction(label = "optimiseWithRecurringStartTime", description = "Calculates the optimal time and cost for an activity.")
+    public @Nullable @ActionOutput(name = "lastUpdatedTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedStartTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedAverageUnitCost", type = "java.math.BigDecimal") @ActionOutput(name = "requestedDuration", type = "java.time.Duration") @ActionOutput(name = "requestedEndTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "requestedStartTime", type = "java.time.ZonedDateTime") Map<String, Object> optimiseWithRecurringStartTime(
+            @ActionInput(name = "duration", label = "duration", description = "The duration of the activity.") Duration duration,
+            @ActionInput(name = "earliestStartHour", label = "earliestStartHour", description = "The earliest hour the activity can start.") int earliestStartHour,
+            @ActionInput(name = "earliestStartMinute", label = "earliestStartMinute", description = "The earliest minute the activity can start.") int earliestStartMinute) {
+        try {
+            return toResultMap(PO.optimiseWithRecurringStartTime(duration, earliestStartHour, earliestStartMinute,
+                    ZonedDateTime.now(), getPriceList()));
+        } catch (NotEnoughDataException e) {
+            logger.warn("Not enough data available for optimizer - {}", e.getMessage());
+        } catch (RecordNotFoundException e) {
+            logger.warn("No Meter Point found for optimizer - {}", e.getMessage());
+        }
+        return new HashMap<String, Object>();
+    }
+
+    public static @Nullable Map<String, Object> optimiseWithRecurringStartTime(@Nullable ThingActions actions,
+            Duration duration, int earliestStartHour, int earliestStartMinute) {
+        if (actions instanceof OctopusEnergyElectricityMeterPointActions) {
+            return ((OctopusEnergyElectricityMeterPointActions) actions).optimiseWithRecurringStartTime(duration,
+                    earliestStartHour, earliestStartMinute);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OctopusEnergyElectricityMeterPointActions class.");
+        }
+    }
+
+    @RuleAction(label = "optimiseWithAbsoluteStartTime", description = "Calculates the optimal time and cost for anactivity.")
+    public @Nullable @ActionOutput(name = "lastUpdatedTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedStartTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "optimisedAverageUnitCost", type = "java.math.BigDecimal") @ActionOutput(name = "requestedDuration", type = "java.time.Duration") @ActionOutput(name = "requestedEndTime", type = "java.time.ZonedDateTime") @ActionOutput(name = "requestedStartTime", type = "java.time.ZonedDateTime") Map<String, Object> optimiseWithAbsoluteStartTime(
+            @ActionInput(name = "duration", label = "duration", description = "The duration of the activity.") Duration duration,
+            @ActionInput(name = "earliestStartTime", label = "earliestStartTime", description = "The earliest time the activity can start. If null, as soon as possible.") ZonedDateTime earliestStartTime) {
+        try {
+            return toResultMap(PO.optimiseWithAbsoluteStartTime(duration, earliestStartTime, getPriceList()));
+        } catch (NotEnoughDataException e) {
+            logger.warn("Not enough data available for optimizer - {}", e.getMessage());
+        } catch (RecordNotFoundException e) {
+            logger.warn("No Meter Point found for optimizer - {}", e.getMessage());
+        }
+        return new HashMap<String, Object>();
+    }
+
+    public static @Nullable Map<String, Object> optimiseWithAbsoluteStartTime(@Nullable ThingActions actions,
+            Duration duration, ZonedDateTime earliestStartTime) {
+        if (actions instanceof OctopusEnergyElectricityMeterPointActions) {
+            return ((OctopusEnergyElectricityMeterPointActions) actions).optimiseWithAbsoluteStartTime(duration,
+                    earliestStartTime);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OctopusEnergyElectricityMeterPointActions class.");
+        }
+    }
+
+    private List<Price> getPriceList() throws RecordNotFoundException {
+        OctopusEnergyElectricityMeterPointHandler handler = this.handler;
+        if (handler == null) {
+            throw new RecordNotFoundException("No Handler found");
+        }
+        return handler.getMeterPoint().priceList;
+    }
+
+    private Map<String, Object> toResultMap(PriceOptimiserResult result) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("lastUpdatedTime", result.lastUpdatedTime);
+        map.put("optimisedStartTime", result.optimisedStartTime);
+        map.put("optimisedAverageUnitCost", result.optimisedAverageUnitCost);
+        map.put("requestedDuration", result.requestedDuration);
+        map.put("requestedEndTime", result.requestedEndTime);
+        map.put("requestedStartTime", result.requestedStartTime);
+        return map;
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyElectricityMeterPointHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyElectricityMeterPointHandler.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import static org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants.*;
+
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.measure.quantity.Energy;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyApiHelper;
+import org.openhab.binding.octopusenergy.internal.dto.Consumption;
+import org.openhab.binding.octopusenergy.internal.dto.ElectricityMeterPoint;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.ThingHandlerService;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyElectricityMeterPointHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyElectricityMeterPointHandler extends OctopusEnergyBaseMeterPointHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyElectricityMeterPointHandler.class);
+
+    public OctopusEnergyElectricityMeterPointHandler(Thing thing, OctopusEnergyApiHelper apiHelper) {
+        super(thing, apiHelper);
+    }
+
+    @Override
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Collections.singleton(OctopusEnergyElectricityMeterPointActions.class);
+    }
+
+    public ElectricityMeterPoint getMeterPoint() throws RecordNotFoundException {
+        return apiHelper.getAccounts().getElectricityMeterPoint(thing.getUID().getId());
+    }
+
+    @Override
+    protected void updateThing() {
+        try {
+            ElectricityMeterPoint meterPoint = getMeterPoint();
+            logger.debug("Updating all channels for meter point : {}", meterPoint);
+            updateState(CHANNEL_METERPOINT_MPAN, new StringType(meterPoint.mpan));
+            try {
+                updateState(CHANNEL_METERPOINT_CURRENT_TARIFF,
+                        new StringType(meterPoint.getAgreementAsOf(ZonedDateTime.now()).tariffCode));
+            } catch (RecordNotFoundException e) {
+                updateState(CHANNEL_METERPOINT_CURRENT_TARIFF, UnDefType.UNDEF);
+            }
+            try {
+                Consumption consumption = meterPoint.getMostRecentConsumption();
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_AMOUNT,
+                        new QuantityType<Energy>(consumption.consumption, Units.KILOWATT_HOUR));
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_START_TIME,
+                        new DateTimeType(consumption.intervalStart));
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_END_TIME,
+                        new DateTimeType(consumption.intervalEnd));
+            } catch (RecordNotFoundException e) {
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_AMOUNT, UnDefType.UNDEF);
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_START_TIME, UnDefType.UNDEF);
+                updateState(CHANNEL_METERPOINT_MOST_RECENT_CONSUPTION_END_TIME, UnDefType.UNDEF);
+            }
+
+            if (meterPoint.priceList.isEmpty()) {
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_START_TIME, UnDefType.UNDEF);
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_END_TIME, UnDefType.UNDEF);
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MIN_AMOUNT, UnDefType.UNDEF);
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MAX_AMOUNT, UnDefType.UNDEF);
+            } else {
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_START_TIME,
+                        new DateTimeType(meterPoint.priceList.get(0).validFrom));
+                updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_END_TIME,
+                        new DateTimeType(meterPoint.priceList.get(meterPoint.priceList.size() - 1).validTo));
+                try {
+                    updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MIN_AMOUNT,
+                            new DecimalType(meterPoint.getMinPrice(true)));
+                    updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MAX_AMOUNT,
+                            new DecimalType(meterPoint.getMaxPrice(true)));
+                } catch (RecordNotFoundException e) {
+                    updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MIN_AMOUNT, UnDefType.UNDEF);
+                    updateState(CHANNEL_METERPOINT_UNIT_PRICE_WINDOW_MAX_AMOUNT, UnDefType.UNDEF);
+                }
+            }
+        } catch (RecordNotFoundException e) {
+            logger.debug("Trying to update unknown meter point: {}", thing.getUID().getId());
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyGasMeterPointHandler.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/handler/OctopusEnergyGasMeterPointHandler.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.handler;
+
+import static org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants.*;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyApiHelper;
+import org.openhab.binding.octopusenergy.internal.dto.GasMeterPoint;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OctopusEnergyGasMeterPointHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class OctopusEnergyGasMeterPointHandler extends OctopusEnergyBaseMeterPointHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OctopusEnergyGasMeterPointHandler.class);
+
+    public OctopusEnergyGasMeterPointHandler(Thing thing, OctopusEnergyApiHelper apiHelper) {
+        super(thing, apiHelper);
+    }
+
+    public GasMeterPoint getMeterPoint() throws RecordNotFoundException {
+        return apiHelper.getAccounts().getGasMeterPoint(thing.getUID().getId());
+    }
+
+    @Override
+    protected void updateThing() {
+        try {
+            GasMeterPoint meterPoint = getMeterPoint();
+            logger.debug("Updating all channels for meter point : {}", meterPoint);
+            updateState(CHANNEL_METERPOINT_MPRN, new StringType(meterPoint.mprn));
+            try {
+                updateState(CHANNEL_METERPOINT_CURRENT_TARIFF,
+                        new StringType(meterPoint.getAgreementAsOf(ZonedDateTime.now()).tariffCode));
+            } catch (RecordNotFoundException e) {
+                updateState(CHANNEL_METERPOINT_CURRENT_TARIFF, UnDefType.UNDEF);
+            }
+        } catch (RecordNotFoundException e) {
+            logger.debug("Trying to update unknown meter point: {}", thing.getUID().getId());
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonDurationTypeAdapter.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonDurationTypeAdapter.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import java.lang.reflect.Type;
+import java.time.Duration;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * GSON serialiser/deserialiser for converting {@link Duration} objects.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class GsonDurationTypeAdapter implements JsonSerializer<Duration>, JsonDeserializer<Duration> {
+
+    /**
+     * Gson invokes this call-back method during serialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
+     * non-trivial field of the {@code src} object. However, you should never invoke it on the
+     * {@code src} object itself since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param src the object that needs to be converted to Json.
+     * @param typeOfSrc the actual type (fully genericized version) of the source object.
+     * @return a JsonElement corresponding to the specified object.
+     */
+    @Override
+    public JsonElement serialize(Duration src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toString());
+    }
+
+    /**
+     * Gson invokes this call-back method during deserialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects
+     * for any non-trivial field of the returned object. However, you should never invoke it on the
+     * the same type passing {@code json} since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param json The Json data being deserialized
+     * @param typeOfT The type of the Object to deserialize to
+     * @return a deserialized object of the specified type typeOfT which is a subclass of {@code T}
+     * @throws JsonParseException if json is not in the expected format of {@code typeOfT}
+     */
+    @Override
+    public @Nullable Duration deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return Duration.parse(json.getAsString());
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonLocalDateTypeAdapter.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonLocalDateTypeAdapter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * GSON serialiser/deserialiser for converting {@link LocalDate} objects.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class GsonLocalDateTypeAdapter implements JsonSerializer<LocalDate>, JsonDeserializer<LocalDate> {
+
+    private static final DateTimeFormatter LOCAL_DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter ZONED_DATETIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    /**
+     * Gson invokes this call-back method during serialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
+     * non-trivial field of the {@code src} object. However, you should never invoke it on the
+     * {@code src} object itself since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param src the object that needs to be converted to Json.
+     * @param typeOfSrc the actual type (fully genericized version) of the source object.
+     * @return a JsonElement corresponding to the specified object.
+     */
+    @Override
+    public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(LOCAL_DATE_FORMATTER.format(src));
+    }
+
+    /**
+     * Gson invokes this call-back method during deserialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects
+     * for any non-trivial field of the returned object. However, you should never invoke it on the
+     * the same type passing {@code json} since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param json The Json data being deserialized
+     * @param typeOfT The type of the Object to deserialize to
+     * @return a deserialized object of the specified type typeOfT which is a subclass of {@code T}
+     * @throws JsonParseException if json is not in the expected format of {@code typeOfT}
+     */
+    @Override
+    public @Nullable LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        String el = json.getAsString();
+        // we allow dates to be represented as dates only or with time and timezone offset
+        if (el.length() > 10) {
+            return ZONED_DATETIME_FORMATTER.parse(el, LocalDate::from);
+        } else {
+            return LOCAL_DATE_FORMATTER.parse(el, LocalDate::from);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonLocalTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonLocalTimeTypeAdapter.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import java.lang.reflect.Type;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * GSON serialiser/deserialiser for converting {@link LocalTime} objects.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class GsonLocalTimeTypeAdapter implements JsonSerializer<LocalTime>, JsonDeserializer<LocalTime> {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    /**
+     * Gson invokes this call-back method during serialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
+     * non-trivial field of the {@code src} object. However, you should never invoke it on the
+     * {@code src} object itself since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param src the object that needs to be converted to Json.
+     * @param typeOfSrc the actual type (fully genericized version) of the source object.
+     * @return a JsonElement corresponding to the specified object.
+     */
+    @Override
+    public JsonElement serialize(LocalTime src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(TIME_FORMATTER.format(src));
+    }
+
+    /**
+     * Gson invokes this call-back method during deserialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects
+     * for any non-trivial field of the returned object. However, you should never invoke it on the
+     * the same type passing {@code json} since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param json The Json data being deserialized
+     * @param typeOfT The type of the Object to deserialize to
+     * @return a deserialized object of the specified type typeOfT which is a subclass of {@code T}
+     * @throws JsonParseException if json is not in the expected format of {@code typeOfT}
+     */
+    @Override
+    public @Nullable LocalTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return TIME_FORMATTER.parse(json.getAsString(), LocalTime::from);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonZonedDateTimeTypeAdapter.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/GsonZonedDateTimeTypeAdapter.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import java.lang.reflect.Type;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * GSON serialiser/deserialiser for converting {@link ZonedDateTime} objects.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class GsonZonedDateTimeTypeAdapter implements JsonSerializer<ZonedDateTime>, JsonDeserializer<ZonedDateTime> {
+
+    private static final DateTimeFormatter ZONED_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
+
+    /**
+     * Gson invokes this call-back method during serialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
+     * non-trivial field of the {@code src} object. However, you should never invoke it on the
+     * {@code src} object itself since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param src the object that needs to be converted to Json.
+     * @param typeOfSrc the actual type (fully genericized version) of the source object.
+     * @return a JsonElement corresponding to the specified object.
+     */
+    @Override
+    public JsonElement serialize(ZonedDateTime src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(ZONED_FORMATTER.format(src));
+    }
+
+    /**
+     * Gson invokes this call-back method during deserialization when it encounters a field of the
+     * specified type.
+     * <p>
+     *
+     * In the implementation of this call-back method, you should consider invoking
+     * {@link JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects
+     * for any non-trivial field of the returned object. However, you should never invoke it on the
+     * the same type passing {@code json} since that will cause an infinite loop (Gson will call your
+     * call-back method again).
+     *
+     * @param json The Json data being deserialized
+     * @param typeOfT The type of the Object to deserialize to
+     * @return a deserialized object of the specified type typeOfT which is a subclass of {@code T}
+     * @throws JsonParseException if json is not in the expected format of {@code typeOfT}
+     */
+    @Override
+    public @Nullable ZonedDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        ZonedDateTime zdt = null;
+        try {
+            zdt = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(json.getAsString(), ZonedDateTime::from);
+        } catch (DateTimeParseException e) {
+            // we try with UTC formatter ISO_INSTANT
+            DateTimeFormatter.ISO_INSTANT.parse(json.getAsString(), ZonedDateTime::from);
+        }
+        return zdt;
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/PriceOptimiser.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/java/org/openhab/binding/octopusenergy/internal/util/PriceOptimiser.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.octopusenergy.internal.dto.Price;
+import org.openhab.binding.octopusenergy.internal.dto.PriceOptimiserResult;
+import org.openhab.binding.octopusenergy.internal.exception.NotEnoughDataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link PriceOptimiser} is a calculator to optimise a schedule for an consumer based on agile pricing.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+public class PriceOptimiser {
+
+    private static final MathContext MATH_CONTEXT = new MathContext(4, RoundingMode.HALF_UP);
+
+    private static final PriceOptimiser INSTANCE = new PriceOptimiser();
+
+    private final Logger logger = LoggerFactory.getLogger(PriceOptimiser.class);
+
+    /**
+     * This method will calculate the optimal (price-wise) start time for an activity based on the given duration,
+     * start and end times and priceList.
+     * Based on hours and minutes specified for start and end time, it will calculate the next window or use all
+     * available data.
+     *
+     * @param requestDuration the requested duration for the activity.
+     * @param requestedStartHour the earliest requested hour the activity can start.
+     * @param requestedStartMinute the earliest requested minute the activity can start.
+     * @param requestedEndHour the latest requested hour the activity can finish.
+     * @param requestedEndMinute the latest requested minute the activity can finish.
+     * @param priceList the price list the optimisation should be based on.
+     * @return the optimisation results.
+     * @throws NotEnoughDataException
+     */
+    public PriceOptimiserResult optimise(Duration requestDuration, int requestedStartHour, int requestedStartMinute,
+            int requestedEndHour, int requestedEndMinute, ZonedDateTime now, List<Price> priceList)
+            throws NotEnoughDataException {
+        ZonedDateTime earliestRequestedStartTime = getFutureTimeWithHourAndMinute(now, requestedStartHour,
+                requestedStartMinute);
+        ZonedDateTime latestRequestedFinishTime = getFutureTimeWithHourAndMinute(earliestRequestedStartTime,
+                requestedEndHour, requestedEndMinute);
+        return optimiseWithAbsoluteStartAndEndTime(requestDuration, earliestRequestedStartTime,
+                latestRequestedFinishTime, priceList);
+    }
+
+    /**
+     * This method will calculate the optimal (price-wise) start time for an activity based on the given duration,
+     * start time and priceList.
+     * Based on hours and minutes specified for start time, it will calculate the next window or use all
+     * available data.
+     *
+     * @param requestDuration the requested duration for the activity.
+     * @param requestedStartHour the earliest requested hour the activity can start.
+     * @param requestedStartMinute the earliest requested minute the activity can start.
+     * @param priceList the price list the optimisation should be based on.
+     * @return the optimisation results.
+     * @throws NotEnoughDataException
+     */
+    public PriceOptimiserResult optimiseWithRecurringStartTime(Duration requestDuration, int requestedStartHour,
+            int requestedStartMinute, ZonedDateTime now, List<Price> priceList) throws NotEnoughDataException {
+        ZonedDateTime earliestRequestedStartTime = getFutureTimeWithHourAndMinute(now, requestedStartHour,
+                requestedStartMinute);
+        return optimiseWithAbsoluteStartAndEndTime(requestDuration, earliestRequestedStartTime,
+                priceList.get(priceList.size() - 1).validTo, priceList);
+    }
+
+    /**
+     * This method will calculate the optimal (price-wise) start time for an activity based on the given duration,
+     * earliest start time and priceList.
+     *
+     * @param requestDuration the requested duration for the activity.
+     * @param earliestRequestedStartTime the earliest time the activity can start.
+     * @param priceList the price list the optimisation should be based on.
+     * @return the optimisation results.
+     * @throws NotEnoughDataException
+     */
+    public PriceOptimiserResult optimiseWithAbsoluteStartTime(Duration requestDuration,
+            ZonedDateTime earliestRequestedStartTime, List<Price> priceList) throws NotEnoughDataException {
+        return optimiseWithAbsoluteStartAndEndTime(requestDuration, earliestRequestedStartTime,
+                priceList.get(priceList.size() - 1).validTo, priceList);
+    }
+
+    /**
+     * This method will calculate the optimal (price-wise) start time for an activity based on the given duration,
+     * earliest start time, end time hour and minutes and priceList.
+     *
+     * @param requestDuration the requested duration for the activity.
+     * @param requestedEndHour the latest requested hour the activity can finish.
+     * @param requestedEndMinute the latest requested minute the activity can finish.
+     * @param priceList the price list the optimisation should be based on.
+     * @return the optimisation results.
+     * @throws NotEnoughDataException
+     */
+    public PriceOptimiserResult optimiseWithRecurringEndTime(Duration requestDuration, ZonedDateTime earliestStartTime,
+            int requestedEndHour, int requestedEndMinute, List<Price> priceList) throws NotEnoughDataException {
+        ZonedDateTime latestRequestedFinishTime = getFutureTimeWithHourAndMinute(earliestStartTime, requestedEndHour,
+                requestedEndMinute);
+        return optimiseWithAbsoluteStartAndEndTime(requestDuration, earliestStartTime, latestRequestedFinishTime,
+                priceList);
+    }
+
+    /**
+     * This method will calculate the optimal (price-wise) start time for an activity based on the given duration,
+     * earliest start time, latest end time and priceList.
+     *
+     * @param requestDuration the requested duration for the activity.
+     * @param earliestRequestedStartTime the earliest time the activity can start.
+     * @param latestRequestedFinishTime the latest time the activity can finish.
+     * @param priceList the price list the optimisation should be based on.
+     * @return the optimisation results.
+     * @throws NotEnoughDataException
+     */
+    public PriceOptimiserResult optimiseWithAbsoluteStartAndEndTime(Duration requestDuration,
+            ZonedDateTime earliestRequestedStartTime, ZonedDateTime latestRequestedFinishTime, List<Price> priceList)
+            throws NotEnoughDataException {
+        // round duration down to the next full minute
+        logger.trace("calculateOptimalStartTime - duration: {}, start: {}, end: {}", requestDuration,
+                earliestRequestedStartTime.toString(), latestRequestedFinishTime.toString());
+        Duration duration = Duration.ofMinutes(requestDuration.toMinutes());
+        logger.trace("calculateOptimalStartTime - earliest requested start time: {}, duration: {}",
+                earliestRequestedStartTime.toString(), duration);
+
+        // preparation and validation
+        if (priceList.size() < 1) {
+            throw new NotEnoughDataException("No price data available");
+        }
+        ZonedDateTime possibleStartTime = priceList.get(0).validFrom;
+        int possibleStartSlot = 0;
+        if (earliestRequestedStartTime.isAfter(possibleStartTime)) {
+            // find the correct starting slot based on earliestRequestedStartTime
+            possibleStartTime = earliestRequestedStartTime;
+            possibleStartSlot = findPriceSlotForTime(priceList, earliestRequestedStartTime);
+        }
+
+        ZonedDateTime latestEndTime = latestRequestedFinishTime;
+        if (priceList.get(priceList.size() - 1).validTo.isBefore(latestEndTime)) {
+            latestEndTime = priceList.get(priceList.size() - 1).validTo;
+        }
+        if (possibleStartTime.plus(duration).isAfter(latestEndTime)) {
+            throw new NotEnoughDataException("Earliest possible slot would finish after the last end time");
+        }
+
+        Duration slotSize = Duration.between(priceList.get(0).validFrom, priceList.get(0).validTo);
+        long requiredSlots = duration.getSeconds() / slotSize.getSeconds();
+        Duration leftOverDuration = duration.minus(slotSize.multipliedBy(requiredSlots));
+        logger.trace("slot size: {} mins, required slots: {}, leftover duration: {}", slotSize.toMinutes(),
+                requiredSlots, leftOverDuration);
+
+        ZonedDateTime minCostStartTime = possibleStartTime;
+        BigDecimal minCost = BigDecimal.valueOf(Integer.MAX_VALUE);
+        /*
+         * 3 scenarios:
+         *
+         * R. start activity at requested earliest start time
+         * S. align activity with the beginning of a slot
+         * E. align activity with the end of a slot.
+         */
+        if (possibleStartTime.isAfter(priceList.get(0).validFrom)) {
+            // Calculate cost for scenario R
+            minCost = calculateCostForDuration(duration, possibleStartTime, priceList, true);
+            possibleStartSlot++;
+            possibleStartTime = priceList.get(possibleStartSlot).validFrom;
+            logger.trace("scenario R - startTime: {}, cost: {}, prevMin: {}", possibleStartTime, minCost, minCost);
+        }
+        boolean withinPriceRange = true;
+        while (withinPriceRange) {
+            try {
+                BigDecimal cost;
+                // we align with the beginning of the current slot and test scenario S
+                if (possibleStartTime.plus(duration).isAfter(latestEndTime)) {
+                    throw new NotEnoughDataException(
+                            "Earliest possible slot would finish after the last available price");
+                }
+                cost = calculateCostForDuration(duration, possibleStartTime, priceList, true);
+                logger.trace("scenario S - startTime: {}, cost: {}, prevMin: {}", possibleStartTime, cost, minCost);
+                if (cost.compareTo(minCost) < 0) {
+                    minCost = cost;
+                    minCostStartTime = possibleStartTime;
+                }
+
+                // now we align with the end of the slot after the test scenario E
+                possibleStartTime = possibleStartTime.plus(slotSize.minus(leftOverDuration));
+                if (possibleStartTime.plus(duration).isAfter(latestEndTime)) {
+                    throw new NotEnoughDataException(
+                            "Earliest possible slot would finish after the last available price");
+                }
+                cost = calculateCostForDuration(duration, possibleStartTime, priceList, true);
+                logger.trace("scenario E - startTime: {}, cost: {}, prevMin: {}", possibleStartTime, cost, minCost);
+                if (cost.compareTo(minCost) < 0) {
+                    minCost = cost;
+                    minCostStartTime = possibleStartTime;
+                }
+
+                // and back to the start of the next slot
+                possibleStartSlot++;
+                if (possibleStartTime.equals(priceList.get(possibleStartSlot).validFrom)) {
+                    possibleStartSlot++;
+                }
+                possibleStartTime = priceList.get(possibleStartSlot).validFrom;
+            } catch (NotEnoughDataException | IndexOutOfBoundsException e) {
+                // we've either reached the end of the slots or the duration would go beyond the last available slot
+                withinPriceRange = false;
+            }
+        }
+        BigDecimal averageUnitCost = minCost.multiply(BigDecimal.valueOf(slotSize.toMinutes()))
+                .divide(BigDecimal.valueOf(duration.toMinutes()), MATH_CONTEXT);
+        PriceOptimiserResult result = new PriceOptimiserResult(earliestRequestedStartTime, latestRequestedFinishTime,
+                duration, minCostStartTime, averageUnitCost, ZonedDateTime.now());
+        logger.debug("calculateOptimalStartTime - result: {}", result);
+        return result;
+    }
+
+    /**
+     * Calculates the cost of an 1kW activity based on a given start time and duration. The given is duration is rounded
+     * down to the nearest minute.
+     *
+     * @param duration the duration of the activity
+     * @param startTime the time when the activity starts
+     * @param includeVat use prices incl. VAT if true, otherwise use prices excl. VAT
+     * @return the cost of the activity
+     * @throws NotEnoughDataException if any part of the activity is outside the range of prices, an exception is
+     *             thrown.
+     */
+    protected BigDecimal calculateCostForDuration(Duration duration, ZonedDateTime startTime, List<Price> priceList,
+            boolean includeVat) throws NotEnoughDataException {
+        logger.trace("calculateCostForDuration - duration: {}, start time: {}", duration, startTime);
+        try {
+            BigDecimal cost = BigDecimal.ZERO;
+            // round duration up to the next full minute
+            ZonedDateTime endTime = startTime.plus(Duration.ofMinutes(duration.toMinutes()));
+
+            // the price list is always ordered in time order, we can just get the first and last in the list to
+            // validate
+            // the range
+            if (startTime.isBefore(priceList.get(0).validFrom)
+                    || endTime.isAfter(priceList.get(priceList.size() - 1).validTo)) {
+                throw new NotEnoughDataException("Activity not within price range");
+            }
+            for (Price price : priceList) {
+                // if activity starts before the slot starts, we contribute from the slot start, otherwise activity
+                // start
+                ZonedDateTime costStart = startTime.isBefore(price.validFrom) ? price.validFrom : startTime;
+                // if activity ends after the slot ends, we contribute until the slot end, otherwise activity end
+                ZonedDateTime costEnd = endTime.isAfter(price.validTo) ? price.validTo : endTime;
+
+                // if the activity overlaps with the slot, we calculate the contribution
+                if (costEnd.isAfter(costStart)) {
+                    BigDecimal slotPrice = includeVat ? price.valueIncVat : price.valueExcVat;
+                    BigDecimal slotCost = slotPrice
+                            .multiply(BigDecimal.valueOf(Duration.between(costStart, costEnd).toMinutes()))
+                            .divide(BigDecimal.valueOf(Duration.between(price.validFrom, price.validTo).toMinutes()),
+                                    MATH_CONTEXT);
+                    cost = cost.add(slotCost);
+                    logger.trace("slot : {}, price: {}, slot cost: {}, overall cost: {}", price.validFrom.toString(),
+                            slotPrice, slotCost, cost);
+                }
+            }
+            return cost;
+        } catch (IndexOutOfBoundsException e) {
+            throw new NotEnoughDataException();
+        }
+    }
+
+    /**
+     * Starting at the given time, this method returns a future time with the given hour and minute.
+     *
+     * @param time
+     * @param hour
+     * @param minute
+     * @return
+     */
+    protected ZonedDateTime getFutureTimeWithHourAndMinute(ZonedDateTime time, int hour, int minute) {
+        ZonedDateTime futureTime = ZonedDateTime.of(time.getYear(), time.getMonthValue(), time.getDayOfMonth(), hour,
+                minute, 0, 0, time.getZone());
+        if (futureTime.isBefore(time)) {
+            // newly calculated time is in the past, we'll add one day
+            futureTime = futureTime.plusDays(1);
+        }
+        return futureTime;
+    }
+
+    /**
+     * Returns the index of the price slot matching the given time.
+     *
+     * @param priceList the list of price slots.
+     * @param time the time to search for.
+     * @return price slot index.
+     * @throws NotEnoughDataException time is outside the given price slots.
+     */
+    protected int findPriceSlotForTime(List<Price> priceList, ZonedDateTime time) throws NotEnoughDataException {
+        if (priceList.isEmpty() || time.isBefore(priceList.get(0).validFrom)) {
+            throw new NotEnoughDataException("Time is before the first available price slot");
+        }
+        int slotIndex = 0;
+        for (Price p : priceList) {
+            // assuming within a slot if validFrom <= time < validTo
+            if ((time.isEqual(p.validFrom) || time.isAfter(p.validFrom)) && time.isBefore(p.validTo)) {
+                return slotIndex;
+            }
+            slotIndex++;
+        }
+        throw new NotEnoughDataException("Time is after the last available price slot");
+    }
+
+    public static PriceOptimiser getInstance() {
+        return INSTANCE;
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="octopusenergy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
+
+	<name>OctopusEnergy Binding</name>
+	<description>This binding interacts with Octopus Energy API to retrieve energy consumption and prices.</description>
+	<author>Rene Scherer</author>
+
+</binding:binding>

--- a/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/i18n/octopusenergy.properties
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/i18n/octopusenergy.properties
@@ -1,0 +1,5 @@
+# thing status description
+offline.conf-error-invalid-refresh-intervals = Invalid refresh interval
+offline.conf-error-missing-account-number-or-api-key = Missing account number or API key
+offline.conf-error-authentication = Authentication Error (Invalid API key or account number)
+offline.comm-error-general = General communication error with API

--- a/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/thing/things.xml
+++ b/bundles/org.openhab.binding.octopusenergy/src/main/resources/OH-INF/thing/things.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<thing:thing-descriptions bindingId="octopusenergy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<bridge-type id="bridge">
+
+		<label>Octopus Energy API Bridge</label>
+		<description>The Octopus Energy Cloud API Bridge</description>
+
+		<channels>
+			<channel id="refresh" typeId="refreshType"/>
+			<channel id="lastRefreshTime" typeId="lastRefreshTimeType"/>
+		</channels>
+
+		<config-description>
+
+			<parameter name="accountNumber" type="text" required="true">
+				<label>Account Number</label>
+				<description>The Octopus Energy account number</description>
+			</parameter>
+			<parameter name="apiKey" type="text" required="true">
+				<label>API Key</label>
+				<description>The API key to access the Octopus Energy API</description>
+				<context>password</context>
+			</parameter>
+			<parameter name="refreshInterval" type="integer" required="false" unit="m">
+				<label>Refresh Interval Topology</label>
+				<description>Query interval (in minutes) for consumption and price updates</description>
+				<default>15</default>
+			</parameter>
+
+		</config-description>
+
+	</bridge-type>
+
+	<thing-type id="electricityMeterPoint">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Octopus Energy Electricity Meter Point</label>
+		<description>An Octopus Energy electricity meter point</description>
+
+		<channels>
+			<channel id="mpan" typeId="mpanType"/>
+			<channel id="currentTariff" typeId="tariffType"/>
+			<channel id="mostRecentConsumptionAmount" typeId="consumptionAmountType"/>
+			<channel id="mostRecentConsumptionStartTime" typeId="consumptionStartTimeType"/>
+			<channel id="mostRecentConsumptionEndTime" typeId="consumptionEndTimeType"/>
+			<channel id="unitPriceWindowStartTime" typeId="unitPriceWindowStartTimeType"/>
+			<channel id="unitPriceWindowEndTime" typeId="unitPriceWindowEndTimeType"/>
+			<channel id="unitPriceWindowMinAmount" typeId="minUnitPriceType"/>
+			<channel id="unitPriceWindowMaxAmount" typeId="maxUnitPriceType"/>
+		</channels>
+
+		<properties>
+			<property name="mpan"/>
+			<property name="profileClass"/>
+			<property name="consumptionStandard"/>
+			<property name="isExport"/>
+		</properties>
+	</thing-type>
+
+	<thing-type id="gasMeterPoint">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge"/>
+		</supported-bridge-type-refs>
+
+		<label>Octopus Energy Gas Meter Point</label>
+		<description>An Octopus Energy gas meter point</description>
+
+		<channels>
+			<channel id="mprn" typeId="mprnType"/>
+			<channel id="currentTariff" typeId="tariffType"/>
+		</channels>
+
+		<properties>
+			<property name="mprn"/>
+			<property name="consumptionStandard"/>
+		</properties>
+	</thing-type>
+
+	<channel-type id="refreshType">
+		<item-type>Switch</item-type>
+		<label>Refresh</label>
+		<description>Allows a manual refresh of the API data when sent an ON command.</description>
+		<state readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="lastRefreshTimeType">
+		<item-type>DateTime</item-type>
+		<label>Last Refresh Time</label>
+		<description>The time consumption and tariff information was last refreshed</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="mpanType">
+		<item-type>String</item-type>
+		<label>MPAN</label>
+		<description>Meter Point Administration Number</description>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
+
+	<channel-type id="mprnType">
+		<item-type>String</item-type>
+		<label>MPRN</label>
+		<description>Meter Point Reference Number</description>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
+
+	<channel-type id="tariffType">
+		<item-type>String</item-type>
+		<label>Current Tariff</label>
+		<description>The currently applicable tariff</description>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
+
+	<channel-type id="consumptionAmountType">
+		<item-type>Number:Energy</item-type>
+		<label>Consumed Energy Amount</label>
+		<description>The amount of energy consumed during the given time window</description>
+		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+
+	<channel-type id="consumptionStartTimeType">
+		<item-type>DateTime</item-type>
+		<label>Consumption Window Start Time</label>
+		<description>The start time of the most recent consumption window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="consumptionEndTimeType">
+		<item-type>DateTime</item-type>
+		<label>Consumption Window End Time</label>
+		<description>The end time of the most recent consumption window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="unitPriceWindowStartTimeType">
+		<item-type>DateTime</item-type>
+		<label>Unit Price Window Start Time</label>
+		<description>The start time of the unit price window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="unitPriceWindowEndTimeType">
+		<item-type>DateTime</item-type>
+		<label>Unit Price Window End Time</label>
+		<description>The end time of the unit price window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="maxUnitPriceType">
+		<item-type>Number</item-type>
+		<label>Maximum Unit Price (p/kWh)</label>
+		<description>The maximum unit price of energy in GBp per Kilowatt Hour over the available forecast period</description>
+		<state readOnly="true" pattern="%.1f"/>
+	</channel-type>
+
+	<channel-type id="minUnitPriceType">
+		<item-type>Number</item-type>
+		<label>Minimum Unit Price (p/kWh)</label>
+		<description>The minimum unit price of energy in GBp per Kilowatt Hour over the available forecast period</description>
+		<state readOnly="true" pattern="%.1f"/>
+	</channel-type>
+
+	<channel-type id="requestedStartTimeHourType">
+		<item-type>Number</item-type>
+		<label>Requested Activity Start Hour</label>
+		<description>The earliest start time of the optimized activity window (hour)</description>
+		<state min="0" max="23" step="1" readOnly="false" pattern="%d"/>
+	</channel-type>
+
+	<channel-type id="requestedStartTimeMinuteType">
+		<item-type>Number</item-type>
+		<label>Requested Activity Start Minute</label>
+		<description>The earliest start time of the optimized activity window (minute)</description>
+		<state min="0" max="55" step="5" readOnly="false" pattern="%d"/>
+	</channel-type>
+
+	<channel-type id="requestedEndTimeHourType">
+		<item-type>Number</item-type>
+		<label>Requested Activity End Hour</label>
+		<description>The latest end time of the optimized activity window (hour)</description>
+		<state min="0" max="23" step="1" readOnly="false" pattern="%d"/>
+	</channel-type>
+
+	<channel-type id="requestedEndTimeMinuteType">
+		<item-type>Number</item-type>
+		<label>Requested Activity End Minute</label>
+		<description>The latest end time of the optimized activity window (minute)</description>
+		<state min="0" max="55" step="5" readOnly="false" pattern="%d"/>
+	</channel-type>
+
+	<channel-type id="requestedDurationType">
+		<item-type>Number:Time</item-type>
+		<label>Duration of the Activity to be optimized</label>
+		<description>The duration of the activity for which the cheapest window is calculated</description>
+		<state readOnly="false" pattern="%d %unit%"/>
+	</channel-type>
+
+	<channel-type id="optimizedStartTimeType">
+		<item-type>DateTime</item-type>
+		<label>Optimized Activity Start Time</label>
+		<description>The optimized start time of the cheapest activity window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+	<channel-type id="optimizedEndTimeType">
+		<item-type>DateTime</item-type>
+		<label>Optimized Activity End Time</label>
+		<description>The end time of the optimized activity window</description>
+		<state readOnly="true" pattern="%1$tF %1$tR"/>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelperTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/OctopusEnergyApiHelperTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.net.HttpURLConnection;
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpContentResponse;
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.octopusenergy.internal.dto.AccountProperty;
+import org.openhab.binding.octopusenergy.internal.dto.ElectricityMeterPoint;
+import org.openhab.binding.octopusenergy.internal.dto.GasMeterPoint;
+import org.openhab.binding.octopusenergy.internal.exception.AuthenticationException;
+
+/**
+ * The {@link OctopusEnergyApiHelperTest} is a test class for {@link OctopusEnergyApiHelper}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class OctopusEnergyApiHelperTest {
+
+    private static final String TEST_ACCOUNT_NUMBER = "A-ABCD1234";
+    private static final String TEST_API_KEY_VALID = "sk_live_dshgHYyt46GJHDjd78SDFAdf";
+    private static final String TEST_API_KEY_INVALID = "sk_live_xxxxxxxxxxxxxxxxxxxxxxxx";
+
+    private static final int RESPONSE_200_STATUS = HttpURLConnection.HTTP_OK;
+    private static final String RESPONSE_200_REASON = "OK";
+    private static final int RESPONSE_401_STATUS = HttpURLConnection.HTTP_UNAUTHORIZED;
+    private static final String RESPONSE_401_REASON = "NOT AUTHORIZED";
+    private static final String RESPONSE_401_CONTENT = "";
+
+    private static OctopusEnergyApiHelper apiHelper = new OctopusEnergyApiHelper();
+
+    private static AuthenticationStore authenticationStore = mock(AuthenticationStore.class);
+    private static HttpClient httpClient = mock(HttpClient.class);
+    private static HttpRequest request = mock(HttpRequest.class);
+    private static HttpContentResponse response = mock(HttpContentResponse.class);
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        when(httpClient.getAuthenticationStore()).thenReturn(authenticationStore);
+        when(httpClient.newRequest(anyString())).thenReturn(request);
+        when(request.method(HttpMethod.GET)).thenReturn(request);
+
+        when(request.send()).thenReturn(response);
+        when(response.getStatus()).thenReturn(RESPONSE_200_STATUS);
+        when(response.getReason()).thenReturn(RESPONSE_200_REASON);
+
+        apiHelper.setHttpClient(httpClient);
+        apiHelper.setApiKey(TEST_API_KEY_VALID);
+        apiHelper.setAccountNumber(TEST_ACCOUNT_NUMBER);
+    }
+
+    @Test
+    void testUpdateAccounts() throws Exception {
+        when(response.getContentAsString()).thenReturn(
+                "{\"number\":\"A-ABCD1234\",\"properties\":[{\"id\":2749233,\"moved_in_at\":\"2020-10-09T00:00:00+01:00\",\"moved_out_at\":null,\"address_line_1\":\"ADDRESS LINE 1\",\"address_line_2\":\"ADDRESS LINE 2\",\"address_line_3\":\"ADDRESS LINE 3\",\"town\":\"TOWN\",\"county\":\"COUNTY\",\"postcode\":\"POSTCODE\",\"electricity_meter_points\":[{\"mpan\":\"1019387543623\",\"profile_class\":1,\"consumption_standard\":4514,\"meters\":[{\"serial_number\":\"S81E028123\",\"registers\":[{\"identifier\":\"01\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]},{\"serial_number\":\"20L3251234\",\"registers\":[{\"identifier\":\"1\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]}],\"agreements\":[{\"tariff_code\":\"E-1R-SUPER-GREEN-12M-20-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2020-12-11T00:00:00Z\"},{\"tariff_code\":\"E-1R-AGILE-18-02-21-A\",\"valid_from\":\"2020-12-11T00:00:00Z\",\"valid_to\":\"2021-12-11T00:00:00Z\"}],\"is_export\":false}],\"gas_meter_points\":[{\"mprn\":\"3046829404\",\"consumption_standard\":23882,\"meters\":[{\"serial_number\":\"6326031\"}],\"agreements\":[{\"tariff_code\":\"G-1R-SUPER-GREEN-12M-2* Connection #0 to host api.octopus.energy left intact 0-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2021-11-01T00:00:00Z\"}]}]}]}");
+        // when:
+        apiHelper.updateAccounts();
+        // then:
+        assertEquals("A-ABCD1234", apiHelper.getAccounts().number);
+        assertEquals(1, apiHelper.getAccounts().properties.size());
+        assertEquals(1, apiHelper.getAccounts().getElectricityMeterPoints().size());
+        assertEquals(1, apiHelper.getAccounts().getGasMeterPoints().size());
+
+        AccountProperty property = apiHelper.getAccounts().properties.get(0);
+        assertEquals(2749233, property.id);
+        assertEquals(ZonedDateTime.parse("2020-10-09T00:00+01:00"), property.movedInAt);
+        assertNull(property.movedOutAt);
+        assertEquals("ADDRESS LINE 1", property.addressLine1);
+        assertEquals("ADDRESS LINE 2", property.addressLine2);
+        assertEquals("ADDRESS LINE 3", property.addressLine3);
+        assertEquals("TOWN", property.town);
+        assertEquals("COUNTY", property.county);
+        assertEquals("POSTCODE", property.postcode);
+
+        ElectricityMeterPoint emp = apiHelper.getAccounts().getElectricityMeterPoints().get(0);
+        assertEquals("1019387543623", emp.mpan);
+
+        GasMeterPoint gmp = apiHelper.getAccounts().getGasMeterPoints().get(0);
+        assertEquals("3046829404", gmp.mprn);
+    }
+
+    @Test
+    void testUpdateElectricityConsumption() throws Exception {
+        when(response.getContentAsString()).thenReturn(
+                "{\"number\":\"A-ABCD1234\",\"properties\":[{\"id\":2749233,\"moved_in_at\":\"2020-10-09T00:00:00+01:00\",\"moved_out_at\":null,\"address_line_1\":\"ADDRESS LINE 1\",\"address_line_2\":\"ADDRESS LINE 2\",\"address_line_3\":\"ADDRESS LINE 3\",\"town\":\"TOWN\",\"county\":\"COUNTY\",\"postcode\":\"POSTCODE\",\"electricity_meter_points\":[{\"mpan\":\"1019387543623\",\"profile_class\":1,\"consumption_standard\":4514,\"meters\":[{\"serial_number\":\"S81E028123\",\"registers\":[{\"identifier\":\"01\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]},{\"serial_number\":\"20L3251234\",\"registers\":[{\"identifier\":\"1\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]}],\"agreements\":[{\"tariff_code\":\"E-1R-SUPER-GREEN-12M-20-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2020-12-11T00:00:00Z\"},{\"tariff_code\":\"E-1R-AGILE-18-02-21-A\",\"valid_from\":\"2020-12-11T00:00:00Z\",\"valid_to\":\"2021-12-11T00:00:00Z\"}],\"is_export\":false}],\"gas_meter_points\":[{\"mprn\":\"3046829404\",\"consumption_standard\":23882,\"meters\":[{\"serial_number\":\"6326031\"}],\"agreements\":[{\"tariff_code\":\"G-1R-SUPER-GREEN-12M-2* Connection #0 to host api.octopus.energy left intact 0-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2021-11-01T00:00:00Z\"}]}]}]}");
+        apiHelper.updateAccounts();
+
+        when(response.getContentAsString()).thenReturn(
+                "{\"count\":49,\"next\":\"https://api.octopus.energy/v1/electricity-meter-points/1019387543623/meters/20L3251234/consumption/?order_by=-period&page=2&page_size=10&period_from=2021-01-16T22%3A58%3A25Z&period_to=2021-01-18T22%3A58%3A25Z\",\"previous\":null,\"results\":[{\"consumption\":0.248,\"interval_start\":\"2021-01-17T23:00:00Z\",\"interval_end\":\"2021-01-17T23:30:00Z\"},{\"consumption\":0.305,\"interval_start\":\"2021-01-17T22:30:00Z\",\"interval_end\":\"2021-01-17T23:00:00Z\"},{\"consumption\":0.309,\"interval_start\":\"2021-01-17T22:00:00Z\",\"interval_end\":\"2021-01-17T22:30:00Z\"},{\"consumption\":0.287,\"interval_start\":\"2021-01-17T21:30:00Z\",\"interval_end\":\"2021-01-17T22:00:00Z\"},{\"consumption\":0.279,\"interval_start\":\"2021-01-17T21:00:00Z\",\"interval_end\":\"2021-01-17T21:30:00Z\"},{\"consumption\":0.283,\"interval_start\":\"2021-01-17T20:30:00Z\",\"interval_end\":\"2021-01-17T21:00:00Z\"},{\"consumption\":0.267,\"interval_start\":\"2021-01-17T20:00:00Z\",\"interval_end\":\"2021-01-17T20:30:00Z\"},{\"consumption\":0.266,\"interval_start\":\"2021-01-17T19:30:00Z\",\"interval_end\":\"2021-01-17T20:00:00Z\"},{\"consumption\":0.282,\"interval_start\":\"2021-01-17T19:00:00Z\",\"interval_end\":\"2021-01-17T19:30:00Z\"},{\"consumption\":0.686,\"interval_start\":\"2021-01-17T18:30:00Z\",\"interval_end\":\"2021-01-17T19:00:00Z\"}]}");
+
+        // when:
+        apiHelper.updateElectricityConsumption();
+        // then:
+        // 10 is the default page size
+        assertEquals(10, apiHelper.getAccounts().getElectricityMeterPoints().get(0).consumptionList.size());
+    }
+
+    @Test
+    void testUpdateElectricityPrices() throws Exception {
+        when(response.getContentAsString()).thenReturn(
+                "{\"number\":\"A-ABCD1234\",\"properties\":[{\"id\":2749233,\"moved_in_at\":\"2020-10-09T00:00:00+01:00\",\"moved_out_at\":null,\"address_line_1\":\"ADDRESS LINE 1\",\"address_line_2\":\"ADDRESS LINE 2\",\"address_line_3\":\"ADDRESS LINE 3\",\"town\":\"TOWN\",\"county\":\"COUNTY\",\"postcode\":\"POSTCODE\",\"electricity_meter_points\":[{\"mpan\":\"1019387543623\",\"profile_class\":1,\"consumption_standard\":4514,\"meters\":[{\"serial_number\":\"S81E028123\",\"registers\":[{\"identifier\":\"01\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]},{\"serial_number\":\"20L3251234\",\"registers\":[{\"identifier\":\"1\",\"rate\":\"STANDARD\",\"is_settlement_register\":true}]}],\"agreements\":[{\"tariff_code\":\"E-1R-SUPER-GREEN-12M-20-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2020-12-11T00:00:00Z\"},{\"tariff_code\":\"E-1R-AGILE-18-02-21-A\",\"valid_from\":\"2020-12-11T00:00:00Z\",\"valid_to\":\"2021-12-11T00:00:00Z\"}],\"is_export\":false}],\"gas_meter_points\":[{\"mprn\":\"3046829404\",\"consumption_standard\":23882,\"meters\":[{\"serial_number\":\"6326031\"}],\"agreements\":[{\"tariff_code\":\"G-1R-SUPER-GREEN-12M-2* Connection #0 to host api.octopus.energy left intact 0-09-22-A\",\"valid_from\":\"2020-11-01T00:00:00Z\",\"valid_to\":\"2021-11-01T00:00:00Z\"}]}]}]}");
+        apiHelper.updateAccounts();
+
+        when(response.getContentAsString()).thenReturn(
+                "{\"count\":17,\"next\":null,\"previous\":null,\"results\":[{\"value_exc_vat\":10.92,\"value_inc_vat\":11.466,\"valid_from\":\"2021-01-19T22:30:00Z\",\"valid_to\":\"2021-01-19T23:00:00Z\"},{\"value_exc_vat\":12.18,\"value_inc_vat\":12.789,\"valid_from\":\"2021-01-19T22:00:00Z\",\"valid_to\":\"2021-01-19T22:30:00Z\"},{\"value_exc_vat\":11.76,\"value_inc_vat\":12.348,\"valid_from\":\"2021-01-19T21:30:00Z\",\"valid_to\":\"2021-01-19T22:00:00Z\"},{\"value_exc_vat\":13.44,\"value_inc_vat\":14.112,\"valid_from\":\"2021-01-19T21:00:00Z\",\"valid_to\":\"2021-01-19T21:30:00Z\"},{\"value_exc_vat\":12.18,\"value_inc_vat\":12.789,\"valid_from\":\"2021-01-19T20:30:00Z\",\"valid_to\":\"2021-01-19T21:00:00Z\"},{\"value_exc_vat\":13.23,\"value_inc_vat\":13.8915,\"valid_from\":\"2021-01-19T20:00:00Z\",\"valid_to\":\"2021-01-19T20:30:00Z\"},{\"value_exc_vat\":11.57,\"value_inc_vat\":12.1485,\"valid_from\":\"2021-01-19T19:30:00Z\",\"valid_to\":\"2021-01-19T20:00:00Z\"},{\"value_exc_vat\":14.28,\"value_inc_vat\":14.994,\"valid_from\":\"2021-01-19T19:00:00Z\",\"valid_to\":\"2021-01-19T19:30:00Z\"},{\"value_exc_vat\":27.91,\"value_inc_vat\":29.3055,\"valid_from\":\"2021-01-19T18:30:00Z\",\"valid_to\":\"2021-01-19T19:00:00Z\"},{\"value_exc_vat\":29.8,\"value_inc_vat\":31.29,\"valid_from\":\"2021-01-19T18:00:00Z\",\"valid_to\":\"2021-01-19T18:30:00Z\"},{\"value_exc_vat\":31.48,\"value_inc_vat\":33.054,\"valid_from\":\"2021-01-19T17:30:00Z\",\"valid_to\":\"2021-01-19T18:00:00Z\"},{\"value_exc_vat\":31.07,\"value_inc_vat\":32.6235,\"valid_from\":\"2021-01-19T17:00:00Z\",\"valid_to\":\"2021-01-19T17:30:00Z\"},{\"value_exc_vat\":30.01,\"value_inc_vat\":31.5105,\"valid_from\":\"2021-01-19T16:30:00Z\",\"valid_to\":\"2021-01-19T17:00:00Z\"},{\"value_exc_vat\":26.46,\"value_inc_vat\":27.783,\"valid_from\":\"2021-01-19T16:00:00Z\",\"valid_to\":\"2021-01-19T16:30:00Z\"},{\"value_exc_vat\":12.18,\"value_inc_vat\":12.789,\"valid_from\":\"2021-01-19T15:30:00Z\",\"valid_to\":\"2021-01-19T16:00:00Z\"},{\"value_exc_vat\":11.55,\"value_inc_vat\":12.1275,\"valid_from\":\"2021-01-19T15:00:00Z\",\"valid_to\":\"2021-01-19T15:30:00Z\"},{\"value_exc_vat\":11.63,\"value_inc_vat\":12.2115,\"valid_from\":\"2021-01-19T14:30:00Z\",\"valid_to\":\"2021-01-19T15:00:00Z\"}]}");
+
+        // when:
+        apiHelper.updateElectricityPrices();
+        // then:
+        assertEquals(17, apiHelper.getAccounts().getElectricityMeterPoints().get(0).priceList.size());
+    }
+
+    @Test
+    void testUpdateAccountsInvalidApiKey() throws Exception {
+        when(response.getStatus()).thenReturn(RESPONSE_401_STATUS);
+        when(response.getReason()).thenReturn(RESPONSE_401_REASON);
+
+        when(response.getContentAsString()).thenReturn(RESPONSE_401_CONTENT);
+        apiHelper.setApiKey(TEST_API_KEY_INVALID);
+
+        // then:
+        // we want an authentication exception
+        assertThrows(AuthenticationException.class, () -> {
+            apiHelper.updateAccounts();
+        });
+
+        when(response.getStatus()).thenReturn(RESPONSE_200_STATUS);
+        when(response.getReason()).thenReturn(RESPONSE_200_REASON);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/AgreementTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/AgreementTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+
+/**
+ * The {@link AgreementTest} is a test class for {@link Agreement}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class AgreementTest {
+
+    private static final ZonedDateTime UDT = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    @Test
+    void testGetProduct() {
+        // positive tests
+        try {
+            assertEquals("GREEN-12M-20-09-22", new Agreement("E-1R-GREEN-12M-20-09-22-A", UDT, UDT).getProduct());
+            assertEquals("VAR-19-04-12", new Agreement("E-1R-VAR-19-04-12-N", UDT, UDT).getProduct());
+            assertEquals("AGILE-18-02-21", new Agreement("E-1R-AGILE-18-02-21-A", UDT, UDT).getProduct());
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+
+        // negative tests
+        assertThrows(RecordNotFoundException.class, () -> {
+            new Agreement("AGILE1802-21-A", UDT, UDT).getProduct();
+        });
+        assertThrows(RecordNotFoundException.class, () -> {
+            new Agreement("AGILE1802", UDT, UDT).getProduct();
+        });
+        assertThrows(RecordNotFoundException.class, () -> {
+            new Agreement("", UDT, UDT).getProduct();
+        });
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/ConsumptionTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/ConsumptionTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@link ConsumptionTest} is a test class for {@link Consumption}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class ConsumptionTest {
+
+    @Test
+    void testCompare() {
+        Consumption c1 = new Consumption(BigDecimal.valueOf(12.5), ZonedDateTime.parse("2020-10-09T01:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T01:00:00Z"));
+        Consumption c2 = new Consumption(BigDecimal.valueOf(23.4), ZonedDateTime.parse("2020-10-09T02:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:00:00Z"));
+        Consumption c3 = new Consumption(BigDecimal.valueOf(65.5), ZonedDateTime.parse("2020-10-09T01:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T01:00:00Z"));
+
+        // c1 is less than c2
+        assertEquals(-1, Consumption.INTERVAL_START_ORDER_ASC.compare(c1, c2));
+        // c1 is equal to c3
+        assertEquals(0, Consumption.INTERVAL_START_ORDER_ASC.compare(c1, c3));
+        // c2 is greater than c1
+        assertEquals(1, Consumption.INTERVAL_START_ORDER_ASC.compare(c2, c1));
+
+        // c1 is less than c2
+        assertEquals(-1, Consumption.CONSUMPTION_ORDER_ASC.compare(c1, c2));
+        // c1 is less than c3
+        assertEquals(-1, Consumption.CONSUMPTION_ORDER_ASC.compare(c1, c3));
+        // c2 is greater than c1
+        assertEquals(1, Consumption.CONSUMPTION_ORDER_ASC.compare(c2, c1));
+    }
+
+    @Test
+    void testSort() {
+        Consumption c1 = new Consumption(BigDecimal.valueOf(1.2), ZonedDateTime.parse("2020-10-09T01:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:00:00Z"));
+        Consumption c2 = new Consumption(BigDecimal.valueOf(2.3), ZonedDateTime.parse("2020-10-09T02:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:00:00Z"));
+        Consumption c3 = new Consumption(BigDecimal.valueOf(3.4), ZonedDateTime.parse("2020-10-09T03:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T04:00:00Z"));
+
+        Consumption c4 = new Consumption(BigDecimal.valueOf(4.5), ZonedDateTime.parse("2020-10-09T01:30:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:30:00Z"));
+        Consumption c5 = new Consumption(BigDecimal.valueOf(5.6), ZonedDateTime.parse("2020-10-09T02:30:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:30:00Z"));
+        Consumption c6 = new Consumption(BigDecimal.valueOf(6.7), ZonedDateTime.parse("2020-10-09T03:30:00Z"),
+                ZonedDateTime.parse("2020-10-09T04:30:00Z"));
+
+        List<Consumption> set1 = new ArrayList<>();
+        List<Consumption> set2 = new ArrayList<>();
+        set1.add(c6);
+        set1.add(c1);
+        set1.add(c4);
+        set2.add(c2);
+        set2.add(c5);
+        set2.add(c3);
+
+        List<Consumption> cset1 = new ArrayList<Consumption>(set1);
+        cset1.addAll(set2);
+        Collections.sort(cset1, Consumption.INTERVAL_START_ORDER_ASC);
+        List<Consumption> rset1 = new ArrayList<Consumption>();
+        rset1.add(c1);
+        rset1.add(c4);
+        rset1.add(c2);
+        rset1.add(c5);
+        rset1.add(c3);
+        rset1.add(c6);
+        assertArrayEquals(rset1.toArray(), cset1.toArray());
+
+        List<Consumption> cset2 = new ArrayList<Consumption>(set1);
+        cset2.addAll(set2);
+        Collections.sort(cset2, Consumption.CONSUMPTION_ORDER_ASC);
+        List<Consumption> rset2 = new ArrayList<Consumption>();
+        rset2.add(c1);
+        rset2.add(c2);
+        rset2.add(c3);
+        rset2.add(c4);
+        rset2.add(c5);
+        rset2.add(c6);
+        assertArrayEquals(rset2.toArray(), cset2.toArray());
+    }
+
+    @Test
+    void testAggregate() {
+        Consumption c1 = new Consumption(BigDecimal.valueOf(1.2), ZonedDateTime.parse("2020-10-09T01:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:00:00Z"));
+        Consumption c2 = new Consumption(BigDecimal.valueOf(2.3), ZonedDateTime.parse("2020-10-09T02:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:00:00Z"));
+
+        Consumption c4 = new Consumption(BigDecimal.valueOf(4.5), ZonedDateTime.parse("2020-10-09T02:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:00:00Z"));
+        Consumption c5 = new Consumption(BigDecimal.valueOf(5.6), ZonedDateTime.parse("2020-10-09T03:00:00Z"),
+                ZonedDateTime.parse("2020-10-09T04:00:00Z"));
+
+        List<Consumption> set1 = new ArrayList<>();
+        List<Consumption> set2 = new ArrayList<>();
+        set1.add(c1);
+        set1.add(c2);
+        set2.add(c4);
+        set2.add(c5);
+
+        @NonNull
+        List<@NonNull Consumption> cset1 = Consumption.aggregate(set1, set2);
+        Collections.sort(cset1, Consumption.INTERVAL_START_ORDER_ASC);
+
+        assertEquals(3, cset1.size());
+        assertEquals(ZonedDateTime.parse("2020-10-09T01:00:00Z"), cset1.get(0).intervalStart);
+        assertEquals(BigDecimal.valueOf(1.2), cset1.get(0).consumption);
+        assertEquals(ZonedDateTime.parse("2020-10-09T02:00:00Z"), cset1.get(1).intervalStart);
+        assertEquals(BigDecimal.valueOf(6.8), cset1.get(1).consumption);
+        assertEquals(ZonedDateTime.parse("2020-10-09T03:00:00Z"), cset1.get(2).intervalStart);
+        assertEquals(BigDecimal.valueOf(5.6), cset1.get(2).consumption);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/ElectricityMeterPointTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/ElectricityMeterPointTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.octopusenergy.internal.exception.RecordNotFoundException;
+
+/**
+ * The {@link ElectricityMeterPointTest} is a test class for {@link ElectricityMeterPoint}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class ElectricityMeterPointTest {
+
+    private static final List<Agreement> AGREEMENT_LIST = new ArrayList<>();
+    private static final List<Consumption> CONSUMPTION_LIST = new ArrayList<>();
+    private static final List<Price> PRICE_LIST = new ArrayList<>();
+    private static final ElectricityMeterPoint METER_POINT = new ElectricityMeterPoint();
+
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+        AGREEMENT_LIST.add(new Agreement("E-1R-GREEN-12M-20-09-22-A", ZonedDateTime.parse("2020-10-09T00:00:00Z"),
+                ZonedDateTime.parse("2020-10-19T00:00:00Z")));
+        AGREEMENT_LIST.add(new Agreement("E-1R-VAR-19-04-12-N", ZonedDateTime.parse("2020-10-19T00:00:00Z"),
+                ZonedDateTime.parse("2020-10-29T00:00:00Z")));
+        AGREEMENT_LIST.add(new Agreement("E-1R-AGILE-18-02-21-A", ZonedDateTime.parse("2020-10-29T00:00:00Z"),
+                ZonedDateTime.parse("2020-10-31T00:00:00Z")));
+        METER_POINT.agreements = AGREEMENT_LIST;
+
+        // setting up a consumption list
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(1.5), ZonedDateTime.parse("2020-10-09T00:00Z"),
+                ZonedDateTime.parse("2020-10-09T00:30Z")));
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(2.5), ZonedDateTime.parse("2020-10-09T00:30Z"),
+                ZonedDateTime.parse("2020-10-09T01:00Z")));
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(3.5), ZonedDateTime.parse("2020-10-09T01:00Z"),
+                ZonedDateTime.parse("2020-10-09T01:30Z")));
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(4.5), ZonedDateTime.parse("2020-10-09T01:30Z"),
+                ZonedDateTime.parse("2020-10-09T02:00Z")));
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(1), ZonedDateTime.parse("2020-10-09T02:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:30Z")));
+        CONSUMPTION_LIST.add(new Consumption(BigDecimal.valueOf(3), ZonedDateTime.parse("2020-10-09T02:30Z"),
+                ZonedDateTime.parse("2020-10-09T03:00Z")));
+        METER_POINT.consumptionList = CONSUMPTION_LIST;
+
+        // setting up a price profile of 1,1, 1,9, 9,2, 2,2, 2,3, 1,1, 8,8
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T00:00Z"),
+                ZonedDateTime.parse("2020-10-09T00:30Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T00:30Z"),
+                ZonedDateTime.parse("2020-10-09T01:00Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T01:00Z"),
+                ZonedDateTime.parse("2020-10-09T01:30Z")));
+        PRICE_LIST.add(new Price(9.0, 13.5, ZonedDateTime.parse("2020-10-09T01:30Z"),
+                ZonedDateTime.parse("2020-10-09T02:00Z")));
+        PRICE_LIST.add(new Price(9.0, 13.5, ZonedDateTime.parse("2020-10-09T02:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:30Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T02:30Z"),
+                ZonedDateTime.parse("2020-10-09T03:00Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T03:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:30Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T03:30Z"),
+                ZonedDateTime.parse("2020-10-09T04:00Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T04:00Z"),
+                ZonedDateTime.parse("2020-10-09T04:30Z")));
+        PRICE_LIST.add(new Price(3.0, 4.5, ZonedDateTime.parse("2020-10-09T04:30Z"),
+                ZonedDateTime.parse("2020-10-09T05:00Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T05:00Z"),
+                ZonedDateTime.parse("2020-10-09T05:30Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T05:30Z"),
+                ZonedDateTime.parse("2020-10-09T06:00Z")));
+        PRICE_LIST.add(new Price(8.0, 12.0, ZonedDateTime.parse("2020-10-09T06:00Z"),
+                ZonedDateTime.parse("2020-10-09T06:30Z")));
+        PRICE_LIST.add(new Price(8.0, 12.0, ZonedDateTime.parse("2020-10-09T06:30Z"),
+                ZonedDateTime.parse("2020-10-09T07:00Z")));
+        METER_POINT.priceList = PRICE_LIST;
+    }
+
+    @Test
+    void testGetAgreementAsOf() {
+        try {
+            assertEquals("E-1R-GREEN-12M-20-09-22-A",
+                    METER_POINT.getAgreementAsOf(ZonedDateTime.parse("2020-10-09T00:00:00Z")).tariffCode);
+            assertEquals("E-1R-VAR-19-04-12-N",
+                    METER_POINT.getAgreementAsOf(ZonedDateTime.parse("2020-10-19T00:00:00Z")).tariffCode);
+            assertEquals("E-1R-AGILE-18-02-21-A",
+                    METER_POINT.getAgreementAsOf(ZonedDateTime.parse("2020-10-29T00:00:00Z")).tariffCode);
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+
+        assertThrows(RecordNotFoundException.class, () -> {
+            METER_POINT.getAgreementAsOf(ZonedDateTime.parse("2020-10-08T00:00:00Z"));
+        });
+        assertThrows(RecordNotFoundException.class, () -> {
+            METER_POINT.getAgreementAsOf(ZonedDateTime.parse("2020-10-31T00:00:01Z"));
+        });
+    }
+
+    @Test
+    void testGetProductAsOf() {
+        try {
+            assertEquals("GREEN-12M-20-09-22", METER_POINT.getProductAsOf(ZonedDateTime.parse("2020-10-09T00:00:00Z")));
+            assertEquals("VAR-19-04-12", METER_POINT.getProductAsOf(ZonedDateTime.parse("2020-10-19T00:00:00Z")));
+            assertEquals("AGILE-18-02-21", METER_POINT.getProductAsOf(ZonedDateTime.parse("2020-10-29T00:00:00Z")));
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+
+        assertThrows(RecordNotFoundException.class, () -> {
+            METER_POINT.getProductAsOf(ZonedDateTime.parse("2020-10-08T00:00:00Z"));
+        });
+        assertThrows(RecordNotFoundException.class, () -> {
+            METER_POINT.getProductAsOf(ZonedDateTime.parse("2020-10-31T00:00:01Z"));
+        });
+    }
+
+    @Test
+    void testGetMostRecentConsumption() {
+        try {
+            assertEquals(BigDecimal.valueOf(3), METER_POINT.getMostRecentConsumption().consumption);
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testGetMaxPrice() {
+        try {
+            assertEquals(BigDecimal.valueOf(13.5), METER_POINT.getMaxPrice(true));
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testGetMinPrice() {
+        try {
+            assertEquals(BigDecimal.valueOf(1.5), METER_POINT.getMinPrice(true));
+        } catch (RecordNotFoundException e) {
+            fail(e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/PriceTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/dto/PriceTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.octopusenergy.internal.OctopusEnergyBindingConstants;
+
+/**
+ * The {@link PriceTest} is a test class for {@link Price}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class PriceTest {
+
+    private static final ZonedDateTime UDT = OctopusEnergyBindingConstants.UNDEFINED_TIME;
+
+    private static final List<Price> LIST = new ArrayList<>();
+
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+        LIST.add(new Price(5.2, 5.2, ZonedDateTime.parse("2020-10-09T07:00+00:00"), UDT));
+        LIST.add(new Price(2.1, 2.1, ZonedDateTime.parse("2020-10-09T10:00+00:00"), UDT));
+        LIST.add(new Price(8.4, 8.4, ZonedDateTime.parse("2020-10-09T03:00+00:00"), UDT));
+        LIST.add(new Price(1.8, 1.8, ZonedDateTime.parse("2020-10-09T09:00+00:00"), UDT));
+        LIST.add(new Price(7.3, 7.3, ZonedDateTime.parse("2020-10-09T01:00+00:00"), UDT));
+    }
+
+    @Test
+    void testComparatorPriceOrderAsc() {
+        List<Price> l = new ArrayList<>(LIST);
+        Collections.sort(l, Price.PRICE_ORDER_ASC);
+        assertEquals(BigDecimal.valueOf(1.8), l.get(0).valueExcVat);
+        assertEquals(BigDecimal.valueOf(2.1), l.get(1).valueExcVat);
+        assertEquals(BigDecimal.valueOf(5.2), l.get(2).valueExcVat);
+        assertEquals(BigDecimal.valueOf(7.3), l.get(3).valueExcVat);
+        assertEquals(BigDecimal.valueOf(8.4), l.get(4).valueExcVat);
+    }
+
+    @Test
+    void testComparatorIntervalStartOrderAsc() {
+        List<Price> l = new ArrayList<>(LIST);
+        Collections.sort(l, Price.INTERVAL_START_ORDER_ASC);
+        assertEquals(BigDecimal.valueOf(7.3), l.get(0).valueExcVat);
+        assertEquals(BigDecimal.valueOf(8.4), l.get(1).valueExcVat);
+        assertEquals(BigDecimal.valueOf(5.2), l.get(2).valueExcVat);
+        assertEquals(BigDecimal.valueOf(1.8), l.get(3).valueExcVat);
+        assertEquals(BigDecimal.valueOf(2.1), l.get(4).valueExcVat);
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/util/PriceOptimiserTest.java
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/java/org/openhab/binding/octopusenergy/internal/util/PriceOptimiserTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.octopusenergy.internal.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.octopusenergy.internal.dto.Price;
+import org.openhab.binding.octopusenergy.internal.exception.NotEnoughDataException;
+
+/**
+ * The {@link PriceOptimiserTest} is a test class for {@link PriceOptimiser}.
+ *
+ * @author Rene Scherer - Initial contribution
+ */
+@NonNullByDefault
+class PriceOptimiserTest {
+
+    private static final List<Price> PRICE_LIST = new ArrayList<>();
+
+    // 23.00 - before the first slot is available
+    private static final ZonedDateTime START_TIME_1 = ZonedDateTime.parse("2020-10-08T23:00Z");
+
+    // 00.00 - start of the first slot
+    private static final ZonedDateTime START_TIME_2 = ZonedDateTime.parse("2020-10-09T00:00Z");
+
+    // 00.45 - middle of the second slot
+    private static final ZonedDateTime START_TIME_3 = ZonedDateTime.parse("2020-10-09T00:45Z");
+
+    // 01.40
+    private static final ZonedDateTime START_TIME_4 = ZonedDateTime.parse("2020-10-09T01:40Z");
+
+    private static final PriceOptimiser PO = PriceOptimiser.getInstance();
+
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+        // setting up a price profile of 1,1, 1,9, 9,2, 2,2, 2,3, 1,1, 8,8
+
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T00:00Z"),
+                ZonedDateTime.parse("2020-10-09T00:30Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T00:30Z"),
+                ZonedDateTime.parse("2020-10-09T01:00Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T01:00Z"),
+                ZonedDateTime.parse("2020-10-09T01:30Z")));
+        PRICE_LIST.add(new Price(9.0, 13.5, ZonedDateTime.parse("2020-10-09T01:30Z"),
+                ZonedDateTime.parse("2020-10-09T02:00Z")));
+        PRICE_LIST.add(new Price(9.0, 13.5, ZonedDateTime.parse("2020-10-09T02:00Z"),
+                ZonedDateTime.parse("2020-10-09T02:30Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T02:30Z"),
+                ZonedDateTime.parse("2020-10-09T03:00Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T03:00Z"),
+                ZonedDateTime.parse("2020-10-09T03:30Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T03:30Z"),
+                ZonedDateTime.parse("2020-10-09T04:00Z")));
+        PRICE_LIST.add(new Price(2.0, 3.0, ZonedDateTime.parse("2020-10-09T04:00Z"),
+                ZonedDateTime.parse("2020-10-09T04:30Z")));
+        PRICE_LIST.add(new Price(3.0, 4.5, ZonedDateTime.parse("2020-10-09T04:30Z"),
+                ZonedDateTime.parse("2020-10-09T05:00Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T05:00Z"),
+                ZonedDateTime.parse("2020-10-09T05:30Z")));
+        PRICE_LIST.add(new Price(1.0, 1.5, ZonedDateTime.parse("2020-10-09T05:30Z"),
+                ZonedDateTime.parse("2020-10-09T06:00Z")));
+        PRICE_LIST.add(new Price(8.0, 12.0, ZonedDateTime.parse("2020-10-09T06:00Z"),
+                ZonedDateTime.parse("2020-10-09T06:30Z")));
+        PRICE_LIST.add(new Price(8.0, 12.0, ZonedDateTime.parse("2020-10-09T06:30Z"),
+                ZonedDateTime.parse("2020-10-09T07:00Z")));
+    }
+
+    /**
+     * Test with a 30 mins (1 slot) duration
+     */
+    @Test
+    void testOptimise30min() {
+        try {
+            assertEquals(ZonedDateTime.parse("2020-10-09T00:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofSeconds(30 * 60 + 30), START_TIME_1,
+                            PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T00:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofMinutes(30), START_TIME_2,
+                            PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T00:45Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofMinutes(30), START_TIME_3,
+                            PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Test with a 90 mins duration
+     */
+    @Test
+    void testOptimise90min() {
+        try {
+            assertEquals(ZonedDateTime.parse("2020-10-09T00:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofSeconds(90 * 60 + 30), START_TIME_1,
+                            PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T00:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofMinutes(90), START_TIME_2,
+                            PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T04:30Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofMinutes(90), START_TIME_3,
+                            PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Test with a 3 hour duration
+     */
+    @Test
+    void testOptimise3h() {
+        try {
+            assertEquals(ZonedDateTime.parse("2020-10-09T03:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofHours(3), START_TIME_1, PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T03:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofHours(3), START_TIME_2, PRICE_LIST).optimisedStartTime);
+
+            assertEquals(ZonedDateTime.parse("2020-10-09T03:00Z"),
+                    PO.optimiseWithAbsoluteStartTime(Duration.ofHours(3), START_TIME_3, PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Test with a 90 mins duration
+     */
+    @Test
+    void testCalculateCostForDuration() {
+        try {
+            // excl. VAT
+            // 00.00 - 01.30 => 1 + 1 + 1 = 3
+            assertEquals(BigDecimal.valueOf(3),
+                    PO.calculateCostForDuration(Duration.ofMinutes(90), START_TIME_2, PRICE_LIST, false)
+                            .stripTrailingZeros());
+            // 00.45 - 02.15 => 0.5 + 1 + 9 + 4.5 = 15
+            assertEquals(BigDecimal.valueOf(15),
+                    PO.calculateCostForDuration(Duration.ofMinutes(90), START_TIME_3, PRICE_LIST, false)
+                            .stripTrailingZeros());
+            // 01.40 - 04.15 => 6 + 9 + 2 + 2 + 2 + 1 = 22
+            assertEquals(BigDecimal.valueOf(22),
+                    PO.calculateCostForDuration(Duration.ofMinutes(155), START_TIME_4, PRICE_LIST, false)
+                            .stripTrailingZeros());
+
+            // incl. VAT
+            // 00.00 - 01.30 => 1.5 + 1.5 + 1.5 = 3
+            assertEquals(BigDecimal.valueOf(4.5),
+                    PO.calculateCostForDuration(Duration.ofMinutes(90), START_TIME_2, PRICE_LIST, true)
+                            .stripTrailingZeros());
+            // 00.45 - 02.15 => 0.75 + 1.5 + 13.5 + 6.75 = 22.5
+            assertEquals(BigDecimal.valueOf(22.5),
+                    PO.calculateCostForDuration(Duration.ofMinutes(90), START_TIME_3, PRICE_LIST, true)
+                            .stripTrailingZeros());
+
+            // 01.40 - 04.15 => 9 + 13.5 + 3 + 3 + 3 + 1.5 = 33
+            assertEquals(BigDecimal.valueOf(33),
+                    PO.calculateCostForDuration(Duration.ofMinutes(155), START_TIME_4, PRICE_LIST, true)
+                            .stripTrailingZeros());
+
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Test activities outside of the given price range
+     */
+    @Test
+    void testCalculateCostForDurationExceptions1() {
+        // start time is before the price range start
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.calculateCostForDuration(Duration.ofHours(2), START_TIME_1, PRICE_LIST, false);
+        });
+        // during is longer then the price range
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.calculateCostForDuration(Duration.ofHours(10), START_TIME_2, PRICE_LIST, false);
+        });
+
+        try {
+            // within range
+            PO.calculateCostForDuration(Duration.ofHours(2), START_TIME_3, PRICE_LIST, false);
+            // full range window
+            PO.calculateCostForDuration(Duration.ofHours(7), START_TIME_2, PRICE_LIST, false);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Test activities outside of the given price range
+     */
+    @Test
+    void testCalculateCostForDurationExceptions2() {
+        // start time is before the price range start
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.calculateCostForDuration(Duration.ofHours(2), START_TIME_1, new ArrayList<>(), false);
+        });
+    }
+
+    @Test
+    void testOptimiseWithDelayedStartAndEarlierFinishTime() {
+        try {
+            // setting up a price profile of 1,1, 1,9, 9,2, 2,2, 2,3, 1,1, 8,8
+            // use window from 1.40 to 4.30
+            assertEquals(ZonedDateTime.parse("2020-10-09T02:30Z"),
+                    PO.optimise(Duration.ofMinutes(50), 1, 40, 4, 30, START_TIME_1, PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    // start hour/minute only
+    @Test
+    void testOptimiseWithDelayedStartTime() {
+        try {
+            // setting up a price profile of 1,1, 1,9, 9,2, 2,2, 2,3, 1,1, 8,8
+            // use window from 1.40 to 4.30
+            assertEquals(ZonedDateTime.parse("2020-10-09T05:00Z"),
+                    PO.optimiseWithRecurringStartTime(Duration.ofMinutes(65), 4, 30, START_TIME_1,
+                            PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    // start time & end hour/minute
+    @Test
+    void testOptimiseWithGivenStartTimeAndEarlierFinishTime() {
+        try {
+            // setting up a price profile of 1,1, 1,9, 9,2, 2,2, 2,3, 1,1, 8,8
+            // use window from 1.40 to 4.30
+            assertEquals(ZonedDateTime.parse("2020-10-09T02:30Z"),
+                    PO.optimiseWithRecurringEndTime(Duration.ofMinutes(65), START_TIME_4, 4, 30,
+                            PRICE_LIST).optimisedStartTime);
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testGetFutureTimeWithHourAndMinute() {
+        ZonedDateTime startTime = ZonedDateTime.parse("2020-10-08T12:30Z");
+
+        assertEquals(ZonedDateTime.parse("2020-10-08T23:15Z"), PO.getFutureTimeWithHourAndMinute(startTime, 23, 15));
+        assertEquals(ZonedDateTime.parse("2020-10-08T12:30Z"), PO.getFutureTimeWithHourAndMinute(startTime, 12, 30));
+        assertEquals(ZonedDateTime.parse("2020-10-09T09:15Z"), PO.getFutureTimeWithHourAndMinute(startTime, 9, 15));
+        assertEquals(ZonedDateTime.parse("2020-10-09T00:00Z"), PO.getFutureTimeWithHourAndMinute(startTime, 0, 0));
+    }
+
+    @Test
+    void testFindPriceSlotForTime() {
+        try {
+            // beginning of the list
+            assertEquals(0, PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-09T00:00Z")));
+            // beginning of the second slot
+            assertEquals(1, PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-09T00:30Z")));
+            // middle of the third slot
+            assertEquals(2, PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-09T01:15Z")));
+            // middle of the last slot
+            assertEquals(13, PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-09T06:45Z")));
+        } catch (NotEnoughDataException e) {
+            fail(e);
+        }
+
+        // before the first slot
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-08T22:45Z"));
+        });
+        // end of the last slot
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-08T07:00Z"));
+        });
+        // after the last slot
+        assertThrows(NotEnoughDataException.class, () -> {
+            PO.findPriceSlotForTime(PRICE_LIST, ZonedDateTime.parse("2020-10-08T07:30Z"));
+        });
+    }
+}

--- a/bundles/org.openhab.binding.octopusenergy/src/test/resources/log4j.properties
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+# Root logger
+log4j.rootLogger=DEBUG,console
+ 
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x XXXX- %m%n

--- a/bundles/org.openhab.binding.octopusenergy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/bundles/org.openhab.binding.octopusenergy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -221,6 +221,7 @@
     <module>org.openhab.binding.nuvo</module>
     <module>org.openhab.binding.nzwateralerts</module>
     <module>org.openhab.binding.oceanic</module>
+    <module>org.openhab.binding.octopusenergy</module>
     <module>org.openhab.binding.ojelectronics</module>
     <module>org.openhab.binding.omnikinverter</module>
     <module>org.openhab.binding.omnilink</module>


### PR DESCRIPTION
# Octopus Energy Binding

This binding allows openHAB to communicate with the public API from Octopus Energy (https://octopus.energy), an energy provider in the UK. The following features are provided by the binding:
- retrieval of latest meter readings (consumption)
- retrieval of agile tariff schedule / unit rates (if on an agile tariff, half-hourly future rates are provided based on availability)

The key feature of this binding is a number of actions to calculate the optimal time and cost for running a certain appliance (e.g. Dishwasher). This can be used in a variety of ways, such as:

- display the recommended Dishwasher or Washing machine start time on a wall panel
- schedule a nightly EV charging session if your EVSE or car allows automated scheduling
- switching of storage heaters overnight
- schedule wake up time for a server to run nightly backups

### Current Limitations / Work in Progress

- only tested with Octopus "Agile" electricity tariff. I would welcome users of "Go" or "Go Faster" for testing.
