### PR TITLE
[airvisualnode] Change dependency group id to version available on Maven Central

### DIFF
--- a/bundles/org.openhab.binding.airvisualnode/pom.xml
+++ b/bundles/org.openhab.binding.airvisualnode/pom.xml
@@ -14,11 +14,17 @@
 
   <name>openHAB Add-ons :: Bundles :: AirVisual Node Air Quality Monitor Binding</name>
 
+  <properties>
+    <bnd.importpackage>
+      !jcifs
+    </bnd.importpackage>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.samba.jcifs</groupId>
       <artifactId>jcifs</artifactId>
-      <version>1.3.17</version>
+      <version>1.3.14-kohsuke-1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.airvisualnode/pom.xml
+++ b/bundles/org.openhab.binding.airvisualnode/pom.xml
@@ -22,9 +22,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.samba.jcifs</groupId>
+      <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
-      <version>1.3.14-kohsuke-1</version>
+      <version>1.3.17</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.binding.airvisualnode/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.airvisualnode/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-airvisualnode" description="AirVisual Node Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true" start-level="80">mvn:org.samba.jcifs/jcifs/1.3.17</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.airvisualnode/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
...and also included dependency in the binding.

Related to https://github.com/openhab/openhab-distro/issues/1256

Fixes sandbox release build https://ci.openhab.org/view/Sandbox/job/sandbox-openhab3-release/170/

Signed-off-by: Kai Kreuzer <kai@openhab.org>