### PR TITLE
[avmfritz] Correct spelling error and add new device to list of tested devices

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/README.md
+++ b/bundles/org.openhab.binding.avmfritz/README.md
@@ -84,7 +84,8 @@ The following sensors have been successfully tested using FRITZ!OS 7 for FRITZ!B
 - [SmartHome Bewegungsmelder](https://www.smarthome.de/geraete/telekom-smarthome-bewegungsmelder-innen) - a motion sensor (thing type `HAN_FUN_CONTACT`)
 - [SmartHome Rauchmelder](https://www.smarthome.de/geraete/smarthome-rauchmelder-weiss) - a smoke detector (thing type `HAN_FUN_CONTACT`)
 - [SmartHome Wandtaster](https://www.smarthome.de/geraete/telekom-smarthome-wandtaster) - a switch with two buttons (thing type `HAN_FUN_SWITCH`)
-- [Rollershutter/Blinds](https://www.rademacher.de/shop/rollladen-sonnenschutz/elektrischer-gurtwickler/rollotron-dect-1213) - an electronic belt winder (thing type `HAN_FUN_BLINDS`)
+- [Rollotron DECT 1213](https://www.rademacher.de/shop/rollladen-sonnenschutz/elektrischer-gurtwickler/rollotron-dect-1213) - an electronic belt winder (thing type `HAN_FUN_BLINDS`)
+- [Becker BoxCTRL](https://becker-antriebe.shop/) - a radio controlled roller shutter drive (thing type `HAN_FUN_BLINDS`)
 
 The use of other Sensors should be possible, if these are compatible with DECT-ULE / HAN-FUN standards.
 

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/i18n/avmfritz_de.properties
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/i18n/avmfritz_de.properties
@@ -99,8 +99,8 @@ thing-type.avmfritz.FRITZ_DECT_440.description = FRITZ!DECT 440 Taster. Dient zu
 
 thing-type.avmfritz.FRITZ_Powerline_546E.description = FRITZ!Powerline 546E schaltbare Steckdose. Dient zur Steuerung der integrierten Steckdose und liefert Daten wie z.B. Temperatur.
 
-thing-type.avmfritz.HAN_FUN_BLINDS.label = HAN-FUN Rolladen
-thing-type.avmfritz.HAN_FUN_BLINDS.description = HAN-FUN Rolladen (z.B. Rollotron DECT 1213).
+thing-type.avmfritz.HAN_FUN_BLINDS.label = HAN-FUN Rollladen
+thing-type.avmfritz.HAN_FUN_BLINDS.description = HAN-FUN Rollladen (z.B. Rollotron DECT 1213, Becker BoxCTRL).
 
 # thing types config groups
 thing-type.avmfritz.FRITZ_GROUP_HEATING.label = Heizkörperregler
@@ -217,8 +217,8 @@ thing-type.avmfritz.FRITZ_DECT_400.channel.press.description = Wird ausgelöst, w
 thing-type.avmfritz.FRITZ_DECT_440.channel.press.label = Tastendruck
 thing-type.avmfritz.FRITZ_DECT_440.channel.press.description = Wird ausgelöst, wenn eine Taste gedrückt wird.
 
-channel-type.avmfritz.rollershutter.label = Rolladensteuerung
-channel-type.avmfritz.rollershutter.description = Steuert den Rolladen und zeigt seinen Öffnungsgrad in Prozent an.
+channel-type.avmfritz.rollershutter.label = Rollladensteuerung
+channel-type.avmfritz.rollershutter.description = Steuert den Rollladen und zeigt seinen Öffnungsgrad in Prozent an.
 
 channel-type.avmfritz.last_change.label = Letzte Änderung
 channel-type.avmfritz.last_change.description = Zeigt an, wann der Schalter zuletzt gedrückt wurde.


### PR DESCRIPTION
This PR corrects a spelling error in the German translation (Rolladen with 2 instead of 3 l's) and adds the Becker BoxCTRL roller shutter drive to the list of tested devices.

There are no functional changes in this PR, just text changes.