### PR TITLE
[hpprinter] Prevent "handler disposed" warnings on shutdown

### DIFF
--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
@@ -629,29 +629,31 @@ public class HPPrinterBinder {
     private void checkScannerStatus() {
         HPServerResult<HPScannerStatus> result = printerClient.getScannerStatus();
 
-        if (!handlerDisposed) {
-            if (result.getStatus() == RequestStatus.SUCCESS) {
-                handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_STATUS,
-                        new StringType(result.getData().getScannerStatus()));
-                handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_ADFLOADED,
-                        convertToOnOffType(result.getData().getAdfLoaded()));
-            } else {
-                goneOffline();
-            }
+        if (handlerDisposed) {
+            return;
+        }
+        if (result.getStatus() == RequestStatus.SUCCESS) {
+            handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_STATUS,
+                    new StringType(result.getData().getScannerStatus()));
+            handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_ADFLOADED,
+                    convertToOnOffType(result.getData().getAdfLoaded()));
+        } else {
+            goneOffline();
         }
     }
 
     private void checkStatus() {
         HPServerResult<HPStatus> result = printerClient.getStatus();
 
-        if (!handlerDisposed) {
-            if (result.getStatus() == RequestStatus.SUCCESS) {
-                handler.updateState(CGROUP_STATUS, CHANNEL_STATUS, new StringType(result.getData().getPrinterStatus()));
-                handler.updateState(CGROUP_STATUS, CHANNEL_TRAYEMPTYOROPEN,
-                        convertToOnOffType(result.getData().getTrayEmptyOrOpen()));
-            } else {
-                goneOffline();
-            }
+        if (handlerDisposed) {
+            return;
+        }
+        if (result.getStatus() == RequestStatus.SUCCESS) {
+            handler.updateState(CGROUP_STATUS, CHANNEL_STATUS, new StringType(result.getData().getPrinterStatus()));
+            handler.updateState(CGROUP_STATUS, CHANNEL_TRAYEMPTYOROPEN,
+                    convertToOnOffType(result.getData().getTrayEmptyOrOpen()));
+        } else {
+            goneOffline();
         }
     }
 
@@ -666,117 +668,115 @@ public class HPPrinterBinder {
     private void checkUsage() {
         HPServerResult<HPUsage> result = printerClient.getUsage();
 
-        if (!handlerDisposed) {
-            if (result.getStatus() == RequestStatus.SUCCESS) {
-                // Inks
-                handler.updateState(CGROUP_INK, CHANNEL_BLACK_LEVEL,
-                        new QuantityType<>(result.getData().getInkBlack(), Units.PERCENT));
-                handler.updateState(CGROUP_INK, CHANNEL_COLOR_LEVEL,
-                        new QuantityType<>(result.getData().getInkColor(), Units.PERCENT));
-                handler.updateState(CGROUP_INK, CHANNEL_CYAN_LEVEL,
-                        new QuantityType<>(result.getData().getInkCyan(), Units.PERCENT));
-                handler.updateState(CGROUP_INK, CHANNEL_MAGENTA_LEVEL,
-                        new QuantityType<>(result.getData().getInkMagenta(), Units.PERCENT));
-                handler.updateState(CGROUP_INK, CHANNEL_YELLOW_LEVEL,
-                        new QuantityType<>(result.getData().getInkYellow(), Units.PERCENT));
+        if (handlerDisposed) {
+            return;
+        }
+        if (result.getStatus() == RequestStatus.SUCCESS) {
+            // Inks
+            handler.updateState(CGROUP_INK, CHANNEL_BLACK_LEVEL,
+                    new QuantityType<>(result.getData().getInkBlack(), Units.PERCENT));
+            handler.updateState(CGROUP_INK, CHANNEL_COLOR_LEVEL,
+                    new QuantityType<>(result.getData().getInkColor(), Units.PERCENT));
+            handler.updateState(CGROUP_INK, CHANNEL_CYAN_LEVEL,
+                    new QuantityType<>(result.getData().getInkCyan(), Units.PERCENT));
+            handler.updateState(CGROUP_INK, CHANNEL_MAGENTA_LEVEL,
+                    new QuantityType<>(result.getData().getInkMagenta(), Units.PERCENT));
+            handler.updateState(CGROUP_INK, CHANNEL_YELLOW_LEVEL,
+                    new QuantityType<>(result.getData().getInkYellow(), Units.PERCENT));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_JAM_EVENTS, new DecimalType(result.getData().getJamEvents()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_SUBSCRIPTION,
-                        new DecimalType(result.getData().getTotalSubscriptionImpressions()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_COLORPAGES,
-                        new DecimalType(result.getData().getTotalColorImpressions()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_MONOPAGES,
-                        new DecimalType(result.getData().getTotalMonochromeImpressions()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_PAGES,
-                        new DecimalType(result.getData().getTotalImpressions()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_MISPICK_EVENTS,
-                        new DecimalType(result.getData().getMispickEvents()));
-                handler.updateState(CGROUP_USAGE, CHANNEL_FRONT_PANEL_CANCEL,
-                        new DecimalType(result.getData().getFrontPanelCancelCount()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_JAM_EVENTS, new DecimalType(result.getData().getJamEvents()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_SUBSCRIPTION,
+                    new DecimalType(result.getData().getTotalSubscriptionImpressions()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_COLORPAGES,
+                    new DecimalType(result.getData().getTotalColorImpressions()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_MONOPAGES,
+                    new DecimalType(result.getData().getTotalMonochromeImpressions()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_PAGES,
+                    new DecimalType(result.getData().getTotalImpressions()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_MISPICK_EVENTS,
+                    new DecimalType(result.getData().getMispickEvents()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_FRONT_PANEL_CANCEL,
+                    new DecimalType(result.getData().getFrontPanelCancelCount()));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_MARKING,
-                        new QuantityType<>(result.getData().getInkBlackMarking(), MetricPrefix.MILLI(Units.LITRE)));
-                handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_MARKING,
-                        new QuantityType<>(result.getData().getInkColorMarking(), MetricPrefix.MILLI(Units.LITRE)));
-                handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_MARKING,
-                        new QuantityType<>(result.getData().getInkCyanMarking(), MetricPrefix.MILLI(Units.LITRE)));
-                handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_MARKING,
-                        new QuantityType<>(result.getData().getInkMagentaMarking(), MetricPrefix.MILLI(Units.LITRE)));
-                handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_MARKING,
-                        new QuantityType<>(result.getData().getInkYellowMarking(), MetricPrefix.MILLI(Units.LITRE)));
+            handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_MARKING,
+                    new QuantityType<>(result.getData().getInkBlackMarking(), MetricPrefix.MILLI(Units.LITRE)));
+            handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_MARKING,
+                    new QuantityType<>(result.getData().getInkColorMarking(), MetricPrefix.MILLI(Units.LITRE)));
+            handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_MARKING,
+                    new QuantityType<>(result.getData().getInkCyanMarking(), MetricPrefix.MILLI(Units.LITRE)));
+            handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_MARKING,
+                    new QuantityType<>(result.getData().getInkMagentaMarking(), MetricPrefix.MILLI(Units.LITRE)));
+            handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_MARKING,
+                    new QuantityType<>(result.getData().getInkYellowMarking(), MetricPrefix.MILLI(Units.LITRE)));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_PAGES_REMAINING,
-                        new DecimalType(result.getData().getInkBlackPagesRemaining()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_PAGES_REMAINING,
+                    new DecimalType(result.getData().getInkBlackPagesRemaining()));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_PAGES_REMAINING,
-                        new DecimalType(result.getData().getInkColorPagesRemaining()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_PAGES_REMAINING,
+                    new DecimalType(result.getData().getInkColorPagesRemaining()));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_PAGES_REMAINING,
-                        new DecimalType(result.getData().getInkCyanPagesRemaining()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_PAGES_REMAINING,
+                    new DecimalType(result.getData().getInkCyanPagesRemaining()));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_PAGES_REMAINING,
-                        new DecimalType(result.getData().getInkMagentaPagesRemaining()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_PAGES_REMAINING,
+                    new DecimalType(result.getData().getInkMagentaPagesRemaining()));
 
-                handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_PAGES_REMAINING,
-                        new DecimalType(result.getData().getInkYellowPagesRemaining()));
+            handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_PAGES_REMAINING,
+                    new DecimalType(result.getData().getInkYellowPagesRemaining()));
 
-                // Scan
-                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_ADF,
-                        new DecimalType(result.getData().getScanAdfCount()));
+            // Scan
+            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_ADF, new DecimalType(result.getData().getScanAdfCount()));
 
-                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_FLATBED,
-                        new DecimalType(result.getData().getScanFlatbedCount()));
+            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_FLATBED,
+                    new DecimalType(result.getData().getScanFlatbedCount()));
 
-                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOEMAIL,
-                        new DecimalType(result.getData().getScanToEmailCount()));
+            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOEMAIL,
+                    new DecimalType(result.getData().getScanToEmailCount()));
 
