### PR TITLE
[keba] Improve connection establishment and stability

### DIFF
--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -4,12 +4,13 @@ This binding integrates the [Keba KeContact EV Charging Stations](https://www.ke
 
 ## Supported Things
 
-The Keba KeContact P20 and P30 stations are supported by this binding, the thing type id is `kecontact`.
+The Keba KeContact P20 and P30 stations which are providing the UDP interface (P20 LSA+ socket, P30 c-series and x-series) are supported by this binding, the thing type id is `kecontact`.
 
 
 ## Thing Configuration
 
-The Keba KeContact P20/30 requires the ip address as the configuration parameter `ipAddress`. Optionally, a refresh interval (in seconds) can be defined as parameter `refreshInterval` that defines the polling of values from the charging station.
+The Keba KeContact P20/30 requires the IP address as the configuration parameter `ipAddress`.
+Optionally, a refresh interval (in seconds) can be defined as parameter `refreshInterval` that defines the polling of values from the charging station.
 
 
 ## Channels
@@ -103,3 +104,49 @@ sitemap demo label="Main Menu"
 			}
 }
 ```
+
+## Troubleshooting
+
+### Enable Verbose Logging
+
+Enable `DEBUG` or `TRACE` (even more verbose) logging for the logger named:
+
+    org.openhab.binding.keba
+
+If everything is working fine, you see the cyclic reception of `report 1`, `2` & `3` from the station. The frequency is according to the `refreshInterval` configuration.
+
+### UDP Ports used
+
+Send port = UDP 7090
+
+The Keba station is the server
+
+Receive port = UDP 7090
+
+This binding is providing the server
+
+UDP Port 7090 needs to be available on the openHAB server
+
+
+In order to enable the UDP port 7090 on the Keba station with all its features, `DIP switch 1.3` must be `ON`.
+
+
+With `DIP switch 1.3 OFF` only ident-data can be read (`i` and `report 1`) but not the other parameters as well as the commands needed for the write access.
+
+
+After setting the DIP switch, you need to `power OFF` and `ON` the station. SW-reset via WebGUI seems not to be sufficient in order to apply the new configuration.
+
+
+The right configuration can be validated as follows:
+- WebGUI DSW Settings:
+  - `DIP 1.3 | ON | UDP interface (SmartHome)`
+- UDP response of `report 1`:
+  - `DIP-Sw1` `0x20` Bit is set (enable at least `DEBUG` log-level for the binding)
+
+### Supported stations
+
+- KeContact P20 charging station with network connection (LSA+ socket)
+  - Product code: `KC-P20-xxxxxx2x-xxx` or `KC-P20-xxxxxx3x-xxx`
+  - Firmware version: 2.5 or higher
+- KeContact P30 charging station (c- or x-series) or BMW wallbox
+  - Firmware version 3.05 or higher

--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -6,45 +6,46 @@ This binding integrates the [Keba KeContact EV Charging Stations](https://www.ke
 
 The Keba KeContact P20 and P30 stations which are providing the UDP interface (P20 LSA+ socket, P30 c-series and x-series) are supported by this binding, the thing type id is `kecontact`.
 
-
 ## Thing Configuration
 
 The Keba KeContact P20/30 requires the IP address as the configuration parameter `ipAddress`.
 Optionally, a refresh interval (in seconds) can be defined as parameter `refreshInterval` that defines the polling of values from the charging station.
 
-
 ## Channels
 
 All devices support the following channels:
 
-| Channel ID         | Item Type | Read-only | Description                                                            |
-|--------------------|-----------|-----------|------------------------------------------------------------------------|
-| state              | Number    | yes       | current operational state of the wallbox                               |
-| enabled            | Switch    | no        | activation state of the wallbox                                        |
-| maxpresetcurrent   | Number    | no        | maximum current the charging station should deliver to the EV          |
-| power              | Number    | yes       | active power delivered by the charging station                         |
-| wallbox            | Switch    | yes       | plug state of wallbox                                                  |
-| vehicle            | Switch    | yes       | plug state of vehicle                                                  |
-| locked             | Switch    | yes       | lock state of plug at vehicle                                          |
-| I1/2/3             | Number    | yes       | current for the given phase                                            |
-| U1/2/3             | Number    | yes       | voltage for the given phase                                            |
-| output             | Switch    | no        | state of the X1 relais                                                 |
-| input              | Switch    | yes       | state of the X2 contact                                                |
-| display            | String    | yes       | display text on wallbox                                                |
-| error1             | String    | yes       | error code state 1, if in error (see the KeContact FAQ)                |
-| error2             | String    | yes       | error code state 2, if in error (see the KeContact FAQ)                |
-| maxsystemcurrent   | Number    | yes       | maximum current the wallbox can deliver                                |
-| failsafecurrent    | Number    | yes       | maximum current the wallbox can deliver, if network is lost            |
-| uptime             | DateTime  | yes       | system uptime since the last reset of the wallbox                      |
-| sessionconsumption | Number    | yes       | energy delivered in current session                                    |
-| totalconsumption   | Number    | yes       | total energy delivered since the last reset of the wallbox             |
-| authreq            | Switch    | yes       | authentication required                                                |
-| authon             | Switch    | yes       | authentication enabled                                                 |
-| sessionrfidtag     | String    | yes       | RFID tag used for the last charging session                            |
-| sessionrfidclass   | String    | yes       | RFID tag class used for the last charging session                      |
-| sessionid          | Number    | yes       | session ID of the last charging session                                |
-| setenergylimit     | Number    | no        | set an energy limit for an already running or the next charging session|
-| authenticate       | String    | no        | authenticate and start a session using RFID tag+RFID class             |
+| Channel ID         		| Item Type 				| Read-only | Description                                                            	|
+|---------------------------|---------------------------|-----------|---------------------------------------------------------------------------|
+| state              		| Number    				| yes       | current operational state of the wallbox                               	|
+| enabled            		| Switch    				| no        | activation state of the wallbox                                        	|
+| maxpresetcurrent   		| Number:ElectricCurrent   	| no        | maximum current the charging station should deliver to the EV in A      	|
+| maxpresetcurrentrange		| Number:Dimensionless      | no 		| maximum current the charging station should deliver to the EV in %        |
+| power              		| Number:Power             	| yes       | active power delivered by the charging station                         	|
+| wallbox            		| Switch    				| yes       | plug state of wallbox                                                  	|
+| vehicle            		| Switch    				| yes       | plug state of vehicle                                                  	|
+| locked             		| Switch    				| yes       | lock state of plug at vehicle                                          	|
+| I1/2/3             		| Number:ElectricCurrent   	| yes       | current for the given phase                                            	|
+| U1/2/3             		| Number:ElectricPotential 	| yes       | voltage for the given phase                                            	|
+| output             		| Switch    				| no        | state of the X1 relais                                                 	|
+| input              		| Switch    				| yes       | state of the X2 contact                                                	|
+| display           		| String    				| no        | display text on wallbox                                                	|
+| error1             		| String    				| yes       | error code state 1, if in error (see the KeContact FAQ)                	|
+| error2             		| String    				| yes       | error code state 2, if in error (see the KeContact FAQ)                	|
+| maxsystemcurrent   		| Number:ElectricCurrent   	| yes       | maximum current the wallbox can deliver                                	|
+| failsafecurrent    		| Number:ElectricCurrent   	| yes       | maximum current the wallbox can deliver, if network is lost            	|
+| uptime             		| Number:Time  				| yes       | system uptime since the last reset of the wallbox                      	|
+| sessionconsumption 		| Number:Energy    			| yes       | energy delivered in current session                                    	|
+| totalconsumption   		| Number:Energy    			| yes       | total energy delivered since the last reset of the wallbox             	|
+| authreq            		| Switch    				| yes       | authentication required                                                	|
+| authon             		| Switch    				| yes       | authentication enabled                                                 	|
+| sessionrfidtag     		| String    				| yes       | RFID tag used for the last charging session                            	|
+| sessionrfidclass   		| String    				| yes       | RFID tag class used for the last charging session                      	|
+| sessionid          		| Number    				| yes       | session ID of the last charging session                                	|
+| setenergylimit     		| Number:Energy    			| no        | set an energy limit for an already running or the next charging session	|
+| authenticate       		| String    				| no        | authenticate and start a session using RFID tag+RFID class             	|
+| maxpilotcurrent         	| Number:ElectricCurrent	| yes  		| current offered to the vehicle via control pilot signalization         	|
+| maxpilotcurrentdutycyle 	| Number:Dimensionless 		| yes  		| duty cycle of the control pilot signal									|
 
 
 ## Example
@@ -58,28 +59,28 @@ Thing keba:kecontact:1 [ipAddress="192.168.0.64", refreshInterval=30]
 demo.items:
 
 ```
