### PR TITLE
[openthermgateway] add new statistics channels

### DIFF
--- a/bundles/org.openhab.binding.openthermgateway/README.md
+++ b/bundles/org.openhab.binding.openthermgateway/README.md
@@ -137,10 +137,10 @@ Number:Dimensionless BurnerStarts "Burner starts" { channel="openthermgateway:ot
 Number:Dimensionless CentralHeatingPumpStarts "Central heating pump starts" { channel="openthermgateway:otgw:1:chpumpstarts" }
 Number:Dimensionless DomesticHotWaterPumpValveStarts "Domestic hot water pump/valve starts" { channel="openthermgateway:otgw:1:dhwpvstarts" }
 Number:Dimensionless DomesticHotWaterBurnerStarts "Domestic hot water burner starts" { channel="openthermgateway:otgw:1:dhwburnerstarts" }
-Number:Dimensionless BurnerHours "Burner hours" { channel="openthermgateway:otgw:1:burnerhours" }
-Number:Dimensionless CentralHeatingPumpHours "Central heating pump hours" { channel="openthermgateway:otgw:1:chpumphours" }
-Number:Dimensionless DomesticHotWaterPumpValveHours "Domestic hot water pump/valve hours" { channel="openthermgateway:otgw:1:dhwpvhours" }
-Number:Dimensionless DomesticHotWaterBurnerHours "Domestic hot water burner hours" { channel="openthermgateway:otgw:1:dhwburnerhours" }
+Number:Time BurnerHours "Burner hours" { channel="openthermgateway:otgw:1:burnerhours" }
+Number:Time CentralHeatingPumpHours "Central heating pump hours" { channel="openthermgateway:otgw:1:chpumphours" }
+Number:Time DomesticHotWaterPumpValveHours "Domestic hot water pump/valve hours" { channel="openthermgateway:otgw:1:dhwpvhours" }
+Number:Time DomesticHotWaterBurnerHours "Domestic hot water burner hours" { channel="openthermgateway:otgw:1:dhwburnerhours" }
 Text SendCommand "Send command channel" { channel="openthermgateway:otgw:1:sendcommand" }
 ```
 

--- a/bundles/org.openhab.binding.openthermgateway/README.md
+++ b/bundles/org.openhab.binding.openthermgateway/README.md
@@ -71,7 +71,16 @@ The OpenTherm Gateway binding supports the following channels:
 | airpressfault             | Switch               | Air pressure fault                                       | R      |
 | waterovtemp               | Switch               | Water over-temperature fault                             | R      |
 | oemfaultcode              | Switch               | OEM fault code                                           | R      |
-| diag                      | Switch               | Diagr / wstics indication                                | R      |
+| diag                      | Switch               | Diagnostics indication                                   | R      |
+| unsuccessfulburnerstarts  | Number:Dimensionless | Unsuccessful burner starts                               | R      |
+| burnerstarts              | Number:Dimensionless | Burner starts                                            | R      |
+| chpumpstarts              | Number:Dimensionless | Central heating pump starts                              | R      |
+| dhwpvstarts               | Number:Dimensionless | Domestic hot water pump/valve starts                     | R      |
+| dhwburnerstarts           | Number:Dimensionless | Domestic hot water burner starts                         | R      |
+| burnerhours               | Number:Dimensionless | Burner hours                                             | R      |
+| chpumphours               | Number:Dimensionless | Central heating pump hours                               | R      |
+| dhwpvhours                | Number:Dimensionless | Domestic hot water pump/valve hours                      | R      |
+| dhwburnerhours            | Number:Dimensionless | Domestic hot water burner hours                          | R      |
 | sendcommand               | Text                 | Channel to send commands to the OpenTherm Gateway device | W      |
 
 ## Full Example
@@ -123,6 +132,15 @@ Switch AirPressFault "Air pressure fault" <switch> { channel="openthermgateway:o
 Switch WaterOvTemp "Water over-temperature fault" <switch> { channel="openthermgateway:otgw:1:waterovtemp" }
 Number OemFaultCode "OEM fault code" { channel="openthermgateway:otgw:1:oemfaultcode" }
 Switch Diagnostics "Diagnostics indication" { channel="openthermgateway:otgw:1:diag" }
+Number:Dimensionless UnsuccessfulBurnerStarts "Unsuccessful burner starts" { channel="openthermgateway:otgw:1:unsuccessfulburnerstarts" }
+Number:Dimensionless BurnerStarts "Burner starts" { channel="openthermgateway:otgw:1:burnerstarts" }
+Number:Dimensionless CentralHeatingPumpStarts "Central heating pump starts" { channel="openthermgateway:otgw:1:chpumpstarts" }
+Number:Dimensionless DomesticHotWaterPumpValveStarts "Domestic hot water pump/valve starts" { channel="openthermgateway:otgw:1:dhwpvstarts" }
+Number:Dimensionless DomesticHotWaterBurnerStarts "Domestic hot water burner starts" { channel="openthermgateway:otgw:1:dhwburnerstarts" }
+Number:Dimensionless BurnerHours "Burner hours" { channel="openthermgateway:otgw:1:burnerhours" }
+Number:Dimensionless CentralHeatingPumpHours "Central heating pump hours" { channel="openthermgateway:otgw:1:chpumphours" }
+Number:Dimensionless DomesticHotWaterPumpValveHours "Domestic hot water pump/valve hours" { channel="openthermgateway:otgw:1:dhwpvhours" }
+Number:Dimensionless DomesticHotWaterBurnerHours "Domestic hot water burner hours" { channel="openthermgateway:otgw:1:dhwburnerhours" }
 Text SendCommand "Send command channel" { channel="openthermgateway:otgw:1:sendcommand" }
 ```
 
@@ -163,6 +181,15 @@ sitemap demo label="Main Menu" {
         Switch item="waterOvTemp" icon="" label="Water over-temperature fault"
         Text item="OemFaultCode" icon="" label="OEM fault code"
         Switch item="Diagnostics" icon="" label="Diagnostics indication"
+        Text item="UnsuccessfulBurnerStarts" icon="" label="Unsuccessful burner starts"
+        Text item="BurnerStarts" icon="" label="Burner starts"
+        Text item="CentralHeatingPumpStarts" icon="" label="Central heating pump starts"
+        Text item="DomesticHotWaterPumpValveStarts" icon="" label="Domestic hot water pump/valve starts"
+        Text item="DomesticHotWaterBurnerStarts" icon="" label="Domestic hot water burner starts"
+        Text item="BurnerHours" icon="" label="Burner hours"
+        Text item="CentralHeatingPumpHours" icon="" label="Central heating pump hours"
+        Text item="DomesticHotWaterPumpValveHours" icon="" label="Domestic hot water pump/valve hours"
+        Text item="DomesticHotWaterBurnerHours" icon="" label="Domestic hot water burner hours"
     }
 }
 ```

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/OpenThermGatewayBindingConstants.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/OpenThermGatewayBindingConstants.java
@@ -72,6 +72,15 @@ public class OpenThermGatewayBindingConstants {
     public static final String CHANNEL_WATER_OVER_TEMP = "waterovtemp";
     public static final String CHANNEL_OEM_FAULTCODE = "oemfaultcode";
     public static final String CHANNEL_DIAGNOSTICS_INDICATION = "diag";
+    public static final String CHANNEL_UNSUCCESSFUL_BURNER_STARTS = "unsuccessfulburnerstarts";
+    public static final String CHANNEL_BURNER_STARTS = "burnerstarts";
+    public static final String CHANNEL_CH_PUMP_STARTS = "chpumpstarts";
+    public static final String CHANNEL_DHW_PV_STARTS = "dhwpvstarts";
+    public static final String CHANNEL_DHW_BURNER_STARTS = "dhwburnerstarts";
+    public static final String CHANNEL_BURNER_HOURS = "burnerhours";
+    public static final String CHANNEL_CH_PUMP_HOURS = "chpumphours";
+    public static final String CHANNEL_DHW_PV_HOURS = "dhwpvhours";
+    public static final String CHANNEL_DHW_BURNER_HOURS = "dhwburnerhours";
 
     public static final Set<String> SUPPORTED_CHANNEL_IDS = Set.of(CHANNEL_ROOM_TEMPERATURE, CHANNEL_ROOM_SETPOINT,
             CHANNEL_FLOW_TEMPERATURE, CHANNEL_RETURN_TEMPERATURE, CHANNEL_OUTSIDE_TEMPERATURE,
@@ -86,5 +95,7 @@ public class OpenThermGatewayBindingConstants {
             CHANNEL_DOMESTIC_HOT_WATER_SETPOINT, CHANNEL_FLAME, CHANNEL_RELATIVE_MODULATION_LEVEL,
             CHANNEL_MAXIMUM_MODULATION_LEVEL, CHANNEL_FAULT, CHANNEL_SERVICEREQUEST, CHANNEL_REMOTE_RESET,
             CHANNEL_LOW_WATER_PRESSURE, CHANNEL_GAS_FLAME_FAULT, CHANNEL_AIR_PRESSURE_FAULT, CHANNEL_WATER_OVER_TEMP,
-            CHANNEL_OEM_FAULTCODE, CHANNEL_DIAGNOSTICS_INDICATION);
+            CHANNEL_OEM_FAULTCODE, CHANNEL_DIAGNOSTICS_INDICATION, CHANNEL_UNSUCCESSFUL_BURNER_STARTS,
+            CHANNEL_BURNER_STARTS, CHANNEL_CH_PUMP_STARTS, CHANNEL_DHW_PV_STARTS, CHANNEL_DHW_BURNER_STARTS,
+            CHANNEL_BURNER_HOURS, CHANNEL_CH_PUMP_HOURS, CHANNEL_DHW_PV_HOURS, CHANNEL_DHW_BURNER_HOURS);
 }

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/DataItemGroup.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/DataItemGroup.java
@@ -180,10 +180,14 @@ public class DataItemGroup {
         g.put(118, new DataItem[] { new DataItem(118, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwpvstarts") });
         g.put(119,
                 new DataItem[] { new DataItem(119, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwburnerstarts") });
-        g.put(120, new DataItem[] { new DataItem(120, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "burnerhours") });
-        g.put(121, new DataItem[] { new DataItem(121, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "chpumphours") });
-        g.put(122, new DataItem[] { new DataItem(122, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwpvhours") });
-        g.put(123, new DataItem[] { new DataItem(123, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwburnerhours") });
+        g.put(120, new DataItem[] {
+                new DataItem(120, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "burnerhours", Units.HOUR) });
+        g.put(121, new DataItem[] {
+                new DataItem(121, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "chpumphours", Units.HOUR) });
+        g.put(122, new DataItem[] {
+                new DataItem(122, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwpvhours", Units.HOUR) });
+        g.put(123, new DataItem[] {
+                new DataItem(123, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "dhwburnerhours", Units.HOUR) });
         g.put(124,
                 new DataItem[] { new DataItem(124, Msg.WRITE, ByteType.BOTH, DataType.FLOAT, 0, "masterotversion") });
         g.put(125, new DataItem[] { new DataItem(125, Msg.READ, ByteType.BOTH, DataType.FLOAT, 0, "slaveotversion") });

--- a/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/DataItemGroup.java
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/DataItemGroup.java
@@ -172,6 +172,8 @@ public class DataItemGroup {
                         new DataItem(100, Msg.READ, ByteType.HIGHBYTE, DataType.FLAGS, 5, "rof5"),
                         new DataItem(100, Msg.READ, ByteType.HIGHBYTE, DataType.FLAGS, 6, "rof6"),
                         new DataItem(100, Msg.READ, ByteType.HIGHBYTE, DataType.FLAGS, 7, "rof7") });
+        g.put(113, new DataItem[] {
+                new DataItem(113, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "unsuccessfulburnerstarts") });
         g.put(115, new DataItem[] { new DataItem(115, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "oemdiagcode") });
         g.put(116, new DataItem[] { new DataItem(116, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "burnerstarts") });
         g.put(117, new DataItem[] { new DataItem(117, Msg.READ, ByteType.BOTH, DataType.UINT16, 0, "chpumpstarts") });

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
@@ -337,7 +337,7 @@
 
 	<channel-type id="dhwpvhours">
 		<item-type>Number:Dimensionless</item-type>
-		<label>Domestic Hot Water Pump/Valve Hours starts</label>
+		<label>Domestic Hot Water Pump/Valve Hours</label>
 		<description>Domestic hot water pump/valve hours</description>
 		<state readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
@@ -322,28 +322,28 @@
 	</channel-type>
 
 	<channel-type id="burnerhours">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Burner Hours</label>
 		<description>Burner hours</description>
 		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="chpumphours">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Central Heating Pump Hours</label>
 		<description>Central heating pump hours</description>
 		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="dhwpvhours">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Domestic Hot Water Pump/Valve Hours</label>
 		<description>Domestic hot water pump/valve hours</description>
 		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="dhwburnerhours">
-		<item-type>Number:Dimensionless</item-type>
+		<item-type>Number:Time</item-type>
 		<label>Domestic Hot Water Burner Hours</label>
 		<description>Domestic hot water burner hours</description>
 		<state readOnly="true"/>

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/channels.xml
@@ -286,6 +286,69 @@
 		<state readOnly="true"/>
 	</channel-type>
 
+	<channel-type id="unsuccessfulburnerstarts">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Unsuccessful Burner Starts</label>
+		<description>Unsuccessful burner starts</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="burnerstarts">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Burner Starts</label>
+		<description>Burner starts</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="chpumpstarts">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Central Heating Pump Starts</label>
+		<description>Central heating pump starts</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dhwpvstarts">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Domestic Hot Water Pump/Valve Starts</label>
+		<description>Domestic hot water pump/valve starts</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dhwburnerstarts">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Domestic Hot Water Burner Starts</label>
+		<description>Domestic hot water burner starts</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="burnerhours">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Burner Hours</label>
+		<description>Burner hours</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="chpumphours">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Central Heating Pump Hours</label>
+		<description>Central heating pump hours</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dhwpvhours">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Domestic Hot Water Pump/Valve Hours starts</label>
+		<description>Domestic hot water pump/valve hours</description>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="dhwburnerhours">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Domestic Hot Water Burner Hours</label>
+		<description>Domestic hot water burner hours</description>
+		<state readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="sendcommand">
 		<item-type>String</item-type>
 		<label>Send Command</label>

--- a/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/otgw.xml
+++ b/bundles/org.openhab.binding.openthermgateway/src/main/resources/OH-INF/thing/otgw.xml
@@ -44,10 +44,19 @@
 			<channel id="airpressfault" typeId="airpressfault"/>
 			<channel id="waterovtemp" typeId="waterovtemp"/>
 			<channel id="oemfaultcode" typeId="oemfaultcode"/>
+			<channel id="unsuccessfulburnerstarts" typeId="unsuccessfulburnerstarts"/>
+			<channel id="burnerstarts" typeId="burnerstarts"/>
+			<channel id="chpumpstarts" typeId="chpumpstarts"/>
+			<channel id="dhwpvstarts" typeId="dhwpvstarts"/>
+			<channel id="dhwburnerstarts" typeId="dhwburnerstarts"/>
+			<channel id="burnerhours" typeId="burnerhours"/>
+			<channel id="chpumphours" typeId="chpumphours"/>
+			<channel id="dhwpvhours" typeId="dhwpvhours"/>
+			<channel id="dhwburnerhours" typeId="dhwburnerhours"/>
 			<channel id="sendcommand" typeId="sendcommand"/>
 		</channels>
 		<properties>
-			<property name="version">1.2.0</property>
+			<property name="version">1.3.0</property>
 		</properties>
 		<config-description-ref uri="thing-type:openthermgateway:otgw"/>
 	</thing-type>


### PR DESCRIPTION
Please see feature request #10198 

Added these new channels to the OpenTherm Gateway binding:

- Unsuccessful burner starts
- Burner starts
- Central heating pump starts
- Domestic hot water pump/valve starts
- Domestic hot water burner starts
- Burner hours
- Central heating pump hours
- Domestic hot water pump/valve hours
- Domestic hot water burner hours *

*\* the last one wasn't actually part of the feature request, but it is part of the same set of statistics/counters of the OpenTherm protocol (message id's 116 - 123) so I added it for the sake of completeness.*

Also fixed a copy/paste error on the diagnostics channel in the README.