### PR TITLE
[enocean] Update Enocean ser2net documentation

### DIFF
--- a/bundles/org.openhab.binding.enocean/README.md
+++ b/bundles/org.openhab.binding.enocean/README.md
@@ -14,7 +14,7 @@ First of all you have to configure an EnOcean transceiver (gateway).
 A directly connected USB300 can be auto discovered, an EnOceanPi has to be added manually to openHAB.
 Both gateways are represented by an _EnOcean gateway_ in openHAB.
 If you want to place the gateway for better reception apart from your openHAB server, you can forward its serial messages over TCP/IP (_ser2net_).
-In this case you have to define the path to the gateway like this rfc2217://x.x.x.x:3001.
+In this case you have to define the path to the gateway like this rfc2217://x.x.x.x:3001. When using _ser2net_ make sure to use _telnet_  instead of _raw_ in the _set2net_ config file.
 If everything is running fine you should see the _base id_ of your gateway in the properties of your bridge.
 
 Another way to improve sending and reception reliability is to setup a wired connection.


### PR DESCRIPTION
# Update Enocean ser2net documentation

This PR clarifies how to use the enocean binding with `ser2net`. Most of the setup guides for `ser2net` and `enocean` use `raw` as configuration parameter. 
Openhab however requires `telnet`, otherwise the binding will simply not work / stuck at `getting base id`.

By adding this sentence it makes it immediately clear that a different configuration for `ser2net` is required.