### PR TITLE
[modbus] correct parameter names in docs, logs and code comments

### DIFF
--- a/bundles/org.openhab.binding.modbus/README.md
+++ b/bundles/org.openhab.binding.modbus/README.md
@@ -319,7 +319,7 @@ The profile works also in the reverse direction, when commanding items.
 
 In addition, the profile allows attaching units to the raw numbers, as well as converting the quantity-aware numbers to bare numbers on write.
 
-Profile has two parameters, `gain` (bare number or number with unit) and `pre-offset` (bare number), both of which must be provided.
+Profile has two parameters, `gain` (bare number or number with unit) and `pre-gain-offset` (bare number), both of which must be provided.
 
 When reading from Modbus, the result will be `updateTowardsItem = (raw_value_from_modbus + preOffset) * gain`.
 When applying command, the calculation goes in reverse.
@@ -775,7 +775,7 @@ Bridge modbus:tcp:localhostTCP3 [ host="127.0.0.1", port=502 ] {
 `items/modbus_ex_scaling.items`:
 
 ```
-Number:Temperature TemperatureItem            "Temperature [%.1f °C]"   { channel="modbus:data:localhostTCP3:holdingPoller:temperatureDeciCelsius:number"[ profile="modbus:gainOffset", gain="0.1 °C", offset="0" ] }
+Number:Temperature TemperatureItem            "Temperature [%.1f °C]"   { channel="modbus:data:localhostTCP3:holdingPoller:temperatureDeciCelsius:number"[ profile="modbus:gainOffset", gain="0.1 °C", pre-gain-offset="0" ] }
 ```
 
 `sitemaps/modbus_ex_scaling.sitemap`:

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/profiles/ModbusGainOffsetProfile.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/profiles/ModbusGainOffsetProfile.java
@@ -131,7 +131,7 @@ public class ModbusGainOffsetProfile<Q extends Quantity<Q>> implements StateProf
         Optional<QuantityType<Q>> localGain = gain;
         Optional<QuantityType<Dimensionless>> localPregainOffset = pregainOffset;
         if (localGain.isEmpty() || localPregainOffset.isEmpty()) {
-            logger.warn("Gain or offset unavailable. Check logs for configuration errors.");
+            logger.warn("Gain or pre-gain-offset unavailable. Check logs for configuration errors.");
             return UnDefType.UNDEF;
         } else if (state instanceof UnDefType) {
             return UnDefType.UNDEF;
@@ -162,7 +162,7 @@ public class ModbusGainOffsetProfile<Q extends Quantity<Q>> implements StateProf
                 }
             } catch (UnconvertibleException | UnsupportedOperationException e) {
                 logger.warn(
-                        "Cannot apply gain ('{}') and offset ('{}') to state ('{}') (formula {}) because types do not match (towardsItem={}): {}",
+                        "Cannot apply gain ('{}') and pre-gain-offset ('{}') to state ('{}') (formula {}) because types do not match (towardsItem={}): {}",
                         gain, pregainOffsetQt, state, formula, towardsItem, e.getMessage());
                 return UnDefType.UNDEF;
             }


### PR DESCRIPTION
Corrects profile parameter name in docs, logging and code comments.

Correct parameter name is `pre-gain-offset`.  Functionally everything worked:
- https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/profiles/ModbusGainOffsetProfile.java#L56
- https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.modbus/src/main/resources/OH-INF/config/gainOffset.xml#L9

Related: https://github.com/openhab/openhab-addons/pull/9980

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
