### PR TITLE
[enocean] Fix discovery of D2-50 devices

### DIFF
--- a/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
+++ b/bundles/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/eep/D2_50/D2_50.java
@@ -44,6 +44,7 @@ public class D2_50 extends _VLDMessage {
     protected static final byte MT_CONTROL = 0x20;
     protected static final byte MT_BASIC_STATUS = 0x40;
     protected static final byte MT_EXTENDED_STATUS = 0x60; // not yet implemented
+    protected static final byte MT_UNKNOWN_STATUS = (byte) 0x80; // Sent by some systems during teach in
 
     protected static final byte rmtMask = (byte) 0x0f;
     protected static final byte RMT_BASIC_STATUS = 0x00;
@@ -177,7 +178,10 @@ public class D2_50 extends _VLDMessage {
                 return bytes.length == 14;
             case MT_EXTENDED_STATUS: // MT_EXTENDED_STATUS is not yet supported, however return true to avoid Exceptions
                 return true;
+            case MT_UNKNOWN_STATUS:
+                return true;
             default:
+                logger.error("Invalid data, unknown message type: {} ({})", getMessageType(bytes[0]), bytes);
                 return false;
         }
     }


### PR DESCRIPTION
This change accepts a new message type which is sent by some air ventilation devices durin teach in. This is required for the search feature to detect these devices correctly.

Signed-off-by: David Schumann <david@dev-core.org>

This PR fixes the broken search for enocean air ventilation systems.

It's not yet clear to me what exactly the new message type contains in terms of information, but accepting the type restores the previous behavior where the search is fully detecting those devices. Packet details are in the related issue.
To ease debugging with other devices I added a debug log statement for other unknown message types

This PR has been successfully tested with Dimplex DL 50 devices.