### PR TITLE
Fix broken configfile GAV with karaf:kar

### DIFF
--- a/bundles/org.openhab.binding.exec/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.exec/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-binding-exec" description="Exec Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<configfile finalname="${openhab.conf}/misc/exec.whitelist" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/exec.whitelist</configfile>
+		<configfile finalname="${openhab.conf}/misc/exec.whitelist" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/exec.whitelist</configfile>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.exec/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.leapmotion/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.leapmotion/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-binding-leapmotion" description="LeapMotion Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.leapmotion/${project.version}</bundle>
-		<configfile finalname="${openhab.userdata}/tmp/lib/libLeap.dylib" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/lib/libLeap</configfile>
-		<configfile finalname="${openhab.userdata}/tmp/lib/libLeapJava.dylib" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/lib/libLeapJava</configfile>
+		<configfile finalname="${openhab.userdata}/tmp/lib/libLeap.dylib" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/lib/libLeap</configfile>
+		<configfile finalname="${openhab.userdata}/tmp/lib/libLeapJava.dylib" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/lib/libLeapJava</configfile>
 	</feature>
 </features>

--- a/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-misc-openhabcloud" description="openHAB Cloud Connector" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<configfile finalname="${openhab.conf}/services/openhabcloud.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/openhabcloud</configfile>
+		<configfile finalname="${openhab.conf}/services/openhabcloud.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/openhabcloud</configfile>
 		<bundle dependency="true">mvn:org.json/json/20180813</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsr305/3.0.2_1</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.8.1_1</bundle>

--- a/bundles/org.openhab.persistence.dynamodb/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/feature/feature.xml
@@ -6,7 +6,7 @@
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.dynamodb/${project.version}</bundle>
-		<configfile finalname="${openhab.conf}/services/dynamodb.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/dynamodb</configfile>
+		<configfile finalname="${openhab.conf}/services/dynamodb.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/dynamodb</configfile>
 	</feature>
 
 </features>

--- a/bundles/org.openhab.persistence.influxdb/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.influxdb/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-persistence-influxdb" description="InfluxDB Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.influxdb/${project.version}</bundle>
-		<configfile finalname="${openhab.conf}/services/influxdb.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/influxdb</configfile>
+		<configfile finalname="${openhab.conf}/services/influxdb.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/influxdb</configfile>
 	</feature>
 
 </features>

--- a/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jdbc/src/main/feature/feature.xml
@@ -4,49 +4,49 @@
 
 	<!-- JDBC Persistence for: Apache Derby, H2, HSQLDB, MariaDB, MySQL, PostgreSQL, SQLite -->
 	<feature name="openhab-persistence-jdbc-derby" description="JDBC Persistence Apache Derby" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.apache.derby/derbyclient/10.12.1.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-h2" description="JDBC Persistence H2" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:com.h2database/h2/1.4.191</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-hsqldb" description="JDBC Persistence HSQLDB" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.hsqldb/hsqldb/2.3.3</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-mariadb" description="JDBC Persistence MariaDB" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.mariadb.jdbc/mariadb-java-client/1.4.6</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:mysql/mysql-connector-java/8.0.22</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-postgresql" description="JDBC Persistence PostgreSQL" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.postgresql/postgresql/9.4.1212</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-persistence-jdbc-sqlite" description="JDBC Persistence SQLite" version="${project.version}">
-		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+		<configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jdbc</configfile>
 		<feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.xerial/sqlite-jdbc/3.16.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jdbc/${project.version}</bundle>

--- a/bundles/org.openhab.persistence.jpa/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.jpa/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-persistence-jpa" description="JPA Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.jpa/${project.version}</bundle>
-		<configfile finalname="${openhab.conf}/services/jpa.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jpa</configfile>
+		<configfile finalname="${openhab.conf}/services/jpa.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/jpa</configfile>
 	</feature>
 
 </features>

--- a/bundles/org.openhab.persistence.rrd4j/src/main/feature/feature.xml
+++ b/bundles/org.openhab.persistence.rrd4j/src/main/feature/feature.xml
@@ -5,7 +5,7 @@
 	<feature name="openhab-persistence-rrd4j" description="RRD4j Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.persistence.rrd4j/${project.version}</bundle>
-		<configfile finalname="${openhab.conf}/services/rrd4j.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/rrd4j</configfile>
+		<configfile finalname="${openhab.conf}/services/rrd4j.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/rrd4j</configfile>
 	</feature>
 
 </features>

--- a/bundles/org.openhab.transform.exec/src/main/feature/feature.xml
+++ b/bundles/org.openhab.transform.exec/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-transformation-exec" description="Exec Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<configfile finalname="${openhab.conf}/misc/exec.whitelist" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/exec.whitelist</configfile>
+		<configfile finalname="${openhab.conf}/misc/exec.whitelist" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/exec.whitelist</configfile>
 		<bundle start-level="75">mvn:org.openhab.addons.bundles/org.openhab.transform.exec/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.voice.voicerss/src/main/feature/feature.xml
+++ b/bundles/org.openhab.voice.voicerss/src/main/feature/feature.xml
@@ -4,7 +4,7 @@
 
 	<feature name="openhab-voice-voicerss" description="VoiceRSS Text-to-Speech" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
-		<configfile finalname="${openhab.conf}/services/voicerss.cfg" override="false">mvn:${project.groupId}/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/voicerss</configfile>
+		<configfile finalname="${openhab.conf}/services/voicerss.cfg" override="false">mvn:org.openhab.addons.features.karaf/org.openhab.addons.features.karaf.openhab-addons-external/${project.version}/cfg/voicerss</configfile>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.voice.voicerss/${project.version}</bundle>
 	</feature>
 </features>


### PR DESCRIPTION
The groupId variable results in the wrong configfile GAV when building a single KAR with `karaf:kar` for an add-on.