### PR TITLE
[mqtt] Discovery services shall not unsubscribe unless they have already subscribed

### DIFF
--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/discovery/AbstractMQTTDiscovery.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -48,23 +49,22 @@ public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService imp
 
     private @Nullable ScheduledFuture<?> scheduledStop;
 
-    private boolean isSubscribed;
+    private AtomicBoolean isSubscribed;
 
     public AbstractMQTTDiscovery(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout,
             boolean backgroundDiscoveryEnabledByDefault, String baseTopic) {
         super(supportedThingTypes, 0, backgroundDiscoveryEnabledByDefault);
         this.subscribeTopic = baseTopic;
         this.timeout = timeout;
-        isSubscribed = false;
+        isSubscribed = new AtomicBoolean(false);
     }
 
     /**
      * Only subscribe if we were not already subscribed
      */
     private void subscribe() {
-        if (!isSubscribed) {
+        if (!isSubscribed.getAndSet(true)) {
             getDiscoveryService().subscribe(this, subscribeTopic);
-            isSubscribed = true;
         }
     }
 
@@ -72,9 +72,8 @@ public abstract class AbstractMQTTDiscovery extends AbstractDiscoveryService imp
      * Only unsubscribe if we were already subscribed
      */
     private void unSubscribe() {
-        if (isSubscribed) {
+        if (isSubscribed.getAndSet(false)) {
             getDiscoveryService().unsubscribe(this);
-            isSubscribed = false;
         }
     }
 

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
@@ -78,8 +78,8 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
      */
     protected void createdHandler(AbstractBrokerHandler handler) {
         handlers.add(handler);
-        discoveryTopics.forEach((topic, listenerList) -> {
-            listenerList.forEach(listener -> {
+        discoveryTopics.forEach((topic, listeners) -> {
+            listeners.forEach(listener -> {
                 handler.registerDiscoveryListener(listener, topic);
             });
         });
@@ -114,8 +114,8 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
     @Override
     @SuppressWarnings("null")
     public void subscribe(MQTTTopicDiscoveryParticipant listener, String topic) {
-        Set<MQTTTopicDiscoveryParticipant> listenerList = discoveryTopics.computeIfAbsent(topic, t -> new HashSet<>());
-        if (listenerList.add(listener)) {
+        Set<MQTTTopicDiscoveryParticipant> listeners = discoveryTopics.computeIfAbsent(topic, t -> new HashSet<>());
+        if (listeners.add(listener)) {
             handlers.forEach(broker -> broker.registerDiscoveryListener(listener, topic));
         }
     }
@@ -126,8 +126,8 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
     @Override
     @SuppressWarnings("null")
     public void unsubscribe(MQTTTopicDiscoveryParticipant listener) {
-        discoveryTopics.forEach((topic, listenerList) -> {
-            if (listenerList.remove(listener)) {
+        discoveryTopics.forEach((topic, listeners) -> {
+            if (listeners.remove(listener)) {
                 handlers.forEach(broker -> broker.unregisterDiscoveryListener(listener, topic));
             }
         });

--- a/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
+++ b/bundles/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttBrokerHandlerFactory.java
@@ -13,11 +13,10 @@
 package org.openhab.binding.mqtt.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,7 +63,7 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
      * This Map provides a lookup between a Topic string (key) and a Set of MQTTTopicDiscoveryParticipants (value),
      * where the Set itself is a list of participants which are subscribed to the respective Topic.
      */
-    protected final Map<String, Set<MQTTTopicDiscoveryParticipant>> discoveryTopics = new HashMap<>();
+    protected final Map<String, Set<MQTTTopicDiscoveryParticipant>> discoveryTopics = new ConcurrentHashMap<>();
 
     /**
      * This Set contains a list of all the Broker handlers that have been created by this factory
@@ -129,7 +128,8 @@ public class MqttBrokerHandlerFactory extends BaseThingHandlerFactory implements
     @Override
     @SuppressWarnings("null")
     public void subscribe(MQTTTopicDiscoveryParticipant listener, String topic) {
-        Set<MQTTTopicDiscoveryParticipant> listeners = discoveryTopics.computeIfAbsent(topic, t -> new HashSet<>());
+        Set<MQTTTopicDiscoveryParticipant> listeners = discoveryTopics.computeIfAbsent(topic,
+                t -> ConcurrentHashMap.newKeySet());
         if (listeners.add(listener)) {
             handlers.forEach(broker -> broker.registerDiscoveryListener(listener, topic));
         }


### PR DESCRIPTION
The MQTT AbstractBrokerHandler produces erroneous logger warnings when OH is being shutdown for the EspMilight, HomeAssistant, and Homie, discovery services. See #10562 

I think that the problem is because of some or all of the following issues: 
1. The three respective discovery participant classes extend AbstractMQTTDiscovery, and that class may be calling `getDiscoveryService().unsubscribe()` although it might not already have called `getDiscoveryService().subscribe()`.
2. The MqttBrokerHandlerFactory discoveryTopics Map allows duplicate entries of the same listener in each topic's listenerList.
3. The MqttBrokerHandlerFactory subscribe method would re-subscribe the given listener/topic even if already subscribed.
4. The MqttBrokerHandlerFactory unsubscribe method would unsubscribe ALL the topics (even if the listener was not in the listenerList for that topic) -- **_this IMHO is the most critical error in the current code._**

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
