### PR TITLE
[bluetooth] Adapt labels of discovery results to standard

### DIFF
--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/discovery/internal/BluetoothDiscoveryService.java
@@ -155,10 +155,6 @@ public class BluetoothDiscoveryService extends AbstractDiscoveryService implemen
 
     private static DiscoveryResult copyWithNewBridge(DiscoveryResult result, BluetoothAdapter adapter) {
         String label = result.getLabel();
-        String adapterLabel = adapter.getLabel();
-        if (adapterLabel != null) {
-            label = adapterLabel + " - " + label;
-        }
 
         return DiscoveryResultBuilder.create(createThingUIDWithBridge(result, adapter))//
                 .withBridge(adapter.getUID())//


### PR DESCRIPTION
Since https://github.com/openhab/openhab-webui/pull/920 has been merged, we can return to standard labels for Bluetooth results, see https://github.com/openhab/openhab-addons/pull/10154#issuecomment-779422785.

Signed-off-by: Kai Kreuzer <kai@openhab.org>