### PR TITLE
[irobot] Fix MQTT - Quality of Service

### DIFF
--- a/bundles/org.openhab.binding.irobot/README.md
+++ b/bundles/org.openhab.binding.irobot/README.md
@@ -27,6 +27,8 @@ known, however, whether the password is eternal or can change during factory res
 |-----------|----------------------------------------|
 | ipaddress | IP address (or hostname) of your robot |
 | password  | Password for the robot                 |
+| mqttQos   | MQTT - Quality of Service              |
+
 
 ## Channels
 

--- a/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/RoombaConfiguration.java
+++ b/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/RoombaConfiguration.java
@@ -24,4 +24,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class RoombaConfiguration {
     public String ipaddress = "";
     public String password = "";
+    public int mqttQos = 1;
 }

--- a/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/handler/RoombaHandler.java
+++ b/bundles/org.openhab.binding.irobot/src/main/java/org/openhab/binding/irobot/internal/handler/RoombaHandler.java
@@ -214,9 +214,7 @@ public class RoombaHandler extends BaseThingHandler implements MqttConnectionObs
         if (conn != null) {
             String json = gson.toJson(request);
             logger.trace("Sending {}: {}", request.getTopic(), json);
-            // 1 here actually corresponds to MQTT qos 0 (AT_MOST_ONCE). Only this value is accepted
-            // by Roomba, others just cause it to reject the command and drop the connection.
-            conn.publish(request.getTopic(), json.getBytes(), 1, false);
+            conn.publish(request.getTopic(), json.getBytes(), config.mqttQos, false);
         }
     }
 

--- a/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.irobot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -62,6 +62,12 @@
 			<parameter name="password" type="text">
 				<label>Password</label>
 			</parameter>
+			<parameter name="mqttQos" type="integer">
+				<label>MQTT - Quality of Service</label>
+				<description>There are 3 QoS levels in MQTT: At most once (0), at least once (1), and exactly once (2)</description>
+				<advanced>true</advanced>
+				<default>1</default>
+			</parameter>
 
 		</config-description>
 	</thing-type>


### PR DESCRIPTION
When I updated my openhab installation from 3.1.0.M1 to 3.1.0.M3 the iRobot Binding stopped working. It was still able to connect to my i7 and get all the information, but no commands could be sent anymore.

I figured out that the problem was the MQTT - Quality of Service. When it was set to 1 it did not work, but when I set it to 0 it worked again.

To not break other setups I made the MQTT as property with 1 (the old value) as default value.

Signed-off-by: Florian Binder <fb@java4.info>
