### PR TITLE
[velbus] Fixed parsing of channel bytes on VMB4AN.

### DIFF
--- a/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
+++ b/bundles/org.openhab.binding.velbus/src/main/java/org/openhab/binding/velbus/internal/handler/VelbusVMB4ANHandler.java
@@ -232,7 +232,7 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected byte convertAlarmChannelUIDToChannelByte(ChannelUID channelUID) {
-        return Byte.parseByte(channelUID.getIdWithoutGroup());
+        return Byte.parseByte(channelUID.getIdWithoutGroup().replaceAll(CHANNEL, ""));
     }
 
     protected boolean isTextAnalogInputChannel(ChannelUID channelUID) {
@@ -246,11 +246,12 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected byte convertRawAnalogInputChannelUIDToChannelByte(ChannelUID channelUID) {
-        return Byte.parseByte(channelUID.getIdWithoutGroup().replaceAll(RAW_CHANNEL_SUFFIX, ""));
+        return Byte
+                .parseByte(channelUID.getIdWithoutGroup().replaceAll(CHANNEL, "").replaceAll(RAW_CHANNEL_SUFFIX, ""));
     }
 
     protected byte convertTextAnalogInputChannelUIDToChannelByte(ChannelUID channelUID) {
-        return Byte.parseByte(channelUID.getIdWithoutGroup());
+        return Byte.parseByte(channelUID.getIdWithoutGroup().replaceAll(CHANNEL, ""));
     }
 
     protected String convertAnalogInputChannelByteToRawChannelUID(byte channelByte) {
@@ -258,7 +259,7 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected String convertAnalogInputChannelByteToChannelUID(byte channelByte) {
-        return ANALOG_INPUT_GROUP + "#" + channelByte;
+        return ANALOG_INPUT_GROUP + "#" + CHANNEL + channelByte;
     }
 
     protected boolean isAnalogOutputChannel(ChannelUID channelUID) {
@@ -266,7 +267,7 @@ public class VelbusVMB4ANHandler extends VelbusSensorWithAlarmClockHandler {
     }
 
     protected byte convertAnalogOutputChannelUIDToChannelByte(ChannelUID channelUID) {
-        return Byte.parseByte(channelUID.getIdWithoutGroup());
+        return Byte.parseByte(channelUID.getIdWithoutGroup().replaceAll(CHANNEL, ""));
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a wrong parsing of the channel on the VMB4AN module, which prevented the values to be shown correctly.

Signed-off-by: Cedric Boon <cedric.boon@hotmail.com>