-                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOFOLDER,
-                        new DecimalType(result.getData().getScanToFolderCount()));
+            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOFOLDER,
+                    new DecimalType(result.getData().getScanToFolderCount()));
 
-                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOHOST,
-                        new DecimalType(result.getData().getScanToHostCount()));
+            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOHOST,
+                    new DecimalType(result.getData().getScanToHostCount()));
 
-                // Scanner
-                handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_ADF,
-                        new DecimalType(result.getData().getScannerAdfCount()));
-                handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_FLATBED,
-                        new DecimalType(result.getData().getScannerFlatbedCount()));
-                handler.updateState(CGROUP_SCANNER, CHANNEL_JAM_EVENTS,
-                        new DecimalType(result.getData().getScannerJamEvents()));
-                handler.updateState(CGROUP_SCANNER, CHANNEL_MISPICK_EVENTS,
-                        new DecimalType(result.getData().getScannerMispickEvents()));
+            // Scanner
+            handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_ADF,
+                    new DecimalType(result.getData().getScannerAdfCount()));
+            handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_FLATBED,
+                    new DecimalType(result.getData().getScannerFlatbedCount()));
+            handler.updateState(CGROUP_SCANNER, CHANNEL_JAM_EVENTS,
+                    new DecimalType(result.getData().getScannerJamEvents()));
+            handler.updateState(CGROUP_SCANNER, CHANNEL_MISPICK_EVENTS,
+                    new DecimalType(result.getData().getScannerMispickEvents()));
 
