### PR TITLE
[enocean] Do not set attr "required" for the param "senderIdOffset"

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/CentralCommand.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/CentralCommand.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/ClassicDevice.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/ClassicDevice.xml
@@ -20,7 +20,7 @@
 		</channels>
 
 		<config-description>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/GenericThing.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/GenericThing.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/HeatRecoveryVentilation.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/HeatRecoveryVentilation.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/MeasurementSwitch.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/MeasurementSwitch.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Rollershutter.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Rollershutter.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>

--- a/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Thermostat.xml
+++ b/bundles/org.openhab.binding.enocean/src/main/resources/OH-INF/thing/Thermostat.xml
@@ -17,7 +17,7 @@
 				<label>EnOceanId</label>
 				<description>EnOceanId of device this thing belongs to</description>
 			</parameter>
-			<parameter name="senderIdOffset" type="integer" required="false" min="1" max="127">
+			<parameter name="senderIdOffset" type="integer" min="1" max="127">
 				<label>Sender Id</label>
 				<description>Id is used to generate the EnOcean Id (Int between [1-127]). If not specified the next free Id will be
 					determined by bridge</description>


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>