### PR TITLE
[velux] Fix synchronisation of handler initialization and disposal

### DIFF
--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridge.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/VeluxBridge.java
@@ -281,4 +281,13 @@ public abstract class VeluxBridge {
      */
     protected abstract boolean bridgeDirectCommunicate(BridgeCommunicationProtocol communication,
             boolean useAuthentication);
+
+    /**
+     * Check is the last communication was a good one
+     *
+     * @return true if the last communication was a good one
+     */
+    public boolean lastCommunicationOk() {
+        return lastCommunication() != 0 && lastSuccessfulCommunication() == lastCommunication();
+    }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/SClogin.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/SClogin.java
@@ -13,7 +13,6 @@
 package org.openhab.binding.velux.internal.bridge.slip;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.velux.internal.VeluxBindingConstants;
 import org.openhab.binding.velux.internal.bridge.common.Login;
 import org.openhab.binding.velux.internal.bridge.slip.utils.KLF200Response;
 import org.openhab.binding.velux.internal.bridge.slip.utils.Packet;
@@ -112,15 +111,11 @@ class SClogin extends Login implements SlipBridgeCommunicationProtocol {
                 int cfmStatus = responseData.getOneByteValue(0);
                 switch (cfmStatus) {
                     case 0:
-                        logger.info("{} bridge connection successfully established (login succeeded).",
-                                VeluxBindingConstants.BINDING_ID);
-                        logger.debug("setResponse(): returned status: The request was successful.");
+                        logger.debug("setResponse(): bridge connection successfully established (login succeeded).");
                         success = true;
                         break;
                     case 1:
-                        logger.warn("{} bridge connection successfully established but login failed.",
-                                VeluxBindingConstants.BINDING_ID);
-                        logger.debug("setResponse(): returned status: The request failed.");
+                        logger.warn("setResponse(): bridge connection successfully established but login failed.");
                         break;
                     default:
                         logger.warn("setResponse(): returned status={} (not defined).", cfmStatus);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
@@ -210,7 +210,6 @@ class DataInputStreamWithTimeout implements Closeable {
                 Thread.sleep(SLEEP_INTERVAL_MSECS);
             } catch (InterruptedException e) {
                 logger.debug("readSlipMessage() => thread interrupt");
-                throw new IOException("Thread Interrupted");
             }
         }
         logger.debug("readSlipMessage() => no slip message after {}mS => time out", timeoutMSecs);

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
@@ -132,7 +132,10 @@ class DataInputStreamWithTimeout implements Closeable {
                         i = 0;
                     }
                 } catch (SocketTimeoutException e) {
-                    // socket read time outs are OK => keep on polling
+                    // socket read time outs are OK => keep on polling; unless interrupted
+                    if (interrupted) {
+                        break;
+                    }
                     continue;
                 } catch (IOException e) {
                     // any other exception => stop polling

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/DataInputStreamWithTimeout.java
@@ -97,8 +97,8 @@ class DataInputStreamWithTimeout implements Closeable {
             pollException = null;
             slipMessageQueue.clear();
 
-            // loop forever or until externally interrupted
-            while (!Thread.interrupted()) {
+            // loop forever; on shutdown interrupt() gets called to break out of the loop
+            while (true) {
                 try {
                     if (interrupted) {
                         // fully flush the input buffer

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/SSLconnection.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/bridge/slip/io/SSLconnection.java
@@ -116,8 +116,7 @@ class SSLconnection implements Closeable {
      * @throws java.net.UnknownHostException in case of continuous communication I/O failures.
      */
     SSLconnection(VeluxBridgeHandler bridgeInstance) throws ConnectException, IOException, UnknownHostException {
-        logger.debug("SSLconnection() called");
-        logger.info("Starting {} bridge connection.", VeluxBindingConstants.BINDING_ID);
+        logger.debug("Starting {} bridge connection.", VeluxBindingConstants.BINDING_ID);
         SSLContext ctx = null;
         try {
             ctx = SSLContext.getInstance("SSL");

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -187,7 +187,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         } else {
             logger.warn("createHandler({}) failed: ThingHandler not found for {}.", thingTypeUID, thing.getLabel());
         }
-        // updateBindingState();
+        updateBindingState();
         return resultHandler;
     }
 
@@ -209,7 +209,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
             logger.trace("removeHandler() removing thing '{}'.", thingHandler.toString());
             veluxHandlers.remove(thingHandler);
         }
-        // updateBindingState();
+        updateBindingState();
         super.removeHandler(thingHandler);
     }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/factory/VeluxHandlerFactory.java
@@ -34,6 +34,7 @@ import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -63,6 +64,8 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
     private @NonNullByDefault({}) LocaleProvider localeProvider;
     private @NonNullByDefault({}) TranslationProvider i18nProvider;
     private Localization localization = Localization.UNKNOWN;
+
+    private @Nullable static VeluxHandlerFactory activeInstance = null;
 
     // Private
 
@@ -184,7 +187,7 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
         } else {
             logger.warn("createHandler({}) failed: ThingHandler not found for {}.", thingTypeUID, thing.getLabel());
         }
-        updateBindingState();
+        // updateBindingState();
         return resultHandler;
     }
 
@@ -206,7 +209,26 @@ public class VeluxHandlerFactory extends BaseThingHandlerFactory {
             logger.trace("removeHandler() removing thing '{}'.", thingHandler.toString());
             veluxHandlers.remove(thingHandler);
         }
-        updateBindingState();
+        // updateBindingState();
         super.removeHandler(thingHandler);
+    }
+
+    @Override
+    protected void activate(ComponentContext componentContext) {
+        activeInstance = this;
+        super.activate(componentContext);
+    }
+
+    @Override
+    protected void deactivate(ComponentContext componentContext) {
+        activeInstance = null;
+        super.deactivate(componentContext);
+    }
+
+    public static void refreshBindingInfo() {
+        VeluxHandlerFactory instance = VeluxHandlerFactory.activeInstance;
+        if (instance != null) {
+            instance.updateBindingState();
+        }
     }
 }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
@@ -170,7 +170,7 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
             logger.trace("initialize.scheduled(): Setting ThingStatus to ONLINE.");
             updateStatus(ThingStatus.ONLINE);
             updateVisibleInformation();
-            logger.info("Velux Binding Info Thing '{}' is initialized.", getThing().getUID());
+            logger.info("Velux Binding Info Element '{}' is initialized.", getThing().getUID());
         });
         logger.trace("initialize() done.");
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
@@ -156,7 +156,6 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
     @Override
     public void initialize() {
         logger.debug("initialize() called.");
-        logger.info("Initializing VeluxBindingHandler for '{}'.", getThing().getUID());
         // The framework requires you to return from this method quickly.
         // Setting the thing status to UNKNOWN temporarily and let the background task decide for the real status.
         updateStatus(ThingStatus.UNKNOWN);
@@ -171,7 +170,7 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
             logger.trace("initialize.scheduled(): Setting ThingStatus to ONLINE.");
             updateStatus(ThingStatus.ONLINE);
             updateVisibleInformation();
-            logger.trace("initialize.scheduled(): done.");
+            logger.info("Velux Binding Info Thing '{}' is initialized.", getThing().getUID());
         });
         logger.trace("initialize() done.");
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBindingHandler.java
@@ -170,7 +170,7 @@ public class VeluxBindingHandler extends ExtendedBaseThingHandler {
             logger.trace("initialize.scheduled(): Setting ThingStatus to ONLINE.");
             updateStatus(ThingStatus.ONLINE);
             updateVisibleInformation();
-            logger.info("Velux Binding Info Element '{}' is initialized.", getThing().getUID());
+            logger.debug("Velux Binding Info Element '{}' is initialized.", getThing().getUID());
         });
         logger.trace("initialize() done.");
     }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -670,7 +670,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
                         ThingProperty.setValue(this, itemType.getIdentifier(), val);
                     }
                 } else {
-                    logger.info("handleCommandCommsJob({},{}): updating of item {} (type {}) failed.",
+                    logger.warn("handleCommandCommsJob({},{}): updating of item {} (type {}) failed.",
                             channelUID.getAsString(), command, itemName, itemType);
                 }
             }

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -297,7 +297,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
             refreshSchedulerJob();
         }, mSecs, mSecs, TimeUnit.MILLISECONDS);
         VeluxHandlerFactory.refreshBindingInfo();