-Dimmer KebaCurrentRange  {channel="keba:kecontact:1:maxpresetcurrentrange"} 
-Number KebaCurrent  {channel="keba:kecontact:1:maxpresetcurrent"}
-Number KebaSystemCurrent  {channel="keba:kecontact:1:maxsystemcurrent"} 
-Number KebaFailSafeCurrent  {channel="keba:kecontact:1:failsafecurrent"} 
-String KebaState  {channel="keba:kecontact:1:state"}
-Switch KebaSwitch  {channel="keba:kecontact:1:enabled"}
-Switch KebaWallboxPlugged  {channel="keba:kecontact:1:wallbox"}
-Switch KebaVehiclePlugged  {channel="keba:kecontact:1:vehicle"}
-Switch KebaPlugLocked  {channel="keba:kecontact:1:locked"}
-DateTime KebaUptime "Uptime [%1$tY Y, %1$tm M, %1$td D,  %1$tT]"  {channel="keba:kecontact:1:uptime"}
-Number KebaI1  {channel="keba:kecontact:1:I1"}
-Number KebaI2  {channel="keba:kecontact:1:I2"}
-Number KebaI3  {channel="keba:kecontact:1:I3"}
-Number KebaU1  {channel="keba:kecontact:1:U1"}
-Number KebaU2  {channel="keba:kecontact:1:U2"}
-Number KebaU3  {channel="keba:kecontact:1:U3"}
-Number KebaPower  {channel="keba:kecontact:1:power"}
-Number KebaSessionEnergy  {channel="keba:kecontact:1:sessionconsumption"}
-Number KebaTotalEnergy  {channel="keba:kecontact:1:totalconsumption"}
-Switch KebaInputSwitch  {channel="keba:kecontact:1:input"}
-Switch KebaOutputSwitch  {channel="keba:kecontact:1:output"}
-Number KebaSetEnergyLimit {channel="keba:kecontact:1:setenergylimit"}
+Dimmer 						KebaCurrentRange  		"Maximum supply current [%.1f %%]"			{channel="keba:kecontact:1:maxpresetcurrentrange"} 
+Number:ElectricCurrent  	KebaCurrent  			"Maximum supply current [%.3f A]"			{channel="keba:kecontact:1:maxpresetcurrent"}
+Number:ElectricCurrent  	KebaSystemCurrent  		"Maximum system supply current [%.3f A]"	{channel="keba:kecontact:1:maxsystemcurrent"} 
+Number:ElectricCurrent  	KebaFailSafeCurrent  	"Failsafe supply current [%.3f A]"			{channel="keba:kecontact:1:failsafecurrent"} 
+String 						KebaState  				"Operating State [%s]"						{channel="keba:kecontact:1:state"}
+Switch 						KebaSwitch  			"Enabled"									{channel="keba:kecontact:1:enabled"}
+Switch 						KebaWallboxPlugged  	"Plugged into wallbox"						{channel="keba:kecontact:1:wallbox"}
+Switch 						KebaVehiclePlugged  	"Plugged into vehicle"						{channel="keba:kecontact:1:vehicle"}
+Switch 						KebaPlugLocked  		"Plug locked"								{channel="keba:kecontact:1:locked"}
+DateTime					KebaUptime 				"Uptime [%s s]"  							{channel="keba:kecontact:1:uptime"}
+Number:ElectricCurrent  	KebaI1  															{channel="keba:kecontact:1:I1"}
+Number:ElectricCurrent  	KebaI2  															{channel="keba:kecontact:1:I2"}
+Number:ElectricCurrent  	KebaI3  															{channel="keba:kecontact:1:I3"}
+Number:ElectricPotential 	KebaU1  															{channel="keba:kecontact:1:U1"}
+Number:ElectricPotential 	KebaU2  															{channel="keba:kecontact:1:U2"}
+Number:ElectricPotential 	KebaU3  															{channel="keba:kecontact:1:U3"}
+Number:Power 				KebaPower  				"Energy during current session [%.1f Wh]"	{channel="keba:kecontact:1:power"}
+Number:Energy 				KebaSessionEnergy  													{channel="keba:kecontact:1:sessionconsumption"}
+Number:Energy 				KebaTotalEnergy  		"Energy during all sessions [%.1f Wh]"		{channel="keba:kecontact:1:totalconsumption"}
+Switch 						KebaInputSwitch  													{channel="keba:kecontact:1:input"}
+Switch 						KebaOutputSwitch  													{channel="keba:kecontact:1:output"}
+Number:Energy 				KebaSetEnergyLimit 		"Set charge energy limit [%.1f Wh]"			{channel="keba:kecontact:1:setenergylimit"}
 ```
 
 demo.sitemap:
@@ -87,21 +88,21 @@ demo.sitemap:
 ```
 sitemap demo label="Main Menu"
 {
-			Text label="Charging Station" {
-				Text item=KebaState label="Operating State [%s]"
-				Text item=KebaUptime
-				Switch item=KebaSwitch label="Enabled" mappings=[ON=ON, OFF=OFF ]
-				Switch item=KebaWallboxPlugged label="Plugged into wallbox" mappings=[ON=ON, OFF=OFF ]
-				Switch item=KebaVehiclePlugged label="Plugged into vehicle" mappings=[ON=ON, OFF=OFF ]
-				Switch item=KebaPlugLocked label="Plug locked" mappings=[ON=ON, OFF=OFF ]
-				Slider item=KebaCurrentRange switchSupport label="Maximum supply current [%.1f %%]"
-				Text item=KebaCurrent label="Maximum supply current [%.0f mA]"
-				Text item=KebaSystemCurrent label="Maximum system supply current [%.0f mA]"
-				Text item=KebaFailSafeCurrent label="Failsafe supply current [%.0f mA]"
-				Text item=KebaSessionEnergy label="Energy during current session [%.0f Wh]"
-				Text item=KebaTotalEnergy label="Energy during all sessions [%.0f Wh]"
-				Switch item=KebaSetEnergyLimit label="Set charge energy limit" mappings=[0="off", 20000="20kWh"]
-			}
+	Text label="Charging Station" {
+		Text 	item=KebaState
+		Text 	item=KebaUptime
+		Switch 	item=KebaSwitch
+		Switch 	item=KebaWallboxPlugged
+		Switch 	item=KebaVehiclePlugged
+		Switch 	item=KebaPlugLocked
+		Slider 	item=KebaCurrentRange
+		Text 	item=KebaCurrent
+		Text 	item=KebaSystemCurrent
+		Text 	item=KebaFailSafeCurrent
+		Text 	item=KebaSessionEnergy
+		Text 	item=KebaTotalEnergy
+		Switch 	item=KebaSetEnergyLimit
+	}
 }
 ```
 
@@ -117,27 +118,24 @@ If everything is working fine, you see the cyclic reception of `report 1`, `2` &
 
 ### UDP Ports used
 
-Send port = UDP 7090
+	Send port = UDP 7090
 
 The Keba station is the server
 
-Receive port = UDP 7090
+	Receive port = UDP 7090
 
 This binding is providing the server
 
-UDP Port 7090 needs to be available on the openHAB server
+UDP port 7090 needs to be available/free on the openHAB server.
 
 
-In order to enable the UDP port 7090 on the Keba station with all its features, `DIP switch 1.3` must be `ON`.
-
-
-With `DIP switch 1.3 OFF` only ident-data can be read (`i` and `report 1`) but not the other parameters as well as the commands needed for the write access.
-
-
+In order to enable the UDP port 7090 on the Keba station with full functionality, `DIP switch 1.3` must be `ON`.
+With `DIP switch 1.3 OFF` only ident-data can be read (`i` and `report 1`) but not the other reports as well as the commands needed for the write access.
 After setting the DIP switch, you need to `power OFF` and `ON` the station. SW-reset via WebGUI seems not to be sufficient in order to apply the new configuration.
 
 
 The right configuration can be validated as follows:
+
 - WebGUI DSW Settings:
   - `DIP 1.3 | ON | UDP interface (SmartHome)`
 - UDP response of `report 1`:

--- a/bundles/org.openhab.binding.keba/README.md
+++ b/bundles/org.openhab.binding.keba/README.md
@@ -59,7 +59,7 @@ Thing keba:kecontact:1 [ipAddress="192.168.0.64", refreshInterval=30]
 demo.items:
 
 ```
