### PR TITLE
[espmilighthub] Describe group 0 handling

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -154,7 +154,7 @@ For example:
 | 0xB4CA    | 8        | 0xB4CA8  |
 | 0xB4CA    | 0        | 0xB4CA0  |
 
-## Using the group 0
+## Using Group 0
 
 The group 0 (or ALL group) with the Group ID 0 can be used to control all bulbs that are paired with one specific remote at once.
 While this functionality can also be achieved by using openHAB groups with even greater flexibility, the group 0 must be setup if you want to capture physical remote control events for the ALL group, and keep physical devices synchronized to their openHAB representations.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -163,7 +163,7 @@ If the group 0 has not been setup these events will be lost and your Item states
 If you do not use a remote at all or you only control other bulbs than the ones controlled by openHAB you should not need to setup the ALL group.
 
 Since the group 0 is not needed in every case the autodiscovery feature will not detect this group as a Thing automatically.
-To create the group manually proceed as described in section [Important for Textual Configuration](#important-for-textual-configuration) or use the openHAB 3 MainUI for this purpose.
+To create the group, use textual files or the openHAB UI to manually add a Thing with the correct Unique ID as described in section [Important for Textual Configuration](#important-for-textual-configuration).
 To create a Thing for the group 0 via MainUI simply create a new Thing that has the same type as one of autodiscovered Things of the same remote and modify the ThingUID as described in section linked above (replace the trailing 1-digit number of an autodiscovered ThingUID with a 0).
 
 If you do not need separate group 0 controls in openHAB, but wish to have all the controls for the sub groups update when a physical remote is used, you only need to create the thing for group 0.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -93,6 +93,8 @@ To remove a saved state from your MQTT broker that causes an entry in your INBOX
 mosquitto_pub -u username -P password -p 1883 -t 'milight/states/0x0/rgb_cct/1' -n -r
 ```
 
+Note that the group 0 (or ALL group) is not autodiscovered as a thing and thus has to be added manually if needed (see section [Using the group 0](#using-the-group-0) for details on when and how to do this)
+
 ## Thing Configuration
 
 | Parameter | Description | Required | Default |
@@ -151,6 +153,21 @@ For example:
 | 0xB4CA    | 4        | 0xB4CA4  | 
 | 0xB4CA    | 8        | 0xB4CA8  |
 | 0xB4CA    | 0        | 0xB4CA0  |
+
+## Using the group 0
+
+The group 0 (or ALL group) with the Group ID 0 can be used to control all bulbs that are paired with one specific remote at once.
+While this functionality can also be achieved by using openHAB groups with even greater flexibility the group 0 must be setup if you want to capture remote events for the ALL group to keep physical devices synchronized to their openHAB representations.
+Milight remotes send all commands with the Group ID 0 after the master ON/OFF buttons have been used.
+If the group 0 has not been setup these events will be lost and your Item states will no longer be synchonized with the actual device states until you issue a command via openHAB.
+If you do not use a remote at all or you only control other bulbs than the ones controlled by openHAB you should not need to setup the ALL group.
+
+Since the group 0 is not needed in every case the autodiscovery feature will not detect this group as a Thing automatically.
+To create the group manually proceed as described in section [Important for Textual Configuration](#important-for-textual-configuration) or use the openHAB 3 MainUI for this purpose.
+To create a Thing for the group 0 via MainUI simply create a new Thing that has the same type as one of autodiscovered Things of the same remote and modify the ThingUID as described in section linked above (replace the trailing 1-digit number of an autodiscovered ThingUID with a 0).
+
+If you do not need separate group 0 controls in openHAB, but wish to have all the controls for the sub groups update when a physical remote is used, you only need to create the thing for group 0.
+Only if you want the controls do you need to link any channels and create the items, as creating the thing will subscribe the binding to the MQTT topic for group 0.
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -164,7 +164,7 @@ If you do not use a remote at all or you only control other bulbs than the ones 
 
 Since the group 0 is not needed in every case the autodiscovery feature will not detect this group as a Thing automatically.
 To create the group, use textual files or the openHAB UI to manually add a Thing with the correct Unique ID as described in section [Important for Textual Configuration](#important-for-textual-configuration).
-To create a Thing for the group 0 via MainUI simply create a new Thing that has the same type as one of autodiscovered Things of the same remote and modify the ThingUID as described in section linked above (replace the trailing 1-digit number of an autodiscovered ThingUID with a 0).
+To create a Thing for the group 0, simply create a new Thing that has the same type as one of the auto discovered Things of the same remote and modify the ThingUID as described in section linked above.
 
 If you do not need separate group 0 controls in openHAB, but wish to have all the controls for the sub groups update when a physical remote is used, you only need to create the thing for group 0.
 Only if you want the controls do you need to link any channels and create the items, as creating the thing will subscribe the binding to the MQTT topic for group 0.

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -157,7 +157,7 @@ For example:
 ## Using the group 0
 
 The group 0 (or ALL group) with the Group ID 0 can be used to control all bulbs that are paired with one specific remote at once.
-While this functionality can also be achieved by using openHAB groups with even greater flexibility the group 0 must be setup if you want to capture remote events for the ALL group to keep physical devices synchronized to their openHAB representations.
+While this functionality can also be achieved by using openHAB groups with even greater flexibility, the group 0 must be setup if you want to capture physical remote control events for the ALL group, and keep physical devices synchronized to their openHAB representations.
 Milight remotes send all commands with the Group ID 0 after the master ON/OFF buttons have been used.
 If the group 0 has not been setup these events will be lost and your Item states will no longer be synchonized with the actual device states until you issue a command via openHAB.
 If you do not use a remote at all or you only control other bulbs than the ones controlled by openHAB you should not need to setup the ALL group.


### PR DESCRIPTION
Created a new PR since I messed up the old one...

This PR aims to add documentation for the handling of group 0 / ALL group.

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
