### PR TITLE
[pioneeravr] Added channel for changing MCACC Memory profile on AVR

### DIFF
--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/PioneerAvrBindingConstants.java
@@ -92,6 +92,7 @@ public class PioneerAvrBindingConstants {
     public static final String LISTENING_MODE_CHANNEL = "listeningMode";
     public static final String PLAYING_LISTENING_MODE_CHANNEL = "playingListeningMode";
     public static final String DISPLAY_INFORMATION_CHANNEL = "displayInformation#displayInformation";
+    public static final String MCACC_MEMORY_CHANNEL = "MCACCMemory#MCACCMemory";
 
     public static final String GROUP_CHANNEL_PATTERN = "zone%s#%s";
     public static final Pattern GROUP_CHANNEL_ZONE_PATTERN = Pattern.compile("zone([0-4])#.*");

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ParameterizedCommand.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/ParameterizedCommand.java
@@ -31,7 +31,8 @@ public class ParameterizedCommand extends SimpleCommand {
 
         VOLUME_SET("[0-9]{2,3}", "VL", "ZV", "YV", "HZV"),
         INPUT_CHANNEL_SET("[0-9]{2}", "FN", "ZS", "ZT", "ZEA"),
-        LISTENING_MODE_SET("[0-9]{4}", "SR");
+        LISTENING_MODE_SET("[0-9]{4}", "SR"),
+        MCACC_MEMORY_SET("[1-6]{1}", "MC");
 
         private String[] zoneCommands;
         private String parameterPattern;
@@ -39,6 +40,11 @@ public class ParameterizedCommand extends SimpleCommand {
         private ParameterizedCommandType(String parameterPattern, String... zoneCommands) {
             this.zoneCommands = zoneCommands;
             this.parameterPattern = parameterPattern;
+        }
+
+        @Override
+        public String getCommand() {
+            return zoneCommands[0];
         }
 
         @Override
@@ -54,6 +60,10 @@ public class ParameterizedCommand extends SimpleCommand {
     private String parameter;
 
     private String parameterPattern;
+
+    protected ParameterizedCommand(ParameterizedCommandType command) {
+        this(command, 0);
+    }
 
     protected ParameterizedCommand(ParameterizedCommandType command, int zone) {
         super(command, zone);

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/RequestResponseFactory.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/RequestResponseFactory.java
@@ -35,6 +35,17 @@ public final class RequestResponseFactory {
     }
 
     /**
+     * Return a SimpleCommand of the type given in parameter.
+     *
+     * @param command
+     * @return
+     */
+    public static SimpleCommand getIpControlCommand(SimpleCommandType command) {
+        SimpleCommand result = new SimpleCommand(command);
+        return result;
+    }
+
+    /**
      * Return a ParameterizedCommand of the type given in parameter and for the given zone.
      *
      * @param command
@@ -43,6 +54,18 @@ public final class RequestResponseFactory {
      */
     public static SimpleCommand getIpControlCommand(SimpleCommandType command, int zone) {
         SimpleCommand result = new SimpleCommand(command, zone);
+        return result;
+    }
+
+    /**
+     * Return a ParameterizedCommand of the type given in parameter. The
+     * parameter of the command has to be set before send.
+     *
+     * @param command
+     * @return
+     */
+    public static ParameterizedCommand getIpControlCommand(ParameterizedCommandType command) {
+        ParameterizedCommand result = new ParameterizedCommand(command);
         return result;
     }
 
@@ -61,7 +84,22 @@ public final class RequestResponseFactory {
 
     /**
      * Return a ParameterizedCommand of the type given in parameter. The
-     * parameter of the command is set with the given paramter value.
+     * parameter of the command is set with the given parameter value.
+     *
+     * @param command
+     * @param parameter
+     * @param zone
+     * @return
+     */
+    public static ParameterizedCommand getIpControlCommand(ParameterizedCommandType command, String parameter) {
+        ParameterizedCommand result = getIpControlCommand(command);
+        result.setParameter(parameter);
+        return result;
+    }
+
+    /**
+     * Return a ParameterizedCommand of the type given in parameter. The
+     * parameter of the command is set with the given parameter value.
      *
      * @param command
      * @param parameter

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/Response.java
@@ -37,7 +37,8 @@ public class Response implements AvrResponse {
         INPUT_SOURCE_CHANNEL("[0-9]{2}", "FN", "Z2F", "Z3F", "ZEA"),
         LISTENING_MODE("[0-9]{4}", "SR"),
         PLAYING_LISTENING_MODE("[0-9a-f]{4}", "LM"),
-        DISPLAY_INFORMATION("[0-9a-fA-F]{30}", "FL");
+        DISPLAY_INFORMATION("[0-9a-fA-F]{30}", "FL"),
+        MCACC_MEMORY("[1-6]{1}", "MC");
 
         private String[] responsePrefixZone;
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/SimpleCommand.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/SimpleCommand.java
@@ -40,12 +40,19 @@ public class SimpleCommand implements AvrCommand {
         INPUT_CHANGE_REVERSE("FD"),
         LISTENING_MODE_CHANGE_CYCLIC("0010SR"),
         LISTENING_MODE_QUERY("?S"),
-        INPUT_QUERY("?F", "?ZS", "?ZT", "?ZEA");
+        INPUT_QUERY("?F", "?ZS", "?ZT", "?ZEA"),
+        MCACC_MEMORY_CHANGE_CYCLIC("0MC"),
+        MCACC_MEMORY_QUERY("?MC");
 
         private String zoneCommands[];
 
         private SimpleCommandType(String... command) {
             this.zoneCommands = command;
+        }
+
+        @Override
+        public String getCommand() {
+            return zoneCommands[0];
         }
 
         @Override
@@ -62,8 +69,15 @@ public class SimpleCommand implements AvrCommand {
         this.zone = zone;
     }
 
+    public SimpleCommand(CommandType commandType) {
+        this(commandType, 0);
+    }
+
     @Override
     public String getCommand() {
+        if (zone == 0) {
+            return commandType.getCommand() + "\r";
+        }
         return commandType.getCommand(zone) + "\r";
     }
 

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/StreamAvrConnection.java
@@ -196,6 +196,11 @@ public abstract class StreamAvrConnection implements AvrConnection {
     }
 
     @Override
+    public boolean sendMCACCMemoryQuery() {
+        return sendCommand(RequestResponseFactory.getIpControlCommand(SimpleCommandType.MCACC_MEMORY_QUERY));
+    }
+
+    @Override
     public boolean sendPowerCommand(Command command, int zone) throws CommandTypeNotSupportedException {
         AvrCommand commandToSend = null;
 
@@ -300,6 +305,23 @@ public abstract class StreamAvrConnection implements AvrConnection {
             commandToSend = RequestResponseFactory.getIpControlCommand(SimpleCommandType.MUTE_ON, zone);
         } else if (command == OnOffType.OFF) {
             commandToSend = RequestResponseFactory.getIpControlCommand(SimpleCommandType.MUTE_OFF, zone);
+        } else {
+            throw new CommandTypeNotSupportedException("Command type not supported.");
+        }
+
+        return sendCommand(commandToSend);
+    }
+
+    @Override
+    public boolean sendMCACCMemoryCommand(Command command) throws CommandTypeNotSupportedException {
+        AvrCommand commandToSend = null;
+
+        if (command == IncreaseDecreaseType.INCREASE) {
+            commandToSend = RequestResponseFactory.getIpControlCommand(SimpleCommandType.MCACC_MEMORY_CHANGE_CYCLIC);
+        } else if (command instanceof StringType) {
+            String MCACCMemoryValue = ((StringType) command).toString();
+            commandToSend = RequestResponseFactory.getIpControlCommand(ParameterizedCommandType.MCACC_MEMORY_SET)
+                    .setParameter(MCACCMemoryValue);
         } else {
             throw new CommandTypeNotSupportedException("Command type not supported.");
         }

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrCommand.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrCommand.java
@@ -23,6 +23,12 @@ public interface AvrCommand {
      * Represent a CommandType of command requests
      */
     public interface CommandType {
+        /**
+         * Return the command of this command type.
+         *
+         * @return
+         */
+        public String getCommand();
 
         /**
          * Return the command of this command type for the given zone.

--- a/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/java/org/openhab/binding/pioneeravr/internal/protocol/avr/AvrConnection.java
@@ -97,6 +97,13 @@ public interface AvrConnection {
     public boolean sendListeningModeQuery(int zone);
 
     /**
+     * Send an MCACC Memory query to the AVR
+     *
+     * @return
+     */
+    public boolean sendMCACCMemoryQuery();
+
+    /**
      * Send a power command ot the AVR based on the openHAB command
      *
      * @param command
@@ -140,6 +147,15 @@ public interface AvrConnection {
      * @return
      */
     public boolean sendMuteCommand(Command command, int zone) throws CommandTypeNotSupportedException;
+
+    /**
+     * Send an MCACC Memory selection command to the AVR based on the openHAB command
+     *
+     * @param command
+     * @param zone
+     * @return
+     */
+    public boolean sendMCACCMemoryCommand(Command command) throws CommandTypeNotSupportedException;
 
     /**
      * Return the connection name

--- a/bundles/org.openhab.binding.pioneeravr/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/resources/OH-INF/thing/thing-types.xml
@@ -14,6 +14,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zoneControls" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -44,6 +45,7 @@
 		<description>Control a 2014 Pioneer AVR (SC-LX87, SC-LX77, SC-LX57, SC-2023, SC-1223, VSX-1123, VSX-923) over IP </description>
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2014" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -80,6 +82,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2015" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -116,6 +119,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2016" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -152,6 +156,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2017" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -186,6 +191,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2018" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -220,6 +226,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2019" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -254,6 +261,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2020" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -290,6 +298,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zoneControls" id="zone1"/>
 			<channel-group typeId="zoneControls" id="zone2"/>
 			<channel-group typeId="zoneControls" id="zone3"/>
@@ -316,9 +325,10 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
+            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zone1Controls" id="zone1"/>
 			<channel-group typeId="zone2Controls" id="zone2"/>
-			<channel-group typeId="zone3Controls" id="zone3"/>
+            <channel-group typeId="zone3Controls" id="zone3"/>
 		</channel-groups>
 
 		<config-description>
@@ -331,12 +341,19 @@
 		</config-description>
 	</thing-type>
 
-	<channel-group-type id="displayInformationGroup">
-		<label>Display</label>
-		<channels>
-			<channel id="displayInformation" typeId="displayInformationChannel"/>
-		</channels>
-	</channel-group-type>
+    <channel-group-type id="displayInformationGroup">
+        <label>Display</label>
+        <channels>
+            <channel id="displayInformation" typeId="displayInformationChannel"/>
+        </channels>
+    </channel-group-type>
+    
+    <channel-group-type id="MCACCMemoryGroup">
+        <label>MCACC Memory</label>
+        <channels>
+            <channel id="MCACCMemory" typeId="setMCACCMemoryChannel"/>
+        </channels>
+    </channel-group-type>
 
 	<channel-group-type id="zoneControls">
 		<label>Zone Controls</label>
@@ -643,7 +660,7 @@
 		<label>Volume</label>
 		<description>Set the volume level (dB)</description>
 		<category>SoundVolume</category>
-		<state min="-80" max="12" step="0.5" pattern="%.1f dB"/>
+		<state min="-80" max="12" step="0.5" pattern="%.1f dB"></state>
 	</channel-type>
 
 	<channel-type id="muteChannel">
@@ -1377,5 +1394,22 @@
 		<description>Display the effective listening mode</description>
 		<state readOnly="true"/>
 	</channel-type>
+	
+	<channel-type id="setMCACCMemoryChannel">
+        <item-type>String</item-type>
+        <label>MCACC Memory</label>
+        <description>Set the MCACC Memory profile</description>
+        <state>
+            <options>
+                <option value="0000">MCACC MEMORY (cyclic)</option>
+                <option value="0001">MEMORY 1</option>
+                <option value="0002">MEMORY 2</option>
+                <option value="0003">MEMORY 3</option>
+                <option value="0004">MEMORY 4</option>
+                <option value="0005">MEMORY 5</option>
+                <option value="0006">MEMORY 6</option>
+            </options>
+        </state>
+    </channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.pioneeravr/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.pioneeravr/src/main/resources/OH-INF/thing/thing-types.xml
@@ -14,7 +14,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zoneControls" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -45,7 +45,7 @@
 		<description>Control a 2014 Pioneer AVR (SC-LX87, SC-LX77, SC-LX57, SC-2023, SC-1223, VSX-1123, VSX-923) over IP </description>
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2014" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -82,7 +82,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2015" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -119,7 +119,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2016" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -156,7 +156,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2017" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -191,7 +191,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2018" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -226,7 +226,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2019" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -261,7 +261,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="controls2020" id="zone1">
 				<label>Zone 1</label>
 			</channel-group>
@@ -298,7 +298,7 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zoneControls" id="zone1"/>
 			<channel-group typeId="zoneControls" id="zone2"/>
 			<channel-group typeId="zoneControls" id="zone3"/>
@@ -325,10 +325,10 @@
 
 		<channel-groups>
 			<channel-group typeId="displayInformationGroup" id="displayInformation"/>
-            <channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
+			<channel-group typeId="MCACCMemoryGroup" id="MCACCMemory"/>
 			<channel-group typeId="zone1Controls" id="zone1"/>
 			<channel-group typeId="zone2Controls" id="zone2"/>
-            <channel-group typeId="zone3Controls" id="zone3"/>
+			<channel-group typeId="zone3Controls" id="zone3"/>
 		</channel-groups>
 
 		<config-description>
@@ -341,19 +341,19 @@
 		</config-description>
 	</thing-type>
 
-    <channel-group-type id="displayInformationGroup">
-        <label>Display</label>
-        <channels>
-            <channel id="displayInformation" typeId="displayInformationChannel"/>
-        </channels>
-    </channel-group-type>
-    
-    <channel-group-type id="MCACCMemoryGroup">
-        <label>MCACC Memory</label>
-        <channels>
-            <channel id="MCACCMemory" typeId="setMCACCMemoryChannel"/>
-        </channels>
-    </channel-group-type>
+	<channel-group-type id="displayInformationGroup">
+		<label>Display</label>
+		<channels>
+			<channel id="displayInformation" typeId="displayInformationChannel"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="MCACCMemoryGroup">
+		<label>MCACC Memory</label>
+		<channels>
+			<channel id="MCACCMemory" typeId="setMCACCMemoryChannel"/>
+		</channels>
+	</channel-group-type>
 
 	<channel-group-type id="zoneControls">
 		<label>Zone Controls</label>
@@ -1394,22 +1394,22 @@
 		<description>Display the effective listening mode</description>
 		<state readOnly="true"/>
 	</channel-type>
-	
+
 	<channel-type id="setMCACCMemoryChannel">
-        <item-type>String</item-type>
-        <label>MCACC Memory</label>
-        <description>Set the MCACC Memory profile</description>
-        <state>
-            <options>
-                <option value="0000">MCACC MEMORY (cyclic)</option>
-                <option value="0001">MEMORY 1</option>
-                <option value="0002">MEMORY 2</option>
-                <option value="0003">MEMORY 3</option>
-                <option value="0004">MEMORY 4</option>
-                <option value="0005">MEMORY 5</option>
-                <option value="0006">MEMORY 6</option>
-            </options>
-        </state>
-    </channel-type>
+		<item-type>String</item-type>
+		<label>MCACC Memory</label>
+		<description>Set the MCACC Memory profile</description>
+		<state>
+			<options>
+				<option value="0000">MCACC MEMORY (cyclic)</option>
+				<option value="0001">MEMORY 1</option>
+				<option value="0002">MEMORY 2</option>
+				<option value="0003">MEMORY 3</option>
+				<option value="0004">MEMORY 4</option>
+				<option value="0005">MEMORY 5</option>
+				<option value="0006">MEMORY 6</option>
+			</options>
+		</state>
+	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
* Added channel for changing the active MCACC memory profile on Pioneer AVRs

![image](https://user-images.githubusercontent.com/11078362/111068832-a87da980-84ca-11eb-9883-29479da98eb9.png)

![mcacc_demo](https://user-images.githubusercontent.com/11078362/111069004-512c0900-84cb-11eb-94f5-cde156787413.gif)
The left widget is linked to the MCACC channel. The right widget shows the live data on the AVR display for confirmation.

Signed-off-by: Nathan Prins <nathanprins@hotmail.com>
