### PR TITLE
[gpstracker] Support for military grade GPS accuracy (<1yd)

### DIFF
--- a/bundles/org.openhab.binding.gpstracker/src/main/resources/OH-INF/thing/tracker.xml
+++ b/bundles/org.openhab.binding.gpstracker/src/main/resources/OH-INF/thing/tracker.xml
@@ -31,7 +31,7 @@
 		<item-type>Number:Length</item-type>
 		<label>Accuracy</label>
 		<description>GPS accuracy</description>
-		<state pattern="%d %unit%" readOnly="true"/>
+		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="lastReport">
 		<item-type>DateTime</item-type>


### PR DESCRIPTION
Signed-off-by: Gabor Bicskei <gbicskei@gmail.com>

Converting received GPS accuracy from SI to Imperial resulted a value with decimal fraction (<1 yd) . When the state description is created from the thing (Create Equipment From Thing option) the default label pattern is taken from the binding. Using %d pattern threw a formatting exception. Changed to %.1f %unit%.

Fixes #10053