-                // Copy
-                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_ADF,
-                        new DecimalType(result.getData().getCopyAdfCount()));
-                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_FLATBED,
-                        new DecimalType(result.getData().getCopyFlatbedCount()));
-                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_PAGES,
-                        new DecimalType(result.getData().getCopyTotalImpressions()));
-                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_COLORPAGES,
-                        new DecimalType(result.getData().getCopyTotalColorImpressions()));
-                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_MONOPAGES,
-                        new DecimalType(result.getData().getCopyTotalMonochromeImpressions()));
+            // Copy
+            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_ADF, new DecimalType(result.getData().getCopyAdfCount()));
+            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_FLATBED,
+                    new DecimalType(result.getData().getCopyFlatbedCount()));
+            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_PAGES,
+                    new DecimalType(result.getData().getCopyTotalImpressions()));
+            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_COLORPAGES,
+                    new DecimalType(result.getData().getCopyTotalColorImpressions()));
+            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_MONOPAGES,
+                    new DecimalType(result.getData().getCopyTotalMonochromeImpressions()));
 
-                // App Usage
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_WIN,
-                        new DecimalType(result.getData().getAppWindowsCount()));
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_OSX, new DecimalType(result.getData().getAppOSXCount()));
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_IOS, new DecimalType(result.getData().getAppIosCount()));
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_ANDROID,
-                        new DecimalType(result.getData().getAppAndroidCount()));
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_SAMSUNG,
-                        new DecimalType(result.getData().getAppSamsungCount()));
-                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_CHROME,
-                        new DecimalType(result.getData().getAppChromeCount()));
+            // App Usage
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_WIN, new DecimalType(result.getData().getAppWindowsCount()));
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_OSX, new DecimalType(result.getData().getAppOSXCount()));
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_IOS, new DecimalType(result.getData().getAppIosCount()));
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_ANDROID,
+                    new DecimalType(result.getData().getAppAndroidCount()));
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_SAMSUNG,
+                    new DecimalType(result.getData().getAppSamsungCount()));
+            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_CHROME,
+                    new DecimalType(result.getData().getAppChromeCount()));
 
-                // Other
-                handler.updateState(CGROUP_OTHER, CHANNEL_CLOUD_PRINT,
-                        new DecimalType(result.getData().getCloudPrintImpressions()));
+            // Other
+            handler.updateState(CGROUP_OTHER, CHANNEL_CLOUD_PRINT,
+                    new DecimalType(result.getData().getCloudPrintImpressions()));
 
