### PR TITLE
[androiddebugbridge] fix power wake lock and minor fixes

### DIFF
--- a/bundles/org.openhab.binding.androiddebugbridge/README.md
+++ b/bundles/org.openhab.binding.androiddebugbridge/README.md
@@ -6,7 +6,7 @@ If you are not familiar with adb I suggest you to search "How to enable adb over
 
 ## Supported Things
 
-This binding was tested on the Fire TV Stick (android version 7.1.2, volume control not working) and Nexus5x (android version 8.1.0, everything works nice), please update this document if you tested it with other android versions to reflect the compatibility of the biding. 
+This binding was tested on the Fire TV Stick (android version 7.1.2, volume control not working) and Nexus5x (android version 8.1.0, everything works nice), please update this document if you tested it with other android versions to reflect the compatibility of the binding. 
 
 ## Discovery
 

--- a/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.openhab.binding.androiddebugbridge/src/main/java/org/openhab/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -117,7 +117,7 @@ public class AndroidDebugBridgeDevice {
             if (packageActivityName.contains("/"))
                 return packageActivityName.split("/")[0];
         }
-        throw new AndroidDebugBridgeDeviceReadException("can read package name");
+        throw new AndroidDebugBridgeDeviceReadException("Unable to read package name");
     }
 
     public boolean isAwake()
@@ -137,7 +137,7 @@ public class AndroidDebugBridgeDevice {
                 logger.debug("Unable to parse device wake lock: {}", e.getMessage());
             }
         }
-        throw new AndroidDebugBridgeDeviceReadException("can read screen state");
+        throw new AndroidDebugBridgeDeviceReadException("Unable to read screen state");
     }
 
     public boolean isPlayingMedia(String currentApp)
@@ -175,12 +175,12 @@ public class AndroidDebugBridgeDevice {
         String lockResp = runAdbShell("dumpsys", "power", "|", "grep", "Locks", "|", "grep", "'size='");
         if (lockResp.contains("=")) {
             try {
-                return Integer.parseInt(lockResp.replace("\n", "").split("=")[1]);
+                return Integer.parseInt(lockResp.replace("\n", "").split("=")[1].trim());
             } catch (NumberFormatException e) {
                 logger.debug("Unable to parse device wake lock: {}", e.getMessage());
             }
         }
-        throw new AndroidDebugBridgeDeviceReadException("can read wake lock");
+        throw new AndroidDebugBridgeDeviceReadException("Unable to read wake lock");
     }
 
     private void setVolume(int stream, int volume)


### PR DESCRIPTION
Signed-off-by: Miguel <miguelwork92@gmail.com>
Try to avoid possible parse errors on the power wake lock channel, improve error messages and fix a typo in the readme.
Based on the feedback I got by email from @Trinitus01.