### PR TITLE
[atlona] Fix PROPERTY_VERSION not displaying correct value on UHD models

### DIFF
--- a/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
+++ b/bundles/org.openhab.binding.atlona/src/main/java/org/openhab/binding/atlona/internal/pro3/AtlonaPro3PortocolHandler.java
@@ -1118,7 +1118,7 @@ class AtlonaPro3PortocolHandler {
             }
 
             m = versionHdPattern.matcher(response);
-            if (m.matches()) {
+            if (!capabilities.isUHDModel() && m.matches()) {
                 handleVersionResponse(m, response);
                 return;
             }


### PR DESCRIPTION
Fix bug caused by #9385. When used with the UHD models, the version number in the Thing properties was displaying an incorrect value.