-        logger.info("Velux Bridge Thing '{}' is initialized (with {} scenes and {} actuators).", getThing().getUID(),
+        logger.info("Velux Bridge '{}' is initialized (with {} scenes and {} actuators).", getThing().getUID(),
                 bridgeParameters.scenes.getChannel().existingScenes.getNoMembers(),
                 bridgeParameters.actuators.getChannel().existingProducts.getNoMembers());
     }
@@ -335,7 +335,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         logger.trace("disposeSchedulerJob(): shut down SLIP connection interface.");
         mySlipBridge.shutdown();
         VeluxHandlerFactory.refreshBindingInfo();
-        logger.info("Velux Bridge Thing '{}' is shut down.", getThing().getUID());
+        logger.info("Velux Bridge '{}' is shut down.", getThing().getUID());
         return true;
     }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -48,6 +48,7 @@ import org.openhab.binding.velux.internal.bridge.json.JsonVeluxBridge;
 import org.openhab.binding.velux.internal.bridge.slip.SlipVeluxBridge;
 import org.openhab.binding.velux.internal.config.VeluxBridgeConfiguration;
 import org.openhab.binding.velux.internal.development.Threads;
+import org.openhab.binding.velux.internal.factory.VeluxHandlerFactory;
 import org.openhab.binding.velux.internal.handler.utils.ExtendedBaseBridgeHandler;
 import org.openhab.binding.velux.internal.handler.utils.Thing2VeluxActuator;
 import org.openhab.binding.velux.internal.handler.utils.ThingProperty;
@@ -300,8 +301,9 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
                         e.getMessage());
             }
         }, mSecs, mSecs, TimeUnit.MILLISECONDS);
