### PR TITLE
[bluetooth] Add support for service data

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/BlueZBluetoothDevice.java
@@ -37,6 +37,7 @@ import org.openhab.binding.bluetooth.bluez.internal.events.ConnectedEvent;
 import org.openhab.binding.bluetooth.bluez.internal.events.ManufacturerDataEvent;
 import org.openhab.binding.bluetooth.bluez.internal.events.NameEvent;
 import org.openhab.binding.bluetooth.bluez.internal.events.RssiEvent;
+import org.openhab.binding.bluetooth.bluez.internal.events.ServiceDataEvent;
 import org.openhab.binding.bluetooth.bluez.internal.events.ServicesResolvedEvent;
 import org.openhab.binding.bluetooth.bluez.internal.events.TXPowerEvent;
 import org.openhab.binding.bluetooth.notification.BluetoothConnectionStatusNotification;
@@ -356,6 +357,13 @@ public class BlueZBluetoothDevice extends BaseBluetoothDevice implements BlueZEv
             notification.setManufacturerData(data);
             notifyListeners(BluetoothEventType.SCAN_RECORD, notification);
         }
+    }
+
+    @Override
+    public void onServiceDataUpdate(ServiceDataEvent event) {
+        BluetoothScanNotification notification = new BluetoothScanNotification();
+        notification.setServiceData(event.getData());
+        notifyListeners(BluetoothEventType.SCAN_RECORD, notification);
     }
 
     @Override

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/BlueZEventListener.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/BlueZEventListener.java
@@ -49,6 +49,10 @@ public interface BlueZEventListener {
         onDBusBlueZEvent(event);
     }
 
+    public default void onServiceDataUpdate(ServiceDataEvent event) {
+        onDBusBlueZEvent(event);
+    }
+
     public default void onConnectedStatusUpdate(ConnectedEvent event) {
         onDBusBlueZEvent(event);
     }

--- a/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/ServiceDataEvent.java
+++ b/bundles/org.openhab.binding.bluetooth.bluez/src/main/java/org/openhab/binding/bluetooth/bluez/internal/events/ServiceDataEvent.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bluetooth.bluez.internal.events;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This event is triggered when an update to a device's service data is received.
+ *
+ * @author Peter Rosenberg - Initial Contribution
+ *
+ */
+@NonNullByDefault
+public class ServiceDataEvent extends BlueZEvent {
+
+    final private Map<String, byte[]> data;
+
+    public ServiceDataEvent(String dbusPath, Map<String, byte[]> data) {
+        super(dbusPath);
+        this.data = data;
+    }
+
+    public Map<String, byte[]> getData() {
+        return data;
+    }
+
+    @Override
+    public void dispatch(BlueZEventListener listener) {
+        listener.onServiceDataUpdate(this);
+    }
+}

--- a/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.generic/src/main/java/org/openhab/binding/bluetooth/generic/internal/GenericBluetoothHandler.java
@@ -28,7 +28,9 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.bluetooth.BluetoothBindingConstants;
 import org.openhab.binding.bluetooth.BluetoothCharacteristic;
 import org.openhab.binding.bluetooth.BluetoothDevice.ConnectionState;
+import org.openhab.binding.bluetooth.BluetoothService;
 import org.openhab.binding.bluetooth.ConnectedBluetoothHandler;
+import org.openhab.binding.bluetooth.notification.BluetoothScanNotification;
 import org.openhab.bluetooth.gattparser.BluetoothGattParser;
 import org.openhab.bluetooth.gattparser.BluetoothGattParserFactory;
 import org.openhab.bluetooth.gattparser.FieldHolder;
@@ -57,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * channels based off of a bluetooth device's GATT characteristics.
  *
  * @author Connor Petty - Initial contribution
- * @author Peter Rosenberg - Use notifications
+ * @author Peter Rosenberg - Use notifications, add support for ServiceData
  *
  */
 @NonNullByDefault
