### PR TITLE
[homematic] Additional check for convert to double

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuVariablesAndScriptsParser.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/parser/CcuVariablesAndScriptsParser.java
@@ -50,7 +50,7 @@ public class CcuVariablesAndScriptsParser extends CommonRpcParser<TclScriptDataL
                     if (dp.isIntegerType()) {
                         dp.setMinValue(toInteger(entry.minValue));
                         dp.setMaxValue(toInteger(entry.maxValue));
-                    } else {
+                    } else if (dp.isFloatType()) {
                         dp.setMinValue(toDouble(entry.minValue));
                         dp.setMaxValue(toDouble(entry.maxValue));
                     }


### PR DESCRIPTION
In the homematic ccu I can create system variables of type enum.
In method parse() of class CcuVariablesAndScriptsParser the attributes entry.minValue and entry.maxValue contains in this case "" and "" can't be converted to a double. So an exception was raise.

With this additional check the exception doesn't occurs anymore.

