### PR TITLE
[http] Add intersection character to descriptions.

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.http/src/main/resources/OH-INF/config/config.xml
@@ -7,13 +7,13 @@
 	<config-description uri="channel-type:http:channel-config">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -46,13 +46,13 @@
 	<config-description uri="channel-type:http:channel-config-color">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -117,13 +117,13 @@
 	<config-description uri="channel-type:http:channel-config-contact">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -164,13 +164,13 @@
 	<config-description uri="channel-type:http:channel-config-dimmer">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -238,13 +238,13 @@
 	<config-description uri="channel-type:http:channel-config-number">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -282,13 +282,13 @@
 	<config-description uri="channel-type:http:channel-config-player">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -345,13 +345,13 @@
 	<config-description uri="channel-type:http:channel-config-rollershutter">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values Chain multiple transformations with the 
-				mathematical intersection character "∩"..</description>
+			<description>Transformation pattern used when sending values Chain multiple transformations with the mathematical
+				intersection character "∩"..</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -400,13 +400,13 @@
 	<config-description uri="channel-type:http:channel-config-switch">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
-				mathematical intersection character "∩".</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the mathematical
+				intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>

--- a/bundles/org.openhab.binding.http/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.http/src/main/resources/OH-INF/config/config.xml
@@ -7,11 +7,13 @@
 	<config-description uri="channel-type:http:channel-config">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -44,11 +46,13 @@
 	<config-description uri="channel-type:http:channel-config-color">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -113,11 +117,13 @@
 	<config-description uri="channel-type:http:channel-config-contact">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -158,11 +164,13 @@
 	<config-description uri="channel-type:http:channel-config-dimmer">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -230,11 +238,13 @@
 	<config-description uri="channel-type:http:channel-config-number">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -272,11 +282,13 @@
 	<config-description uri="channel-type:http:channel-config-player">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -333,11 +345,13 @@
 	<config-description uri="channel-type:http:channel-config-rollershutter">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values Chain multiple transformations with the 
+				mathematical intersection character "∩"..</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>
@@ -386,11 +400,13 @@
 	<config-description uri="channel-type:http:channel-config-switch">
 		<parameter name="stateTransformation" type="text">
 			<label>State Transformation</label>
-			<description>Transformation pattern used when receiving values.</description>
+			<description>Transformation pattern used when receiving values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="commandTransformation" type="text">
 			<label>Command Transformation</label>
-			<description>Transformation pattern used when sending values.</description>
+			<description>Transformation pattern used when sending values. Chain multiple transformations with the 
+				mathematical intersection character "∩".</description>
 		</parameter>
 		<parameter name="stateExtension" type="text">
 			<label>State URL Extension</label>


### PR DESCRIPTION
Added the  mathematical intersection character "∩" to the descriptions for each of the transformation fields; stateTransformation and commandTransformation. This makes it easier to enter this obscure character when building up chained transformations, as opposed to going back and forth to the documentation to find and copy/paste the character. Now it can be copy/pasted from the same page as the form fields.

Signed-off-by: Justin Wilczek <justinwilczek@gmail.com>