### PR TITLE
[bsblan] Updated the link to the BSB-LAN device repository in README.md

### DIFF
--- a/bundles/org.openhab.binding.bsblan/README.md
+++ b/bundles/org.openhab.binding.bsblan/README.md
@@ -1,6 +1,6 @@
 # BSB-LAN Binding
 
-This binding uses the REST API of [BSB-LPB-PPS-LAN](https://github.com/fredlcore/bsb_lan) to obtain data from the device.
+This binding uses the REST API of [BSB-LPB-PPS-LAN](https://github.com/fredlcore/BSB-LAN) to obtain data from the device.
 
 ## Supported Things
 


### PR DESCRIPTION
The repository of the BSB-LAN device has been renamed, this PR updates the link to it.