### PR TITLE
[modbus e3dc] remove logo from readme and add default state patterns

### DIFF
--- a/bundles/org.openhab.binding.modbus.e3dc/README.md
+++ b/bundles/org.openhab.binding.modbus.e3dc/README.md
@@ -1,7 +1,5 @@
 # E3DC
 
-<img align="right" src="./doc/E3DC_logo.png"/>
-
 Integrates the Home Power Plants from E3/DC GmbH into openHAB. 
 See [E3DC Website](https://www.e3dc.com/) to find more informations about the device.
 The Power Plant handles all your Electrical Energy Resources like Photovoltaic Producers, Battery Storage, Wallbox Power Supply, Household Consumption and even more.  

--- a/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/power-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/power-channel-types.xml
@@ -7,60 +7,72 @@
 		<item-type>Number:Power</item-type>
 		<label>PV Output</label>
 		<description>Photovoltaic Power Production</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="battery-power-supply-channel">
 		<item-type>Number:Power</item-type>
 		<label>Battery Discharge</label>
 		<description>Battery discharges and provides Power</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="battery-power-consumption-channel">
 		<item-type>Number:Power</item-type>
 		<label>Battery Charge</label>
 		<description>Battery charges and consumes Power</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="household-power-consumption-channel">
 		<item-type>Number:Power</item-type>
 		<label>Household Consumption</label>
 		<description>Household consuming Power</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="grid-power-consumption-channel">
 		<item-type>Number:Power</item-type>
 		<label>Grid Power Consumption</label>
 		<description>More Photovoltaic Power is produced than needed. Additional Power is consumed by Grid</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="grid-power-supply-channel">
 		<item-type>Number:Power</item-type>
 		<label>Grid Power Supply</label>
 		<description>Grid Power is needed in order to satisfy your overall Power consumption</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="external-power-supply-channel">
 		<item-type>Number:Power</item-type>
 		<label>External Power Supply</label>
 		<description>Power produced by an external device which is attached to your E3DC device</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="wallbox-power-consumption-channel">
 		<item-type>Number:Power</item-type>
 		<label>Wallbox Power Consumption</label>
 		<description>Power consumption of attached Wallboxes</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="wallbox-pv-power-consumption-channel">
 		<item-type>Number:Power</item-type>
 		<label>Wallbox PV Power Consumption</label>
 		<description>Photovoltaic Power consumption (PV plus Battery) of attached Wallboxes</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="autarky-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Autarky</label>
 		<description>Your current Autarky Level in Percent</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="self-consumption-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Self Consumtion</label>
 		<description>Your current Photovoltaic Self Consumption Level in Percent</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="battery-soc-channel">
 		<item-type>Number:Dimensionless</item-type>
 		<label>Battery State Of Charge</label>
 		<description>Charge Level of your attached Battery in Percent</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/strings-channel-types.xml
+++ b/bundles/org.openhab.binding.modbus.e3dc/src/main/resources/OH-INF/thing/strings-channel-types.xml
@@ -7,45 +7,54 @@
 		<item-type>Number:ElectricPotential</item-type>
 		<label>String 1 Potential</label>
 		<description>Voltage on String 1</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string2-dc-voltage-channel">
 		<item-type>Number:ElectricPotential</item-type>
 		<label>String 2 Potential</label>
 		<description>Voltage on String 2</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string3-dc-voltage-channel">
 		<item-type>Number:ElectricPotential</item-type>
 		<label>String 3 Potential</label>
 		<description>Voltage on String 3</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string1-dc-current-channel">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>String 1 Current</label>
 		<description>Current on String 1</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string2-dc-current-channel">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>String 2 Current</label>
 		<description>Current on String 2</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string3-dc-current-channel">
 		<item-type>Number:ElectricCurrent</item-type>
 		<label>String 3 Current</label>
 		<description>Current on String 3</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string1-dc-output-channel">
 		<item-type>Number:Power</item-type>
 		<label>String 1 Power</label>
 		<description>Power produced by String 1</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string2-dc-output-channel">
 		<item-type>Number:Power</item-type>
 		<label>String 2 Power</label>
 		<description>Power produced by String 2</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="string3-dc-output-channel">
 		<item-type>Number:Power</item-type>
 		<label>String 3 Power</label>
 		<description>Power produced by String 3</description>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Removed logo from readme.md and added it to openhab-docs repo https://github.com/openhab/openhab-docs/pull/1566
Added default state patterns in xml to provide proper UI display with units of measure