-Dimmer 						KebaCurrentRange  		"Maximum supply current [%.1f %%]"			{channel="keba:kecontact:1:maxpresetcurrentrange"} 
+Number:Dimensionless		KebaCurrentRange  		"Maximum supply current [%.1f %%]"			{channel="keba:kecontact:1:maxpresetcurrentrange"} 
 Number:ElectricCurrent  	KebaCurrent  			"Maximum supply current [%.3f A]"			{channel="keba:kecontact:1:maxpresetcurrent"}
 Number:ElectricCurrent  	KebaSystemCurrent  		"Maximum system supply current [%.3f A]"	{channel="keba:kecontact:1:maxsystemcurrent"} 
 Number:ElectricCurrent  	KebaFailSafeCurrent  	"Failsafe supply current [%.3f A]"			{channel="keba:kecontact:1:failsafecurrent"} 

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -82,7 +82,7 @@ public class KebaBindingConstants {
         E('0'),
         B('1'),
         C('2', '3'),
-        X('A', 'B', 'C', 'D');
+        X('A', 'B', 'C', 'D', 'E', 'G', 'H');
 
         private final List<Character> things = new ArrayList<>();
 

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/KebaBindingConstants.java
@@ -44,7 +44,7 @@ public class KebaBindingConstants {
     public static final String CHANNEL_PLUG_LOCKED = "locked";
     public static final String CHANNEL_ENABLED = "enabled";
     public static final String CHANNEL_PILOT_CURRENT = "maxpilotcurrent";
-    public static final String CHANNEL_PILOT_PWM = "pwmpilotcurrent";
+    public static final String CHANNEL_PILOT_PWM = "maxpilotcurrentdutycyle";
     public static final String CHANNEL_MAX_SYSTEM_CURRENT = "maxsystemcurrent";
     public static final String CHANNEL_MAX_PRESET_CURRENT_RANGE = "maxpresetcurrentrange";
     public static final String CHANNEL_MAX_PRESET_CURRENT = "maxpresetcurrent";
@@ -104,7 +104,7 @@ public class KebaBindingConstants {
                 }
             }
 
-            throw new IllegalArgumentException("Not a valid series");
+            throw new IllegalArgumentException("Not a valid series: '" + text + "'");
         }
     }
 }

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactHandler.java
@@ -16,7 +16,9 @@ import static org.openhab.binding.keba.internal.KebaBindingConstants.*;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -64,13 +66,14 @@ public class KeContactHandler extends BaseThingHandler {
     public static final String IP_ADDRESS = "ipAddress";
     public static final String POLLING_REFRESH_INTERVAL = "refreshInterval";
     public static final int REPORT_INTERVAL = 3000;
-    public static final int PING_TIME_OUT = 3000;
     public static final int BUFFER_SIZE = 1024;
     public static final int REMOTE_PORT_NUMBER = 7090;
     private static final String CACHE_REPORT_1 = "REPORT_1";
     private static final String CACHE_REPORT_2 = "REPORT_2";
     private static final String CACHE_REPORT_3 = "REPORT_3";
     private static final String CACHE_REPORT_100 = "REPORT_100";
+    public static final int SOCKET_TIME_OUT = 3000;
+    public static final int SOCKET_CHECK_PORT_NUMBER = 80;
 
     private final Logger logger = LoggerFactory.getLogger(KeContactHandler.class);
 
@@ -94,30 +97,49 @@ public class KeContactHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        if (getConfig().get(IP_ADDRESS) != null && !getConfig().get(IP_ADDRESS).equals("")) {
-            transceiver.registerHandler(this);
+        logger.debug("Initializing Keba binding");
+        try {
+            if (isKebaReachable()) {
+                transceiver.registerHandler(this);
 
-            cache = new ExpiringCacheMap<>(
-                    Math.max((((BigDecimal) getConfig().get(POLLING_REFRESH_INTERVAL)).intValue()) - 5, 0) * 1000);
+                cache = new ExpiringCacheMap<>(
+                        Math.max((((BigDecimal) getConfig().get(POLLING_REFRESH_INTERVAL)).intValue()) - 5, 0) * 1000);
 
-            cache.put(CACHE_REPORT_1, () -> transceiver.send("report 1", getHandler()));
-            cache.put(CACHE_REPORT_2, () -> transceiver.send("report 2", getHandler()));
-            cache.put(CACHE_REPORT_3, () -> transceiver.send("report 3", getHandler()));
-            cache.put(CACHE_REPORT_100, () -> transceiver.send("report 100", getHandler()));
+                cache.put(CACHE_REPORT_1, () -> transceiver.send("report 1", getHandler()));
+                cache.put(CACHE_REPORT_2, () -> transceiver.send("report 2", getHandler()));
+                cache.put(CACHE_REPORT_3, () -> transceiver.send("report 3", getHandler()));
+                cache.put(CACHE_REPORT_100, () -> transceiver.send("report 100", getHandler()));
 
-            if (pollingJob == null || pollingJob.isCancelled()) {
-                try {
-                    pollingJob = scheduler.scheduleWithFixedDelay(this::pollingRunnable, 0,
-                            ((BigDecimal) getConfig().get(POLLING_REFRESH_INTERVAL)).intValue(), TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
-                            "An exception occurred while scheduling the polling job");
+                if (pollingJob == null || pollingJob.isCancelled()) {
+                    try {
+                        pollingJob = scheduler.scheduleWithFixedDelay(this::pollingRunnable, 0,
+                                ((BigDecimal) getConfig().get(POLLING_REFRESH_INTERVAL)).intValue(), TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
+                                "An exception occurred while scheduling the polling job");
+                    }
                 }
+            } else {
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                        "IP address or port number not set");
             }
-        } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "IP address or port number not set");
+        } catch (Exception e) {
+            logger.error("Exception during Ping check and Http Backup check", e);
         }
+    }
+
+    private boolean isKebaReachable() throws IOException {
+        boolean isReachable = false;
+        SocketAddress sockAddr = new InetSocketAddress((String) getConfig().get(IP_ADDRESS), SOCKET_CHECK_PORT_NUMBER);
+        Socket socket = new Socket();
+        try {
+            socket.connect(sockAddr, SOCKET_TIME_OUT);
+            isReachable = true;
+        } finally {
+            socket.close();
+        }
+        logger.debug("isKebaReachable() returns {}", isReachable);
+        return isReachable;
     }
 
     @Override
