### PR TITLE
[oppo] Fix setting verbose mode at startup

### DIFF
--- a/bundles/org.openhab.binding.oppo/README.md
+++ b/bundles/org.openhab.binding.oppo/README.md
@@ -44,7 +44,7 @@ The thing has the following configuration parameters:
 | Address          | host         | Host name or IP address of the Oppo player or serial over IP device.                                                             | host name or ip           |
 | Port             | port         | Communication port for using serial over IP. Leave blank if using direct IP connection to the player.                            | ip port number            |
 | Serial Port      | serialPort   | Serial port to use for directly connecting to the Oppo player                                                                    | a comm port name          |
-| Verbose Mode     | verboseMode  | (Optional) If true, the player will send time updates every second. If set false, the binding polls the player every 15 seconds. | Boolean; default false    |
+| Verbose Mode     | verboseMode  | (Optional) If true, the player will send time updates every second. If set false, the binding polls the player every 10 seconds. | Boolean; default false    |
 
 Some notes:
 
@@ -54,9 +54,10 @@ Some notes:
 * The UDP-20x series should be fully functional over direct IP connection but this was not able to be tested by the developer.
 * As previously noted, when using verbose mode, the player will send time code messages once per second while playback is ongoing.
 * Be aware that this could cause performance impacts to your openHAB system.
-* In non-verbose (the default), the binding will poll the player every 15 seconds to update play time, track and chapter information instead.
+* In non-verbose (the default), the binding will poll the player every 10 seconds to update play time, track and chapter information instead.
 * In order for the direct IP connection to work while the player is turned off, the Standby Mode setting must be set to "Quick Start" in the Device Setup menu.
 * Likewise if the player is turned off, it may not be discoverable by the Binding's discovery scan.
+* If the player is switched off when the binding first starts up or if power to the player is ever interrupted, up to 30 seconds may elapse before the binding begins to update when the player is switched on.
 * If you experience any issues using the binding, first ensure that the player's firmware is up to date with the latest available version (especially on the older models).
 * For the older models, some of the features in the control API were added after the players were shipped.
 * Available HDMI modes for BDP-83 & BDP-9x: AUTO, SRC, 1080P, 1080I, 720P, SDP, SDI

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoConnector.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/communication/OppoConnector.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.oppo.internal.communication;
 
+import static org.openhab.binding.oppo.internal.OppoBindingConstants.*;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,6 +40,8 @@ public abstract class OppoConnector {
     private static final Pattern QRY_PATTERN = Pattern.compile("^@(Q[A-Z0-9]{2}|VUP|VDN) OK (.*)$");
     private static final Pattern STUS_PATTERN = Pattern.compile("^@(U[A-Z0-9]{2}) (.*)$");
 
+    private static final String OK_ON = "@OK ON";
+    private static final String OK_OFF = "@OK OFF";
     private static final String NOP_OK = "@NOP OK";
     private static final String NOP = "NOP";
     private static final String OK = "OK";
@@ -246,6 +250,17 @@ public abstract class OppoConnector {
 
         if (NOP_OK.equals(message)) {
             dispatchKeyValue(NOP, OK);
+            return;
+        }
+
+        // Before verbose mode 2 & 3 get set, these are the responses to QPW
+        if (OK_ON.equals(message)) {
+            dispatchKeyValue(QPW, ON);
+            return;
+        }
+
+        if (OK_OFF.equals(message)) {
+            dispatchKeyValue(QPW, OFF);
             return;
         }
 

--- a/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/discovery/OppoDiscoveryService.java
+++ b/bundles/org.openhab.binding.oppo/src/main/java/org/openhab/binding/oppo/internal/discovery/OppoDiscoveryService.java
@@ -148,7 +148,7 @@ public class OppoDiscoveryService extends AbstractDiscoveryService {
                                 multiSocket.receive(receivePacket);
 
                                 String message = new String(receivePacket.getData(), StandardCharsets.US_ASCII).trim();
-                                if (message != null && message.length() > 0) {
+                                if (message.length() > 0) {
                                     messageReceive(message);
                                 }
                             } catch (SocketTimeoutException e) {
@@ -158,7 +158,7 @@ public class OppoDiscoveryService extends AbstractDiscoveryService {
 
                         multiSocket.close();
                     } catch (IOException e) {
-                        if (!e.getMessage().contains("No IP addresses bound to interface")) {
+                        if (e.getMessage() != null && !e.getMessage().contains("No IP addresses bound to interface")) {
                             logger.debug("OppoDiscoveryService IOException: {}", e.getMessage(), e);
                         }
                     }


### PR DESCRIPTION
Fix the bug identified in issue #10282. These changes improve the polling routine to properly detect when the player power is on or off. If the connection is interrupted the verbose mode will be set again in case the power to the player was interrupted.

Test build here:
https://github.com/mlobstein/mlobstein-beta-test/raw/master/org.openhab.binding.oppo-3.1.0-SNAPSHOT.jar
https://github.com/mlobstein/mlobstein-beta-test/raw/master/org.openhab.binding.oppo-3.1.0-SNAPSHOT-sources.jar