### PR TITLE
[openwebnet] Move to io.github.openwebnet4j 0.4.1 from Maven Central

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -21,9 +21,9 @@
   <dependencies>
 
     <dependency>
-      <groupId>com.github.openwebnet4j</groupId>
+      <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.1</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Move to new openwebnet4j lib version 0.4.1 published on Maven Central instead of JCenter (Fixes #10395).
New groupId for the lib is `io.github.openwebnet4j`.
The new lib also Fixes #10298.