@@ -150,8 +172,9 @@ public class KeContactHandler extends BaseThingHandler {
 
     private void pollingRunnable() {
         try {
+            logger.debug("Running pollingRunnable to connect Keba wallbox");
             long stamp = System.currentTimeMillis();
-            if (!InetAddress.getByName(((String) getConfig().get(IP_ADDRESS))).isReachable(PING_TIME_OUT)) {
+            if (!isKebaReachable()) {
                 logger.debug("Ping timed out after '{}' milliseconds", System.currentTimeMillis() - stamp);
                 transceiver.unRegisterHandler(getHandler());
             } else {

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -50,7 +50,6 @@ public class KeContactTransceiver {
     public static final int LISTENER_PORT_NUMBER = 7090;
     public static final int LISTENING_INTERVAL = 100;
     public static final int BUFFER_SIZE = 1024;
-    public static final String IP_ADDRESS = "ipAddress";
 
     private DatagramChannel broadcastChannel;
     private SelectionKey broadcastKey;
@@ -404,8 +403,9 @@ public class KeContactTransceiver {
     };
 
     private void establishConnection(KeContactHandler handler) {
+        String ipAddress = handler.getIPAddress();
         if (handler.getThing().getStatusInfo().getStatusDetail() != ThingStatusDetail.CONFIGURATION_ERROR
-                && handler.getConfig().get(IP_ADDRESS) != null && !handler.getConfig().get(IP_ADDRESS).equals("")) {
+                && !ipAddress.equals("")) {
             logger.debug("Establishing the connection to the KEBA KeContact '{}'", handler.getThing().getUID());
 
             DatagramChannel datagramChannel = null;
@@ -436,8 +436,7 @@ public class KeContactTransceiver {
                                 "An exception occurred while registering a selector");
                     }
 
-                    InetSocketAddress remoteAddress = new InetSocketAddress(
-                            (String) handler.getConfig().get(IP_ADDRESS), LISTENER_PORT_NUMBER);
+                    InetSocketAddress remoteAddress = new InetSocketAddress(ipAddress, LISTENER_PORT_NUMBER);
 
                     try {
                         if (logger.isTraceEnabled()) {
@@ -447,8 +446,8 @@ public class KeContactTransceiver {
 
                         handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
                     } catch (Exception e) {
-                        logger.debug("An exception occurred while connecting connecting to '{}:{}' : {}", new Object[] {
-                                (String) handler.getConfig().get(IP_ADDRESS), LISTENER_PORT_NUMBER, e.getMessage() });
+                        logger.debug("An exception occurred while connecting connecting to '{}:{}' : {}",
+                                new Object[] { ipAddress, LISTENER_PORT_NUMBER, e.getMessage() });
                         handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "An exception occurred while connecting");
                     }

--- a/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
+++ b/bundles/org.openhab.binding.keba/src/main/java/org/openhab/binding/keba/internal/handler/KeContactTransceiver.java
@@ -48,11 +48,9 @@ import org.slf4j.LoggerFactory;
 public class KeContactTransceiver {
 
     public static final int LISTENER_PORT_NUMBER = 7090;
-    public static final int REMOTE_PORT_NUMBER = 7090;
     public static final int LISTENING_INTERVAL = 100;
     public static final int BUFFER_SIZE = 1024;
     public static final String IP_ADDRESS = "ipAddress";
-    public static final String POLLING_REFRESH_INTERVAL = "refreshInterval";
 
     private DatagramChannel broadcastChannel;
     private SelectionKey broadcastKey;
@@ -439,7 +437,7 @@ public class KeContactTransceiver {
                     }
 
                     InetSocketAddress remoteAddress = new InetSocketAddress(
-                            (String) handler.getConfig().get(IP_ADDRESS), REMOTE_PORT_NUMBER);
+                            (String) handler.getConfig().get(IP_ADDRESS), LISTENER_PORT_NUMBER);
 
                     try {
                         if (logger.isTraceEnabled()) {
@@ -450,7 +448,7 @@ public class KeContactTransceiver {
                         handler.updateStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE, "");
                     } catch (Exception e) {
                         logger.debug("An exception occurred while connecting connecting to '{}:{}' : {}", new Object[] {
-                                (String) handler.getConfig().get(IP_ADDRESS), REMOTE_PORT_NUMBER, e.getMessage() });
+                                (String) handler.getConfig().get(IP_ADDRESS), LISTENER_PORT_NUMBER, e.getMessage() });
                         handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "An exception occurred while connecting");
                     }

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
@@ -21,7 +21,7 @@
 			<channel id="vehicle" typeId="plugvehicle"/>
 			<channel id="locked" typeId="locked"/>
 			<channel id="maxpilotcurrent" typeId="pilotcurrent"/>
-			<channel id="pwmpilotcurrent" typeId="pilotrange"/>
+			<channel id="maxpilotcurrentdutycyle" typeId="pilotcurrentdutycyle"/>
 			<channel id="maxsystemcurrent" typeId="maxcurrent"/>
 			<channel id="failsafecurrent" typeId="failsafecurrent"/>
 			<channel id="output" typeId="x2"/>
@@ -62,9 +62,9 @@
 				<label>Network Address</label>
 				<description>Network address of the wallbox</description>
 			</parameter>
-			<parameter name="refreshInterval" type="integer" required="false">
+			<parameter name="refreshInterval" type="integer" required="true">
 				<label>Refresh Interval</label>
-				<description>Specifies the refresh interval in seconds.</description>
+				<description>Specifies the refresh interval in seconds</description>
 				<default>15</default>
 			</parameter>
 		</config-description>
@@ -134,82 +134,82 @@
 		<state readOnly="false"></state>
 	</channel-type>
 	<channel-type id="current_settable">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricCurrent</item-type>
 		<label>Preset Current</label>
-		<description>Preset Current in mA</description>
-		<state pattern="%d mA" readOnly="false"></state>
+		<description>Preset Current in A</description>
+		<state pattern="%.3f A" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="current" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricCurrent</item-type>
 		<label>Current</label>
-		<description>Current in mA</description>
-		<state pattern="%d mA" readOnly="true"></state>
+		<description>Current in A</description>
+		<state pattern="%.3f A" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="maxcurrent" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricCurrent</item-type>
 		<label>Max. System Current</label>
-		<description>Maximal System Current in mA</description>
-		<state pattern="%d mA" readOnly="true"></state>
+		<description>Maximal System Current in A</description>
+		<state pattern="%.3f A" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="failsafecurrent" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricCurrent</item-type>
 		<label>Failsafe Current</label>
-		<description>Failsafe Current in mA (if network is lost)</description>
-		<state pattern="%d mA" readOnly="true"></state>
+		<description>Failsafe Current in A (if network is lost)</description>
+		<state pattern="%.3f A" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="range" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Rel. Current</label>
-		<description>Current in % of the 6000-63000 mA range accepted by the wallbox</description>
+		<description>Current in % of the 6-63 A range accepted by the wallbox</description>
 		<state pattern="%d %%" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="pilotcurrent" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricCurrent</item-type>
 		<label>Pilot Current</label>
-		<description>Current preset value via Control pilot in mA</description>
-		<state pattern="%d mA" readOnly="true"></state>
+		<description>Current value in A offered to the vehicle via control pilot signalization (PWM)</description>
+		<state pattern="%.3f A" readOnly="true"></state>
 	</channel-type>
-	<channel-type id="pilotrange" advanced="true">
-		<item-type>Number</item-type>
-		<label>Pilot Range</label>
-		<description>Current preset value via Control pilot in 0,1% of the PWM value</description>
-		<state pattern="%d" readOnly="true"></state>
+	<channel-type id="pilotcurrentdutycyle" advanced="true">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Pilot Current Duty Cycle</label>
+		<description>Duty cycle of the control pilot signal</description>
+		<state pattern="%.1f %%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="uptime" advanced="true">
-		<item-type>DateTime</item-type>
+		<item-type>Number:Time</item-type>
 		<label>System Uptime</label>
 		<description>System uptime since the last reset of the wallbox</description>
-		<state readOnly="true"></state>
+		<state pattern="%d s" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="voltage" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:ElectricPotential</item-type>
 		<label>Voltage</label>
 		<description>Voltage in V</description>
 		<state pattern="%d V" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="power">
-		<item-type>Number</item-type>
+		<item-type>Number:Power</item-type>
 		<label>Power</label>
 		<description>Active Power in W</description>
-		<state pattern="%d W" readOnly="true"></state>
+		<state pattern="%.3f W" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="powerfactor" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Power Factor</label>
 		<description>Power factor (cosphi)</description>
-		<state readOnly="true"></state>
+		<state pattern="%.1f %%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="energy" advanced="true">
-		<item-type>Number</item-type>
-		<label>Energy</label>
+		<item-type>Number:Energy</item-type>
+		<label>Energy Session</label>
 		<description>Power consumption in Wh.</description>
-		<state pattern="%d Wh" readOnly="true"></state>
+		<state pattern="%.1f Wh" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="totalenergy" advanced="true">
-		<item-type>Number</item-type>
-		<label>Energy</label>
+		<item-type>Number:Energy</item-type>
+		<label>Energy Total</label>
 		<description>Total energy consumption is added up after each completed charging session</description>
-		<state pattern="%d Wh" readOnly="true"></state>
+		<state pattern="%.1f Wh" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="display" advanced="true">
 		<item-type>String</item-type>
@@ -248,10 +248,10 @@
 		<state readOnly="true"></state>
 	</channel-type>
 	<channel-type id="setenergylimit">
-		<item-type>Number</item-type>
+		<item-type>Number:Energy</item-type>
 		<label>Energy Limit</label>
 		<description>An energy limit for an already running or the next charging session.</description>
-		<state pattern="%d Wh" readOnly="false"></state>
+		<state pattern="%.1f Wh" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="authenticate">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
@@ -136,38 +136,38 @@
 	<channel-type id="current_settable">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Preset Current</label>
-		<description>Preset Current in A</description>
-		<state pattern="%.3f A" readOnly="false"></state>
+		<description>Preset Current</description>
+		<state pattern="%.3f %unit%" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="current" advanced="true">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Current</label>
-		<description>Current in A</description>
-		<state pattern="%.3f A" readOnly="true"></state>
+		<description>Current</description>
+		<state pattern="%.3f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="maxcurrent" advanced="true">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Max. System Current</label>
-		<description>Maximal System Current in A</description>
-		<state pattern="%.3f A" readOnly="true"></state>
+		<description>Maximal System Current</description>
+		<state pattern="%.3f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="failsafecurrent" advanced="true">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Failsafe Current</label>
-		<description>Failsafe Current in A (if network is lost)</description>
-		<state pattern="%.3f A" readOnly="true"></state>
+		<description>Failsafe Current (if network is lost)</description>
+		<state pattern="%.3f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="range" advanced="true">
-		<item-type>Dimmer</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Rel. Current</label>
 		<description>Current in % of the 6-63 A range accepted by the wallbox</description>
-		<state pattern="%d %%" readOnly="false"></state>
+		<state pattern="%.1f %%" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="pilotcurrent" advanced="true">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>Pilot Current</label>
-		<description>Current value in A offered to the vehicle via control pilot signalization (PWM)</description>
-		<state pattern="%.3f A" readOnly="true"></state>
+		<description>Current value offered to the vehicle via control pilot signalization (PWM)</description>
+		<state pattern="%.3f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="pilotcurrentdutycyle" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
@@ -179,19 +179,19 @@
 		<item-type>Number:Time</item-type>
 		<label>System Uptime</label>
 		<description>System uptime since the last reset of the wallbox</description>
-		<state pattern="%d s" readOnly="true"></state>
+		<state pattern="%d %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="voltage" advanced="true">
 		<item-type>Number:ElectricPotential</item-type>
 		<label>Voltage</label>
-		<description>Voltage in V</description>
-		<state pattern="%d V" readOnly="true"></state>
+		<description>Voltage</description>
+		<state pattern="%d %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="power">
 		<item-type>Number:Power</item-type>
 		<label>Power</label>
-		<description>Active Power in W</description>
-		<state pattern="%.3f W" readOnly="true"></state>
+		<description>Active Power</description>
+		<state pattern="%.3f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="powerfactor" advanced="true">
 		<item-type>Number:Dimensionless</item-type>
@@ -202,14 +202,14 @@
 	<channel-type id="energy" advanced="true">
 		<item-type>Number:Energy</item-type>
 		<label>Energy Session</label>
-		<description>Power consumption in Wh.</description>
-		<state pattern="%.1f Wh" readOnly="true"></state>
+		<description>Power consumption</description>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="totalenergy" advanced="true">
 		<item-type>Number:Energy</item-type>
 		<label>Energy Total</label>
 		<description>Total energy consumption is added up after each completed charging session</description>
-		<state pattern="%.1f Wh" readOnly="true"></state>
+		<state pattern="%.1f %unit%" readOnly="true"></state>
 	</channel-type>
 	<channel-type id="display" advanced="true">
 		<item-type>String</item-type>
@@ -250,8 +250,8 @@
 	<channel-type id="setenergylimit">
 		<item-type>Number:Energy</item-type>
 		<label>Energy Limit</label>
-		<description>An energy limit for an already running or the next charging session.</description>
-		<state pattern="%.1f Wh" readOnly="false"></state>
+		<description>An energy limit for an already running or the next charging session</description>
+		<state pattern="%.1f %unit%" readOnly="false"></state>
 	</channel-type>
 	<channel-type id="authenticate">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
+++ b/bundles/org.openhab.binding.keba/src/main/resources/OH-INF/thing/kecontact.xml
@@ -62,7 +62,7 @@
 				<label>Network Address</label>
 				<description>Network address of the wallbox</description>
 			</parameter>
-			<parameter name="refreshInterval" type="integer" required="true">
+			<parameter name="refreshInterval" type="integer" required="false">
 				<label>Refresh Interval</label>
 				<description>Specifies the refresh interval in seconds</description>
 				<default>15</default>


### PR DESCRIPTION
Signed-off-by: Michael Weger <weger.michael@gmx.net>

My second try of a pull request for the changes discussed in #6347 (comment)

I had some troubles with my first pull requst #10151 and therefore deleted it.

I still have the problem, that parts of this pull request have been developed by @Raketenschnitzel  and I do not know how to reach out to him in order to ask for his approval.
He might reply to this conversation, as he is mentioned ...

All other problems from the first PR should be resolved.


**[keba] Improve connection establishment and stability**

- Connection establishment no longer requires root permissions under Linux.
- Added support of additional P30 x-series stations 'E', 'G' & 'H'
- Extended add-on README
- introduced QuantityTypes (incompatible change)
- removed redundant pwmpilotcurrent (duplicate of maxpilotcurrent) (incompatible change)
- added maxpilotcurrentdutycyle

Binding for testing:
- [org.openhab.binding.keba-3.1.0-SNAPSHOT20210219.zip](https://github.com/openhab/openhab-addons/files/6012913/org.openhab.binding.keba-3.1.0-SNAPSHOT20210219.zip)
- [org.openhab.binding.keba-3.1.0-SNAPSHOT20210224.zip](https://github.com/openhab/openhab-addons/files/6033937/org.openhab.binding.keba-3.1.0-SNAPSHOT20210224.zip)
