### PR TITLE
[nikohomecontrol] Fix energy meter

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -577,7 +577,9 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
         deviceProperties.stream().map(p -> p.electricalPower).filter(Objects::nonNull).findFirst()
                 .ifPresent(electricalPower -> {
                     try {
-                        energyMeter.setPower(Integer.parseInt(electricalPower));
+                        // Sometimes API sends a fractional part, although API should only send whole units in W,
+                        // therefore drop fractional part
+                        energyMeter.setPower((int) Double.parseDouble(electricalPower));
                         logger.trace("setting energy meter {} power to {}", energyMeter.getId(), electricalPower);
                     } catch (NumberFormatException e) {
                         energyMeter.setPower(null);


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

Fixes missing power data if API sends fractional part.