### PR TITLE
[epsonprojector] Fix ONLINE status reporting

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
@@ -156,9 +156,11 @@ public class EpsonProjectorHandler extends BaseThingHandler {
             State state = queryDataFromDevice(epsonCommand);
 
             if (state != null) {
-                updateStatus(ThingStatus.ONLINE);
                 if (isLinked(channel.getUID())) {
                     updateState(channel.getUID(), state);
+                }
+                if (state != UnDefType.UNDEF && getThing().getStatus() != ThingStatus.ONLINE) {
+                    updateStatus(ThingStatus.ONLINE);
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/handler/EpsonProjectorHandler.java
@@ -159,7 +159,8 @@ public class EpsonProjectorHandler extends BaseThingHandler {
                 if (isLinked(channel.getUID())) {
                     updateState(channel.getUID(), state);
                 }
-                if (state != UnDefType.UNDEF && getThing().getStatus() != ThingStatus.ONLINE) {
+                // the first valid response will cause the thing to go ONLINE
+                if (state != UnDefType.UNDEF) {
                     updateStatus(ThingStatus.ONLINE);
                 }
             }


### PR DESCRIPTION
Fix issue with the Epson projector binding reporting the thing status as ONLINE even when no valid responses were being received. When connecting the binding to a serial port that generated any response, the thing would show as being ONLINE. The fix checks for valid responses and will only switch the thing to ONLINE when a valid response is received.