-            } else {
-                goneOffline();
-            }
+        } else {
+            goneOffline();
         }
     }
 
@@ -797,15 +797,15 @@ public class HPPrinterBinder {
     private void checkOnline() {
         HPServerResult<HPStatus> result = printerClient.getStatus();
 
-        if (!handlerDisposed) {
-            if (result.getStatus() == RequestStatus.SUCCESS) {
-                goneOnline();
-            } else if (result.getStatus() == RequestStatus.TIMEOUT) {
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        result.getErrorMessage());
-            } else {
-                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, result.getErrorMessage());
-            }
+        if (handlerDisposed) {
+            return;
+        }
+        if (result.getStatus() == RequestStatus.SUCCESS) {
+            goneOnline();
+        } else if (result.getStatus() == RequestStatus.TIMEOUT) {
+            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, result.getErrorMessage());
+        } else {
+            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, result.getErrorMessage());
         }
     }
 }

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
@@ -110,7 +110,7 @@ public class HPPrinterBinder {
 
     public synchronized void channelsChanged() {
         logger.trace("Channels have been changed");
-        close0();
+        closeInternal();
         open();
     }
 
@@ -558,13 +558,13 @@ public class HPPrinterBinder {
      */
     public void close() {
         handlerDisposed = true;
-        close0();
+        closeInternal();
     }
 
     /**
      * Private (internal) method to close the connection to the Embedded Web Server
      */
-    private void close0() {
+    private void closeInternal() {
         stopBackgroundSchedules();
 
         final ScheduledFuture<?> localOfflineScheduler = offlineScheduler;
@@ -581,7 +581,7 @@ public class HPPrinterBinder {
     private void goneOffline() {
         handler.updateStatus(ThingStatus.OFFLINE);
 
-        close0();
+        closeInternal();
         runOfflineScheduler();
     }
 

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
@@ -75,9 +75,11 @@ public class HPPrinterBinder {
     private @Nullable ScheduledFuture<?> usageScheduler;
     private @Nullable ScheduledFuture<?> offlineScheduler;
 
+    private boolean handlerDisposed;
+
     /**
      * Creates a new HP Printer Binder object
-     * 
+     *
      * @param handler {HPPrinterBinderEvent} The Event handler for the binder.
      * @param httpClient {HttpClient} The HttpClient object to use to perform HTTP
      *            requests.
@@ -95,6 +97,7 @@ public class HPPrinterBinder {
             throw new IllegalStateException("ip-address should have been validated already and may not be empty.");
         }
         printerClient = new HPWebServerClient(httpClient, ipAddress);
+        handlerDisposed = false;
     }
 
     public void retrieveProperties() {
@@ -107,7 +110,7 @@ public class HPPrinterBinder {
 
     public synchronized void channelsChanged() {
         logger.trace("Channels have been changed");
-        close();
+        close0();
         open();
     }
 
@@ -548,9 +551,20 @@ public class HPPrinterBinder {
     }
 
     /**
-     * Close the connection to the Embedded Web Server
+     * Public method to close the connection to the Embedded Web Server
+     *
+     * Set handlerDisposed to prevent call-backs to the handler after it has been disposed
+     * Then call the intrnal close0()
      */
     public void close() {
+        handlerDisposed = true;
+        close0();
+    }
+
+    /**
+     * Private (internal) method to close the connection to the Embedded Web Server
+     */
+    private void close0() {
         stopBackgroundSchedules();
 
         final ScheduledFuture<?> localOfflineScheduler = offlineScheduler;
@@ -564,10 +578,10 @@ public class HPPrinterBinder {
     /**
      * The device has gone offline
      */
-    public void goneOffline() {
+    private void goneOffline() {
         handler.updateStatus(ThingStatus.OFFLINE);
 
-        close();
+        close0();
         runOfflineScheduler();
     }
 
@@ -615,25 +629,29 @@ public class HPPrinterBinder {
     private void checkScannerStatus() {
         HPServerResult<HPScannerStatus> result = printerClient.getScannerStatus();
 
-        if (result.getStatus() == RequestStatus.SUCCESS) {
-            handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_STATUS,
-                    new StringType(result.getData().getScannerStatus()));
-            handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_ADFLOADED,
-                    convertToOnOffType(result.getData().getAdfLoaded()));
-        } else {
-            goneOffline();
+        if (!handlerDisposed) {
+            if (result.getStatus() == RequestStatus.SUCCESS) {
+                handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_STATUS,
+                        new StringType(result.getData().getScannerStatus()));
+                handler.updateState(CGROUP_STATUS, CHANNEL_SCANNER_ADFLOADED,
+                        convertToOnOffType(result.getData().getAdfLoaded()));
+            } else {
+                goneOffline();
+            }
         }
     }
 
     private void checkStatus() {
         HPServerResult<HPStatus> result = printerClient.getStatus();
 
-        if (result.getStatus() == RequestStatus.SUCCESS) {
-            handler.updateState(CGROUP_STATUS, CHANNEL_STATUS, new StringType(result.getData().getPrinterStatus()));
-            handler.updateState(CGROUP_STATUS, CHANNEL_TRAYEMPTYOROPEN,
-                    convertToOnOffType(result.getData().getTrayEmptyOrOpen()));
-        } else {
-            goneOffline();
+        if (!handlerDisposed) {
+            if (result.getStatus() == RequestStatus.SUCCESS) {
+                handler.updateState(CGROUP_STATUS, CHANNEL_STATUS, new StringType(result.getData().getPrinterStatus()));
+                handler.updateState(CGROUP_STATUS, CHANNEL_TRAYEMPTYOROPEN,
+                        convertToOnOffType(result.getData().getTrayEmptyOrOpen()));
+            } else {
+                goneOffline();
+            }
         }
     }
 
@@ -648,112 +666,117 @@ public class HPPrinterBinder {
     private void checkUsage() {
         HPServerResult<HPUsage> result = printerClient.getUsage();
 
-        if (result.getStatus() == RequestStatus.SUCCESS) {
-            // Inks
-            handler.updateState(CGROUP_INK, CHANNEL_BLACK_LEVEL,
-                    new QuantityType<>(result.getData().getInkBlack(), Units.PERCENT));
-            handler.updateState(CGROUP_INK, CHANNEL_COLOR_LEVEL,
-                    new QuantityType<>(result.getData().getInkColor(), Units.PERCENT));
-            handler.updateState(CGROUP_INK, CHANNEL_CYAN_LEVEL,
-                    new QuantityType<>(result.getData().getInkCyan(), Units.PERCENT));
-            handler.updateState(CGROUP_INK, CHANNEL_MAGENTA_LEVEL,
-                    new QuantityType<>(result.getData().getInkMagenta(), Units.PERCENT));
-            handler.updateState(CGROUP_INK, CHANNEL_YELLOW_LEVEL,
-                    new QuantityType<>(result.getData().getInkYellow(), Units.PERCENT));
+        if (!handlerDisposed) {
+            if (result.getStatus() == RequestStatus.SUCCESS) {
+                // Inks
+                handler.updateState(CGROUP_INK, CHANNEL_BLACK_LEVEL,
+                        new QuantityType<>(result.getData().getInkBlack(), Units.PERCENT));
+                handler.updateState(CGROUP_INK, CHANNEL_COLOR_LEVEL,
+                        new QuantityType<>(result.getData().getInkColor(), Units.PERCENT));
+                handler.updateState(CGROUP_INK, CHANNEL_CYAN_LEVEL,
+                        new QuantityType<>(result.getData().getInkCyan(), Units.PERCENT));
+                handler.updateState(CGROUP_INK, CHANNEL_MAGENTA_LEVEL,
+                        new QuantityType<>(result.getData().getInkMagenta(), Units.PERCENT));
+                handler.updateState(CGROUP_INK, CHANNEL_YELLOW_LEVEL,
+                        new QuantityType<>(result.getData().getInkYellow(), Units.PERCENT));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_JAM_EVENTS, new DecimalType(result.getData().getJamEvents()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_SUBSCRIPTION,
-                    new DecimalType(result.getData().getTotalSubscriptionImpressions()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_COLORPAGES,
-                    new DecimalType(result.getData().getTotalColorImpressions()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_MONOPAGES,
-                    new DecimalType(result.getData().getTotalMonochromeImpressions()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_PAGES,
-                    new DecimalType(result.getData().getTotalImpressions()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_MISPICK_EVENTS,
-                    new DecimalType(result.getData().getMispickEvents()));
-            handler.updateState(CGROUP_USAGE, CHANNEL_FRONT_PANEL_CANCEL,
-                    new DecimalType(result.getData().getFrontPanelCancelCount()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_JAM_EVENTS, new DecimalType(result.getData().getJamEvents()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_SUBSCRIPTION,
+                        new DecimalType(result.getData().getTotalSubscriptionImpressions()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_COLORPAGES,
+                        new DecimalType(result.getData().getTotalColorImpressions()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_MONOPAGES,
+                        new DecimalType(result.getData().getTotalMonochromeImpressions()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_TOTAL_PAGES,
+                        new DecimalType(result.getData().getTotalImpressions()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_MISPICK_EVENTS,
+                        new DecimalType(result.getData().getMispickEvents()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_FRONT_PANEL_CANCEL,
+                        new DecimalType(result.getData().getFrontPanelCancelCount()));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_MARKING,
-                    new QuantityType<>(result.getData().getInkBlackMarking(), MetricPrefix.MILLI(Units.LITRE)));
-            handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_MARKING,
-                    new QuantityType<>(result.getData().getInkColorMarking(), MetricPrefix.MILLI(Units.LITRE)));
-            handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_MARKING,
-                    new QuantityType<>(result.getData().getInkCyanMarking(), MetricPrefix.MILLI(Units.LITRE)));
-            handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_MARKING,
-                    new QuantityType<>(result.getData().getInkMagentaMarking(), MetricPrefix.MILLI(Units.LITRE)));
-            handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_MARKING,
-                    new QuantityType<>(result.getData().getInkYellowMarking(), MetricPrefix.MILLI(Units.LITRE)));
+                handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_MARKING,
+                        new QuantityType<>(result.getData().getInkBlackMarking(), MetricPrefix.MILLI(Units.LITRE)));
+                handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_MARKING,
+                        new QuantityType<>(result.getData().getInkColorMarking(), MetricPrefix.MILLI(Units.LITRE)));
+                handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_MARKING,
+                        new QuantityType<>(result.getData().getInkCyanMarking(), MetricPrefix.MILLI(Units.LITRE)));
+                handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_MARKING,
+                        new QuantityType<>(result.getData().getInkMagentaMarking(), MetricPrefix.MILLI(Units.LITRE)));
+                handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_MARKING,
+                        new QuantityType<>(result.getData().getInkYellowMarking(), MetricPrefix.MILLI(Units.LITRE)));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_PAGES_REMAINING,
-                    new DecimalType(result.getData().getInkBlackPagesRemaining()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_BLACK_PAGES_REMAINING,
+                        new DecimalType(result.getData().getInkBlackPagesRemaining()));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_PAGES_REMAINING,
-                    new DecimalType(result.getData().getInkColorPagesRemaining()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_COLOR_PAGES_REMAINING,
+                        new DecimalType(result.getData().getInkColorPagesRemaining()));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_PAGES_REMAINING,
-                    new DecimalType(result.getData().getInkCyanPagesRemaining()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_CYAN_PAGES_REMAINING,
+                        new DecimalType(result.getData().getInkCyanPagesRemaining()));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_PAGES_REMAINING,
-                    new DecimalType(result.getData().getInkMagentaPagesRemaining()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_MAGENTA_PAGES_REMAINING,
+                        new DecimalType(result.getData().getInkMagentaPagesRemaining()));
 
-            handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_PAGES_REMAINING,
-                    new DecimalType(result.getData().getInkYellowPagesRemaining()));
+                handler.updateState(CGROUP_USAGE, CHANNEL_YELLOW_PAGES_REMAINING,
+                        new DecimalType(result.getData().getInkYellowPagesRemaining()));
 
-            // Scan
-            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_ADF, new DecimalType(result.getData().getScanAdfCount()));
+                // Scan
+                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_ADF,
+                        new DecimalType(result.getData().getScanAdfCount()));
 
-            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_FLATBED,
-                    new DecimalType(result.getData().getScanFlatbedCount()));
+                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_FLATBED,
+                        new DecimalType(result.getData().getScanFlatbedCount()));
 
-            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOEMAIL,
-                    new DecimalType(result.getData().getScanToEmailCount()));
+                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOEMAIL,
+                        new DecimalType(result.getData().getScanToEmailCount()));
 
-            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOFOLDER,
-                    new DecimalType(result.getData().getScanToFolderCount()));
+                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOFOLDER,
+                        new DecimalType(result.getData().getScanToFolderCount()));
 
-            handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOHOST,
-                    new DecimalType(result.getData().getScanToHostCount()));
+                handler.updateState(CGROUP_SCAN, CHANNEL_TOTAL_TOHOST,
+                        new DecimalType(result.getData().getScanToHostCount()));
 
-            // Scanner
-            handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_ADF,
-                    new DecimalType(result.getData().getScannerAdfCount()));
-            handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_FLATBED,
-                    new DecimalType(result.getData().getScannerFlatbedCount()));
-            handler.updateState(CGROUP_SCANNER, CHANNEL_JAM_EVENTS,
-                    new DecimalType(result.getData().getScannerJamEvents()));
-            handler.updateState(CGROUP_SCANNER, CHANNEL_MISPICK_EVENTS,
-                    new DecimalType(result.getData().getScannerMispickEvents()));
+                // Scanner
+                handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_ADF,
+                        new DecimalType(result.getData().getScannerAdfCount()));
+                handler.updateState(CGROUP_SCANNER, CHANNEL_TOTAL_FLATBED,
+                        new DecimalType(result.getData().getScannerFlatbedCount()));
+                handler.updateState(CGROUP_SCANNER, CHANNEL_JAM_EVENTS,
+                        new DecimalType(result.getData().getScannerJamEvents()));
+                handler.updateState(CGROUP_SCANNER, CHANNEL_MISPICK_EVENTS,
+                        new DecimalType(result.getData().getScannerMispickEvents()));
 
-            // Copy
-            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_ADF, new DecimalType(result.getData().getCopyAdfCount()));
-            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_FLATBED,
-                    new DecimalType(result.getData().getCopyFlatbedCount()));
-            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_PAGES,
-                    new DecimalType(result.getData().getCopyTotalImpressions()));
-            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_COLORPAGES,
-                    new DecimalType(result.getData().getCopyTotalColorImpressions()));
-            handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_MONOPAGES,
-                    new DecimalType(result.getData().getCopyTotalMonochromeImpressions()));
+                // Copy
+                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_ADF,
+                        new DecimalType(result.getData().getCopyAdfCount()));
+                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_FLATBED,
+                        new DecimalType(result.getData().getCopyFlatbedCount()));
+                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_PAGES,
+                        new DecimalType(result.getData().getCopyTotalImpressions()));
+                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_COLORPAGES,
+                        new DecimalType(result.getData().getCopyTotalColorImpressions()));
+                handler.updateState(CGROUP_COPY, CHANNEL_TOTAL_MONOPAGES,
+                        new DecimalType(result.getData().getCopyTotalMonochromeImpressions()));
 
