### PR TITLE
[wled] Fix: White LED turns on to max brightness for any RGB changes.

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -256,7 +256,7 @@ public class WLedHandler extends BaseThingHandler {
      * @return WLED needs the letter h followed by 2 digit HEX code for RRGGBB
      */
     private String createColorHex(HSBType hsb) {
-        return String.format("h%06X", hsb.getRGB());
+        return String.format("h%06X", hsb.getRGB() & 0x00FFFFFF);
     }
 
     @Override


### PR DESCRIPTION
When you are using WLED with an RGBW strip every time you set a color the white channel is set to maximum brightness.
The source of the problem is the conversion from HSB to RGB that sets the MSB of the resulting int to 0xFF. This is then interpreted as white channel value by WLED.

This PR fixes this problem by zeroing the MSB.

