### PR TITLE
[velux] fix 'required' tag change again

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.velux/src/main/resources/OH-INF/config/config.xml
@@ -39,10 +39,9 @@
 			<!-- Velux Bridge factory default -->
 			<default>velux123</default>
 		</parameter>
-		<parameter name="timeoutMsecs" type="integer" min="500" step="1" max="10000">
+		<parameter name="timeoutMsecs" type="integer" min="500" step="1" max="10000" required="false">
 			<label>@text/config.velux.bridge.timeoutMsecs.label</label>
 			<description>@text/config.velux.bridge.timeoutMsecs.description</description>
-			<required>false</required>
 			<default>3000</default>
 			<advanced>true</advanced>
 		</parameter>


### PR DESCRIPTION
Unfortunately #10119 over wrote a change that @lolodomo had made in #10362 so this PR merges the two fixes again.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>