### PR TITLE
[loxone] Support for HTTPS websocket connections.

### DIFF
--- a/bundles/org.openhab.binding.loxone/README.md
+++ b/bundles/org.openhab.binding.loxone/README.md
@@ -96,6 +96,9 @@ The acquired token will remain active for several weeks following the last succe
 
 In case a websocket connection to the Miniserver remains active for the whole duration of the token's life span, the binding will refresh the token one day before token expiration, without the need of providing the password.
 
+In case of connecting to Generation 2 Miniservers, it is possible to establish a secure WebSocket connection over HTTPS protocol. Binding will automatically detect if HTTPS connection is available and will use it. In that case, commands sent to the Miniserver will not be additionally encrypted. When HTTPS is not available, binding will use unsecure HTTP connection and will encrypt each command.
+
+It is possible to override the communication protocol by setting `webSocketType` configuration parameter. Setting it to 1 will force to always establish HTTPS connection. Setting it to 2 will force to always establish HTTP connection. Default value of 0 means the binding will determine the right protocol in the runtime.
 
 A method to enable unrestricted security policy depends on the JRE version and vendor, some examples can be found [here](https://www.petefreitag.com/item/844.cfm) and [here](https://stackoverflow.com/questions/41580489/how-to-install-unlimited-strength-jurisdiction-policy-files).
 
@@ -195,9 +198,10 @@ To define a parameter value in a .things file, please refer to it by parameter's
 
 ### Security
 
-| ID           | Name                  | Values                                          | Default      | Description                                           |
-|--------------|-----------------------|-------------------------------------------------|--------------|-------------------------------------------------------|
-| `authMethod` | Authentication method | 0: Automatic<br>1: Hash-based<br>2: Token-based | 0: Automatic | A method used to authenticate user in the Miniserver. |
+| ID              | Name                  | Values                                          | Default      | Description                                           |
+|-----------------|-----------------------|-------------------------------------------------|--------------|-------------------------------------------------------|
+| `authMethod`    | Authentication method | 0: Automatic<br>1: Hash-based<br>2: Token-based | 0: Automatic | A method used to authenticate user in the Miniserver. |
+| `webSocketType` | WebSocket protocol    | 0: Automatic<br>1: Force HTTPS<br>2: Force HTTP | 0: Automatic | Communication protocol used for WebSocket connection. |
 
 ### Timeouts
 

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxBindingConfiguration.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxBindingConfiguration.java
@@ -24,9 +24,13 @@ public class LxBindingConfiguration {
      */
     public String host;
     /**
-     * Port of web service of the Miniserver
+     * Port of HTTP web service of the Miniserver
      */
     public int port;
+    /**
+     * Port of HTTPS web service of the Miniserver
+     */
+    public int httpsPort;
     /**
      * User name used to log into the Miniserver
      */
@@ -76,4 +80,8 @@ public class LxBindingConfiguration {
      * Authentication method (0-auto, 1-hash, 2-token)
      */
     public int authMethod;
+    /**
+     * WebSocket connection type (0-auto, 1-HTTPS, 2-HTTP)
+     */
+    public int webSocketType;
 }

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxServerHandler.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/LxServerHandler.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -72,7 +73,7 @@ import com.google.gson.GsonBuilder;
 public class LxServerHandler extends BaseThingHandler implements LxServerHandlerApi {
 
     private static final String SOCKET_URL = "/ws/rfc6455";
-    private static final String CMD_CFG_API = "jdev/cfg/api";
+    private static final String CMD_CFG_API = "jdev/cfg/apiKey";
 
     private static final Gson GSON;
 
@@ -139,6 +140,7 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("[{}] Handle command: channelUID={}, command={}", debugId, channelUID, command);
         if (command instanceof RefreshType) {
             updateChannelState(channelUID);
             return;
@@ -146,6 +148,8 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
         try {
             LxControl control = channels.get(channelUID);
             if (control != null) {
+                logger.debug("[{}] Dispatching command to control UUID={}, name={}", debugId, control.getUuid(),
+                        control.getName());
                 control.handleCommand(channelUID, command);
             } else {
                 logger.error("[{}] Received command {} for unknown control.", debugId, command);
@@ -182,7 +186,7 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
             jettyThreadPool.setDaemon(true);
 
             socket = new LxWebSocket(debugId, this, bindingConfig, host);
-            wsClient = new WebSocketClient();
+            wsClient = new WebSocketClient(new SslContextFactory.Client(true));
             wsClient.setExecutor(jettyThreadPool);
             if (debugId > 1) {
                 reconnectDelay.set(0);
@@ -478,8 +482,16 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
         Map<LxUuid, LxState> perStateUuid = states.get(update.getUuid());
         if (perStateUuid != null) {
             perStateUuid.forEach((controlUuid, state) -> {
+                logger.debug("[{}] State update (UUID={}, value={}) dispatched to control UUID={}, state name={}",
+                        debugId, update.getUuid(), update.getValue(), controlUuid, state.getName());
+
                 state.setStateValue(update.getValue());
             });
+            if (perStateUuid.size() == 0) {
+                logger.debug("[{}] State update UUID={} has empty controls table", debugId, update.getUuid());
+            }
+        } else {
+            logger.debug("[{}] State update UUID={} has no controls table", debugId, update.getUuid());
         }
     }
 
@@ -553,14 +565,34 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
          * Try to read CfgApi structure from the miniserver. It contains serial number and firmware version. If it can't
          * be read this is not a fatal issue, we will assume most recent version running.
          */
+        boolean httpsCapable = false;
         String message = socket.httpGet(CMD_CFG_API);
         if (message != null) {
             LxResponse resp = socket.getResponse(message);
             if (resp != null) {
-                socket.setFwVersion(GSON.fromJson(resp.getValueAsString(), LxResponse.LxResponseCfgApi.class).version);
+                LxResponse.LxResponseCfgApi apiResp = GSON.fromJson(resp.getValueAsString(),
+                        LxResponse.LxResponseCfgApi.class);
+                if (apiResp != null) {
+                    socket.setFwVersion(apiResp.version);
+                    httpsCapable = apiResp.httpsStatus != null && apiResp.httpsStatus == 1;
+                }
             }
         } else {
             logger.debug("[{}] Http get failed for API config request.", debugId);
+        }
+
+        switch (bindingConfig.webSocketType) {
+            case 0:
+                // keep automatically determined option
+                break;
+            case 1:
+                logger.debug("[{}] Forcing HTTPS websocket connection.", debugId);
+                httpsCapable = true;
+                break;
+            case 2:
+                logger.debug("[{}] Forcing HTTP websocket connection.", debugId);
+                httpsCapable = false;
+                break;
         }
 
         try {
@@ -570,7 +602,14 @@ public class LxServerHandler extends BaseThingHandler implements LxServerHandler
             // without this zero timeout, jetty will wait 30 seconds for stopping the client to eventually fail
             // with the timeout it is immediate and all threads end correctly
             jettyThreadPool.setStopTimeout(0);
-            URI target = new URI("ws://" + host.getHostAddress() + ":" + bindingConfig.port + SOCKET_URL);
+            URI target;
+            if (httpsCapable) {
+                target = new URI("wss://" + host.getHostAddress() + ":" + bindingConfig.httpsPort + SOCKET_URL);
+                socket.setHttps(true);
+            } else {
+                target = new URI("ws://" + host.getHostAddress() + ":" + bindingConfig.port + SOCKET_URL);
+                socket.setHttps(false);
+            }
             ClientUpgradeRequest request = new ClientUpgradeRequest();
             request.setSubProtocols("remotecontrol");
 

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControl.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/controls/LxControl.java
@@ -264,6 +264,8 @@ public class LxControl {
         Callbacks c = callbacks.get(channelId);
         if (c != null && c.commandCallback != null) {
             c.commandCallback.handleCommand(command);
+        } else {
+            logger.debug("Control UUID={} has no command handler", getUuid());
         }
     }
 

--- a/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxResponse.java
+++ b/bundles/org.openhab.binding.loxone/src/main/java/org/openhab/binding/loxone/internal/types/LxResponse.java
@@ -39,6 +39,8 @@ public class LxResponse {
     public class LxResponseCfgApi {
         public String snr;
         public String version;
+        public String key;
+        public Integer httpsStatus;
     }
 
     /**

--- a/bundles/org.openhab.binding.loxone/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.loxone/src/main/resources/OH-INF/thing/thing-types.xml
@@ -39,9 +39,14 @@
 				<description>Host address or IP of the Loxone Miniserver</description>
 			</parameter>
 			<parameter name="port" type="integer" min="1" max="65535" groupName="miniserver">
-				<label>Port</label>
-				<description>Web interface port of the Loxone Miniserver</description>
+				<label>HTTP Port</label>
+				<description>HTTP Web interface port of the Loxone Miniserver</description>
 				<default>80</default>
+			</parameter>
+			<parameter name="httpsPort" type="integer" min="1" max="65535" groupName="miniserver">
+				<label>HTTPS Port</label>
+				<description>HTTPS Web interface port of the Loxone Miniserver</description>
+				<default>443</default>
 			</parameter>
 
 			<parameter name="authMethod" type="integer" min="0" max="2" groupName="security">
@@ -71,6 +76,18 @@
 				<advanced>true</advanced>
 			</parameter>
 
+			<parameter name="webSocketType" type="integer" min="0" max="2" groupName="security">
+				<label>WebSocket Connection Type</label>
+				<description>Protocol used to communicate over WebSocket to the Miniserver</description>
+				<default>0</default>
+				<options>
+					<option value="0">Automatic</option>
+					<option value="1">Force HTTPS</option>
+					<option value="2">Force HTTP</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="firstConDelay" type="integer" min="0" max="120" groupName="timeouts">
 				<label>First Connection Delay</label>
 				<description>Time between binding initialization and first connection attempt (seconds, 0-120)</description>


### PR DESCRIPTION
With generation 2 of Loxone Miniserver, it is possible to use HTTPS websocket connection to the Miniserver. This PR adds support for it. HTTP connections are still used for some of the commands which receive insensitive data during connection process. The possibility to connect to GEN2 Miniservers over HTTP can be removed in the near future.
What is added:
- new parameter to pass HTTPS port
- new parameter to force HTTP or HTTPS connection (the method to determine what is supported by Miniserver is adviced by the API document, but it is not confirmed that it works in all cases)
- reading new remote configuration parameter to determine if HTTPS is supported
- using HTTPS websocket if possible - all certificates are accepted, it is often the case the Miniservers use locally generated certificates
- when HTTPS is used, the commands and responses encryption in the binding is disabled

Signed-off-by: Pawel Pieczul <pieczul@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
