### PR TITLE
[homekit] make usage of mDNS configurable

### DIFF
--- a/bundles/org.openhab.io.homekit/README.md
+++ b/bundles/org.openhab.io.homekit/README.md
@@ -40,7 +40,7 @@ HomeKit integration supports following accessory types:
   
 - add metadata to an existing item (see [UI based configuration](#UI-based-Configuration))
   
-- go to scan QR code from UI->Setting-HomeKit Integration
+- scan QR code from UI->Settings->HomeKit Integration
   
   ![settings_qrcode.png](doc/settings_qrcode.png)
   
@@ -70,18 +70,16 @@ Add metadata to more item or fine-tune your configuration using further settings
 
 ## Global Configuration
 
-Your first step will be to create the `homekit.cfg` in your `$OPENHAB_CONF/services` folder.
-At the very least, you will need to define a pin number for the bridge.
-This will be used in iOS when pairing. The pin code is in the form "###-##-###".
+You can define HomeKit settings either via mainUI or via `$OPENHAB_CONF/services/homekit.cfg`.
+HomeKit works with default settings, but we recommend changing the pin for the bridge.
+This will be used in iOS when pairing without QR Code. The pin code is in the form "###-##-###".
 Requirements beyond this are not clear, and Apple enforces limitations on eligible pins within iOS.
 At the very least, you cannot use repeating (111-11-111) or sequential (123-45-678) pin codes.
-If your home network is secure, a good starting point is the pin code used in most sample applications: 031-45-154.
-Check for typos in the pin-code if you encounter "Bad Client Credential" errors during pairing.
 
-Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the HomeKit bridge (which can be edited in Paper UI standard mode) are also illustrated in the following sample:
+Other settings, such as using Fahrenheit temperatures, customizing the thermostat heat/cool/auto modes, and specifying the interface to advertise the HomeKit bridge are also illustrated in the following sample:
 
 ```
-org.openhab.homekit:port=9124
+org.openhab.homekit:port=9123
 org.openhab.homekit:pin=031-45-154
 org.openhab.homekit:useFahrenheitTemperature=true
 org.openhab.homekit:thermostatTargetModeCool=CoolOn
@@ -89,14 +87,8 @@ org.openhab.homekit:thermostatTargetModeHeat=HeatOn
 org.openhab.homekit:thermostatTargetModeAuto=Auto
 org.openhab.homekit:thermostatTargetModeOff=Off
 org.openhab.homekit:networkInterface=192.168.0.6
-```
-
-The following additional settings can be added or edited in Paper UI after switching to expert mode:
-
-```
+org.openhab.homekit:useOHmDNS=false
 org.openhab.homekit:name=openHAB
-org.openhab.homekit:minimumTemperature=-100
-org.openhab.homekit:maximumTemperature=100
 ```
 
 ### Overview of all settings
@@ -105,6 +97,7 @@ org.openhab.homekit:maximumTemperature=100
 |:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|
 | networkInterface         | IP address or domain name under which the HomeKit bridge can be reached. If no value is configured, the add-on uses the first network adapter address configured for openHAB.                                                                                  | (none)        |
 | port                     | Port under which the HomeKit bridge can be reached.                                                                                                                                                                                     | 9123          |
+| useOHmDNS                | mDNS service is used to advertise openHAB as HomeKit bridge in the network so that HomeKit clients can find it. openHAB has already mDNS service running. This option defines whether the mDNS service of openHAB or a separate service should be used.   | false  |
 | pin                      | Pin code used for pairing with iOS devices. Apparently, pin codes are provided by Apple and represent specific device types, so they cannot be chosen freely. The pin code 031-45-154 is used in sample applications and known to work. | 031-45-154    |
 | startDelay               | HomeKit start delay in seconds in case the number of accessories is lower than last time. This helps to avoid resetting home app in case not all items have been initialised properly before HomeKit integration start.                 | 30            |
 | useFahrenheitTemperature | Set to true to use Fahrenheit degrees, or false to use Celsius degrees.                                                                                                                                                                 | false         |
@@ -112,8 +105,6 @@ org.openhab.homekit:maximumTemperature=100
 | thermostatTargetModeHeat | Word used for activating the heating mode of the device (if applicable). It can be overwritten at item level.                                                                                                                                                                | HeatOn        |
 | thermostatTargetModeAuto | Word used for activating the automatic mode of the device (if applicable). It can be overwritten at item level.                                                                                                                                                               | Auto          |
 | thermostatTargetModeOff  | Word used to set the thermostat mode of the device to off (if applicable).  It can be overwritten at item level.                                                                                                                                                             | Off           |
-| minimumTemperature       | Lower bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                  | -100          |
-| maximumTemperature       | Upper bound of possible temperatures, used in the user interface of the iOS device to display the allowed temperature range. Note that this setting applies to all devices in HomeKit.                                                  | 100           |
 | name                     | Name under which this HomeKit bridge is announced on the network. This is also the name displayed on the iOS device when searching for available bridges.                                                                               | openHAB       |
 
 ## Item Configuration
@@ -586,7 +577,7 @@ or using UI
 |                      |                             | Name                         | String                   | Name of the switch                                                                                                                                                                                                                                                                                        |
 | Outlet               |                             |                              |                          | An accessory that can be turned off and on. While similar to a lightbulb, this will be presented differently in the Siri grammar and iOS apps                                                                                                                                                             |
 |                      | OnState                     |                              | Switch                   | State of the outlet - ON/OFF                                                                                                                                                                                                                                                                              |
-|                      | InUseStatus                 |                              | Switch                   | indicates whether current flowing through the outlet                                                                                                                                                                                                                                                      |
+|                      | InUseStatus                 |                              | Switch                   | Indicates whether the outlet has an appliance e.g., a floor lamp, physically plugged in. This characteristic is set to True even if the plugged-in appliance is off.                                                                                                                                                                                                                                                     |
 |                      |                             | Name                         | String                   | Name of the switch                                                                                                                                                                                                                                                                                        |
 | Lighting             |                             |                              |                          | A lightbulb, can have further optional parameters for brightness, hue, etc                                                                                                                                                                                                                                |
 |                      | OnState                     |                              | Switch                   | State of the light - ON/OFF                                                                                                                                                                                                                                                                               |

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -215,7 +215,8 @@ public class HomekitImpl implements Homekit {
                     networkInterface = InetAddress.getByName(settings.networkInterface);
                     for (JmDNS mdns : mdnsClient.getClientInstances()) {
                         if (mdns.getInetAddress().equals(networkInterface)) {
-                            logger.trace("Suitable mDNS client for IP {} found and will be used for HomeKit", networkInterface);
+                            logger.trace("Suitable mDNS client for IP {} found and will be used for HomeKit",
+                                    networkInterface);
                             homekitServer = new HomekitServer(mdns, settings.port);
                         }
                     }

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitImpl.java
@@ -145,7 +145,8 @@ public class HomekitImpl implements Homekit {
             HomekitSettings oldSettings = settings;
             settings = processConfig(config);
             changeListener.updateSettings(settings);
-            if (!oldSettings.networkInterface.equals(settings.networkInterface) || oldSettings.port != settings.port) {
+            if (!oldSettings.networkInterface.equals(settings.networkInterface) || oldSettings.port != settings.port
+                    || oldSettings.useOHmDNS != settings.useOHmDNS) {
                 // the HomeKit server settings changed. we do a complete re-init
                 stopHomekitServer();
                 startHomekitServer();
@@ -205,23 +206,27 @@ public class HomekitImpl implements Homekit {
 
     private void startHomekitServer() throws IOException {
         if (homekitServer == null) {
-            if ((settings.networkInterface == null) || (settings.networkInterface.isEmpty())) {
-                logger.trace(
-                        "No IP address configured in homekit settings. HomeKit will use the first configured address of openHAB");
-                homekitServer = new HomekitServer(mdnsClient.getClientInstances().iterator().next(), settings.port);
-            } else {
-                networkInterface = InetAddress.getByName(settings.networkInterface);
-                for (JmDNS mdns : mdnsClient.getClientInstances()) {
-                    if (mdns.getInetAddress().equals(networkInterface)) {
-                        logger.trace("suitable mDNS client for IP {} found. Reusing it.", networkInterface);
-                        homekitServer = new HomekitServer(mdns, settings.port);
+            if (settings.useOHmDNS) {
+                if ((settings.networkInterface == null) || (settings.networkInterface.isEmpty())) {
+                    logger.trace(
+                            "No IP address configured in HomeKit settings. HomeKit will use the first configured address of openHAB");
+                    homekitServer = new HomekitServer(mdnsClient.getClientInstances().iterator().next(), settings.port);
+                } else {
+                    networkInterface = InetAddress.getByName(settings.networkInterface);
+                    for (JmDNS mdns : mdnsClient.getClientInstances()) {
+                        if (mdns.getInetAddress().equals(networkInterface)) {
+                            logger.trace("Suitable mDNS client for IP {} found and will be used for HomeKit", networkInterface);
+                            homekitServer = new HomekitServer(mdns, settings.port);
+                        }
                     }
                 }
-                if (homekitServer == null) {
-                    logger.trace("Not suitable mDNS client fpr IP {} found. Create new mDNS instance.",
-                            networkInterface);
-                    homekitServer = new HomekitServer(networkInterface, settings.port);
+            }
+            if (homekitServer == null) {
+                if (settings.useOHmDNS) {
+                    logger.trace("Not suitable mDNS server for IP {} found", networkInterface);
                 }
+                logger.trace("Create HomeKit server with dedicated mDNS server");
+                homekitServer = new HomekitServer(networkInterface, settings.port);
             }
             startBridge();
         } else {

--- a/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
+++ b/bundles/org.openhab.io.homekit/src/main/java/org/openhab/io/homekit/internal/HomekitSettings.java
@@ -31,6 +31,7 @@ public class HomekitSettings {
     public String qrCode;
     public int startDelay = 30;
     public boolean useFahrenheitTemperature = false;
+    public boolean useOHmDNS = false;
     public String thermostatTargetModeHeat = "HeatOn";
     public String thermostatTargetModeCool = "CoolOn";
     public String thermostatTargetModeAuto = "Auto";
@@ -78,6 +79,8 @@ public class HomekitSettings {
             if (other.pin != null) {
                 return false;
             }
+        } else if (!useOHmDNS != other.useOHmDNS) {
+            return false;
         } else if (!pin.equals(other.pin)) {
             return false;
         } else if (!setupId.equals(other.setupId)) {

--- a/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/config/config.xml
@@ -14,6 +14,10 @@
 			<label>Thermostat Settings</label>
 			<description>General thermostat settings</description>
 		</parameter-group>
+		<parameter-group name="network">
+			<label>Network Settings</label>
+			<description>General network settings</description>
+		</parameter-group>
 		<parameter-group name="thermostatTargetHeatingCooling">
 			<label>Thermostat Target Heating/Cooling Mapping</label>
 			<description>String values used by your thermostat to set different targetHeatingCooling modes</description>
@@ -30,7 +34,7 @@
 		<parameter name="port" type="integer" required="true" groupName="core">
 			<label>Port</label>
 			<description>Defines the port the HomeKit integration listens on.</description>
-			<default>9124</default>
+			<default>9123</default>
 		</parameter>
 		<parameter name="pin" type="text" pattern="\d{3}-\d{2}-\d{3}" required="true" groupName="core">
 			<label>Pin</label>
@@ -41,7 +45,7 @@
 			<label>Setup ID</label>
 			<description>Setup ID used for pairing using QR Code. Alphanumeric code of length 4.</description>
 		</parameter>
-		<parameter name="networkInterface" type="text" required="false" groupName="core">
+		<parameter name="networkInterface" type="text" required="false" groupName="network">
 			<label>Network Interface</label>
 			<description>Defines the IP address of the network interface to expose the HomeKit integration on.</description>
 		</parameter>
@@ -102,6 +106,10 @@
 				target temperature has been reached per the mode).</description>
 			<default>Off</default>
 		</parameter>
-
+		<parameter name="useOHmDNS" type="boolean" required="false" groupName="network">
+			<label>Use openHAB mDNS service</label>
+			<description>Defines whether mDNS service of openHAB or a separate instance of mDNS should be used.</description>
+			<default>false</default>
+		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.homekit/src/main/resources/OH-INF/config/config.xml
@@ -26,6 +26,11 @@
 			<label>Thermostat Current Heating/Cooling Mapping</label>
 			<description>String values used by your thermostat to set different targetHeatingCooling modes</description>
 		</parameter-group>
+		<parameter name="name" type="text" required="false" groupName="core">
+			<label>Bridge name</label>
+			<description>Name of the HomeKit bridge</description>
+			<default>openHAB</default>
+		</parameter>
 		<parameter name="qrCode" type="text" required="false" groupName="core">
 			<label>HomeKit QR Code</label>
 			<context>qrcode</context>


### PR DESCRIPTION
one of the recent PR has introduced the logic to re-use mDNS service of openHAB instead of creation of a new mDNS instance just for HomeKit. this should reduce the memory footprint. 

however, this change led to some connection issues, especially if openHAB runs in a docker container. 
https://community.openhab.org/t/homekit-no-response-error-on-all-openhab-items/118200/22

this PR 
- makes this mDNS re-use logic configurable and disable by default. 
- fix inconsistency between README and settings. some settings are not available anymore, other like bridge name were missing, the default value were different
- fix some wording as requested in #10227 

Signed-off-by: Eugen Freiter <freiter@gmx.de>

