### PR TITLE
[hdpowerview] Change dependency group id to version available on Maven Central

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/pom.xml
+++ b/bundles/org.openhab.binding.hdpowerview/pom.xml
@@ -14,9 +14,15 @@
 
   <name>openHAB Add-ons :: Bundles :: Hunter Douglas PowerView Binding</name>
 
+  <properties>
+    <bnd.importpackage>
+      !jcifs.*
+    </bnd.importpackage>
+  </properties>
+
   <dependencies>
     <dependency>
-      <groupId>org.samba.jcifs</groupId>
+      <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
       <version>1.3.17</version>
       <scope>compile</scope>

--- a/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/feature/feature.xml
@@ -4,7 +4,6 @@
 
 	<feature name="openhab-binding-hdpowerview" description="HD PowerView Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<bundle dependency="true">mvn:org.samba.jcifs/jcifs/1.3.17</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.hdpowerview/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
Identical change as in https://github.com/openhab/openhab-addons/pull/10333

Signed-off-by: Kai Kreuzer <kai@openhab.org>