### PR TITLE
[MongoDB Persistence] Fix error 500 and various improvements

### DIFF
--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -211,9 +211,6 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
         return value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void store(Item item) {
         store(item, null);

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -330,7 +330,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
         Item item = getItem(realItemName);
 
         List<HistoricItem> items = new ArrayList<>();
-        DBObject query = new BasicDBObject();
+        BasicDBObject query = new BasicDBObject();
         if (filter.getItemName() != null) {
             query.put(FIELD_ITEM, filter.getItemName());
         }
@@ -350,6 +350,8 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
         if (!dateQueries.isEmpty()) {
             query.put(FIELD_TIMESTAMP, dateQueries);
         }
+
+        logger.debug("Query: {}", query);
 
         Integer sortDir = (filter.getOrdering() == Ordering.ASCENDING) ? 1 : -1;
         DBCursor cursor = collection.find(query).sort(new BasicDBObject(FIELD_TIMESTAMP, sortDir))

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -252,6 +252,12 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
             this.cl = new MongoClient(new MongoClientURI(this.url));
 
+            // The mongo always succeeds in creating the connection.
+            // We have to actually force it to test the connection to try to connect to the server.
+            if (!isConnected()) {
+                throw new RuntimeException("Failed to connect");
+            }
+
             logger.debug("Connect MongoDB ... done");
             return true;
         } catch (Exception e) {

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -264,9 +264,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
             // The mongo always succeeds in creating the connection.
             // We have to actually force it to test the connection to try to connect to the server.
-            if (!isConnected()) {
-                throw new RuntimeException("Failed to connect");
-            }
+            cl.getAddress();
 
             logger.debug("Connect MongoDB ... done");
             return true;

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -251,6 +251,8 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
     private boolean tryConnectToDatabase() {
         try {
             logger.debug("Connect MongoDB");
+            disconnectFromDatabase();
+
             this.cl = new MongoClient(new MongoClientURI(this.url));
             if (collectionPerItem) {
                 mongoCollection = cl.getDB(this.db).getCollection(this.collection);

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -158,7 +158,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
         // Connect to mongodb server if we're not already connected
         // If we can't connect, log.
-        if (!isConnected() || !tryConnectToDatabase()) {
+        if (!tryConnectToDatabase()) {
             logger.warn(
                     "mongodb: No connection to database. Cannot persist item '{}'! Will retry connecting to database next time.",
                     item);
@@ -244,6 +244,10 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
      * @return True, if the connection was successfully established.
      */
     private boolean tryConnectToDatabase() {
+        if (isConnected()) {
+            return true;
+        }
+
         try {
             logger.debug("Connect MongoDB");
             disconnectFromDatabase();
@@ -306,7 +310,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             return Collections.emptyList();
         }
 
-        if (!isConnected() && !tryConnectToDatabase()) {
+        if (!tryConnectToDatabase()) {
             return Collections.emptyList();
         }
 

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -222,7 +222,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
      *
      * @return true if connection has been established, false otherwise
      */
-    private boolean isConnected() {
+    private synchronized boolean isConnected() {
         if (cl == null) {
             return false;
         }
@@ -243,7 +243,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
      *
      * @return True, if the connection was successfully established.
      */
-    private boolean tryConnectToDatabase() {
+    private synchronized boolean tryConnectToDatabase() {
         if (isConnected()) {
             return true;
         }
@@ -268,7 +268,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
      *
      * @return The database object
      */
-    private MongoClient getDatabase() {
+    private synchronized MongoClient getDatabase() {
         return cl;
     }
 
@@ -295,8 +295,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
     /**
      * Disconnects from the database
      */
-    private void disconnectFromDatabase() {
-        this.mongoCollection = null;
+    private synchronized void disconnectFromDatabase() {
         if (this.cl != null) {
             this.cl.close();
         }

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -262,7 +262,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             logger.debug("Connect MongoDB ... done");
             return true;
         } catch (Exception e) {
-            logger.error("Failed to connect to database {}", this.url);
+            logger.error("Failed to connect to database {}: {}", this.url, e.getMessage(), e);
             disconnectFromDatabase();
             return false;
         }
@@ -292,7 +292,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
             return mongoCollection;
         } catch (Exception e) {
-            logger.error("Failed to connect to collection {}", collectionName);
+            logger.error("Failed to connect to collection {}: {}", collectionName, e.getMessage(), e);
             return null;
         }
     }

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -108,19 +108,17 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             logger.warn("The MongoDB database URL is missing - please configure the mongodb:url parameter.");
             return;
         }
+
         db = (String) config.get("database");
         logger.debug("MongoDB database {}", db);
         if (db == null || db.isBlank()) {
             logger.warn("The MongoDB database name is missing - please configure the mongodb:database parameter.");
             return;
         }
+
         collection = (String) config.get("collection");
         logger.debug("MongoDB collection {}", collection);
-        if (collection == null || collection.isBlank()) {
-            collectionPerItem = false;
-        } else {
-            collectionPerItem = true;
-        }
+        collectionPerItem = collection == null || collection.isBlank();
 
         if (!tryConnectToDatabase()) {
             logger.warn("Failed to connect to MongoDB server. Trying to reconnect later.");
@@ -298,6 +296,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
         if (this.cl != null) {
             this.cl.close();
         }
+
         cl = null;
     }
 
@@ -334,7 +333,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             query.put(FIELD_VALUE, new BasicDBObject(op, value));
         }
         if (filter.getBeginDate() != null) {
-            query.put(FIELD_TIMESTAMP, new BasicDBObject("$gte", filter.getBeginDate()));
+            dateQueries.put("$gte", Date.from(filter.getBeginDate().toInstant()));
         }
         if (filter.getBeginDate() != null) {
             query.put(FIELD_TIMESTAMP, new BasicDBObject("$lte", filter.getBeginDate()));

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -143,7 +143,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
     @Override
     public String getLabel(@Nullable Locale locale) {
-        return "Mongo DB";
+        return "MongoDB";
     }
 
     @Override

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.bson.types.ObjectId;
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
@@ -71,7 +70,6 @@ import com.mongodb.MongoClientURI;
  *
  * @author Thorsten Hoeger - Initial contribution
  */
-@NonNullByDefault
 @Component(service = { PersistenceService.class,
         QueryablePersistenceService.class }, configurationPid = "org.openhab.mongodb", configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class MongoDBPersistenceService implements QueryablePersistenceService {
@@ -84,16 +82,16 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
     private final Logger logger = LoggerFactory.getLogger(MongoDBPersistenceService.class);
 
-    private @NonNullByDefault({}) String url;
-    private @NonNullByDefault({}) String db;
-    private @NonNullByDefault({}) String collection;
+    private String url;
+    private String db;
+    private String collection;
     private boolean collectionPerItem;
 
     private boolean initialized = false;
 
     protected final ItemRegistry itemRegistry;
 
-    private @NonNullByDefault({}) MongoClient cl;
+    private MongoClient cl;
 
     @Activate
     public MongoDBPersistenceService(final @Reference ItemRegistry itemRegistry) {

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -286,7 +286,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             DBCollection mongoCollection = getDatabase().getDB(this.db).getCollection(collectionName);
 
             BasicDBObject idx = new BasicDBObject();
-            idx.append(FIELD_TIMESTAMP, 1).append(FIELD_ITEM, 1);
+            idx.append(FIELD_ITEM, 1).append(FIELD_TIMESTAMP, 1);
             mongoCollection.createIndex(idx);
 
             return mongoCollection;

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -169,7 +169,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
         DBCollection collection = connectToCollection(collectionName);
 
         if (collection == null) {
-            logger.warn("Failed to create collection {}", collectionName);
+            // Logging is done in connectToCollection()
             return;
         }
 
@@ -317,7 +317,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
 
         // If collection creation failed, return nothing.
         if (collection == null) {
-            logger.warn("Failed to connect to collection {}", collectionName);
+            // Logging is done in connectToCollection()
             return Collections.emptyList();
         }
 

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -69,6 +69,7 @@ import com.mongodb.MongoClientURI;
  * This is the implementation of the MongoDB {@link PersistenceService}.
  *
  * @author Thorsten Hoeger - Initial contribution
+ * @author Stephan Brunner - Query fixes, Cleanup
  */
 @Component(service = { PersistenceService.class,
         QueryablePersistenceService.class }, configurationPid = "org.openhab.mongodb", configurationPolicy = ConfigurationPolicy.REQUIRE)

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -222,12 +222,25 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
     }
 
     /**
-     * Checks if we have a database connection
+     * Checks if we have a database connection.
+     * Also tests if communication with the MongoDB-Server is available.
      *
      * @return true if connection has been established, false otherwise
      */
     private boolean isConnected() {
-        return cl != null;
+        if (cl == null) {
+            return false;
+        }
+
+        // Also check if the connection is valid.
+        // Network problems may cause failure sometimes,
+        // even if the connection object was successfully created before.
+        try {
+            cl.getAddress();
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
     }
 
     /**

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -266,6 +266,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             return true;
         } catch (Exception e) {
             logger.error("Failed to connect to database {}", this.url);
+            disconnectFromDatabase();
             return false;
         }
     }

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -209,7 +209,7 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public void store(Item item) {

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -254,7 +254,8 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             disconnectFromDatabase();
 
             this.cl = new MongoClient(new MongoClientURI(this.url));
-            if (collectionPerItem) {
+
+            if (!collectionPerItem) {
                 mongoCollection = cl.getDB(this.db).getCollection(this.collection);
 
                 BasicDBObject idx = new BasicDBObject();

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -339,11 +339,16 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
             Object value = convertValue(filter.getState());
             query.put(FIELD_VALUE, new BasicDBObject(op, value));
         }
+
+        BasicDBObject dateQueries = new BasicDBObject();
         if (filter.getBeginDate() != null) {
             dateQueries.put("$gte", Date.from(filter.getBeginDate().toInstant()));
         }
-        if (filter.getBeginDate() != null) {
-            query.put(FIELD_TIMESTAMP, new BasicDBObject("$lte", filter.getBeginDate()));
+        if (filter.getEndDate() != null) {
+            dateQueries.put("$lte", Date.from(filter.getEndDate().toInstant()));
+        }
+        if (!dateQueries.isEmpty()) {
+            query.put(FIELD_TIMESTAMP, dateQueries);
         }
 
         Integer sortDir = (filter.getOrdering() == Ordering.ASCENDING) ? 1 : -1;

--- a/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
+++ b/bundles/org.openhab.persistence.mongodb/src/main/java/org/openhab/persistence/mongodb/internal/MongoDBPersistenceService.java
@@ -273,11 +273,20 @@ public class MongoDBPersistenceService implements QueryablePersistenceService {
     }
 
     /**
+     * Fetches the currently valid database.
+     *
+     * @return The database object
+     */
+    private MongoClient getDatabase() {
+        return cl;
+    }
+
+    /**
      * Connects to the Collection
      */
     private void connectToCollection(String collectionName) {
         try {
-            mongoCollection = cl.getDB(this.db).getCollection(collectionName);
+            DBCollection mongoCollection = getDatabase().getDB(this.db).getCollection(collectionName);
 
             BasicDBObject idx = new BasicDBObject();
             idx.append(FIELD_TIMESTAMP, 1).append(FIELD_ITEM, 1);


### PR DESCRIPTION
[MongoDB Persistence] Bugfixes and various improvements

I noticed the MongoDB persistence driver had several issues, with the biggest one being the completely broken query support.
Additionally, connection recovery to the database server was not working, either. 
Also, the indices were reordered to improve performance.
Last but not least some code style changed were introduced.
Please see the commits for detailed changes. I split the changes in small commits for easier review.

The changes were tested in my local openHAB snapshot instance, running in docker.

Prebuilt module:
[mongodb-persistence.zip](https://github.com/openhab/openhab-addons/files/6408092/mongodb-persistence.zip)

Fixes #10574
