### PR TITLE
[squeezebox] Add sleep channel

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/README.md
+++ b/bundles/org.openhab.binding.squeezebox/README.md
@@ -119,6 +119,7 @@ All devices support some of the following channels:
 | numberPlaylistTracks    | Number    | Number of playlist tracks                                                              |
 | playFavorite            | String    | ID of Favorite to play (channel's state options contains available favorites)          |
 | rate                    | Switch    | "Like" or "unlike" the currently playing song (if supported by the streaming service)  |
+| sleep                   | Number    | Power off the player in the specified number of minutes. Sending 0 cancels the timer   |
 
 ## Example .Items File
 

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeBoxBindingConstants.java
@@ -68,4 +68,5 @@ public class SqueezeBoxBindingConstants {
     public static final String CHANNEL_MODEL = "model";
     public static final String CHANNEL_FAVORITES_PLAY = "playFavorite";
     public static final String CHANNEL_RATE = "rate";
+    public static final String CHANNEL_SLEEP = "sleep";
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.squeezebox.internal.SqueezeBoxBindingConstants
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -306,6 +307,16 @@ public class SqueezeBoxPlayerHandler extends BaseThingHandler implements Squeeze
                     squeezeBoxServerHandler.rate(mac, likeCommand);
                 } else if (command.equals(OnOffType.OFF)) {
                     squeezeBoxServerHandler.rate(mac, unlikeCommand);
+                }
+                break;
+            case CHANNEL_SLEEP:
+                if (command instanceof DecimalType) {
+                    Duration sleepDuration = Duration.ofMinutes(((DecimalType) command).longValue());
+                    if (sleepDuration.isNegative() || sleepDuration.compareTo(Duration.ofDays(1)) > 0) {
+                        logger.debug("Sleep timer of {} minutes must be >= 0 and <= 1 day", sleepDuration.toMinutes());
+                        return;
+                    }
+                    squeezeBoxServerHandler.sleep(mac, sleepDuration);
                 }
                 break;
             default:

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -301,6 +301,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
     }
 
+    public void sleep(String mac, Duration sleepDuration) {
+        sendCommand(mac + " sleep " + String.valueOf(sleepDuration.toSeconds()));
+    }
+
     /**
      * Send a generic command to a given player
      *

--- a/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.squeezebox/src/main/resources/OH-INF/thing/thing-types.xml
@@ -84,6 +84,7 @@
 			<channel id="numberPlaylistTracks" typeId="numberPlaylistTracks"/>
 			<channel id="playFavorite" typeId="playFavorite"/>
 			<channel id="rate" typeId="rate"/>
+			<channel id="sleep" typeId="sleep"/>
 		</channels>
 
 		<properties>
@@ -303,5 +304,11 @@
 		<item-type>Switch</item-type>
 		<label>Like or Unlike Song</label>
 		<description>Likes or unlikes the current song (if the service supports it)</description>
+	</channel-type>
+	<channel-type id="sleep">
+		<item-type>Number</item-type>
+		<label>Sleep</label>
+		<description>Power off player in specified number of minutes</description>
+		<state pattern="%d"></state>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Add a sleep channel to the player thing that powers off the player after the specified number of minutes.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
