### PR TITLE
[xmppclient] Add getEvent() to examples in README

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/README.md
+++ b/bundles/org.openhab.binding.xmppclient/README.md
@@ -66,7 +66,7 @@ rule "Turn off all lights without separator"
 when
     Channel "xmppclient:xmppBridge:xmpp:xmpp_command" triggered
 then
-    var actionName = receivedEvent
+    var actionName = receivedEvent.getEvent()
     if(actionName.toLowerCase() == "turn off lights") {
         Group_Light_Home_All.sendCommand(OFF)
     }
@@ -76,7 +76,7 @@ rule "Turn off all lights with separator and reply"
 when
     Channel "xmppclient:xmppBridge:xmpp:xmpp_command" triggered
 then
-    var actionName = receivedEvent.split("##")
+    var actionName = receivedEvent.getEvent().split("##")
     if(actionName.get(1).toLowerCase() == "turn off lights") {
         Group_Light_Home_All.sendCommand(OFF)
 


### PR DESCRIPTION
I had to add these to my rules to avoid `'split' is not a member of 'org.eclipse.smarthome.core.thing.events.ChannelTriggeredEvent'` errors.
