### PR TITLE
[sensebox] Gracefully handle JsonSyntaxException

### DIFF
--- a/bundles/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxAPIConnection.java
+++ b/bundles/org.openhab.binding.sensebox/src/main/java/org/openhab/binding/sensebox/internal/SenseBoxAPIConnection.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link SenseBoxAPIConnection} is responsible for fetching data from the senseBox API server.
@@ -63,8 +64,9 @@ public class SenseBoxAPIConnection {
         // the caching layer does not like null values
         SenseBoxData result = new SenseBoxData();
 
+        String body = null;
         try {
-            String body = HttpUtil.executeUrl(METHOD, query, HEADERS, null, null, TIMEOUT);
+            body = HttpUtil.executeUrl(METHOD, query, HEADERS, null, null, TIMEOUT);
 
             logger.trace("Fetched Data: {}", body);
             SenseBoxData parsedData = gson.fromJson(body, SenseBoxData.class);
@@ -148,6 +150,10 @@ public class SenseBoxAPIConnection {
             logger.trace("=================================");
 
             result = parsedData;
+        } catch (JsonSyntaxException e) {
+            logger.debug("An error occurred while parsing the data into desired class: {} / {} / {}", body,
+                    SenseBoxData.class.getName(), e.getMessage());
+            result.setStatus(ThingStatus.OFFLINE);
         } catch (IOException e) {
             logger.debug("IO problems while fetching data: {} / {}", query, e.getMessage());
             result.setStatus(ThingStatus.OFFLINE);


### PR DESCRIPTION
- Gracefully handle `JsonSyntaxException`

```
2021-03-17 10:55:02.872 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was NUMBER at line 1 column 4 path $
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:224) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:888) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:853) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:802) ~[?:?]
        at com.google.gson.Gson.fromJson(Gson.java:774) ~[?:?]
        at org.openhab.binding.sensebox.internal.SenseBoxAPIConnection.reallyFetchDataFromServer(SenseBoxAPIConnection.java:70) ~[?:?]
        at org.openhab.binding.sensebox.internal.handler.SenseBoxHandler.lambda$0(SenseBoxHandler.java:106) ~[?:?]
        at org.openhab.core.cache.ExpiringCache.refreshValue(ExpiringCache.java:101) ~[?:?]
        at org.openhab.core.cache.ExpiringCache.getValue(ExpiringCache.java:72) ~[?:?]
        at org.openhab.core.cache.ExpiringCacheMap.get(ExpiringCacheMap.java:198) ~[?:?]
        at org.openhab.binding.sensebox.internal.handler.SenseBoxHandler.fetchData(SenseBoxHandler.java:163) ~[?:?]
        at org.openhab.binding.sensebox.internal.handler.SenseBoxHandler.publishData(SenseBoxHandler.java:146) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(Unknown Source) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
        at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was NUMBER at line 1 column 4 path $
        at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:385) ~[?:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:213) ~[?:?]
        ... 17 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
