### PR TITLE
[comfoair] Update README.md

### DIFF
--- a/bundles/org.openhab.binding.comfoair/README.md
+++ b/bundles/org.openhab.binding.comfoair/README.md
@@ -4,6 +4,8 @@ This binding allows to monitor and control Zehnder ComfoAir serial controlled ve
 Though the binding is developed based on the protocol description for Zehnder ComfoAir devices it should also work for mostly identical systems from different manufacturers, like StorkAir WHR930, Wernig G90-380 and Paul Santos 370 DC.
 It was also successfully tested on a Wernig G90-160.
 
+!!! This binding does not work on the ComfoAir Q-series (Q350 / Q450). These ventilation units use a CAN bus for communication, see the zcan or ComfoConnect projects for integration !!!
+
 ### Limitations
 
 * Either the ComfoAir binding or the CCEase Comfocontrol can be active, but not together.

--- a/bundles/org.openhab.binding.comfoair/README.md
+++ b/bundles/org.openhab.binding.comfoair/README.md
@@ -4,7 +4,7 @@ This binding allows to monitor and control Zehnder ComfoAir serial controlled ve
 Though the binding is developed based on the protocol description for Zehnder ComfoAir devices it should also work for mostly identical systems from different manufacturers, like StorkAir WHR930, Wernig G90-380 and Paul Santos 370 DC.
 It was also successfully tested on a Wernig G90-160.
 
-!!! This binding does not work on the ComfoAir Q-series (Q350 / Q450). These ventilation units use a CAN bus for communication, see the zcan or ComfoConnect projects for integration !!!
+**NOTE:** This binding does not work with the ComfoAir Q-series (e.g. Q350 or Q450). These ventilation units use a CAN bus for communication and a different protocol.
 
 ### Limitations
 


### PR DESCRIPTION
This binding supports RS232 communication to ComfoAir 350 series, such as the ComfoAir 350 Luxe.

Zehnder has released a new ComfoAir Q-series. These units are confusingly named "ComfoAir Q350". They also offer an RJ45 jack, but use CAN bus signaling to communicate (*not* RS232).
There should be a message warning users about this, before they try to fit square pegs in round holes (such as I did, it was a frustrating experience).