### PR TITLE
[nikohomecontrol] Improvements and fixes #10263

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlBridgeDiscoveryService.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlBridgeDiscoveryService.java
@@ -55,7 +55,7 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
 
     public NikoHomeControlBridgeDiscoveryService() {
         super(NikoHomeControlBindingConstants.BRIDGE_THING_TYPES_UIDS, TIMEOUT);
-        logger.debug("Niko Home Control: bridge discovery service started");
+        logger.debug("bridge discovery service started");
     }
 
     /**
@@ -65,10 +65,10 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
         try {
             String broadcastAddr = networkAddressService.getConfiguredBroadcastAddress();
             if (broadcastAddr == null) {
-                logger.warn("Niko Home Control: discovery not possible, no broadcast address found");
+                logger.warn("discovery not possible, no broadcast address found");
                 return;
             }
-            logger.debug("Niko Home Control: discovery broadcast on {}", broadcastAddr);
+            logger.debug("discovery broadcast on {}", broadcastAddr);
             NikoHomeControlDiscover nhcDiscover = new NikoHomeControlDiscover(broadcastAddr);
             if (nhcDiscover.isNhcII()) {
                 addNhcIIBridge(nhcDiscover.getAddr(), nhcDiscover.getNhcBridgeId());
@@ -76,12 +76,12 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
                 addNhcIBridge(nhcDiscover.getAddr(), nhcDiscover.getNhcBridgeId());
             }
         } catch (IOException e) {
-            logger.debug("Niko Home Control: no bridge found.");
+            logger.debug("no bridge found.");
         }
     }
 
     private void addNhcIBridge(InetAddress addr, String bridgeId) {
-        logger.debug("Niko Home Control: NHC I bridge found at {}", addr);
+        logger.debug("NHC I bridge found at {}", addr);
 
         String bridgeName = "Niko Home Control Bridge";
         ThingUID uid = new ThingUID(BINDING_ID, "bridge", bridgeId);
@@ -92,7 +92,7 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
     }
 
     private void addNhcIIBridge(InetAddress addr, String bridgeId) {
-        logger.debug("Niko Home Control: NHC II bridge found at {}", addr);
+        logger.debug("NHC II bridge found at {}", addr);
 
         String bridgeName = "Niko Home Control II Bridge";
         ThingUID uid = new ThingUID(BINDING_ID, "bridge2", bridgeId);
@@ -115,7 +115,7 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
 
     @Override
     protected void startBackgroundDiscovery() {
-        logger.debug("Niko Home Control: Start background bridge discovery");
+        logger.debug("Start background bridge discovery");
         ScheduledFuture<?> job = nhcDiscoveryJob;
         if (job == null || job.isCancelled()) {
             nhcDiscoveryJob = scheduler.scheduleWithFixedDelay(this::discoverBridge, 0, REFRESH_INTERVAL,
@@ -125,7 +125,7 @@ public class NikoHomeControlBridgeDiscoveryService extends AbstractDiscoveryServ
 
     @Override
     protected void stopBackgroundDiscovery() {
-        logger.debug("Niko Home Control: Stop bridge background discovery");
+        logger.debug("Stop bridge background discovery");
         ScheduledFuture<?> job = nhcDiscoveryJob;
         if (job != null && !job.isCancelled()) {
             job.cancel(true);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
@@ -70,7 +70,7 @@ public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
         NikoHomeControlCommunication nhcComm = handler.getCommunication();
 
         if ((nhcComm == null) || !nhcComm.communicationActive()) {
-            logger.warn("not connected.");
+            logger.warn("not connected");
             return;
         }
         logger.debug("getting devices on {}", handler.getThing().getUID().getId());

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
@@ -99,8 +99,7 @@ public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
                             thingName, thingLocation);
                     break;
                 default:
-                    logger.debug("unrecognized action type {} for {} {}", nhcAction.getType(),
-                            actionId, thingName);
+                    logger.debug("unrecognized action type {} for {} {}", nhcAction.getType(), actionId, thingName);
             }
         });
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/discovery/NikoHomeControlDiscoveryService.java
@@ -48,7 +48,7 @@ public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
 
     public NikoHomeControlDiscoveryService(NikoHomeControlBridgeHandler handler) {
         super(SUPPORTED_THING_TYPES_UIDS, TIMEOUT, false);
-        logger.debug("Niko Home Control: discovery service {}", handler);
+        logger.debug("discovery service {}", handler);
         bridgeUID = handler.getThing().getUID();
         this.handler = handler;
     }
@@ -70,10 +70,10 @@ public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
         NikoHomeControlCommunication nhcComm = handler.getCommunication();
 
         if ((nhcComm == null) || !nhcComm.communicationActive()) {
-            logger.warn("Niko Home Control: not connected.");
+            logger.warn("not connected.");
             return;
         }
-        logger.debug("Niko Home Control: getting devices on {}", handler.getThing().getUID().getId());
+        logger.debug("getting devices on {}", handler.getThing().getUID().getId());
 
         Map<String, NhcAction> actions = nhcComm.getActions();
 
@@ -99,7 +99,7 @@ public class NikoHomeControlDiscoveryService extends AbstractDiscoveryService {
                             thingName, thingLocation);
                     break;
                 default:
-                    logger.debug("Niko Home Control: unrecognized action type {} for {} {}", nhcAction.getType(),
+                    logger.debug("unrecognized action type {} for {} {}", nhcAction.getType(),
                             actionId, thingName);
             }
         });

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NhcJwtToken2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NhcJwtToken2.java
@@ -14,17 +14,20 @@ package org.openhab.binding.nikohomecontrol.internal.handler;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NhcJwtToken2} represents the Niko Home Control II hobby API token payload.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 class NhcJwtToken2 {
-    String sub;
-    String iat;
-    String exp;
-    String aud;
-    String iss;
-    String jti;
-    List<String> role;
+    String sub = "";
+    String iat = "";
+    String exp = "";
+    String aud = "";
+    String iss = "";
+    String jti = "";
+    List<String> role = List.of();
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionBlindConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionBlindConfig.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nikohomecontrol.internal.handler;
+
+/**
+ * {@link NikoHomeControlActionBlindConfig} is the config class for Niko Home Control Blind Actions.
+ *
+ * @author Mark Herwege - Initial Contribution
+ */
+public class NikoHomeControlActionBlindConfig extends NikoHomeControlActionConfig {
+    public boolean invert;
+}

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionBlindConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionBlindConfig.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlActionBlindConfig} is the config class for Niko Home Control Blind Actions.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlActionBlindConfig extends NikoHomeControlActionConfig {
     public boolean invert;
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionConfig.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlActionConfig} is the general config class for Niko Home Control Actions.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlActionConfig {
-    public String actionId;
+    public String actionId = "";
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionDimmerConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionDimmerConfig.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlActionDimmerConfig} is the config class for Niko Home Control Dimmer Actions.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlActionDimmerConfig extends NikoHomeControlActionConfig {
-    public int step;
+    public int step = 10;
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -67,8 +67,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Niko Home Control: bridge communication not initialized when trying to execute action command "
-                            + actionId);
+                    "Bridge communication not initialized when trying to execute action command " + actionId);
             return;
         }
 
@@ -116,7 +115,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
             default:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Niko Home Control: channel unknown " + channelUID.getId());
+                        "Channel unknown " + channelUID.getId());
         }
     }
 
@@ -218,6 +217,8 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Connection with controller not started yet, could not initialize action " + actionId);
             return;
         }
 
@@ -225,15 +226,14 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Niko Home Control: no connection with Niko Home Control, could not initialize action "
-                                + actionId);
+                        "No connection with controller, could not initialize action " + actionId);
                 return;
             }
 
             NhcAction nhcAction = nhcComm.getActions().get(actionId);
             if (nhcAction == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Niko Home Control: actionId does not match an action in the controller " + actionId);
+                        "Action " + actionId + " does not match an action in the controller");
                 return;
             }
 
@@ -313,14 +313,22 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
                 break;
             default:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Niko Home Control: unknown action type " + actionType);
+                        "Unknown action type " + actionType);
+        }
+    }
+
+    @Override
+    public void actionInitialized() {
+        Bridge bridge = getBridge();
+        if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+            updateStatus(ThingStatus.ONLINE);
         }
     }
 
     @Override
     public void actionRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Niko Home Control: action has been removed from the controller " + actionId);
+                "Action " + actionId + " has been removed from the controller");
     }
 
     private void restartCommunication(NikoHomeControlCommunication nhcComm) {
@@ -329,8 +337,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Niko Home Control: communication socket error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
             return;
         }
         // Also put the bridge back online
@@ -344,7 +351,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for action " + actionId);
+                    "No bridge initialized for action " + actionId);
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -355,7 +362,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for action " + actionId);
+                    "No bridge initialized for action " + actionId);
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -52,7 +52,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
     private final Logger logger = LoggerFactory.getLogger(NikoHomeControlActionHandler.class);
 
-    private volatile @NonNullByDefault({}) NhcAction nhcAction;
+    private volatile @Nullable NhcAction nhcAction;
 
     private String actionId = "";
     private int stepValue;