-            // App Usage
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_WIN, new DecimalType(result.getData().getAppWindowsCount()));
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_OSX, new DecimalType(result.getData().getAppOSXCount()));
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_IOS, new DecimalType(result.getData().getAppIosCount()));
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_ANDROID,
-                    new DecimalType(result.getData().getAppAndroidCount()));
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_SAMSUNG,
-                    new DecimalType(result.getData().getAppSamsungCount()));
-            handler.updateState(CGROUP_APP, CHANNEL_TOTAL_CHROME,
-                    new DecimalType(result.getData().getAppChromeCount()));
+                // App Usage
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_WIN,
+                        new DecimalType(result.getData().getAppWindowsCount()));
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_OSX, new DecimalType(result.getData().getAppOSXCount()));
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_IOS, new DecimalType(result.getData().getAppIosCount()));
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_ANDROID,
+                        new DecimalType(result.getData().getAppAndroidCount()));
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_SAMSUNG,
+                        new DecimalType(result.getData().getAppSamsungCount()));
+                handler.updateState(CGROUP_APP, CHANNEL_TOTAL_CHROME,
+                        new DecimalType(result.getData().getAppChromeCount()));
 
-            // Other
-            handler.updateState(CGROUP_OTHER, CHANNEL_CLOUD_PRINT,
-                    new DecimalType(result.getData().getCloudPrintImpressions()));
+                // Other
+                handler.updateState(CGROUP_OTHER, CHANNEL_CLOUD_PRINT,
+                        new DecimalType(result.getData().getCloudPrintImpressions()));
 
