### PR TITLE
[tado] Prevent "handler disposed" warnings on shutdown

### DIFF
--- a/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoZoneHandler.java
+++ b/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoZoneHandler.java
@@ -186,6 +186,11 @@ public class TadoZoneHandler extends BaseHomeThingHandler {
     }
 
     @Override
+    public void dispose() {
+        cancelScheduledZoneStateUpdate();
+    }
+
+    @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
             try {
@@ -219,9 +224,6 @@ public class TadoZoneHandler extends BaseHomeThingHandler {
     }
 
     private void updateZoneState(boolean forceUpdate) {
-        if (thing.getStatus() != ThingStatus.ONLINE) {
-            return;
-        }
         TadoHomeHandler home = getHomeHandler();
         if (home != null) {
             home.updateHomeState();

--- a/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoZoneHandler.java
+++ b/bundles/org.openhab.binding.tado/src/main/java/org/openhab/binding/tado/internal/handler/TadoZoneHandler.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dennis Frommknecht - Initial contribution
  * @author Andrew Fiddian-Green - Added Low Battery Alarm, A/C Power and Open Window channels
- * 
+ *
  */
 public class TadoZoneHandler extends BaseHomeThingHandler {
     private Logger logger = LoggerFactory.getLogger(TadoZoneHandler.class);
@@ -219,6 +219,9 @@ public class TadoZoneHandler extends BaseHomeThingHandler {
     }
 
     private void updateZoneState(boolean forceUpdate) {
+        if (thing.getStatus() != ThingStatus.ONLINE) {
+            return;
+        }
         TadoHomeHandler home = getHomeHandler();
         if (home != null) {
             home.updateHomeState();


### PR DESCRIPTION
This PR eliminates the "handler disposed" warnings when OH is shutting down.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