-        logger.info("Velux Bridge '{}' initialization completed (with {} scenes and {} actuators).",
-                getThing().getUID(), bridgeParameters.scenes.getChannel().existingScenes.getNoMembers(),
+        VeluxHandlerFactory.refreshBindingInfo();
+        logger.info("Velux Bridge Thing '{}' is initialized (with {} scenes and {} actuators).", getThing().getUID(),
+                bridgeParameters.scenes.getChannel().existingScenes.getNoMembers(),
                 bridgeParameters.actuators.getChannel().existingProducts.getNoMembers());
     }
 
@@ -315,7 +317,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
     /**
      * Various disposal actions to be executed on a background thread
      */
-    private Boolean disposeScheduled() {
+    private synchronized Boolean disposeScheduled() {
         logger.trace("disposeScheduled(): cancel the refresh polling task.");
         ScheduledFuture<?> refreshJob = this.refreshJob;
         if (refreshJob != null) {
@@ -337,7 +339,8 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         myJsonBridge.shutdown();
         logger.trace("disposeScheduled(): shut down SLIP connection interface.");
         mySlipBridge.shutdown();
-        logger.info("Velux Bridge '{}' shut down completed.", getThing().getUID());
+        VeluxHandlerFactory.refreshBindingInfo();
+        logger.info("Velux Bridge Thing '{}' is shut down.", getThing().getUID());
         return true;
     }
 

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -297,7 +297,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
             refreshSchedulerJob();
         }, mSecs, mSecs, TimeUnit.MILLISECONDS);
         VeluxHandlerFactory.refreshBindingInfo();
-        logger.info("Velux Bridge '{}' is initialized (with {} scenes and {} actuators).", getThing().getUID(),
+        logger.debug("Velux Bridge '{}' is initialized (with {} scenes and {} actuators).", getThing().getUID(),
                 bridgeParameters.scenes.getChannel().existingScenes.getNoMembers(),
                 bridgeParameters.actuators.getChannel().existingProducts.getNoMembers());
     }
@@ -335,7 +335,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         logger.trace("disposeSchedulerJob(): shut down SLIP connection interface.");
         mySlipBridge.shutdown();
         VeluxHandlerFactory.refreshBindingInfo();
-        logger.info("Velux Bridge '{}' is shut down.", getThing().getUID());
+        logger.debug("Velux Bridge '{}' is shut down.", getThing().getUID());
         return true;
     }
 
@@ -401,11 +401,11 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
 
         logger.trace("bridgeParamsUpdated(): Fetching existing scenes.");
         bridgeParameters.scenes.getScenes(thisBridge);
-        logger.info("Found Velux scenes:\n\t{}",
+        logger.debug("Found Velux scenes:\n\t{}",
                 bridgeParameters.scenes.getChannel().existingScenes.toString(false, "\n\t"));
         logger.trace("bridgeParamsUpdated(): Fetching existing actuators/products.");
         bridgeParameters.actuators.getProducts(thisBridge);
-        logger.info("Found Velux actuators:\n\t{}",
+        logger.debug("Found Velux actuators:\n\t{}",
                 bridgeParameters.actuators.getChannel().existingProducts.toString(false, "\n\t"));
 
         if (thisBridge.bridgeAPI().setHouseStatusMonitor() != null) {

--- a/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
+++ b/bundles/org.openhab.binding.velux/src/main/java/org/openhab/binding/velux/internal/handler/VeluxBridgeHandler.java
@@ -316,7 +316,7 @@ public class VeluxBridgeHandler extends ExtendedBaseBridgeHandler implements Vel
         logger.trace("disposeSchedulerJob(): cancel the refresh polling job.");
         ScheduledFuture<?> refreshSchedulerJob = this.refreshSchedulerJob;
         if (refreshSchedulerJob != null) {
-            refreshSchedulerJob.cancel(true);
+            refreshSchedulerJob.cancel(false);
         }
         logger.trace("disposeSchedulerJob(): cancel any other scheduled jobs.");
         ExecutorService commsJobExecutor = this.communicationsJobExecutor;


### PR DESCRIPTION
The Velux hub initialization and shutdown processes are very slow and deliberate. And sometimes when OH reloads the binding, it was possible for a newly created `VeluxBridgeHandler` instance's `.initialize()` method to be called before the prior `VeluxBridgeHandler` instance's `.dispose()` method had finished processing i.e. it was attempting to shut down and re-start the hub communication at the same time!

See this [forum post](https://community.openhab.org/t/velux-new-openhab2-binding-feedback-welcome/32926/1259?u=andrewfg)

Therefore this PR introduces the following fixes resp. improvements:
- The `.initialize()` / `.dispose()` methods now defer slow processes to scheduled tasks, so the OH caller thread returns faster.
- The `.initializeScheduled()` method now waits for the Future<> result of a prior `.disposeScheduled()` (if any) before proceeding.
- If a socket timeout occurs during the shut down process, the communication polling loop will exit faster.
- Cleaned up the logging a bit, to eliminate un- needed logger.info() reports, and make others more easily understandable.
- Cleaned up the initialization of the Velux Binding Info thing.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
