### PR TITLE
[gpstracker] Forced channel triggering without previous state

### DIFF
--- a/bundles/org.openhab.binding.gpstracker/README.md
+++ b/bundles/org.openhab.binding.gpstracker/README.md
@@ -249,8 +249,6 @@ After a location message received from the tracker the log should contain these 
 2018-10-05 09:27:58.794 [TRACE] [cker.internal.handler.TrackerHandler] - System uses SI measurement units. No conversion is needed.
 ```
 
-**Note**: If the binding was restarted or the distance channel is new (this is the first location message for the channel) only the second location update will trigger event as the binding has to know the previous state.
-
 ### External Region and Presence Switch
 
 Assumptions:

--- a/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
+++ b/bundles/org.openhab.binding.gpstracker/src/main/java/org/openhab/binding/gpstracker/internal/handler/TrackerHandler.java
@@ -262,7 +262,7 @@ public class TrackerHandler extends BaseThingHandler {
      */
     private void updateTriggerChannelsWithTransition(TransitionMessage message) {
         String regionName = message.getRegionName();
-        triggerRegionChannel(regionName, message.getEvent());
+        triggerRegionChannel(regionName, message.getEvent(), true);
     }
 
     /**
@@ -270,11 +270,12 @@ public class TrackerHandler extends BaseThingHandler {
      *
      * @param regionName Region name
      * @param event Occurred event
+     * @param forced Force channel triggering in case the transition event is received from the mobile application.
      */
-    private void triggerRegionChannel(@NonNull String regionName, @NonNull String event) {
+    private void triggerRegionChannel(@NonNull String regionName, @NonNull String event, boolean forced) {
         Boolean lastState = lastTriggeredStates.get(regionName);
         Boolean newState = EVENT_ENTER.equals(event);
-        if (!newState.equals(lastState) && lastState != null) {
+        if (!newState.equals(lastState) || forced) {
             String payload = regionName + "/" + event;
             triggerChannel(CHANNEL_REGION_TRIGGER, payload);
             lastTriggeredStates.put(regionName, newState);
@@ -327,9 +328,9 @@ public class TrackerHandler extends BaseThingHandler {
                     // convert into meters which is the unit of the calculated distance
                     double radiusMeter = convertToMeters(ConfigHelper.getRegionRadius(c.getConfiguration()));
                     if (radiusMeter > newDistance) {
-                        triggerRegionChannel(regionName, EVENT_ENTER);
+                        triggerRegionChannel(regionName, EVENT_ENTER, false);
                     } else {
-                        triggerRegionChannel(regionName, EVENT_LEAVE);
+                        triggerRegionChannel(regionName, EVENT_LEAVE, false);
                     }
                 }
             }


### PR DESCRIPTION
Users were complaining about missing region channel triggering after OH restarts. Region channel triggering doesn't depend on binding's previous state anymore:

- In case a location message is received it will trigger the channel if based on the the new calculated distance the state differs from the previous state (now this includes the NULL state as well). So after an OH restart the linked switch will be updated even after the first location message

- In case the message is a transition (e.g. configured in OT application) the trigger event is forced regardless on any previous states

Fixes #6939 