### PR TITLE
Fix .gitattributes (#10472)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-.java text=auto
-.xml text=auto
+*.java text=auto
+*.xml text=auto


### PR DESCRIPTION
Added wildcards so that the rules apply to all .java and .xml files.

This makes sure line endings on windows system are properly converted when pulling/pushing and make sure the spotless check will pass both locally and remotely.

Closes #10472