### PR TITLE
[caddx] Correct thing status on bridge initialization

### DIFF
--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/CaddxBridgeHandler.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/CaddxBridgeHandler.java
@@ -65,7 +65,6 @@ import org.slf4j.LoggerFactory;
 public class CaddxBridgeHandler extends BaseBridgeHandler implements CaddxPanelListener {
     private final Logger logger = LoggerFactory.getLogger(CaddxBridgeHandler.class);
 
-    static final byte[] DISCOVERY_PARTITION_STATUS_REQUEST_0 = { 0x26, 0x00 };
     static final byte[] DISCOVERY_ZONES_SNAPSHOT_REQUEST_00 = { 0x25, 0x00 }; // 1 - 16
     static final byte[] DISCOVERY_ZONES_SNAPSHOT_REQUEST_10 = { 0x25, 0x01 }; // 17 - 32
     static final byte[] DISCOVERY_ZONES_SNAPSHOT_REQUEST_20 = { 0x25, 0x02 }; // 33 - 48
@@ -156,8 +155,13 @@ public class CaddxBridgeHandler extends BaseBridgeHandler implements CaddxPanelL
             comm.transmit(new CaddxMessage(DISCOVERY_ZONES_SNAPSHOT_REQUEST_B0, false));
 
             // Send discovery commands for the partitions
-            comm.transmit(new CaddxMessage(DISCOVERY_PARTITION_STATUS_REQUEST_0, false));
             comm.transmit(new CaddxMessage(DISCOVERY_PARTITIONS_SNAPSHOT_REQUEST, false));
+
+            // Send status commands to the zones and partitions
+            thingZonesMap.forEach((k, v) -> sendCommand(CaddxBindingConstants.ZONE_STATUS_REQUEST,
+                    k.subtract(BigDecimal.ONE).toString()));
+            thingPartitionsMap.forEach((k, v) -> sendCommand(CaddxBindingConstants.PARTITION_STATUS_REQUEST,
+                    k.subtract(BigDecimal.ONE).toString()));
         }
 
         // list all channels

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/LogEventMessage.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/LogEventMessage.java
@@ -56,9 +56,6 @@ public class LogEventMessage {
             int eventType = Integer.parseInt(type);
             logger.trace("eventType received: {}", eventType);
             LogEventType logEventType = LogEventType.valueOfLogEventType(eventType);
-            if (logEventType == null) {
-                return "Unknown log event type received";
-            }
 
             // Date
             sb.append(String.format("%02d", Integer.parseInt(day))).append('-')
@@ -66,23 +63,27 @@ public class LogEventMessage {
                     .append(String.format("%02d", Integer.parseInt(hour))).append(':')
                     .append(String.format("%02d", Integer.parseInt(minute))).append(' ');
 
-            sb.append(logEventType.description);
-            if (logEventType.isPartitionValid) {
-                sb.append(" Partition ").append(Integer.parseInt(partition) + 1);
-            }
+            if (logEventType == null) {
+                sb.append("Unknown log event type");
+            } else {
+                sb.append(logEventType.description);
+                if (logEventType.isPartitionValid) {
+                    sb.append(" Partition ").append(Integer.parseInt(partition) + 1);
+                }
 
-            switch (logEventType.zud) {
-                case None:
-                    break;
-                case Zone:
-                    sb.append(" Zone ").append(Integer.parseInt(zud) + 1);
-                    break;
-                case User:
-                    sb.append(" User ").append(Integer.parseInt(zud) + 1);
-                    break;
-                case Device:
-                    sb.append(" Device ").append(zud);
-                    break;
+                switch (logEventType.zud) {
+                    case None:
+                        break;
+                    case Zone:
+                        sb.append(" Zone ").append(Integer.parseInt(zud) + 1);
+                        break;
+                    case User:
+                        sb.append(" User ").append(Integer.parseInt(zud) + 1);
+                        break;
+                    case Device:
+                        sb.append(" Device ").append(zud);
+                        break;
+                }
             }
 
             return sb.toString();

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerPanel.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerPanel.java
@@ -67,7 +67,7 @@ public class ThingHandlerPanel extends CaddxBaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.trace("handleCommand(): Command Received - {} {}.", channelUID, command);
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
 
         String cmd = null;
         String data = null;
@@ -167,10 +167,12 @@ public class ThingHandlerPanel extends CaddxBaseThingHandler {
 
         // get the channel id from the map
         HashMap<String, String> logMap = panelLogMessagesMap;
-        String id = logMap.get(eventNumberString);
-        if (logMap != null && id != null) {
-            ChannelUID channelUID = new ChannelUID(getThing().getUID(), id);
-            updateChannel(channelUID, logEventMessage.toString());
+        if (logMap != null) {
+            String id = logMap.get(eventNumberString);
+            if (id != null) {
+                ChannelUID channelUID = new ChannelUID(getThing().getUID(), id);
+                updateChannel(channelUID, logEventMessage.toString());
+            }
         }
 
         if (communicatorStackPointer != null && eventNumberString.equals(communicatorStackPointer)) {

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
@@ -52,7 +52,6 @@ public class ThingHandlerZone extends CaddxBaseThingHandler {
     @Override
     public void updateChannel(ChannelUID channelUID, String data) {
         if (channelUID.getId().equals(CaddxBindingConstants.ZONE_NAME)) {
-            // getThing().setLabel(data);
             updateState(channelUID, new StringType(data));
 
             logger.trace("  updateChannel: {} = {}", channelUID, data);

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
@@ -52,7 +52,7 @@ public class ThingHandlerZone extends CaddxBaseThingHandler {
     @Override
     public void updateChannel(ChannelUID channelUID, String data) {
         if (channelUID.getId().equals(CaddxBindingConstants.ZONE_NAME)) {
-            getThing().setLabel(data);
+            // getThing().setLabel(data);
             updateState(channelUID, new StringType(data));
 
             logger.trace("  updateChannel: {} = {}", channelUID, data);
@@ -124,9 +124,9 @@ public class ThingHandlerZone extends CaddxBaseThingHandler {
                     logger.trace("  updateChannel: {} = {}", channelUID, value);
                 }
             }
-
-            updateStatus(ThingStatus.ONLINE);
         }
+
+        updateStatus(ThingStatus.ONLINE);
     }
 
     @Override

--- a/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
+++ b/bundles/org.openhab.binding.caddx/src/main/java/org/openhab/binding/caddx/internal/handler/ThingHandlerZone.java
@@ -71,7 +71,7 @@ public class ThingHandlerZone extends CaddxBaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        logger.trace("handleCommand(): Command Received - {} {}.", channelUID, command);
+        logger.debug("handleCommand(): Command Received - {} {}.", channelUID, command);
 
         String cmd1 = null;
         String cmd2 = null;


### PR DESCRIPTION
On openhab start/restart the things stayed offline until a message arrived from the alarm panel. Changed the behavior by requesting from the panel the state of the things on bridge initialization. 
Also improved the alarm panel messages in case of unknown events.
