### PR TITLE
Upgrade Jackson to 2.12.2

### DIFF
--- a/bundles/org.openhab.binding.chromecast/pom.xml
+++ b/bundles/org.openhab.binding.chromecast/pom.xml
@@ -16,7 +16,6 @@
 
   <properties>
     <dep.noembedding>jackson-core,jackson-annotations,jackson-databind</dep.noembedding>
-    <jackson.version>2.9.10</jackson.version>
   </properties>
 
   <dependencies>
@@ -25,6 +24,12 @@
       <artifactId>api-v2</artifactId>
       <version>0.11.3</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/bundles/org.openhab.binding.icalendar/pom.xml
+++ b/bundles/org.openhab.binding.icalendar/pom.xml
@@ -11,7 +11,6 @@
   <name>openHAB Add-ons :: Bundles :: iCalendar Binding</name>
   <properties>
     <dep.noembedding>jackson-core,jackson-annotations,jackson-databind</dep.noembedding>
-    <jackson.version>2.10.3</jackson.version>
   </properties>
   <dependencies>
     <!-- own dependencies -->
@@ -20,6 +19,12 @@
       <artifactId>biweekly</artifactId>
       <version>0.6.4</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- dependencies of biweekly -->
     <dependency>

--- a/bundles/org.openhab.persistence.dynamodb/pom.xml
+++ b/bundles/org.openhab.persistence.dynamodb/pom.xml
@@ -15,6 +15,7 @@
   <name>openHAB Add-ons :: Bundles :: Persistence Service :: DynamoDB</name>
 
   <properties>
+    <dep.noembedding>jackson-core,jackson-annotations,jackson-databind,jackson-dataformat-cbor</dep.noembedding>
     <bnd.importpackage>!com.amazonaws.*,!org.joda.convert.*,!com.sun.org.apache.xpath.*,!kotlin,!org.apache.log.*,!org.bouncycastle.*,!org.apache.avalon.*</bnd.importpackage>
   </properties>
 
@@ -24,6 +25,16 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
       <version>1.11.213</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -47,6 +58,12 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>jmespath-java</artifactId>
       <version>1.11.213</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
     <dependency>
@@ -91,25 +108,25 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.6.0</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.7</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.7.1</version>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>2.6.7</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/bundles/org.openhab.persistence.dynamodb/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="openhab-persistence-dynamodb" description="DynamoDB Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.dynamodb/${project.version}</bundle>
 		<configfile finalname="${openhab.conf}/services/dynamodb.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/dynamodb</configfile>
 	</feature>

--- a/bundles/org.openhab.transform.jinja/pom.xml
+++ b/bundles/org.openhab.transform.jinja/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.pollytts/src/main/feature/feature.xml
@@ -5,7 +5,6 @@
 	<feature name="openhab-voice-pollytts" description="Polly Text-to-Speech" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.9.9</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.9</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.5</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.amazonaws.aws-java-sdk-core/1.11.490</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <bnd.version>5.3.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
+    <jackson.version>2.12.2</jackson.version>
     <karaf.version>4.2.7</karaf.version>
     <sat.version>0.10.0</sat.version>
     <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
* Adds a jackson.version property to simplify managing the version
* Make sure the specified version is used as add-on dependency by excluding Jackson from transitive dependencies
* Use openhab.tp-jackson feature with dynamodb
* Remove jackson-dataformat-cbor dependency from features which is now also provided by the openhab.tp-jackson feature

---

Depends on https://github.com/openhab/openhab-core/pull/2226