### PR TITLE
[espmilighthub] Fix things stay initializing

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -347,10 +347,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                     "Bridge is missing or offline, you need to setup a working MQTT broker first.");
             return;
         }
-        ThingUID thingUID = localBridge.getBridgeUID();
-        if (thingUID == null) {
-            return;
-        }
+        ThingUID thingUID = localBridge.getUID();
         Thing thing = thingRegistry.get(thingUID);
         if (thing == null) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED,


### PR DESCRIPTION
Fixed bug caused by asking a bridge thing for its bridge's UID instead of just the UID.

Signed-off-by: Matthew Skinner <matt@pcmus.com>