-        } else {
-            goneOffline();
+            } else {
+                goneOffline();
+            }
         }
     }
 
@@ -774,12 +797,15 @@ public class HPPrinterBinder {
     private void checkOnline() {
         HPServerResult<HPStatus> result = printerClient.getStatus();
 
-        if (result.getStatus() == RequestStatus.SUCCESS) {
-            goneOnline();
-        } else if (result.getStatus() == RequestStatus.TIMEOUT) {
-            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, result.getErrorMessage());
-        } else {
-            handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, result.getErrorMessage());
+        if (!handlerDisposed) {
+            if (result.getStatus() == RequestStatus.SUCCESS) {
+                goneOnline();
+            } else if (result.getStatus() == RequestStatus.TIMEOUT) {
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                        result.getErrorMessage());
+            } else {
+                handler.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, result.getErrorMessage());
+            }
         }
     }
 }

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterBinder.java
@@ -554,7 +554,7 @@ public class HPPrinterBinder {
      * Public method to close the connection to the Embedded Web Server
      *
      * Set handlerDisposed to prevent call-backs to the handler after it has been disposed
-     * Then call the internal close0()
+     * Then call the closeinternal() method
      */
     public void close() {
         handlerDisposed = true;

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
@@ -65,6 +65,10 @@ public class HPPrinterHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
+        scheduler.submit(() -> initialize0());
+    }
+
+    private void initialize0() {
         final HPPrinterConfiguration config = getConfigAs(HPPrinterConfiguration.class);
 
         if (!"".equals(config.ipAddress)) {
@@ -124,9 +128,7 @@ public class HPPrinterHandler extends BaseThingHandler {
     }
 
     public void updateState(final String group, final String channel, final State state) {
-        if (thing.getStatus() == ThingStatus.ONLINE) {
-            super.updateState(new ChannelUID(thing.getUID(), group, channel), state);
-        }
+        super.updateState(new ChannelUID(thing.getUID(), group, channel), state);
     }
 
     public void binderAddChannels(final List<Channel> channels) {

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.hpprinter.internal;
 
-import static org.openhab.binding.hpprinter.internal.HPPrinterBindingConstants.*;
+import static org.openhab.binding.hpprinter.internal.HPPrinterBindingConstants.CGROUP_STATUS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,6 +96,7 @@ public class HPPrinterHandler extends BaseThingHandler {
         return false;
     }
 
+    @Override
     protected void updateStatus(final ThingStatus status) {
         super.updateStatus(status);
     }
@@ -116,13 +117,16 @@ public class HPPrinterHandler extends BaseThingHandler {
         }
     }
 
+    @Override
     protected void updateStatus(final ThingStatus status, final ThingStatusDetail thingStatusDetail,
             @Nullable final String message) {
         super.updateStatus(status, thingStatusDetail, message);
     }
 
     public void updateState(final String group, final String channel, final State state) {
-        super.updateState(new ChannelUID(thing.getUID(), group, channel), state);
+        if (thing.getStatus() == ThingStatus.ONLINE) {
+            super.updateState(new ChannelUID(thing.getUID(), group, channel), state);
+        }
     }
 
     public void binderAddChannels(final List<Channel> channels) {
@@ -135,14 +139,17 @@ public class HPPrinterHandler extends BaseThingHandler {
         updateThing(editThing().withChannels(thingChannels).build());
     }
 
+    @Override
     protected ThingBuilder editThing() {
         return super.editThing();
     }
 
+    @Override
     protected @Nullable ThingHandlerCallback getCallback() {
         return super.getCallback();
     }
 
+    @Override
     protected void updateProperties(final Map<String, String> properties) {
         super.updateProperties(properties);
     }

--- a/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
+++ b/bundles/org.openhab.binding.hpprinter/src/main/java/org/openhab/binding/hpprinter/internal/HPPrinterHandler.java
@@ -65,10 +65,13 @@ public class HPPrinterHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        scheduler.submit(() -> initialize0());
+        scheduler.submit(() -> initializeScheduled());
     }
 
-    private void initialize0() {
+    /**
+     * Scheduled initialization task which will be executed on a separate thread
+     */
+    private void initializeScheduled() {
         final HPPrinterConfiguration config = getConfigAs(HPPrinterConfiguration.class);
 
         if (!"".equals(config.ipAddress)) {


### PR DESCRIPTION
This PR eliminates the "handler was already disposed" warnings when OH is being shut down.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
