### PR TITLE
[pulseaudio] Add pulseaudio sink as openhab audio sink (#1895)

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -6,7 +6,7 @@ This binding integrates pulseaudio devices.
 
 The Pulseaudio bridge is required as a "bridge" for accessing any other Pulseaudio devices.
 
-You need a running pulseaudio server whith module **module-cli-protocol-tcp** loaded and accessible by the server which runs your openHAB instance. The following pulseaudio devices are supported:
+You need a running pulseaudio server with module **module-cli-protocol-tcp** loaded and accessible by the server which runs your openHAB instance. The following pulseaudio devices are supported:
 
 *   Sink
 *   Source
@@ -34,6 +34,12 @@ All devices support some of the following channels:
 | state           | String    | Current state of the device (suspended, idle, running, corked, drained) |
 | slaves          | String    | Slave sinks of a combined sink                                          |
 | routeToSink     | String    | Shows the sink a sink-input is currently routed to                      |
+
+## Audio sink
+
+Sink things can register themselves as audio sink in openHAB. MP3 and WAV files are supported.
+Use the appropriate parameter in the sink thing to activate this possibility.
+This requires the module **module-simple-protocol-tcp** loaded and accessible by the server which runs your openHAB instance.
 
 ## Full Example
 ### pulseaudio.things

--- a/bundles/org.openhab.binding.pulseaudio/README.md
+++ b/bundles/org.openhab.binding.pulseaudio/README.md
@@ -38,15 +38,15 @@ All devices support some of the following channels:
 ## Audio sink
 
 Sink things can register themselves as audio sink in openHAB. MP3 and WAV files are supported.
-Use the appropriate parameter in the sink thing to activate this possibility.
-This requires the module **module-simple-protocol-tcp** loaded and accessible by the server which runs your openHAB instance.
+Use the appropriate parameter in the sink thing to activate this possibility (activateSimpleProtocolSink).
+This requires the module **module-simple-protocol-tcp** to be present on the server which runs your openHAB instance. The binding will try to command (if not discovered first) the load of this module on the pulseaudio server.
 
 ## Full Example
 ### pulseaudio.things
 ```
 Bridge pulseaudio:bridge:<bridgname> "<Bridge Label>" @ "<Room>" [ host="<ipAddress>", port=4712 ] {
   Things:
-  	Thing sink          multiroom       "Snapcast"           @ "Room"       [name="alsa_card.pci-0000_00_1f.3"] // this name corresponds to pactl list-sinks output
+  	Thing sink          multiroom       "Snapcast"           @ "Room"       [name="alsa_card.pci-0000_00_1f.3", activateSimpleProtocolSink="true", simpleProtocolSinkPort="4711"] // the name corresponds to pactl list-sinks output
 	Thing source        microphone      "microphone"         @ "Room"       [name="alsa_input.pci-0000_00_14.2.analog-stereo"]
 	Thing sink-input    openhabTTS      "OH-Voice"           @ "Room"       [name="alsa_output.pci-0000_00_1f.3.hdmi-stereo-extra1"]
 	Thing source-output remotePulseSink "Other Room Speaker" @ "Other Room" [name="alsa_input.pci-0000_00_14.2.analog-stereo"]

--- a/bundles/org.openhab.binding.pulseaudio/pom.xml
+++ b/bundles/org.openhab.binding.pulseaudio/pom.xml
@@ -14,4 +14,25 @@
 
   <name>openHAB Add-ons :: Bundles :: Pulseaudio Binding</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.googlecode.soundlibs</groupId>
+      <artifactId>mp3spi</artifactId>
+      <version> 1.9.5.4</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.soundlibs</groupId>
+      <artifactId>jlayer</artifactId>
+      <version>1.0.1.4</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.soundlibs</groupId>
+      <artifactId>tritonus-share</artifactId>
+      <version>0.3.7.4</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/bundles/org.openhab.binding.pulseaudio/pom.xml
+++ b/bundles/org.openhab.binding.pulseaudio/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.googlecode.soundlibs</groupId>
       <artifactId>mp3spi</artifactId>
-      <version> 1.9.5.4</version>
+      <version>1.9.5.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/feature/feature.xml
@@ -7,5 +7,8 @@
 		<feature>openhab-transport-mdns</feature>
 		<feature>openhab-transport-upnp</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.pulseaudio/${project.version}</bundle>
+		<bundle dependency="true">mvn:com.googlecode.soundlibs/tritonus-share/0.3.7.4</bundle>
+		<bundle dependency="true">mvn:com.googlecode.soundlibs/mp3spi/1.9.5.4</bundle>
+		<bundle dependency="true">mvn:com.googlecode.soundlibs/jlayer/1.0.1.4</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSink.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.pulseaudio.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import javazoom.spi.mpeg.sampled.convert.MpegFormatConversionProvider;
+import javazoom.spi.mpeg.sampled.file.MpegAudioFileReader;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.UnsupportedAudioFileException;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.pulseaudio.internal.handler.PulseaudioHandler;
+import org.openhab.core.audio.AudioFormat;
+import org.openhab.core.audio.AudioSink;
+import org.openhab.core.audio.AudioStream;
+import org.openhab.core.audio.FixedLengthAudioStream;
+import org.openhab.core.audio.UnsupportedAudioFormatException;
+import org.openhab.core.audio.UnsupportedAudioStreamException;
+import org.openhab.core.library.types.PercentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The audio sink for openhab, implemented by a connection to a pulseaudio sink
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ *
+ */
+public class PulseAudioAudioSink implements AudioSink {
+
+    private final Logger logger = LoggerFactory.getLogger(PulseAudioAudioSink.class);
+
+    private static final HashSet<AudioFormat> SUPPORTED_FORMATS = new HashSet<>();
+    private static final HashSet<Class<? extends AudioStream>> SUPPORTED_STREAMS = new HashSet<>();
+
+    private PulseaudioHandler pulseaudioHandler;
+
+    private Socket clientSocket;
+
+    static {
+        SUPPORTED_FORMATS.add(AudioFormat.WAV);
+        SUPPORTED_FORMATS.add(AudioFormat.MP3);
+        SUPPORTED_STREAMS.add(FixedLengthAudioStream.class);
+    }
+
+    public PulseAudioAudioSink(PulseaudioHandler pulseaudioHandler) {
+        this.pulseaudioHandler = pulseaudioHandler;
+    }
+
+    @Override
+    public String getId() {
+        return pulseaudioHandler.getThing().getUID().toString();
+    }
+
+    @Override
+    public @Nullable String getLabel(@Nullable Locale locale) {
+        return pulseaudioHandler.getThing().getLabel();
+    }
+
+    /**
+     * Convert MP3 to PCM, as this is the only possible format
+     *
+     * @param input
+     * @return
+     */
+    private InputStream getPCMStreamFromMp3Stream(InputStream input) {
+        try {
+            MpegAudioFileReader mpegAudioFileReader = new MpegAudioFileReader();
+            AudioInputStream sourceAIS = mpegAudioFileReader.getAudioInputStream(input);
+            javax.sound.sampled.AudioFormat sourceFormat = sourceAIS.getFormat();
+
+            MpegFormatConversionProvider mpegconverter = new MpegFormatConversionProvider();
+            javax.sound.sampled.AudioFormat convertFormat = new javax.sound.sampled.AudioFormat(
+                    javax.sound.sampled.AudioFormat.Encoding.PCM_SIGNED, sourceFormat.getSampleRate(), 16,
+                    sourceFormat.getChannels(), sourceFormat.getChannels() * 2, sourceFormat.getSampleRate(), false);
+
+            return mpegconverter.getAudioInputStream(convertFormat, sourceAIS);
+
+        } catch (IOException | UnsupportedAudioFileException e) {
+            logger.error("Cannot convert this mp3 stream to pcm stream", e);
+        }
+        return null;
+    }
+
+    /**
+     * Connect to pulseaudio with the simple protocol
+     *
+     * @throws UnknownHostException
+     * @throws IOException
+     */
+    private void connectIfNeeded() throws IOException {
+        if (clientSocket == null || !clientSocket.isConnected() || clientSocket.isClosed()) {
+            String host = pulseaudioHandler.getHost();
+            int port = pulseaudioHandler.getSimpleTcpPort();
+            clientSocket = new Socket(host, port);
+            clientSocket.setSoTimeout(500);
+        }
+    }
+
+    /**
+     * Disconnect the socket to pulseaudio simple protocol
+     */
+    public void disconnect() {
+        if (clientSocket == null) {
+            try {
+                clientSocket.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    @Override
+    public void process(@Nullable AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+
+        if (audioStream == null) {
+            return;
+        }
+
+        InputStream audioInputStream = null;
+        try {
+
+            if (AudioFormat.MP3.isCompatible(audioStream.getFormat())) {
+                audioInputStream = getPCMStreamFromMp3Stream(audioStream);
+            } else if (AudioFormat.WAV.isCompatible(audioStream.getFormat())) {
+                audioInputStream = audioStream;
+            } else {
+                throw new UnsupportedAudioFormatException("pulseaudio audio sink can only play pcm or mp3 stream",
+                        audioStream.getFormat());
+            }
+
+            try {
+                connectIfNeeded();
+                // send raw audio to the socket and to pulse audio
+                audioInputStream.transferTo(clientSocket.getOutputStream());
+            } catch (IOException e) {
+                logger.error("Error while trying to send audio to pulseaudio audio sink. Cannot connect to {} : {}",
+                        pulseaudioHandler.getHost(), pulseaudioHandler.getSimpleTcpPort());
+            }
+        } finally {
+            try {
+                if (audioInputStream != null) {
+                    audioInputStream.close();
+                }
+                ;
+                audioStream.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    @Override
+    public Set<AudioFormat> getSupportedFormats() {
+        return SUPPORTED_FORMATS;
+    }
+
+    @Override
+    public Set<Class<? extends AudioStream>> getSupportedStreams() {
+        return SUPPORTED_STREAMS;
+    }
+
+    @Override
+    public PercentType getVolume() {
+        return new PercentType(pulseaudioHandler.getLastVolume());
+    }
+
+    @Override
+    public void setVolume(PercentType volume) {
+        pulseaudioHandler.setVolume(volume.intValue());
+    }
+}

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
@@ -51,6 +51,8 @@ public class PulseaudioBindingConstants {
     public static final String BRIDGE_PARAMETER_REFRESH_INTERVAL = "refresh";
 
     public static final String DEVICE_PARAMETER_NAME = "name";
+    public static final String DEVICE_PARAMETER_AUDIO_SINK_ACTIVATION = "activateSimpleProtocolSink";
+    public static final String DEVICE_PARAMETER_AUDIO_SINK_PORT = "simpleProtocolSinkPort";
 
     public static final Map<String, Boolean> TYPE_FILTERS = new HashMap<>();
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
@@ -54,6 +54,9 @@ public class PulseaudioBindingConstants {
     public static final String DEVICE_PARAMETER_AUDIO_SINK_ACTIVATION = "activateSimpleProtocolSink";
     public static final String DEVICE_PARAMETER_AUDIO_SINK_PORT = "simpleProtocolSinkPort";
 
+    public static final String MODULE_SIMPLE_PROTOCOL_TCP_NAME = "module-simple-protocol-tcp";
+    public static final int MODULE_SIMPLE_PROTOCOL_TCP_DEFAULT_PORT = 4711;
+
     public static final Map<String, Boolean> TYPE_FILTERS = new HashMap<>();
 
     static {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -388,9 +388,10 @@ public class PulseaudioClient {
      * @param item the sink we are searching for
      * @param simpleTcpPortPref the port to use if we have to load the module
      * @return the port on which the module is listening
+     * @throws InterruptedException
      */
     public Optional<Integer> loadModuleSimpleProtocolTcpIfNeeded(AbstractAudioDeviceConfig item,
-            Integer simpleTcpPortPref) {
+            Integer simpleTcpPortPref) throws InterruptedException {
         int currentTry = 0;
         int simpleTcpPortToTry = simpleTcpPortPref;
         do {
@@ -403,11 +404,7 @@ public class PulseaudioClient {
                         + simpleTcpPortToTry);
                 simpleTcpPortToTry = new Random().nextInt(64512) + 1024; // a random port above 1024
             }
-            try { // let time for the module to load
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-            }
-
+            Thread.sleep(100);
             currentTry++;
         } while (currentTry < 3);
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -141,28 +141,30 @@ public class PulseaudioClient {
     /**
      * updates the item states and their relationships
      */
-    public void update() {
-        modules.clear();
-        modules.addAll(Parser.parseModules(listModules()));
+    public synchronized void update() {
+        // one step copy
+        modules = new ArrayList<Module>(Parser.parseModules(listModules()));
 
-        items.clear();
+        List<AbstractAudioDeviceConfig> newItems = new ArrayList<>(); // prepare new list before assigning it
+        newItems.clear();
         if (Optional.ofNullable(TYPE_FILTERS.get(SINK_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sinks");
-            items.addAll(Parser.parseSinks(listSinks(), this));
+            newItems.addAll(Parser.parseSinks(listSinks(), this));
         }
         if (Optional.ofNullable(TYPE_FILTERS.get(SOURCE_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sources");
-            items.addAll(Parser.parseSources(listSources(), this));
+            newItems.addAll(Parser.parseSources(listSources(), this));
         }
         if (Optional.ofNullable(TYPE_FILTERS.get(SINK_INPUT_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sink-inputs");
-            items.addAll(Parser.parseSinkInputs(listSinkInputs(), this));
+            newItems.addAll(Parser.parseSinkInputs(listSinkInputs(), this));
         }
         if (Optional.ofNullable(TYPE_FILTERS.get(SOURCE_OUTPUT_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading source-outputs");
-            items.addAll(Parser.parseSourceOutputs(listSourceOutputs(), this));
+            newItems.addAll(Parser.parseSourceOutputs(listSourceOutputs(), this));
         }
-        logger.debug("Pulseaudio server {}: {} modules and {} items updated", host, modules.size(), items.size());
+        logger.debug("Pulseaudio server {}: {} modules and {} items updated", host, modules.size(), newItems.size());
+        items = newItems;
     }
 
     private String listModules() {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioClient.java
@@ -24,6 +24,7 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.openhab.binding.pulseaudio.internal.cli.Parser;
 import org.openhab.binding.pulseaudio.internal.items.AbstractAudioDeviceConfig;
@@ -143,19 +144,19 @@ public class PulseaudioClient {
         modules.addAll(Parser.parseModules(listModules()));
 
         items.clear();
-        if (TYPE_FILTERS.get(SINK_THING_TYPE.getId())) {
+        if (Optional.ofNullable(TYPE_FILTERS.get(SINK_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sinks");
             items.addAll(Parser.parseSinks(listSinks(), this));
         }
-        if (TYPE_FILTERS.get(SOURCE_THING_TYPE.getId())) {
+        if (Optional.ofNullable(TYPE_FILTERS.get(SOURCE_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sources");
             items.addAll(Parser.parseSources(listSources(), this));
         }
-        if (TYPE_FILTERS.get(SINK_INPUT_THING_TYPE.getId())) {
+        if (Optional.ofNullable(TYPE_FILTERS.get(SINK_INPUT_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading sink-inputs");
             items.addAll(Parser.parseSinkInputs(listSinkInputs(), this));
         }
-        if (TYPE_FILTERS.get(SOURCE_OUTPUT_THING_TYPE.getId())) {
+        if (Optional.ofNullable(TYPE_FILTERS.get(SOURCE_OUTPUT_THING_TYPE.getId())).orElse(false)) {
             logger.debug("reading source-outputs");
             items.addAll(Parser.parseSourceOutputs(listSourceOutputs(), this));
         }
@@ -404,13 +405,14 @@ public class PulseaudioClient {
      *            values from 0 - 100)
      */
     public void setVolumePercent(AbstractAudioDeviceConfig item, int vol) {
+        int volumeToSet = vol;
         if (item == null) {
             return;
         }
-        if (vol <= 100) {
-            vol = toAbsoluteVolume(vol);
+        if (volumeToSet <= 100) {
+            volumeToSet = toAbsoluteVolume(volumeToSet);
         }
-        setVolume(item, vol);
+        setVolume(item, volumeToSet);
     }
 
     /**

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
@@ -99,18 +99,22 @@ public class PulseaudioHandlerFactory extends BaseThingHandlerFactory {
             discoveryServiceReg.get(thingHandler).unregister();
             discoveryServiceReg.remove(thingHandler);
         }
+
         super.removeHandler(thingHandler);
     }
 
     @Override
     protected ThingHandler createHandler(Thing thing) {
+
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
         if (PulseaudioBridgeHandler.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
             PulseaudioBridgeHandler handler = new PulseaudioBridgeHandler((Bridge) thing);
             registerDeviceDiscoveryService(handler);
             return handler;
         } else if (PulseaudioHandler.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
-            return new PulseaudioHandler(thing);
+            PulseaudioHandler pulseaudioHandler = new PulseaudioHandler(thing, bundleContext);
+            return pulseaudioHandler;
         }
 
         return null;

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioHandlerFactory.java
@@ -92,14 +92,14 @@ public class PulseaudioHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected void removeHandler(ThingHandler thingHandler) {
-        if (this.discoveryServiceReg.containsKey(thingHandler)) {
+        ServiceRegistration<?> serviceRegistration = this.discoveryServiceReg.get(thingHandler);
+        if (serviceRegistration != null) {
             PulseaudioDeviceDiscoveryService service = (PulseaudioDeviceDiscoveryService) bundleContext
-                    .getService(discoveryServiceReg.get(thingHandler).getReference());
+                    .getService(serviceRegistration.getReference());
             service.deactivate();
-            discoveryServiceReg.get(thingHandler).unregister();
-            discoveryServiceReg.remove(thingHandler);
+            serviceRegistration.unregister();
         }
-
+        discoveryServiceReg.remove(thingHandler);
         super.removeHandler(thingHandler);
     }
 
@@ -113,8 +113,7 @@ public class PulseaudioHandlerFactory extends BaseThingHandlerFactory {
             registerDeviceDiscoveryService(handler);
             return handler;
         } else if (PulseaudioHandler.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
-            PulseaudioHandler pulseaudioHandler = new PulseaudioHandler(thing, bundleContext);
-            return pulseaudioHandler;
+            return new PulseaudioHandler(thing, bundleContext);
         }
 
         return null;

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/cli/Parser.java
@@ -135,15 +135,18 @@ public class Parser {
                     }
                 }
                 if (properties.containsKey("muted")) {
-                    sink.setMuted(properties.get("muted").equalsIgnoreCase("yes"));
+                    sink.setMuted("yes".equalsIgnoreCase(properties.get("muted")));
                 }
                 if (properties.containsKey("volume")) {
                     sink.setVolume(Integer.valueOf(parseVolume(properties.get("volume"))));
                 }
                 if (properties.containsKey("combine.slaves")) {
                     // this is a combined sink, the combined sink object should be
-                    for (String sinkName : properties.get("combine.slaves").replace("\"", "").split(",")) {
-                        sink.addCombinedSinkName(sinkName);
+                    String sinkNames = properties.get("combine.slaves");
+                    if (sinkNames != null) {
+                        for (String sinkName : sinkNames.replace("\"", "").split(",")) {
+                            sink.addCombinedSinkName(sinkName);
+                        }
                     }
                     combinedSinks.add(sink);
                 }
@@ -203,7 +206,7 @@ public class Parser {
                     }
                 }
                 if (properties.containsKey("muted")) {
-                    item.setMuted(properties.get("muted").equalsIgnoreCase("yes"));
+                    item.setMuted("yes".equalsIgnoreCase(properties.get("muted")));
                 }
                 if (properties.containsKey("volume")) {
                     item.setVolume(Integer.valueOf(parseVolume(properties.get("volume"))));
@@ -262,7 +265,7 @@ public class Parser {
                     }
                 }
                 if (properties.containsKey("muted")) {
-                    source.setMuted(properties.get("muted").equalsIgnoreCase("yes"));
+                    source.setMuted("yes".equalsIgnoreCase(properties.get("muted")));
                 }
                 if (properties.containsKey("volume")) {
                     source.setVolume(parseVolume(properties.get("volume")));
@@ -322,7 +325,7 @@ public class Parser {
                     }
                 }
                 if (properties.containsKey("muted")) {
-                    item.setMuted(properties.get("muted").equalsIgnoreCase("yes"));
+                    item.setMuted("yes".equalsIgnoreCase(properties.get("muted")));
                 }
                 if (properties.containsKey("volume")) {
                     item.setVolume(Integer.valueOf(parseVolume(properties.get("volume"))));

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/discovery/PulseaudioDiscoveryParticipant.java
@@ -73,7 +73,6 @@ public class PulseaudioDiscoveryParticipant implements MDNSDiscoveryParticipant 
                 }
                 return result;
             } catch (IOException e) {
-                result = null;
             }
         }
         return result;

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
@@ -155,7 +155,9 @@ public class PulseaudioBridgeHandler extends BaseBridgeHandler {
 
     @Override
     public void dispose() {
-        pollingJob.cancel(true);
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+        }
         client.disconnect();
         super.dispose();
     }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioBridgeHandler.java
@@ -158,7 +158,9 @@ public class PulseaudioBridgeHandler extends BaseBridgeHandler {
         if (pollingJob != null) {
             pollingJob.cancel(true);
         }
-        client.disconnect();
+        if (client != null) {
+            client.disconnect();
+        }
         super.dispose();
     }
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -317,7 +317,12 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
 
     @SuppressWarnings("null")
     public String getHost() {
-        return (String) getBridge().getConfiguration().get(PulseaudioBindingConstants.BRIDGE_PARAMETER_HOST);
+        if (getBridge() != null) {
+            return (String) getBridge().getConfiguration().get(PulseaudioBindingConstants.BRIDGE_PARAMETER_HOST);
+        } else {
+            logger.error("A bridge must be configured for this pulseaudio thing");
+            return "null";
+        }
     }
 
     public int getSimpleTcpPort() {

--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -14,18 +14,25 @@ package org.openhab.binding.pulseaudio.internal.handler;
 
 import static org.openhab.binding.pulseaudio.internal.PulseaudioBindingConstants.*;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.openhab.binding.pulseaudio.internal.PulseAudioAudioSink;
+import org.openhab.binding.pulseaudio.internal.PulseaudioBindingConstants;
 import org.openhab.binding.pulseaudio.internal.items.AbstractAudioDeviceConfig;
 import org.openhab.binding.pulseaudio.internal.items.Sink;
 import org.openhab.binding.pulseaudio.internal.items.SinkInput;
+import org.openhab.core.audio.AudioSink;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
@@ -44,6 +51,8 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +77,17 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
 
     private String name;
 
-    public PulseaudioHandler(Thing thing) {
+    private PulseAudioAudioSink audioSink;
+
+    private Integer savedVolume;
+
+    private Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
+
+    private BundleContext bundleContext;
+
+    public PulseaudioHandler(Thing thing, BundleContext bundleContext) {
         super(thing);
+        this.bundleContext = bundleContext;
     }
 
     @Override
@@ -80,6 +98,23 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
         // until we get an update put the Thing offline
         updateStatus(ThingStatus.OFFLINE);
         deviceOnlineWatchdog();
+
+        // if it's a SINK thing, then maybe we have to activate the audio sink
+        if (PulseaudioBindingConstants.SINK_THING_TYPE.equals(thing.getThingTypeUID())) {
+            // check the property to see if we it's enabled :
+            Boolean sinkActivated = (Boolean) thing.getConfiguration()
+                    .get(PulseaudioBindingConstants.DEVICE_PARAMETER_AUDIO_SINK_ACTIVATION);
+            if (sinkActivated != null && sinkActivated) {
+                // Register the sink as an audio sink in openhab
+                logger.trace("Registering an audio sink for pulse audio sink thing {}", thing.getUID());
+                PulseAudioAudioSink audioSink = new PulseAudioAudioSink(this);
+                setAudioSink(audioSink);
+                @SuppressWarnings("unchecked")
+                ServiceRegistration<AudioSink> reg = (ServiceRegistration<AudioSink>) bundleContext
+                        .registerService(AudioSink.class.getName(), audioSink, new Hashtable<>());
+                audioSinkRegistrations.put(thing.getUID().toString(), reg);
+            }
+        }
     }
 
     @Override
@@ -92,6 +127,13 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
         bridgeHandler = null;
         logger.trace("Thing {} {} disposed.", getThing().getUID(), name);
         super.dispose();
+
+        // Unregister the potential pulse audio sink's audio sink
+        ServiceRegistration<AudioSink> reg = audioSinkRegistrations.get(getThing().getUID().toString());
+        if (reg != null) {
+            logger.trace("Unregistering the audio sync service for pulse audio sink thing {}", getThing().getUID());
+            reg.unregister();
+        }
     }
 
     private void deviceOnlineWatchdog() {
@@ -162,15 +204,15 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
                     // refresh to get the current volume level
                     bridge.getClient().update();
                     device = bridge.getDevice(name);
-                    int volume = device.getVolume();
+                    savedVolume = device.getVolume();
                     if (command.equals(IncreaseDecreaseType.INCREASE)) {
-                        volume = Math.min(100, volume + 5);
+                        savedVolume = Math.min(100, savedVolume + 5);
                     }
                     if (command.equals(IncreaseDecreaseType.DECREASE)) {
-                        volume = Math.max(0, volume - 5);
+                        savedVolume = Math.max(0, savedVolume - 5);
                     }
-                    bridge.getClient().setVolumePercent(device, volume);
-                    updateState = new PercentType(volume);
+                    bridge.getClient().setVolumePercent(device, savedVolume);
+                    updateState = new PercentType(savedVolume);
                 } else if (command instanceof PercentType) {
                     DecimalType volume = (DecimalType) command;
                     bridge.getClient().setVolumePercent(device, volume.intValue());
@@ -227,12 +269,37 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
         }
     }
 
+    /**
+     * Use last checked volume for faster access
+     *
+     * @return
+     */
+    public int getLastVolume() {
+        if (savedVolume == null) {
+            PulseaudioBridgeHandler bridge = getPulseaudioBridgeHandler();
+            AbstractAudioDeviceConfig device = bridge.getDevice(name);
+            // refresh to get the current volume level
+            bridge.getClient().update();
+            device = bridge.getDevice(name);
+            savedVolume = device.getVolume();
+        }
+        return savedVolume == null ? 50 : savedVolume;
+    }
+
+    public void setVolume(int volume) {
+        PulseaudioBridgeHandler bridge = getPulseaudioBridgeHandler();
+        AbstractAudioDeviceConfig device = bridge.getDevice(name);
+        bridge.getClient().setVolumePercent(device, volume);
+        updateState(VOLUME_CHANNEL, new PercentType(volume));
+    }
+
     @Override
     public void onDeviceStateChanged(ThingUID bridge, AbstractAudioDeviceConfig device) {
         if (device.getPaName().equals(name)) {
             updateStatus(ThingStatus.ONLINE);
             logger.debug("Updating states of {} id: {}", device, VOLUME_CHANNEL);
-            updateState(VOLUME_CHANNEL, new PercentType(device.getVolume()));
+            savedVolume = device.getVolume();
+            updateState(VOLUME_CHANNEL, new PercentType(savedVolume));
             updateState(MUTE_CHANNEL, device.isMuted() ? OnOffType.ON : OnOffType.OFF);
             updateState(STATE_CHANNEL,
                     device.getState() != null ? new StringType(device.getState().toString()) : new StringType("-"));
@@ -248,11 +315,23 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
         }
     }
 
+    @SuppressWarnings("null")
+    public String getHost() {
+        return (String) getBridge().getConfiguration().get(PulseaudioBindingConstants.BRIDGE_PARAMETER_HOST);
+    }
+
+    public int getSimpleTcpPort() {
+        return ((BigDecimal) getThing().getConfiguration()
+                .get(PulseaudioBindingConstants.DEVICE_PARAMETER_AUDIO_SINK_PORT)).intValue();
+    }
+
     @Override
     public void onDeviceRemoved(PulseaudioBridgeHandler bridge, AbstractAudioDeviceConfig device) {
         if (device.getPaName().equals(name)) {
             bridgeHandler.unregisterDeviceStatusListener(this);
             bridgeHandler = null;
+            audioSink.disconnect();
+            audioSink = null;
             updateStatus(ThingStatus.OFFLINE);
         }
     }
@@ -260,5 +339,9 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
     @Override
     public void onDeviceAdded(Bridge bridge, AbstractAudioDeviceConfig device) {
         logger.trace("new device discovered {} by {}", device, bridge);
+    }
+
+    public void setAudioSink(PulseAudioAudioSink audioSink) {
+        this.audioSink = audioSink;
     }
 }

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
@@ -21,6 +21,18 @@
 				<label>Name</label>
 				<description>The name of one specific device.</description>
 			</parameter>
+			<parameter name="activateSimpleProtocolSink" type="boolean">
+				<label>Sink by simple-protocol-tcp</label>
+				<description>Activation of a corresponding sink in openHAB (needs module-simple-protocol-tcp loaded on the server)</description>
+				<default>false</default>
+				<required>false</required>
+			</parameter>
+			<parameter name="simpleProtocolSinkPort" type="integer">
+				<label>Simple protocol port</label>
+				<description>Port of the module-simple-protocol-tcp listening for this sink</description>
+				<default>4711</default>
+				<required>false</required>
+			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
@@ -21,17 +21,15 @@
 				<label>Name</label>
 				<description>The name of one specific device.</description>
 			</parameter>
-			<parameter name="activateSimpleProtocolSink" type="boolean">
+			<parameter name="activateSimpleProtocolSink" type="boolean" required="false">
 				<label>Sink by simple-protocol-tcp</label>
 				<description>Activation of a corresponding sink in openHAB (needs module-simple-protocol-tcp loaded on the server)</description>
 				<default>false</default>
-				<required>false</required>
 			</parameter>
-			<parameter name="simpleProtocolSinkPort" type="integer">
-				<label>Simple protocol port</label>
+			<parameter name="simpleProtocolSinkPort" type="integer" required="false">
+				<label>Simple Protocol Port</label>
 				<description>Port of the module-simple-protocol-tcp listening for this sink</description>
 				<default>4711</default>
-				<required>false</required>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
@@ -10,6 +10,7 @@
 		</supported-bridge-type-refs>
 		<label>A Pulseaudio Sink</label>
 		<description>represents a pulseaudio sink</description>
+		<category>Speaker</category>
 
 		<channels>
 			<channel id="volume" typeId="volume"/>
@@ -22,13 +23,14 @@
 				<description>The name of one specific device.</description>
 			</parameter>
 			<parameter name="activateSimpleProtocolSink" type="boolean" required="false">
-				<label>Sink by simple-protocol-tcp</label>
-				<description>Activation of a corresponding sink in openHAB (needs module-simple-protocol-tcp loaded on the server)</description>
+				<label>Create an Audio Sink with simple-protocol-tcp</label>
+				<description>Activation of a corresponding sink in OpenHAB (module-simple-protocol-tcp must be available on the
+					pulseaudio server)</description>
 				<default>false</default>
 			</parameter>
 			<parameter name="simpleProtocolSinkPort" type="integer" required="false">
 				<label>Simple Protocol Port</label>
-				<description>Port of the module-simple-protocol-tcp listening for this sink</description>
+				<description>Default Port to allocate for use by module-simple-protocol-tcp on the pulseaudio server</description>
 				<default>4711</default>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
Add to the pulseaudio binding the capability to use "pulseaudio sink" as an "openhab sink" to output sound from openhab to a pulse audio server on the network.
You need to load module-simple-protocol-tcp sink in addition to the usual module-cli-protocol-tcp, and enable the sink in the thing configuration

Binding release : 
https://github.com/dalgwen/openhab-addons/releases/tag/3.1.0-SNAPSHOT-Audiosink

Closes #1895

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>
