### PR TITLE
[insteon] leave network binding in INITIALIZING state until state is known.

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
@@ -78,7 +78,6 @@ public class InsteonNetworkHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("Starting Insteon bridge");
         config = getConfigAs(InsteonNetworkConfiguration.class);
-        updateStatus(ThingStatus.UNKNOWN);
 
         scheduler.execute(() -> {
             InsteonNetworkConfiguration config = this.config;


### PR DESCRIPTION
This fixes a race condition where devices try to access insteonBinding before it's created.