### PR TITLE
[openhabcloud] Add note about missing ability to delete things/items/rules.

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/README.md
+++ b/bundles/org.openhab.io.openhabcloud/README.md
@@ -71,4 +71,5 @@ Alternatively, you can configure the settings in the file `conf/services/openhab
 ```
 
 Note: The exposed items will show up after they receive an update to their state.
+
 Note: In order to use an openHAB UI via the Cloud Connector exposing items is not neccessary. Administrative actions are limited to creating things, items and rules, deleting them is inhibited via the CloudConnector.

--- a/bundles/org.openhab.io.openhabcloud/README.md
+++ b/bundles/org.openhab.io.openhabcloud/README.md
@@ -71,3 +71,4 @@ Alternatively, you can configure the settings in the file `conf/services/openhab
 ```
 
 Note: The exposed items will show up after they receive an update to their state.
+Note: In order to use an openHAB UI via the Cloud Connector exposing items is not neccessary. Administrative actions are limited to creating things, items and rules, deleting them is inhibited via the CloudConnector.

--- a/bundles/org.openhab.io.openhabcloud/README.md
+++ b/bundles/org.openhab.io.openhabcloud/README.md
@@ -72,4 +72,4 @@ Alternatively, you can configure the settings in the file `conf/services/openhab
 
 Note: The exposed items will show up after they receive an update to their state.
 
-Note: In order to use an openHAB UI via the Cloud Connector exposing items is not neccessary. Administrative actions are limited to creating things, items and rules, deleting them is inhibited via the CloudConnector.
+Note: In order to use an openHAB UI via the Cloud Connector exposing items is not neccessary. Administrative actions are limited to creating things, items and rules, deleting them is inhibited via the Cloud Connector.


### PR DESCRIPTION
Triggered by a question in the  [community ](https://community.openhab.org/t/cannot-delete-things-or-rules-from-myopenhab/117957) I looked into the code think an additional note like:

 `In order to use an openHAB UI via the Cloud Connector exposing items is not neccessary. Administrative actions are limited to creating things, items and rules, deleting them is inhibited via the Cloud Connector.`

would help.

Signed-off-by: Jürgen Baginski <opus42@gmx.de>