@@ -84,6 +84,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     }
 
     private void handleCommandSelection(ChannelUID channelUID, Command command) {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         logger.debug("Niko Home Control: handle command {} for {}", command, channelUID);
 
         if (command == REFRESH) {
@@ -114,6 +120,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     }
 
     private void handleSwitchCommand(Command command) {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         if (command instanceof OnOffType) {
             OnOffType s = (OnOffType) command;
             if (OnOffType.OFF.equals(s)) {
@@ -125,6 +137,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     }
 
     private void handleBrightnessCommand(Command command) {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         if (command instanceof OnOffType) {
             OnOffType s = (OnOffType) command;
             if (OnOffType.OFF.equals(s)) {
@@ -162,6 +180,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     }
 
     private void handleRollershutterCommand(Command command) {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         if (command instanceof UpDownType) {
             UpDownType s = (UpDownType) command;
             if (UpDownType.UP.equals(s)) {
@@ -202,7 +226,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
                 return;
             }
 
-            nhcAction = nhcComm.getActions().get(actionId);
+            NhcAction nhcAction = nhcComm.getActions().get(actionId);
             if (nhcAction == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Niko Home Control: actionId does not match an action in the controller " + actionId);
@@ -220,6 +244,8 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
             actionEvent(nhcAction.getState());
 
+            this.nhcAction = nhcAction;
+
             logger.debug("Niko Home Control: action initialized {}", actionId);
 
             Bridge bridge = getBridge();
@@ -232,6 +258,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     }
 
     private void updateProperties() {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         Map<String, String> properties = new HashMap<>();
         properties.put("type", String.valueOf(nhcAction.getType()));
         if (getThing().getThingTypeUID() == THING_TYPE_BLIND) {
@@ -250,6 +282,12 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
     @Override
     public void actionEvent(int actionState) {
+        NhcAction nhcAction = this.nhcAction;
+        if (nhcAction == null) {
+            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            return;
+        }
+
         ActionType actionType = nhcAction.getType();
 
         switch (actionType) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -56,6 +56,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
     private String actionId = "";
     private int stepValue;
+    private boolean invert;
 
     public NikoHomeControlActionHandler(Thing thing) {
         super(thing);
@@ -189,15 +190,15 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         if (command instanceof UpDownType) {
             UpDownType s = (UpDownType) command;
             if (UpDownType.UP.equals(s)) {
-                nhcAction.execute(NHCUP);
+                nhcAction.execute(!invert ? NHCUP : NHCDOWN);
             } else {
-                nhcAction.execute(NHCDOWN);
+                nhcAction.execute(!invert ? NHCDOWN : NHCUP);
             }
         } else if (command instanceof StopMoveType) {
             nhcAction.execute(NHCSTOP);
         } else if (command instanceof PercentType) {
             PercentType p = (PercentType) command;
-            nhcAction.execute(Integer.toString(100 - p.intValue()));
+            nhcAction.execute(!invert ? Integer.toString(100 - p.intValue()) : Integer.toString(p.intValue()));
         }
     }
 
@@ -207,6 +208,9 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         if (thing.getThingTypeUID().equals(THING_TYPE_DIMMABLE_LIGHT)) {
             config = getConfig().as(NikoHomeControlActionDimmerConfig.class);
             stepValue = ((NikoHomeControlActionDimmerConfig) config).step;
+        } else if (thing.getThingTypeUID().equals(THING_TYPE_BLIND)) {
+            config = getConfig().as(NikoHomeControlActionBlindConfig.class);
+            invert = ((NikoHomeControlActionBlindConfig) config).invert;
         } else {
             config = getConfig().as(NikoHomeControlActionConfig.class);
         }
@@ -303,7 +307,8 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
                 updateStatus(ThingStatus.ONLINE);
                 break;
             case ROLLERSHUTTER:
-                updateState(CHANNEL_ROLLERSHUTTER, new PercentType(actionState));
+                updateState(CHANNEL_ROLLERSHUTTER,
+                        !invert ? new PercentType(100 - actionState) : new PercentType(actionState));
                 updateStatus(ThingStatus.ONLINE);
                 break;
             default:

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -86,11 +86,11 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     private void handleCommandSelection(ChannelUID channelUID, Command command) {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 
-        logger.debug("Niko Home Control: handle command {} for {}", command, channelUID);
+        logger.debug("handle command {} for {}", command, channelUID);
 
         if (command == REFRESH) {
             actionEvent(nhcAction.getState());
@@ -122,7 +122,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     private void handleSwitchCommand(Command command) {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 
@@ -139,7 +139,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     private void handleBrightnessCommand(Command command) {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 
@@ -182,7 +182,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     private void handleRollershutterCommand(Command command) {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 
@@ -246,7 +246,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
             this.nhcAction = nhcAction;
 
-            logger.debug("Niko Home Control: action initialized {}", actionId);
+            logger.debug("action initialized {}", actionId);
 
             Bridge bridge = getBridge();
             if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
@@ -260,7 +260,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     private void updateProperties() {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 
@@ -284,7 +284,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     public void actionEvent(int actionState) {
         NhcAction nhcAction = this.nhcAction;
         if (nhcAction == null) {
-            logger.debug("Niko Home Control: action with ID {} not initialized", actionId);
+            logger.debug("action with ID {} not initialized", actionId);
             return;
         }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeConfig.java
@@ -12,13 +12,16 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlBridgeConfig} is the general config class for Niko Home Control Bridges.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlBridgeConfig {
-    public String addr;
+    public String addr = "";
     public int port;
     public int refresh;
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeConfig2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeConfig2.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlBridgeConfig2} is the extended config class for Niko Home Control II Bridges.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlBridgeConfig2 extends NikoHomeControlBridgeConfig {
-    public String profile;
-    public String password;
+    public String profile = "";
+    public String password = "";
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
@@ -141,7 +141,7 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
      */
     protected void bridgeOffline() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                "Niko Home Control: error starting bridge connection");
+                "Error with bridge connection");
     }
 
     /**
@@ -153,8 +153,8 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
     }
 
     @Override
-    public void controllerOffline() {
-        bridgeOffline();
+    public void controllerOffline(String message) {
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, message);
     }
 
     @Override

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
@@ -95,7 +95,7 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
             if (discovery != null) {
                 discovery.discoverDevices();
             } else {
-                logger.debug("Niko Home Control: cannot discover devices, discovery service not started");
+                logger.debug("cannot discover devices, discovery service not started");
             }
         });
     }
@@ -117,9 +117,9 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
         }
 
         // This timer will restart the bridge connection periodically
-        logger.debug("Niko Home Control: restart bridge connection every {} min", refreshInterval);
+        logger.debug("restart bridge connection every {} min", refreshInterval);
         refreshTimer = scheduler.scheduleWithFixedDelay(() -> {
-            logger.debug("Niko Home Control: restart communication at scheduled time");
+            logger.debug("restart communication at scheduled time");
 
             NikoHomeControlCommunication comm = nhcComm;
             if (comm != null) {
@@ -231,14 +231,14 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
 
     @Override
     public void alarmEvent(String alarmText) {
-        logger.debug("Niko Home Control: triggering alarm channel with {}", alarmText);
+        logger.debug("triggering alarm channel with {}", alarmText);
         triggerChannel(CHANNEL_ALARM, alarmText);
         updateStatus(ThingStatus.ONLINE);
     }
 
     @Override
     public void noticeEvent(String alarmText) {
-        logger.debug("Niko Home Control: triggering notice channel with {}", alarmText);
+        logger.debug("triggering notice channel with {}", alarmText);
         triggerChannel(CHANNEL_NOTICE, alarmText);
         updateStatus(ThingStatus.ONLINE);
     }
@@ -263,7 +263,7 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
         try {
             addr = InetAddress.getByName(config.addr);
         } catch (UnknownHostException e) {
-            logger.debug("Niko Home Control: Cannot resolve hostname {} to IP adress", config.addr);
+            logger.debug("Cannot resolve hostname {} to IP adress", config.addr);
         }
         return addr;
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -41,13 +41,13 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
 
     @Override
     public void initialize() {
-        logger.debug("Niko Home Control: initializing bridge handler");
+        logger.debug("initializing bridge handler");
 
         setConfig();
         InetAddress addr = getAddr();
         int port = getPort();
 
-        logger.debug("Niko Home Control: bridge handler host {}, port {}", addr, port);
+        logger.debug("bridge handler host {}, port {}", addr, port);
 
         if (addr != null) {
             nhcComm = new NikoHomeControlCommunication1(this, scheduler);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -54,7 +54,7 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
             startCommunication();
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    "Niko Home Control: cannot resolve bridge IP with hostname " + config.addr);
+                    "Cannot resolve bridge IP with hostname " + config.addr);
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
@@ -69,15 +69,14 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
                 // advanced configuration, skipping token validation.
                 // This behavior would allow the same logic to be used (with profile UUID) as before token validation
                 // was introduced.
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
-                        "Niko Home Control: token is empty");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, "Token is empty");
                 return;
             }
         } else {
             Date now = new Date();
             if (expiryDate.before(now)) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
-                        "Niko Home Control: hobby api token has expired");
+                        "Hobby api token has expired");
                 return;
             }
         }
@@ -91,7 +90,7 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
         } catch (CertificateException e) {
             // this should not happen unless there is a programming error
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    "Niko Home Control: not able to set SSL context");
+                    "Not able to set SSL context");
             return;
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
@@ -57,7 +57,7 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
 
     @Override
     public void initialize() {
-        logger.debug("Niko Home Control: initializing NHC II bridge handler");
+        logger.debug("initializing NHC II bridge handler");
 
         setConfig();
 
@@ -168,7 +168,7 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
     public String getToken() {
         String token = ((NikoHomeControlBridgeConfig2) config).password;
         if ((token == null) || token.isEmpty()) {
-            logger.debug("Niko Home Control: no JWT token set.");
+            logger.debug("no JWT token set.");
             return "";
         }
         return token;
@@ -192,10 +192,10 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
             try {
                 jwtToken = gson.fromJson(tokenPayload, NhcJwtToken2.class);
             } catch (JsonSyntaxException e) {
-                logger.debug("Niko Home Control: unexpected token payload {}", tokenPayload);
+                logger.debug("unexpected token payload {}", tokenPayload);
             } catch (NoSuchElementException ignore) {
                 // Ignore if exp not present in response, this should not happen in token payload response
-                logger.trace("Niko Home Control: no expiry date found in payload {}", tokenPayload);
+                logger.trace("no expiry date found in payload {}", tokenPayload);
             }
         }
 
@@ -206,20 +206,20 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
                 long epoch = Long.parseLong(expiryEpoch) * 1000; // convert to milliseconds
                 expiryDate = new Date(epoch);
             } catch (NumberFormatException e) {
-                logger.debug("Niko Home Control: token expiry not valid {}", jwtToken.exp);
+                logger.debug("token expiry not valid {}", jwtToken.exp);
                 return null;
             }
 
             Date now = new Date();
             if (expiryDate.before(now)) {
-                logger.warn("Niko Home Control: hobby API token expired, was valid until {}",
+                logger.warn("hobby API token expired, was valid until {}",
                         DateFormat.getDateInstance().format(expiryDate));
             } else {
                 Calendar c = Calendar.getInstance();
                 c.setTime(expiryDate);
                 c.add(Calendar.DATE, -14);
                 if (c.getTime().before(now)) {
-                    logger.info("Niko Home Control: hobby API token will expire in less than 14 days, valid until {}",
+                    logger.info("hobby API token will expire in less than 14 days, valid until {}",
                             DateFormat.getDateInstance().format(expiryDate));
                 }
             }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
@@ -167,9 +167,8 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
     @Override
     public String getToken() {
         String token = ((NikoHomeControlBridgeConfig2) config).password;
-        if ((token == null) || token.isEmpty()) {
+        if (token.isEmpty()) {
             logger.debug("no JWT token set.");
-            return "";
         }
         return token;
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterConfig.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlEnergyMeterConfig} is the config class for Niko Home Control Thermostats.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlEnergyMeterConfig {
-    public String energyMeterId;
+    public String energyMeterId = "";
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -77,6 +77,8 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Connection with controller not started yet, could not initialize energy meter " + energyMeterId);
             return;
         }
 
@@ -85,16 +87,14 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Niko Home Control: no connection with Niko Home Control, could not initialize energy meter "
-                                + energyMeterId);
+                        "No connection with controller, could not initialize energy meter " + energyMeterId);
                 return;
             }
 
             NhcEnergyMeter nhcEnergyMeter = nhcComm.getEnergyMeters().get(energyMeterId);
             if (nhcEnergyMeter == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Niko Home Control: energyMeterId does not match a energy meter in the controller "
-                                + energyMeterId);
+                        "Energy meter " + energyMeterId + " does not match a energy meter in the controller");
                 return;
             }
 
@@ -153,9 +153,17 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
     }
 
     @Override
+    public void energyMeterInitialized() {
+        Bridge bridge = getBridge();
+        if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    @Override
     public void energyMeterRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Niko Home Control: energy meter has been removed from the controller " + energyMeterId);
+                "Energy meter " + energyMeterId + " has been removed from the controller");
     }
 
     @Override
@@ -165,8 +173,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Niko Home Control: bridge communication not initialized when trying to start energy meter "
-                            + energyMeterId);
+                    "Bridge communication not initialized when trying to start energy meter " + energyMeterId);
             return;
         }
 
@@ -188,8 +195,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Niko Home Control: bridge communication not initialized when trying to stop energy meter "
-                            + energyMeterId);
+                    "Bridge communication not initialized when trying to stop energy meter " + energyMeterId);
             return;
         }
 
@@ -214,8 +220,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Niko Home Control: communication socket error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
             return;
         }
         // Also put the bridge back online
@@ -229,7 +234,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for energy meter " + energyMeterId);
+                    "No bridge initialized for energy meter " + energyMeterId);
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -240,7 +245,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for energy meter " + energyMeterId);
+                    "No bridge initialized for energy meter " + energyMeterId);
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -48,7 +48,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
     private final Logger logger = LoggerFactory.getLogger(NikoHomeControlEnergyMeterHandler.class);
 
-    private volatile @NonNullByDefault({}) NhcEnergyMeter nhcEnergyMeter;
+    private volatile @Nullable NhcEnergyMeter nhcEnergyMeter;
 
     private String energyMeterId = "";
 
@@ -58,6 +58,12 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+        NhcEnergyMeter nhcEnergyMeter = this.nhcEnergyMeter;
+        if (nhcEnergyMeter == null) {
+            logger.debug("Niko Home Control: energy meter with ID {} not initialized", energyMeterId);
+            return;
+        }
+
         if (command == REFRESH) {
             energyMeterEvent(nhcEnergyMeter.getPower());
         }
@@ -84,7 +90,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
                 return;
             }
 
-            nhcEnergyMeter = nhcComm.getEnergyMeters().get(energyMeterId);
+            NhcEnergyMeter nhcEnergyMeter = nhcComm.getEnergyMeters().get(energyMeterId);
             if (nhcEnergyMeter == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                         "Niko Home Control: energyMeterId does not match a energy meter in the controller "
@@ -101,6 +107,8 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
             if (isLinked(CHANNEL_POWER)) {
                 nhcComm.startEnergyMeter(energyMeterId);
             }
+
+            this.nhcEnergyMeter = nhcEnergyMeter;
 
             logger.debug("Niko Home Control: energy meter intialized {}", energyMeterId);
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -60,7 +60,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
     public void handleCommand(ChannelUID channelUID, Command command) {
         NhcEnergyMeter nhcEnergyMeter = this.nhcEnergyMeter;
         if (nhcEnergyMeter == null) {
-            logger.debug("Niko Home Control: energy meter with ID {} not initialized", energyMeterId);
+            logger.debug("energy meter with ID {} not initialized", energyMeterId);
             return;
         }
 
@@ -110,7 +110,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
             this.nhcEnergyMeter = nhcEnergyMeter;
 
-            logger.debug("Niko Home Control: energy meter intialized {}", energyMeterId);
+            logger.debug("energy meter intialized {}", energyMeterId);
 
             Bridge bridge = getBridge();
             if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatConfig.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatConfig.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * {@link NikoHomeControlThermostatConfig} is the config class for Niko Home Control Thermostats.
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 public class NikoHomeControlThermostatConfig {
-    public String thermostatId;
-    public int overruleTime;
+    public String thermostatId = "";
+    public int overruleTime = 60;
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
@@ -69,7 +69,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Niko Home Control: bridge communication not initialized when trying to execute thermostat command "
+                    "Bridge communication not initialized when trying to execute thermostat command on "
                             + thermostatId);
             return;
         }
@@ -146,7 +146,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
 
             default:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Niko Home Control: channel unknown " + channelUID.getId());
+                        "Channel unknown " + channelUID.getId());
         }
     }
 
@@ -159,6 +159,8 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Connection with controller not started yet, could not initialize thermostat " + thermostatId);
             return;
         }
 
@@ -167,16 +169,14 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Niko Home Control: no connection with Niko Home Control, could not initialize thermostat "
-                                + thermostatId);
+                        "No connection with controller, could not initialize thermostat " + thermostatId);
                 return;
             }
 
             NhcThermostat nhcThermostat = nhcComm.getThermostats().get(thermostatId);
             if (nhcThermostat == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Niko Home Control: thermostatId does not match a thermostat in the controller "
-                                + thermostatId);
+                        "Thermostat " + thermostatId + " does not match a thermostat in the controller");
                 return;
             }
 
@@ -278,9 +278,17 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
     }
 
     @Override
+    public void thermostatInitialized() {
+        Bridge bridge = getBridge();
+        if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
+            updateStatus(ThingStatus.ONLINE);
+        }
+    }
+
+    @Override
     public void thermostatRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Niko Home Control: thermostat has been removed from the controller " + thermostatId);
+                "Thermostat " + thermostatId + " has been removed from the controller");
     }
 
     private void restartCommunication(NikoHomeControlCommunication nhcComm) {
@@ -289,8 +297,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Niko Home Control: communication socket error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
             return;
         }
         // Also put the bridge back online
@@ -304,7 +311,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for thermostat " + thermostatId);
+                    "No bridge initialized for thermostat " + thermostatId);
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -315,7 +322,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "Niko Home Control: no bridge initialized for thermostat " + thermostatId);
+                    "No bridge initialized for thermostat " + thermostatId);
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
@@ -89,11 +89,11 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
     private void handleCommandSelection(ChannelUID channelUID, Command command) {
         NhcThermostat nhcThermostat = this.nhcThermostat;
         if (nhcThermostat == null) {
-            logger.debug("Niko Home Control: thermostat with ID {} not initialized", thermostatId);
+            logger.debug("thermostat with ID {} not initialized", thermostatId);
             return;
         }
 
-        logger.debug("Niko Home Control: handle command {} for {}", command, channelUID);
+        logger.debug("handle command {} for {}", command, channelUID);
 
         if (REFRESH.equals(command)) {
             thermostatEvent(nhcThermostat.getMeasured(), nhcThermostat.getSetpoint(), nhcThermostat.getMode(),
@@ -194,7 +194,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
 
             this.nhcThermostat = nhcThermostat;
 
-            logger.debug("Niko Home Control: thermostat intialized {}", thermostatId);
+            logger.debug("thermostat intialized {}", thermostatId);
 
             Bridge bridge = getBridge();
             if ((bridge != null) && (bridge.getStatus() == ThingStatus.ONLINE)) {
@@ -221,7 +221,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
     public void thermostatEvent(int measured, int setpoint, int mode, int overrule, int demand) {
         NhcThermostat nhcThermostat = this.nhcThermostat;
         if (nhcThermostat == null) {
-            logger.debug("Niko Home Control: thermostat with ID {} not initialized", thermostatId);
+            logger.debug("thermostat with ID {} not initialized", thermostatId);
             return;
         }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
@@ -158,7 +158,7 @@ public abstract class NhcAction {
     protected void updateState(int state) {
         NhcActionEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
-            logger.debug("Niko Home Control: update channel state for {} with {}", id, state);
+            logger.debug("update channel state for {} with {}", id, state);
             eventHandler.actionEvent(state);
         }
     }
@@ -167,7 +167,7 @@ public abstract class NhcAction {
      * Method called when action is removed from the Niko Home Control Controller.
      */
     public void actionRemoved() {
-        logger.warn("Niko Home Control: action removed {}, {}", id, name);
+        logger.warn("action removed {}, {}", id, name);
         NhcActionEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.actionRemoved();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcAction.java
@@ -167,7 +167,7 @@ public abstract class NhcAction {
      * Method called when action is removed from the Niko Home Control Controller.
      */
     public void actionRemoved() {
-        logger.warn("action removed {}, {}", id, name);
+        logger.debug("action removed {}, {}", id, name);
         NhcActionEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.actionRemoved();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcActionEvent.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcActionEvent.java
@@ -33,6 +33,12 @@ public interface NhcActionEvent {
     public void actionEvent(int state);
 
     /**
+     * Called to indicate the action has been initialized.
+     *
+     */
+    public void actionInitialized();
+
+    /**
      * Called to indicate the action has been removed from the Niko Home Control controller.
      *
      */

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcControllerEvent.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcControllerEvent.java
@@ -67,8 +67,9 @@ public interface NhcControllerEvent {
     /**
      * Called to indicate the connection with the Niko Home Control Controller is offline.
      *
+     * @param message
      */
-    public void controllerOffline();
+    public void controllerOffline(String message);
 
     /**
      * Called to indicate the connection with the Niko Home Control Controller is online.

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
@@ -56,7 +56,7 @@ public abstract class NhcEnergyMeter {
     public void updateState(int power) {
         NhcEnergyMeterEvent handler = eventHandler;
         if (handler != null) {
-            logger.debug("Niko Home Control: update channel for {}", id);
+            logger.debug("update channel for {}", id);
             handler.energyMeterEvent(power);
         }
     }
@@ -65,7 +65,7 @@ public abstract class NhcEnergyMeter {
      * Method called when energyMeters meter is removed from the Niko Home Control Controller.
      */
     public void energyMeterRemoved() {
-        logger.warn("Niko Home Control: action removed {}, {}", id, name);
+        logger.warn("action removed {}, {}", id, name);
         NhcEnergyMeterEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.energyMeterRemoved();
@@ -117,7 +117,7 @@ public abstract class NhcEnergyMeter {
         this.power = power;
         NhcEnergyMeterEvent handler = eventHandler;
         if (handler != null) {
-            logger.debug("Niko Home Control: update power channel for {} with {}", id, power);
+            logger.debug("update power channel for {} with {}", id, power);
             handler.energyMeterEvent(power);
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeter.java
@@ -65,7 +65,7 @@ public abstract class NhcEnergyMeter {
      * Method called when energyMeters meter is removed from the Niko Home Control Controller.
      */
     public void energyMeterRemoved() {
-        logger.warn("action removed {}, {}", id, name);
+        logger.debug("action removed {}, {}", id, name);
         NhcEnergyMeterEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.energyMeterRemoved();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeterEvent.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcEnergyMeterEvent.java
@@ -28,14 +28,20 @@ import org.eclipse.jdt.annotation.Nullable;
 public interface NhcEnergyMeterEvent {
 
     /**
-     * This method is called when an energyMeters meter event is received from the Niko Home Control controller.
+     * This method is called when an energyMeter event is received from the Niko Home Control controller.
      *
      * @param power current power consumption/production in W (positive for consumption), null for an empty reading
      */
     public void energyMeterEvent(@Nullable Integer power);
 
     /**
-     * Called to indicate the energyMeters meter has been removed from the Niko Home Control controller.
+     * Called to indicate the energyMeter has been initialized.
+     *
+     */
+    public void energyMeterInitialized();
+
+    /**
+     * Called to indicate the energyMeter has been removed from the Niko Home Control controller.
      *
      */
     public void energyMeterRemoved();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostat.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostat.java
@@ -115,7 +115,7 @@ public abstract class NhcThermostat {
      * Method called when thermostat is removed from the Niko Home Control Controller.
      */
     public void thermostatRemoved() {
-        logger.warn("Niko Home Control: action removed {}, {}", id, name);
+        logger.warn("action removed {}, {}", id, name);
         NhcThermostatEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.thermostatRemoved();
@@ -125,7 +125,7 @@ public abstract class NhcThermostat {
     private void updateChannels() {
         NhcThermostatEvent handler = eventHandler;
         if (handler != null) {
-            logger.debug("Niko Home Control: update channels for {}", id);
+            logger.debug("update channels for {}", id);
             handler.thermostatEvent(measured, setpoint, mode, overrule, demand);
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostat.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostat.java
@@ -115,7 +115,7 @@ public abstract class NhcThermostat {
      * Method called when thermostat is removed from the Niko Home Control Controller.
      */
     public void thermostatRemoved() {
-        logger.warn("action removed {}, {}", id, name);
+        logger.debug("action removed {}, {}", id, name);
         NhcThermostatEvent eventHandler = this.eventHandler;
         if (eventHandler != null) {
             eventHandler.thermostatRemoved();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostatEvent.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NhcThermostatEvent.java
@@ -38,6 +38,12 @@ public interface NhcThermostatEvent {
     public void thermostatEvent(int measured, int setpoint, int mode, int overrule, int demand);
 
     /**
+     * Called to indicate the thermostat has been initialized.
+     *
+     */
+    public void thermostatInitialized();
+
+    /**
      * Called to indicate the thermostat has been removed from the Niko Home Control controller.
      *
      */

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlCommunication.java
@@ -65,7 +65,7 @@ public abstract class NikoHomeControlCommunication {
     public synchronized void restartCommunication() {
         stopCommunication();
 
-        logger.debug("Niko Home Control: restart communication from thread {}", Thread.currentThread().getId());
+        logger.debug("restart communication from thread {}", Thread.currentThread().getId());
 
         startCommunication();
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlDiscover.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/NikoHomeControlDiscover.java
@@ -70,7 +70,7 @@ public final class NikoHomeControlDiscover {
             datagramSocket.send(discoveryPacket);
             while (true) {
                 datagramSocket.receive(packet);
-                logger.trace("Niko Home Control: bridge discovery response {}",
+                logger.trace("bridge discovery response {}",
                         HexUtils.bytesToHex(Arrays.copyOf(packet.getData(), packet.getLength())));
                 if (isNhc(packet)) {
                     break;
@@ -79,7 +79,7 @@ public final class NikoHomeControlDiscover {
             addr = packet.getAddress();
             setNhcBridgeId(packet);
             setIsNhcII(packet);
-            logger.debug("Niko Home Control: IP address is {}, unique ID is {}", addr, nhcBridgeId);
+            logger.debug("IP address is {}, unique ID is {}", addr, nhcBridgeId);
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcAction1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcAction1.java
@@ -74,7 +74,7 @@ public class NhcAction1 extends NhcAction {
         if (getType() == ActionType.ROLLERSHUTTER) {
             if (filterEvent) {
                 filterEvent = false;
-                logger.debug("Niko Home Control: filtered event {} for {}", newState, id);
+                logger.debug("filtered event {} for {}", newState, id);
                 return;
             }
 
@@ -88,7 +88,7 @@ public class NhcAction1 extends NhcAction {
             }
         }
         if (waitForEvent) {
-            logger.debug("Niko Home Control: received requested rollershutter {} position event {}", id, newState);
+            logger.debug("received requested rollershutter {} position event {}", id, newState);
             executeRollershutterTask();
         } else {
             state = newState;
@@ -103,7 +103,7 @@ public class NhcAction1 extends NhcAction {
      */
     @Override
     public void execute(String command) {
-        logger.debug("Niko Home Control: execute action {} of type {} for {}", command, type, id);
+        logger.debug("execute action {} of type {} for {}", command, type, id);
 
         String value = "";
         switch (getType()) {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcAction1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcAction1.java
@@ -162,7 +162,7 @@ public class NhcAction1 extends NhcAction {
             } else if (command.equals(NHCSTOP)) {
                 executeRollershutterStop();
             } else {
-                int newValue = 100 - Integer.parseInt(command);
+                int newValue = Integer.parseInt(command);
                 if (logger.isTraceEnabled()) {
                     logger.trace("handleRollerShutterCommand: rollershutter {} percent command, current {}, new {}", id,
                             currentValue, newValue);
@@ -174,9 +174,9 @@ public class NhcAction1 extends NhcAction {
                     scheduleRollershutterStop(currentValue, newValue);
                 }
                 if (newValue < currentValue) {
-                    executeRollershutterDown();
-                } else if (newValue > currentValue) {
                     executeRollershutterUp();
+                } else if (newValue > currentValue) {
+                    executeRollershutterDown();
                 }
             }
         };

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageBase1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageBase1.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Class {@link NhcMessageBase1} used as base class for output from gson for cmd or event feedback from Niko Home
  * Control. This class only contains the common base fields required for the deserializer
@@ -21,10 +23,11 @@ package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 abstract class NhcMessageBase1 {
 
-    private String cmd;
-    private String event;
+    private String cmd = "";
+    private String event = "";
 
     String getCmd() {
         return cmd;

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageCmd1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageCmd1.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Class {@link NhcMessageCmd1} used as input to gson to send commands to Niko Home Control. Extends
  * {@link NhcMessageBase1}.
@@ -21,6 +23,7 @@ package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
  * @author Mark Herwege - Initial Contribution
  */
 @SuppressWarnings("unused")
+@NonNullByDefault
 class NhcMessageCmd1 extends NhcMessageBase1 {
 
     private int id;
@@ -29,7 +32,7 @@ class NhcMessageCmd1 extends NhcMessageBase1 {
     private int value3;
     private int mode;
     private int overrule;
-    private String overruletime;
+    private String overruletime = "";
 
     NhcMessageCmd1(String cmd) {
         super.setCmd(cmd);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageListMap1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageListMap1.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Class {@link NhcMessageListMap1} used as output from gson for cmd or event feedback from Niko Home Control where the
  * data part is enclosed by [] and contains a list of json strings. Extends {@link NhcMessageBase1}.
@@ -25,6 +27,7 @@ import java.util.Map;
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 class NhcMessageListMap1 extends NhcMessageBase1 {
 
     private List<Map<String, String>> data = new ArrayList<>();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageMap1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcMessageMap1.java
@@ -15,6 +15,8 @@ package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Class {@link NhcMessageMap1} used as output from gson for cmd or event feedback from Niko Home Control where the
  * data part is a simple json string. Extends {@link NhcMessageBase1}.
@@ -23,6 +25,7 @@ import java.util.Map;
  *
  * @author Mark Herwege - Initial Contribution
  */
+@NonNullByDefault
 class NhcMessageMap1 extends NhcMessageBase1 {
 
     private Map<String, String> data = new HashMap<>();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcThermostat1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcThermostat1.java
@@ -42,7 +42,7 @@ public class NhcThermostat1 extends NhcThermostat {
      */
     @Override
     public void executeMode(int mode) {
-        logger.debug("Niko Home Control: execute thermostat mode {} for {}", mode, id);
+        logger.debug("execute thermostat mode {} for {}", mode, id);
 
         nhcComm.executeThermostat(id, Integer.toString(mode));
     }
@@ -55,7 +55,7 @@ public class NhcThermostat1 extends NhcThermostat {
      */
     @Override
     public void executeOverrule(int overrule, int overruletime) {
-        logger.debug("Niko Home Control: execute thermostat overrule {} during {} min for {}", overrule, overruletime,
+        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime,
                 id);
 
         nhcComm.executeThermostat(id, overrule, overruletime);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcThermostat1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NhcThermostat1.java
@@ -55,8 +55,7 @@ public class NhcThermostat1 extends NhcThermostat {
      */
     @Override
     public void executeOverrule(int overrule, int overruletime) {
-        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime,
-                id);
+        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime, id);
 
         nhcComm.executeThermostat(id, overrule, overruletime);
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
@@ -116,9 +116,8 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             (new Thread(this::runNhcEvents)).start();
 
         } catch (IOException | InterruptedException e) {
-            logger.warn("error initializing communication");
             stopCommunication();
-            handler.controllerOffline();
+            handler.controllerOffline("Error initializing communication");
         }
     }
 
@@ -171,7 +170,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             if (!listenerStopped) {
                 nhcEventsRunning = false;
                 // this is a socket error, not a communication stop triggered from outside this runnable
-                logger.warn("IO error in listener");
+                logger.debug("IO error in listener");
                 // the IO has stopped working, so we need to close cleanly and try to restart
                 restartCommunication();
                 return;
@@ -222,14 +221,13 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         logger.debug("send json {}", json);
         nhcOut.println(json);
         if (nhcOut.checkError()) {
-            logger.warn("error sending message, trying to restart communication");
+            logger.debug("error sending message, trying to restart communication");
             restartCommunication();
             // retry sending after restart
             logger.debug("resend json {}", json);
             nhcOut.println(json);
             if (nhcOut.checkError()) {
-                logger.warn("error resending message");
-                handler.controllerOffline();
+                handler.controllerOffline("Error resending message");
             }
         }
     }
@@ -317,10 +315,10 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             if (errorCode == 0) {
                 logger.debug("start events success");
             } else {
-                logger.warn("error code {} returned on start events", errorCode);
+                logger.debug("error code {} returned on start events", errorCode);
             }
         } else {
-            logger.warn("could not determine error code returned on start events");
+            logger.debug("could not determine error code returned on start events");
         }
     }
 
@@ -476,10 +474,10 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             if (errorCode == 0) {
                 logger.debug("execute action success");
             } else {
-                logger.warn("error code {} returned on command execution", errorCode);
+                logger.debug("error code {} returned on command execution", errorCode);
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("no error code returned on command execution");
+            logger.debug("no error code returned on command execution");
         }
     }
 
@@ -489,10 +487,10 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             if (errorCode == 0) {
                 logger.debug("execute thermostats success");
             } else {
-                logger.warn("error code {} returned on command execution", errorCode);
+                logger.debug("error code {} returned on command execution", errorCode);
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("no error code returned on command execution");
+            logger.debug("no error code returned on command execution");
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
@@ -95,7 +95,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
                 Thread.sleep(1000);
             }
             if (nhcEventsRunning) {
-                logger.debug("Niko Home Control: starting but previous connection still active after 5000ms");
+                logger.debug("starting but previous connection still active after 5000ms");
                 throw new IOException();
             }
 
@@ -106,7 +106,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             nhcSocket = socket;
             nhcOut = new PrintWriter(socket.getOutputStream(), true);
             nhcIn = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-            logger.debug("Niko Home Control: connected via local port {}", socket.getLocalPort());
+            logger.debug("connected via local port {}", socket.getLocalPort());
 
             // initialize all info in local fields
             initialize();
@@ -116,7 +116,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             (new Thread(this::runNhcEvents)).start();
 
         } catch (IOException | InterruptedException e) {
-            logger.warn("Niko Home Control: error initializing communication");
+            logger.warn("error initializing communication");
             stopCommunication();
             handler.controllerOffline();
         }
@@ -140,7 +140,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         }
         nhcSocket = null;
 
-        logger.debug("Niko Home Control: communication stopped");
+        logger.debug("communication stopped");
     }
 
     @Override
@@ -159,7 +159,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
     private void runNhcEvents() {
         String nhcMessage;
 
-        logger.debug("Niko Home Control: listening for events");
+        logger.debug("listening for events");
         listenerStopped = false;
         nhcEventsRunning = true;
 
@@ -171,7 +171,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             if (!listenerStopped) {
                 nhcEventsRunning = false;
                 // this is a socket error, not a communication stop triggered from outside this runnable
-                logger.warn("Niko Home Control: IO error in listener");
+                logger.warn("IO error in listener");
                 // the IO has stopped working, so we need to close cleanly and try to restart
                 restartCommunication();
                 return;
@@ -182,7 +182,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
 
         nhcEventsRunning = false;
         // this is a stop from outside the runnable, so just log it and stop
-        logger.debug("Niko Home Control: event listener thread stopped");
+        logger.debug("event listener thread stopped");
     }
 
     /**
@@ -219,16 +219,16 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
     @SuppressWarnings("null")
     private synchronized void sendMessage(Object nhcMessage) {
         String json = gsonOut.toJson(nhcMessage);
-        logger.debug("Niko Home Control: send json {}", json);
+        logger.debug("send json {}", json);
         nhcOut.println(json);
         if (nhcOut.checkError()) {
-            logger.warn("Niko Home Control: error sending message, trying to restart communication");
+            logger.warn("error sending message, trying to restart communication");
             restartCommunication();
             // retry sending after restart
-            logger.debug("Niko Home Control: resend json {}", json);
+            logger.debug("resend json {}", json);
             nhcOut.println(json);
             if (nhcOut.checkError()) {
-                logger.warn("Niko Home Control: error resending message");
+                logger.warn("error resending message");
                 handler.controllerOffline();
             }
         }
@@ -240,7 +240,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
      * @param nhcMessage message read from Niko Home Control.
      */
     private void readMessage(@Nullable String nhcMessage) {
-        logger.debug("Niko Home Control: received json {}", nhcMessage);
+        logger.debug("received json {}", nhcMessage);
 
         try {
             NhcMessageBase1 nhcMessageGson = gsonIn.fromJson(nhcMessage, NhcMessageBase1.class);
@@ -272,10 +272,10 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             } else if ("getalarms".equals(event)) {
                 eventGetAlarms(((NhcMessageMap1) nhcMessageGson).getData());
             } else {
-                logger.debug("Niko Home Control: not acted on json {}", nhcMessage);
+                logger.debug("not acted on json {}", nhcMessage);
             }
         } catch (JsonParseException e) {
-            logger.debug("Niko Home Control: not acted on unsupported json {}", nhcMessage);
+            logger.debug("not acted on unsupported json {}", nhcMessage);
         }
     }
 
@@ -287,7 +287,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
     }
 
     private synchronized void cmdSystemInfo(Map<String, String> data) {
-        logger.debug("Niko Home Control: systeminfo");
+        logger.debug("systeminfo");
 
         setIfPresent(data, "swversion", systemInfo::setSwVersion);
         setIfPresent(data, "api", systemInfo::setApi);
@@ -315,17 +315,17 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         if (errorCodeString != null) {
             int errorCode = Integer.parseInt(errorCodeString);
             if (errorCode == 0) {
-                logger.debug("Niko Home Control: start events success");
+                logger.debug("start events success");
             } else {
-                logger.warn("Niko Home Control: error code {} returned on start events", errorCode);
+                logger.warn("error code {} returned on start events", errorCode);
             }
         } else {
-            logger.warn("Niko Home Control: could not determine error code returned on start events");
+            logger.warn("could not determine error code returned on start events");
         }
     }
 
     private void cmdListLocations(List<Map<String, String>> data) {
-        logger.debug("Niko Home Control: list locations");
+        logger.debug("list locations");
 
         locations.clear();
 
@@ -342,7 +342,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
     }
 
     private void cmdListActions(List<Map<String, String>> data) {
-        logger.debug("Niko Home Control: list actions");
+        logger.debug("list actions");
 
         for (Map<String, String> action : data) {
             String id = action.get("id");
@@ -381,7 +381,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
                         actionType = ActionType.ROLLERSHUTTER;
                         break;
                     default:
-                        logger.debug("Niko Home Control: unknown action type {} for action {}", type, id);
+                        logger.debug("unknown action type {} for action {}", type, id);
                         continue;
                 }
                 String locationId = action.get("location");
@@ -419,7 +419,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
     }
 
     private void cmdListThermostat(List<Map<String, String>> data) {
-        logger.debug("Niko Home Control: list thermostats");
+        logger.debug("list thermostats");
 
         for (Map<String, String> thermostat : data) {
             try {
@@ -474,12 +474,12 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         try {
             int errorCode = parseIntOrThrow(data.get("error"));
             if (errorCode == 0) {
-                logger.debug("Niko Home Control: execute action success");
+                logger.debug("execute action success");
             } else {
-                logger.warn("Niko Home Control: error code {} returned on command execution", errorCode);
+                logger.warn("error code {} returned on command execution", errorCode);
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("Niko Home Control: no error code returned on command execution");
+            logger.warn("no error code returned on command execution");
         }
     }
 
@@ -487,12 +487,12 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         try {
             int errorCode = parseIntOrThrow(data.get("error"));
             if (errorCode == 0) {
-                logger.debug("Niko Home Control: execute thermostats success");
+                logger.debug("execute thermostats success");
             } else {
-                logger.warn("Niko Home Control: error code {} returned on command execution", errorCode);
+                logger.warn("error code {} returned on command execution", errorCode);
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("Niko Home Control: no error code returned on command execution");
+            logger.warn("no error code returned on command execution");
         }
     }
 
@@ -500,13 +500,13 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         for (Map<String, String> action : data) {
             String id = action.get("id");
             if (id == null || !actions.containsKey(id)) {
-                logger.warn("Niko Home Control: action in controller not known {}", id);
+                logger.warn("action in controller not known {}", id);
                 return;
             }
             String stateString = action.get("value1");
             if (stateString != null) {
                 int state = Integer.parseInt(stateString);
-                logger.debug("Niko Home Control: event execute action {} with state {}", id, state);
+                logger.debug("event execute action {} with state {}", id, state);
                 NhcAction action1 = actions.get(id);
                 if (action1 != null) {
                     action1.setState(state);
@@ -520,7 +520,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             try {
                 String id = thermostat.get("id");
                 if (!thermostats.containsKey(id)) {
-                    logger.warn("Niko Home Control: thermostat in controller not known {}", id);
+                    logger.warn("thermostat in controller not known {}", id);
                     return;
                 }
 
@@ -560,15 +560,15 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
         }
         switch (data.getOrDefault("type", "")) {
             case "0":
-                logger.debug("Niko Home Control: alarm - {}", alarmText);
+                logger.debug("alarm - {}", alarmText);
                 handler.alarmEvent(alarmText);
                 break;
             case "1":
-                logger.debug("Niko Home Control: notice - {}", alarmText);
+                logger.debug("notice - {}", alarmText);
                 handler.noticeEvent(alarmText);
                 break;
             default:
-                logger.debug("Niko Home Control: unexpected message type {}", data.get("type"));
+                logger.debug("unexpected message type {}", data.get("type"));
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlMessageDeserializer1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlMessageDeserializer1.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -33,16 +36,17 @@ import com.google.gson.JsonParseException;
  * @author Mark Herwege - Initial Contribution
  *
  */
+@NonNullByDefault
 class NikoHomeControlMessageDeserializer1 implements JsonDeserializer<NhcMessageBase1> {
 
     @Override
-    public NhcMessageBase1 deserialize(final JsonElement json, final Type typeOfT,
+    public @Nullable NhcMessageBase1 deserialize(final JsonElement json, final Type typeOfT,
             final JsonDeserializationContext context) throws JsonParseException {
         final JsonObject jsonObject = json.getAsJsonObject();
 
         try {
-            String cmd = null;
-            String event = null;
+            String cmd = "";
+            String event = "";
             if (jsonObject.has("cmd")) {
                 cmd = jsonObject.get("cmd").getAsString();
             }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcAction2.java
@@ -115,7 +115,7 @@ public class NhcAction2 extends NhcAction {
      */
     @Override
     public void execute(String command) {
-        logger.debug("Niko Home Control: execute action {} of type {} for {}", command, type, id);
+        logger.debug("execute action {} of type {} for {}", command, type, id);
 
         nhcComm.executeAction(id, command);
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
@@ -100,7 +100,7 @@ public class NhcMqttConnection2 implements MqttActionCallback {
             tmFactory.init(keyStore);
             return tmFactory.getTrustManagers();
         } catch (CertificateException | KeyStoreException | NoSuchAlgorithmException | IOException e) {
-            logger.warn("error with SSL context creation: {} ", e.getMessage());
+            logger.debug("error with SSL context creation: {} ", e.getMessage());
             throw new CertificateException("SSL context creation exception", e);
         } finally {
             ResourceBundle.clearCache();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
@@ -100,7 +100,7 @@ public class NhcMqttConnection2 implements MqttActionCallback {
             tmFactory.init(keyStore);
             return tmFactory.getTrustManagers();
         } catch (CertificateException | KeyStoreException | NoSuchAlgorithmException | IOException e) {
-            logger.warn("Niko Home Control: error with SSL context creation: {} ", e.getMessage());
+            logger.warn("error with SSL context creation: {} ", e.getMessage());
             throw new CertificateException("SSL context creation exception", e);
         } finally {
             ResourceBundle.clearCache();
@@ -121,14 +121,14 @@ public class NhcMqttConnection2 implements MqttActionCallback {
         if (future != null) {
             try {
                 future.get(5000, TimeUnit.MILLISECONDS);
-                logger.debug("Niko Home Control: finished stopping connection");
+                logger.debug("finished stopping connection");
             } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
-                logger.debug("Niko Home Control: error stopping connection");
+                logger.debug("error stopping connection");
             }
             stoppedFuture = null;
         }
 
-        logger.debug("Niko Home Control: starting connection...");
+        logger.debug("starting connection...");
         this.cocoAddress = cocoAddress;
         this.port = port;
         this.profile = profile;
@@ -142,17 +142,17 @@ public class NhcMqttConnection2 implements MqttActionCallback {
                     subscribedFuture = connection.subscribe("#", messageSubscriber);
                 }
             } else {
-                logger.debug("Niko Home Control: error connecting");
+                logger.debug("error connecting");
                 throw new MqttException("Connection execution exception");
             }
         } catch (InterruptedException e) {
-            logger.debug("Niko Home Control: connection interrupted exception");
+            logger.debug("connection interrupted exception");
             throw new MqttException("Connection interrupted exception");
         } catch (ExecutionException e) {
-            logger.debug("Niko Home Control: connection execution exception", e.getCause());
+            logger.debug("connection execution exception", e.getCause());
             throw new MqttException("Connection execution exception");
         } catch (TimeoutException e) {
-            logger.debug("Niko Home Control: connection timeout exception");
+            logger.debug("connection timeout exception");
             throw new MqttException("Connection timeout exception");
         }
     }
@@ -169,7 +169,7 @@ public class NhcMqttConnection2 implements MqttActionCallback {
      * Stop the MQTT connection.
      */
     void stopConnection() {
-        logger.debug("Niko Home Control: stopping connection...");
+        logger.debug("stopping connection...");
         MqttBrokerConnection connection = mqttConnection;
         if (connection != null) {
             connection.removeConnectionObserver(connectionObserver);
@@ -203,7 +203,7 @@ public class NhcMqttConnection2 implements MqttActionCallback {
             try {
                 if ((future != null) && future.get(5000, TimeUnit.MILLISECONDS)) {
                     MqttConnectionState state = connection.connectionState();
-                    logger.debug("Niko Home Control: connection state {} for {}", state, connection.getClientId());
+                    logger.debug("connection state {} for {}", state, connection.getClientId());
                     return state == MqttConnectionState.CONNECTED;
                 }
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -223,25 +223,25 @@ public class NhcMqttConnection2 implements MqttActionCallback {
     void connectionPublish(String topic, String payload) throws MqttException {
         MqttBrokerConnection connection = mqttConnection;
         if (connection == null) {
-            logger.debug("Niko Home Control: cannot publish, no connection");
+            logger.debug("cannot publish, no connection");
             throw new MqttException("No connection exception");
         }
 
         if (isConnected()) {
-            logger.debug("Niko Home Control: publish {}, {}", topic, payload);
+            logger.debug("publish {}, {}", topic, payload);
             connection.publish(topic, payload.getBytes(), connection.getQos(), false);
         } else {
-            logger.debug("Niko Home Control: cannot publish, not subscribed to connection messages");
+            logger.debug("cannot publish, not subscribed to connection messages");
         }
     }
 
     @Override
     public void onSuccess(String topic) {
-        logger.debug("Niko Home Control: publish succeeded {}", topic);
+        logger.debug("publish succeeded {}", topic);
     }
 
     @Override
     public void onFailure(String topic, Throwable error) {
-        logger.debug("Niko Home Control: publish failed {}, {}", topic, error.getMessage(), error);
+        logger.debug("publish failed {}, {}", topic, error.getMessage(), error);
     }
 }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
@@ -53,8 +53,7 @@ public class NhcThermostat2 extends NhcThermostat {
 
     @Override
     public void executeOverrule(int overrule, int overruletime) {
-        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime,
-                id);
+        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime, id);
 
         nhcComm.executeThermostat(id, overrule, overruletime);
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcThermostat2.java
@@ -45,7 +45,7 @@ public class NhcThermostat2 extends NhcThermostat {
 
     @Override
     public void executeMode(int mode) {
-        logger.debug("Niko Home Control: execute thermostat mode {} for {}", mode, id);
+        logger.debug("execute thermostat mode {} for {}", mode, id);
 
         String program = THERMOSTATMODES[mode];
         nhcComm.executeThermostat(id, program);
@@ -53,7 +53,7 @@ public class NhcThermostat2 extends NhcThermostat {
 
     @Override
     public void executeOverrule(int overrule, int overruletime) {
-        logger.debug("Niko Home Control: execute thermostat overrule {} during {} min for {}", overrule, overruletime,
+        logger.debug("execute thermostat overrule {} during {} min for {}", overrule, overruletime,
                 id);
 
         nhcComm.executeThermostat(id, overrule, overruletime);

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -108,19 +108,19 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
 
         InetAddress addr = handler.getAddr();
         if (addr == null) {
-            logger.warn("Niko Home Control: IP address cannot be empty");
+            logger.warn("IP address cannot be empty");
             stopCommunication();
             return;
         }
         String addrString = addr.getHostAddress();
         int port = handler.getPort();
-        logger.debug("Niko Home Control: initializing for mqtt connection to CoCo on {}:{}", addrString, port);
+        logger.debug("initializing for mqtt connection to CoCo on {}:{}", addrString, port);
 
         profile = handler.getProfile();
 
         String token = handler.getToken();
         if (token.isEmpty()) {
-            logger.warn("Niko Home Control: JWT token cannot be empty");
+            logger.warn("JWT token cannot be empty");
             stopCommunication();
             return;
         }
@@ -129,7 +129,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             mqttConnection.startConnection(addrString, port, profile, token);
             initialize();
         } catch (MqttException e) {
-            logger.warn("Niko Home Control: error in mqtt communication");
+            logger.warn("error in mqtt communication");
             stopCommunication();
         }
     }
@@ -154,7 +154,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             // Wait until we received all devices info to confirm we are active.
             return started.get(5000, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            logger.debug("Niko Home Control: exception waiting for connection start");
+            logger.debug("exception waiting for connection start");
             return false;
         }
     }
@@ -181,7 +181,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
     }
 
     private void connectionLost() {
-        logger.debug("Niko Home Control: connection lost");
+        logger.debug("connection lost");
         stopCommunication();
         handler.controllerOffline();
     }
@@ -199,7 +199,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 systemInfo = messageParams.stream().filter(p -> (p.systemInfo != null)).findFirst().get().systemInfo;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if timeInfo not present in response, this should not happen in a timeInfo response
         }
@@ -223,7 +223,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 systemInfo = messageParams.stream().filter(p -> (p.systemInfo != null)).findFirst().get().systemInfo;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if systemInfo not present in response, this should not happen in a systemInfo response
         }
@@ -243,7 +243,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 serviceList = messageParams.stream().filter(p -> (p.services != null)).findFirst().get().services;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if services not present in response, this should not happen in a services response
         }
@@ -264,7 +264,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 deviceList = messageParams.stream().filter(p -> (p.devices != null)).findFirst().get().devices;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if devices not present in response, this should not happen in a devices response
         }
@@ -278,7 +278,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         }
 
         // Once a devices list response is received, we know the communication is fully started.
-        logger.debug("Niko Home Control: Communication start complete.");
+        logger.debug("Communication start complete.");
         handler.controllerOnline();
         CompletableFuture<Boolean> future = communicationStarted;
         if (future != null) {
@@ -299,7 +299,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 deviceList = messageParams.stream().filter(p -> (p.devices != null)).findFirst().get().devices;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if devices not present in response, this should not happen in a devices event
         }
@@ -329,11 +329,11 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                         .get().notifications;
             }
         } catch (JsonSyntaxException e) {
-            logger.debug("Niko Home Control: unexpected json {}", response);
+            logger.debug("unexpected json {}", response);
         } catch (NoSuchElementException ignore) {
             // Ignore if notifications not present in response, this should not happen in a notifications event
         }
-        logger.debug("Niko Home Control: notifications {}", notificationList);
+        logger.debug("notifications {}", notificationList);
         if (notificationList == null) {
             return;
         }
@@ -349,7 +349,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                         handler.noticeEvent(alarmText);
                         break;
                     default:
-                        logger.debug("Niko Home Control: unexpected message type {}", notification.type);
+                        logger.debug("unexpected message type {}", notification.type);
                 }
             }
         }
@@ -364,7 +364,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
 
         if ("action".equals(device.type)) {
             if (!actions.containsKey(device.uuid)) {
-                logger.debug("Niko Home Control: adding action device {}, {}", device.uuid, device.name);
+                logger.debug("adding action device {}, {}", device.uuid, device.name);
 
                 ActionType actionType;
                 switch (device.model) {
@@ -395,7 +395,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                         break;
                     default:
                         actionType = ActionType.GENERIC;
-                        logger.debug("Niko Home Control: device type {} not recognised, default to GENERIC action",
+                        logger.debug("device type {} not recognised, default to GENERIC action",
                                 device.type);
                 }
 
@@ -405,7 +405,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             }
         } else if ("thermostat".equals(device.type)) {
             if (!thermostats.containsKey(device.uuid)) {
-                logger.debug("Niko Home Control: adding thermostat device {}, {}", device.uuid, device.name);
+                logger.debug("adding thermostat device {}, {}", device.uuid, device.name);
 
                 NhcThermostat2 nhcThermostat = new NhcThermostat2(device.uuid, device.name, device.model,
                         device.technology, location, this);
@@ -413,13 +413,13 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             }
         } else if ("centralmeter".equals(device.type)) {
             if (!energyMeters.containsKey(device.uuid)) {
-                logger.debug("Niko Home Control: adding centralmeter device {}, {}", device.uuid, device.name);
+                logger.debug("adding centralmeter device {}, {}", device.uuid, device.name);
                 NhcEnergyMeter2 nhcEnergyMeter = new NhcEnergyMeter2(device.uuid, device.name, device.model,
                         device.technology, this, scheduler);
                 energyMeters.put(device.uuid, nhcEnergyMeter);
             }
         } else {
-            logger.debug("Niko Home Control: device type {} not supported for {}, {}", device.type, device.uuid,
+            logger.debug("device type {} not supported for {}, {}", device.type, device.uuid,
                     device.name);
         }
     }
@@ -485,10 +485,10 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         if (booleanState != null) {
             if (NHCON.equals(booleanState)) {
                 action.setBooleanState(true);
-                logger.debug("Niko Home Control: setting action {} internally to ON", action.getId());
+                logger.debug("setting action {} internally to ON", action.getId());
             } else if (NHCOFF.equals(booleanState)) {
                 action.setBooleanState(false);
-                logger.debug("Niko Home Control: setting action {} internally to OFF", action.getId());
+                logger.debug("setting action {} internally to OFF", action.getId());
             }
         }
 
@@ -496,7 +496,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             String brightness = dimmerProperty.get().brightness;
             if (brightness != null) {
                 action.setState(Integer.parseInt(brightness));
-                logger.debug("Niko Home Control: setting action {} internally to {}", action.getId(),
+                logger.debug("setting action {} internally to {}", action.getId(),
                         dimmerProperty.get().brightness);
             }
         }
@@ -506,9 +506,9 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         deviceProperties.stream().map(p -> p.position).filter(Objects::nonNull).findFirst().ifPresent(position -> {
             try {
                 action.setState(Integer.parseInt(position));
-                logger.debug("Niko Home Control: setting action {} internally to {}", action.getId(), position);
+                logger.debug("setting action {} internally to {}", action.getId(), position);
             } catch (NumberFormatException e) {
-                logger.trace("Niko Home Control: received empty rollershutter {} position info", action.getId());
+                logger.trace("received empty rollershutter {} position info", action.getId());
             }
         });
     }
@@ -581,11 +581,11 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 .ifPresent(electricalPower -> {
                     try {
                         energyMeter.setPower(Integer.parseInt(electricalPower));
-                        logger.trace("Niko Home Control: setting energy meter {} power to {}", energyMeter.getId(),
+                        logger.trace("setting energy meter {} power to {}", energyMeter.getId(),
                                 electricalPower);
                     } catch (NumberFormatException e) {
                         energyMeter.setPower(null);
-                        logger.trace("Niko Home Control: received empty energy meter {} power reading",
+                        logger.trace("received empty energy meter {} power reading",
                                 energyMeter.getId());
                     }
                 });
@@ -781,18 +781,18 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             mqttConnection.connectionPublish(topic, gsonMessage);
 
         } catch (MqttException e) {
-            logger.warn("Niko Home Control: sending command failed, trying to restart communication");
+            logger.warn("sending command failed, trying to restart communication");
             restartCommunication();
             // retry sending after restart
             try {
                 if (communicationActive()) {
                     mqttConnection.connectionPublish(topic, gsonMessage);
                 } else {
-                    logger.warn("Niko Home Control: failed to restart communication");
+                    logger.warn("failed to restart communication");
                     connectionLost();
                 }
             } catch (MqttException e1) {
-                logger.warn("Niko Home Control: error resending device command");
+                logger.warn("error resending device command");
                 connectionLost();
             }
         }
@@ -804,24 +804,24 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         if ((profile + "/system/evt").equals(topic)) {
             systemEvt(message);
         } else if ((profile + "/system/rsp").equals(topic)) {
-            logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.debug("received topic {}, payload {}", topic, message);
             systeminfoPublishRsp(message);
         } else if ((profile + "/notification/evt").equals(topic)) {
-            logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.debug("received topic {}, payload {}", topic, message);
             notificationEvt(message);
         } else if ((profile + "/control/devices/evt").equals(topic)) {
-            logger.trace("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.trace("received topic {}, payload {}", topic, message);
             devicesEvt(message);
         } else if ((profile + "/control/devices/rsp").equals(topic)) {
-            logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.debug("received topic {}, payload {}", topic, message);
             devicesListRsp(message);
         } else if ((profile + "/authentication/rsp").equals(topic)) {
-            logger.debug("Niko Home Control: received topic {}, payload {}", topic, message);
+            logger.debug("received topic {}, payload {}", topic, message);
             servicesListRsp(message);
         } else if ((profile + "/control/devices.error").equals(topic)) {
-            logger.warn("Niko Home Control: received error {}", message);
+            logger.warn("received error {}", message);
         } else {
-            logger.trace("Niko Home Control: not acted on received message topic {}, payload {}", topic, message);
+            logger.trace("not acted on received message topic {}, payload {}", topic, message);
         }
     }
 
@@ -860,7 +860,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             logger.debug("Connection state: {}", state, error);
             restartCommunication();
             if (!communicationActive()) {
-                logger.warn("Niko Home Control: failed to restart communication");
+                logger.warn("failed to restart communication");
                 connectionLost();
             }
         } else {

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -395,8 +395,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                         break;
                     default:
                         actionType = ActionType.GENERIC;
-                        logger.debug("device type {} not recognised, default to GENERIC action",
-                                device.type);
+                        logger.debug("device type {} not recognised, default to GENERIC action", device.type);
                 }
 
                 NhcAction2 nhcAction = new NhcAction2(device.uuid, device.name, device.model, device.technology,
@@ -419,8 +418,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 energyMeters.put(device.uuid, nhcEnergyMeter);
             }
         } else {
-            logger.debug("device type {} not supported for {}, {}", device.type, device.uuid,
-                    device.name);
+            logger.debug("device type {} not supported for {}, {}", device.type, device.uuid, device.name);
         }
     }
 
@@ -496,8 +494,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             String brightness = dimmerProperty.get().brightness;
             if (brightness != null) {
                 action.setState(Integer.parseInt(brightness));
-                logger.debug("setting action {} internally to {}", action.getId(),
-                        dimmerProperty.get().brightness);
+                logger.debug("setting action {} internally to {}", action.getId(), dimmerProperty.get().brightness);
             }
         }
     }
@@ -581,12 +578,10 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 .ifPresent(electricalPower -> {
                     try {
                         energyMeter.setPower(Integer.parseInt(electricalPower));
-                        logger.trace("setting energy meter {} power to {}", energyMeter.getId(),
-                                electricalPower);
+                        logger.trace("setting energy meter {} power to {}", energyMeter.getId(), electricalPower);
                     } catch (NumberFormatException e) {
                         energyMeter.setPower(null);
-                        logger.trace("received empty energy meter {} power reading",
-                                energyMeter.getId());
+                        logger.trace("received empty energy meter {} power reading", energyMeter.getId());
                     }
                 });
     }
@@ -646,7 +641,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                 } else if (NHCDOWN.equals(value)) {
                     property.position = "0";
                 } else {
-                    int position = 100 - Integer.parseInt(value);
+                    int position = Integer.parseInt(value);
                     property.position = String.valueOf(position);
                 }
                 break;

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -33,7 +33,11 @@ import java.util.stream.IntStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.nikohomecontrol.internal.protocol.*;
+import org.openhab.binding.nikohomecontrol.internal.protocol.NhcAction;
+import org.openhab.binding.nikohomecontrol.internal.protocol.NhcControllerEvent;
+import org.openhab.binding.nikohomecontrol.internal.protocol.NhcEnergyMeter;
+import org.openhab.binding.nikohomecontrol.internal.protocol.NhcThermostat;
+import org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlCommunication;
 import org.openhab.binding.nikohomecontrol.internal.protocol.NikoHomeControlConstants.ActionType;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NhcDevice2.NhcProperty;
 import org.openhab.binding.nikohomecontrol.internal.protocol.nhc2.NhcMessage2.NhcMessageParam;
@@ -307,9 +311,6 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             deviceList.forEach(this::removeDevice);
             return;
         } else if ("devices.added".equals(method)) {
-            deviceList.forEach(this::addDevice);
-        } else if ("devices.changed".equals(method)) {
-            deviceList.forEach(this::removeDevice);
             deviceList.forEach(this::addDevice);
         }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -193,7 +193,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         List<NhcSystemInfo2> systemInfo = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            List<NhcMessageParam> messageParams = message.params;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 timeInfo = messageParams.stream().filter(p -> (p.timeInfo != null)).findFirst().get().timeInfo;
                 systemInfo = messageParams.stream().filter(p -> (p.systemInfo != null)).findFirst().get().systemInfo;
@@ -218,7 +218,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         List<NhcSystemInfo2> systemInfo = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            List<NhcMessageParam> messageParams = message.params;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 systemInfo = messageParams.stream().filter(p -> (p.systemInfo != null)).findFirst().get().systemInfo;
             }
@@ -238,7 +238,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         List<NhcService2> serviceList = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            List<NhcMessageParam> messageParams = message.params;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 serviceList = messageParams.stream().filter(p -> (p.services != null)).findFirst().get().services;
             }
@@ -259,7 +259,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         List<NhcDevice2> deviceList = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            List<NhcMessageParam> messageParams = message.params;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 deviceList = messageParams.stream().filter(p -> (p.devices != null)).findFirst().get().devices;
             }
@@ -293,8 +293,8 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         String method = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            method = message.method;
-            List<NhcMessageParam> messageParams = message.params;
+            method = (message != null) ? message.method : null;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 deviceList = messageParams.stream().filter(p -> (p.devices != null)).findFirst().get().devices;
             }
@@ -323,7 +323,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         List<NhcNotification2> notificationList = null;
         try {
             NhcMessage2 message = gson.fromJson(response, messageType);
-            List<NhcMessageParam> messageParams = message.params;
+            List<NhcMessageParam> messageParams = (message != null) ? message.params : null;
             if (messageParams != null) {
                 notificationList = messageParams.stream().filter(p -> (p.notifications != null)).findFirst()
                         .get().notifications;
@@ -425,14 +425,17 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
     }
 
     private void removeDevice(NhcDevice2 device) {
-        if (actions.containsKey(device.uuid)) {
-            actions.get(device.uuid).actionRemoved();
+        NhcAction action = actions.get(device.uuid);
+        NhcThermostat thermostat = thermostats.get(device.uuid);
+        NhcEnergyMeter energyMeter = energyMeters.get(device.uuid);
+        if (action != null) {
+            action.actionRemoved();
             actions.remove(device.uuid);
-        } else if (thermostats.containsKey(device.uuid)) {
-            thermostats.get(device.uuid).thermostatRemoved();
+        } else if (thermostat != null) {
+            thermostat.thermostatRemoved();
             thermostats.remove(device.uuid);
-        } else if (energyMeters.containsKey(device.uuid)) {
-            energyMeters.get(device.uuid).energyMeterRemoved();
+        } else if (energyMeter != null) {
+            energyMeter.energyMeterRemoved();
             energyMeters.remove(device.uuid);
         }
     }
@@ -608,6 +611,9 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         device.properties = deviceProperties;
 
         NhcAction2 action = (NhcAction2) actions.get(actionId);
+        if (action == null) {
+            return;
+        }
 
         switch (action.getType()) {
             case GENERIC:
@@ -746,12 +752,18 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         String topic = profile + "/control/devices/cmd";
         String gsonMessage = gson.toJson(message);
 
-        ((NhcEnergyMeter2) energyMeters.get(energyMeterId)).startEnergyMeter(topic, gsonMessage);
+        NhcEnergyMeter2 energyMeter = (NhcEnergyMeter2) energyMeters.get(energyMeterId);
+        if (energyMeter != null) {
+            energyMeter.startEnergyMeter(topic, gsonMessage);
+        }
     }
 
     @Override
     public void stopEnergyMeter(String energyMeterId) {
-        ((NhcEnergyMeter2) energyMeters.get(energyMeterId)).stopEnergyMeter();
+        NhcEnergyMeter2 energyMeter = (NhcEnergyMeter2) energyMeters.get(energyMeterId);
+        if (energyMeter != null) {
+            energyMeter.stopEnergyMeter();
+        }
     }
 
     /**

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -152,7 +152,7 @@
 				<advanced>false</advanced>
 			</parameter>
 			<parameter name="invert" type="boolean">
-				<label>Invert direction</label>
+				<label>Invert Direction</label>
 				<description>Invert rollershutter direction</description>
 				<default>false</default>
 				<advanced>true</advanced>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -127,7 +127,7 @@
 				<description>Niko Home Control action ID</description>
 				<advanced>false</advanced>
 			</parameter>
-			<parameter name="step" type="integer" required="true">
+			<parameter name="step" type="integer">
 				<label>Step Value</label>
 				<description>Step value used for increase/decrease of dimmer brightness, default 10%</description>
 				<default>10</default>
@@ -150,6 +150,12 @@
 				<label>Action ID</label>
 				<description>Niko Home Control action ID</description>
 				<advanced>false</advanced>
+			</parameter>
+			<parameter name="invert" type="boolean">
+				<label>Invert direction</label>
+				<description>Invert rollershutter direction</description>
+				<default>false</default>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
- Fixes #10263 
- Introduce rollershutter invert parameter on thing, as some systems seem to have the rollershutter direction inverted.
- Cleaned some null pointer warnings.
- Introduced null annotations in a few remaining classes.
- Improved connection resilience logic.
- Log messages shortening and levels cleanup.
