### PR TITLE
[Onkyo] - Add audio info channel

### DIFF
--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBindingConstants.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBindingConstants.java
@@ -73,6 +73,7 @@ public class OnkyoBindingConstants {
     public static final String CHANNEL_ALBUM_ART = "player#albumArt";
     public static final String CHANNEL_ALBUM_ART_URL = "player#albumArtUrl";
     public static final String CHANNEL_LISTENMODE = "player#listenmode";
+    public static final String CHANNEL_AUDIOINFO = "player#audioinfo";
     public static final String CHANNEL_PLAY_URI = "player#playuri";
 
     public static final String CHANNEL_NET_MENU_TITLE = "netmenu#title";

--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/eiscp/EiscpCommand.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/eiscp/EiscpCommand.java
@@ -38,6 +38,9 @@ public enum EiscpCommand {
     VOLUME_SET("MVL", "%02X"),
     VOLUME("MVL", ""),
 
+    AUDIOINFO("IFA", ""),
+    AUDIOINFO_QUERY("IFA", "QSTN"),
+
     SOURCE_UP("SLI", "UP"),
     SOURCE_DOWN("SLI", "DOWN"),
     SOURCE_QUERY("SLI", "QSTN"),

--- a/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
+++ b/bundles/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/handler/OnkyoHandler.java
@@ -324,7 +324,11 @@ public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventList
                     sendCommand(EiscpCommand.NETUSB_TITLE_QUERY);
                 }
                 break;
-
+            case CHANNEL_AUDIOINFO:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.AUDIOINFO_QUERY);
+                }
+                break;
             /*
              * MISC
              */

--- a/bundles/org.openhab.binding.onkyo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.onkyo/src/main/resources/OH-INF/thing/channels.xml
@@ -107,6 +107,11 @@
 		<label>Play URI</label>
 		<description>Plays a given URI</description>
 	</channel-type>
+	<channel-type id="audioinfo" advanced="true">
+		<item-type>String</item-type>
+		<label>Audio Info</label>
+		<description>Audio info - refresh timer must be set for updates</description>
+	</channel-type>
 	<channel-type id="netControl" advanced="true">
 		<item-type>String</item-type>
 		<label>Control</label>


### PR DESCRIPTION
[Onkyo] - Add audio info channel

Addition of 'audio info' channel to the thing under the advanced channels. This brings back some of the functionality that we previously had with the pioneer bindings. It allows us to see the audio source type as well as what the audio output format is.

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