@@ -157,6 +159,71 @@ public class GenericBluetoothHandler extends ConnectedBluetoothHandler {
     public void onCharacteristicUpdate(BluetoothCharacteristic characteristic, byte[] value) {
         super.onCharacteristicUpdate(characteristic, value);
         getCharacteristicHandler(characteristic).handleCharacteristicUpdate(value);
+    }
+
+    @Override
+    public void onScanRecordReceived(BluetoothScanNotification scanNotification) {
+        super.onScanRecordReceived(scanNotification);
+
+        handleServiceData(scanNotification);
+    }
+
+    /**
+     * Service data is specified in the "Core Specification Supplement"
+     * https://www.bluetooth.com/specifications/specs/
+     * 1.11 SERVICE DATA
+     * <p>
+     * Broadcast configuration to configure what to advertise in service data
+     * is specified in "Core Specification 5.3"
+     * https://www.bluetooth.com/specifications/specs/
+     * Part G: GENERIC ATTRIBUTE PROFILE (GATT): 2.7 CONFIGURED BROADCAST
+     *
+     * This method extracts ServiceData, finds the Service and the Characteristic it belongs
+     * to and notifies a value change.
+     *
+     * @param scanNotification to get serviceData from
+     */
+    private void handleServiceData(BluetoothScanNotification scanNotification) {
+        Map<String, byte[]> serviceData = scanNotification.getServiceData();
+        if (serviceData != null) {
+            for (String uuidStr : serviceData.keySet()) {
+                @Nullable
+                BluetoothService service = device.getServices(UUID.fromString(uuidStr));
+                if (service == null) {
+                    logger.warn("Service with UUID {} not found on {}, ignored.", uuidStr,
+                            scanNotification.getAddress());
+                } else {
+                    // The ServiceData contains the UUID of the Service but no identifier of the
+                    // Characteristic the data belongs to.
+                    // Check which Characteristic within this service has the `Broadcast` property set
+                    // and select this one as the Characteristic to assign the data to.
+                    List<BluetoothCharacteristic> broadcastCharacteristics = service.getCharacteristics().stream()
+                            .filter((characteristic) -> characteristic
+                                    .hasPropertyEnabled(BluetoothCharacteristic.PROPERTY_BROADCAST))
+                            .collect(Collectors.toUnmodifiableList());
+
+                    if (broadcastCharacteristics.size() == 0) {
+                        logger.info(
+                                "No Characteristic of service with UUID {} on {} has the broadcast property set, ignored.",
+                                uuidStr, scanNotification.getAddress());
+                    } else if (broadcastCharacteristics.size() > 1) {
+                        logger.warn(
+                                "Multiple Characteristics of service with UUID {} on {} have the broadcast property set what is not supported, ignored.",
+                                uuidStr, scanNotification.getAddress());
+                    } else {
+                        BluetoothCharacteristic broadcastCharacteristic = broadcastCharacteristics.get(0);
+
+                        byte[] value = serviceData.get(uuidStr);
+                        if (value != null) {
+                            onCharacteristicUpdate(broadcastCharacteristic, value);
+                        } else {
+                            logger.warn("Service Data for Service with UUID {} on {} is null, ignored.", uuidStr,
+                                    scanNotification.getAddress());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private void updateThingChannels() {

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/BeaconBluetoothHandler.java
@@ -224,6 +224,11 @@ public class BeaconBluetoothHandler extends BaseThingHandler implements Bluetoot
         int rssi = scanNotification.getRssi();
         if (rssi != Integer.MIN_VALUE) {
             updateRSSI(rssi);
+        } else {
+            // we received a scan notification from this device so it is online
+            // TODO how can we detect if the underlying bluez stack is still receiving advertising packets when there
+            // are no changes?
+            updateStatus(ThingStatus.ONLINE);
         }
     }
 

--- a/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/notification/BluetoothScanNotification.java
+++ b/bundles/org.openhab.binding.bluetooth/src/main/java/org/openhab/binding/bluetooth/notification/BluetoothScanNotification.java
@@ -12,10 +12,13 @@
  */
 package org.openhab.binding.bluetooth.notification;
 
+import java.util.Map;
+
 /**
  * The {@link BluetoothScanNotification} provides a notification of a received scan packet
  *
  * @author Chris Jackson - Initial contribution
+ * @author Peter Rosenberg - Add support for ServiceData
  */
 public class BluetoothScanNotification extends BluetoothNotification {
     /**
@@ -32,6 +35,13 @@ public class BluetoothScanNotification extends BluetoothNotification {
      * The manufacturer specific data
      */
     private byte[] manufacturerData = null;
+
+    /**
+     * The service data.
+     * Key: UUID of the service
+     * Value: Data of the characteristic
+     */
+    private Map<String, byte[]> serviceData = null;
 
     /**
      * The beacon type
@@ -104,6 +114,14 @@ public class BluetoothScanNotification extends BluetoothNotification {
      */
     public byte[] getManufacturerData() {
         return manufacturerData;
+    }
+
+    public void setServiceData(Map<String, byte[]> serviceData) {
+        this.serviceData = serviceData;
+    }
+
+    public Map<String, byte[]> getServiceData() {
+        return serviceData;
     }
 
     /**


### PR DESCRIPTION
Bluetooth low energy allows broadcasters to advertise not only their presence but also `Service Data`. In `Service Data`, data of a Bluetooth Service's Characteristic can be advertised. Doing so allows a central like openHAB to receive data from a Bluetooth device without the need to connect to it. This helps to reduce power consumption on the peripheral.

[Supplement to the Bluetooth Core Specification](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=282152), 1.11 SERVICE DATA, page 19

The aim of this pull request is to add basic support of `Service Data` to openHAB so that a temperature/humidity sensor broadcasting its value as `Service Data` is supported.

I'm curious what you think about this idea in general @cpmeister and also on how I suggest to implement it. Input and feedback is very welcome.