### PR TITLE
[WebThing] binding bugfix: If WebThing network connection is crashed, WebThing will not be reconnected.

### DIFF
--- a/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/WebThingHandler.java
+++ b/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/WebThingHandler.java
@@ -94,14 +94,12 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
         isActivated.set(true); // set with true, even though the connect may fail. In this case retries will be
                                // triggered
 
-        webThingURI = toUri(getConfigAs(WebThingConfiguration.class).webThingURI);
-
         // perform connect in background
         scheduler.execute(() -> {
             // WebThing URI present?
-            if (webThingURI != null) {
+            if (getWebThingURI() != null) {
                 logger.debug("try to connect WebThing {}", webThingURI);
-                var connected = tryReconnect(webThingURI);
+                var connected = tryReconnect();
                 if (connected) {
                     logger.debug("WebThing {} connected", getWebThingLabel());
                 }
@@ -117,6 +115,13 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
                 .getAndSet(Optional.of(scheduler.scheduleWithFixedDelay(this::checkWebThingConnection,
                         HEALTH_CHECK_PERIOD.getSeconds(), HEALTH_CHECK_PERIOD.getSeconds(), TimeUnit.SECONDS)))
                 .ifPresent(future -> future.cancel(true));
+    }
+
+    private @Nullable URI getWebThingURI() {
+        if (webThingURI == null) {
+            webThingURI = toUri(getConfigAs(WebThingConfiguration.class).webThingURI);
+        }
+        return webThingURI;
     }
 
     private @Nullable URI toUri(@Nullable String uri) {
@@ -143,10 +148,11 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
         }
     }
 
-    private boolean tryReconnect(@Nullable URI uri) {
+    private boolean tryReconnect() {
         if (isActivated.get()) { // will try reconnect only, if activated
             try {
                 // create the client-side WebThing representation
+                var uri = getWebThingURI();
                 if (uri != null) {
                     var webThing = ConsumedThingFactory.instance().create(webSocketClient, httpClient, uri, scheduler,
                             this::onError);
@@ -259,7 +265,7 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
             itemChangedListenerMap.getOrDefault(channelUID, EMPTY_ITEM_CHANGED_LISTENER).onItemStateChanged(channelUID,
                     (State) command);
         } else if (command instanceof RefreshType) {
-            tryReconnect(webThingURI);
+            tryReconnect();
         }
     }
 
@@ -283,7 +289,7 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
         // try reconnect, if necessary
         if (isDisconnected() || (isOnline() && !isAlive())) {
             logger.debug("try reconnecting WebThing {}", getWebThingLabel());
-            if (tryReconnect(webThingURI)) {
+            if (tryReconnect()) {
                 logger.debug("WebThing {} reconnected", getWebThingLabel());
             }
 
@@ -291,7 +297,7 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
             // force reconnecting periodically, to fix erroneous states that occurs for unknown reasons
             var elapsedSinceLastReconnect = Duration.between(lastReconnect.get(), Instant.now());
             if (isOnline() && (elapsedSinceLastReconnect.getSeconds() > RECONNECT_PERIOD.getSeconds())) {
-                if (tryReconnect(webThingURI)) {
+                if (tryReconnect()) {
                     logger.debug("WebThing {} reconnected. Initiated by periodic reconnect", getWebThingLabel());
                 } else {
                     logger.debug("could not reconnect WebThing {} (periodic reconnect failed). Next trial in {} sec",

--- a/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/WebThingHandler.java
+++ b/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/WebThingHandler.java
@@ -94,13 +94,14 @@ public class WebThingHandler extends BaseThingHandler implements ChannelHandler 
         isActivated.set(true); // set with true, even though the connect may fail. In this case retries will be
                                // triggered
 
+        webThingURI = toUri(getConfigAs(WebThingConfiguration.class).webThingURI);
+
         // perform connect in background
         scheduler.execute(() -> {
             // WebThing URI present?
-            var uri = toUri(getConfigAs(WebThingConfiguration.class).webThingURI);
-            if (uri != null) {
-                logger.debug("try to connect WebThing {}", uri);
-                var connected = tryReconnect(uri);
+            if (webThingURI != null) {
+                logger.debug("try to connect WebThing {}", webThingURI);
+                var connected = tryReconnect(webThingURI);
                 if (connected) {
                     logger.debug("WebThing {} connected", getWebThingLabel());
                 }

--- a/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/client/WebSocketConnectionImpl.java
+++ b/bundles/org.openhab.binding.webthing/src/main/java/org/openhab/binding/webthing/internal/client/WebSocketConnectionImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.websocket.api.Session;
@@ -88,7 +87,7 @@ public class WebSocketConnectionImpl implements WebSocketConnection, WebSocketLi
     }
 
     @Override
-    public void observeProperty(@NonNull String propertyName, @NonNull BiConsumer<String, Object> listener) {
+    public void observeProperty(String propertyName, BiConsumer<String, Object> listener) {
         propertyChangedListeners.put(propertyName, listener);
     }
 

--- a/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/client/WebthingTest.java
+++ b/bundles/org.openhab.binding.webthing/src/test/java/org/openhab/binding/webthing/internal/client/WebthingTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
@@ -289,8 +288,8 @@ public class WebthingTest {
         public final AtomicReference<WebSocketImpl> webSocketRef = new AtomicReference<>();
 
         @Override
-        public WebSocketConnection create(@NonNull URI webSocketURI, @NonNull ScheduledExecutorService executor,
-                @NonNull Consumer<String> errorHandler, @NonNull Duration pingPeriod) {
+        public WebSocketConnection create(URI webSocketURI, ScheduledExecutorService executor,
+                Consumer<String> errorHandler, Duration pingPeriod) {
             var webSocketConnection = new WebSocketConnectionImpl(executor, errorHandler, pingPeriod);
             var webSocket = new WebSocketImpl(webSocketConnection);
             webSocketRef.set(webSocket);


### PR DESCRIPTION
This is a bug fix for the new WebThing binding. 

It turned out that a WebThing will not be reconnected, if the WebThing network connection is crashed. The reason for this is the uninitialized variable instance variable webThingURI. Due  to the fact that this variable is null the reconnect code fails.

This merge request includes the changes to fix this. 

Furthermore unnecessary NonNull annotations has been removed

Signed-off-by: Gregor Roth <gregor.roth@web.de>