### PR TITLE
[insteon] delay setting state of network to UNKNOWN

### DIFF
--- a/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
+++ b/bundles/org.openhab.binding.insteon/src/main/java/org/openhab/binding/insteon/internal/handler/InsteonNetworkHandler.java
@@ -78,7 +78,6 @@ public class InsteonNetworkHandler extends BaseBridgeHandler {
     public void initialize() {
         logger.debug("Starting Insteon bridge");
         config = getConfigAs(InsteonNetworkConfiguration.class);
-        updateStatus(ThingStatus.UNKNOWN);
 
         scheduler.execute(() -> {
             InsteonNetworkConfiguration config = this.config;
@@ -99,6 +98,7 @@ public class InsteonNetworkHandler extends BaseBridgeHandler {
                 return;
             }
             insteonBinding = new InsteonBinding(this, config, serialPortManager, scheduler);
+            updateStatus(ThingStatus.UNKNOWN);
 
             // hold off on starting to poll until devices that already are defined as things are added.
             // wait SETTLE_TIME_IN_SECONDS to start then check every second afterwards until it has been at


### PR DESCRIPTION
This fixes a race condition where devices try to access insteonBinding before it's created. See https://community.openhab.org/t/losing-insteon-connectivity-on-reboot/121005

