### PR TITLE
[luxtronikheatpump] Update channel descriptions in README.md

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/README.md
+++ b/bundles/org.openhab.binding.luxtronikheatpump/README.md
@@ -53,7 +53,6 @@ The following channels are holding read only values:
 | temperatureOutside | Number:Temperature |   | Outside temperature |
 | temperatureOutsideMean | Number:Temperature |   | Average temperature outside over 24 h (heating limit function) |
 | temperatureHotWater | Number:Temperature |   | Hot water actual temperature |
-| temperatureHotWaterTarget | Number:Temperature |   | Hot water target temperature |
 | temperatureHeatSourceInlet | Number:Temperature | x | Heat source inlet temperature |
 | temperatureHeatSourceOutlet | Number:Temperature | x | Heat source outlet temperature |
 | temperatureMixingCircuit1Flow | Number:Temperature | x | Mixing circuit 1 Flow temperature |
@@ -253,7 +252,7 @@ The following channels are also writable:
 | channel  | type   | advanced | description                  |
 |----------|--------|----------|------------------------------|
 | temperatureHeatingParallelShift | Number:Temperature |   | Heating temperature (parallel shift) |
-| temperatureTargetHotWater_2 | Number:Temperature |   | Hot water temperature |
+| temperatureHotWaterTarget | Number:Temperature |   | Hot water target temperature |
 | heatingMode | Number |   | Heating mode |
 | hotWaterMode | Number |   | Hot water operating mode |
 | thermalDisinfectionMonday | Switch |  x  | Thermal disinfection (Monday) |

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -60,13 +60,6 @@
 		<state pattern="%.1f %unit%" readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="temperatureHotWaterTarget">
-		<item-type>Number:Temperature</item-type>
-		<label>Hot Water Target Temp.</label>
-		<category>Temperature</category>
-		<state pattern="%.1f %unit%" readOnly="true"/>
-	</channel-type>
-
 	<channel-type id="temperatureHeatSourceInlet" advanced="true">
 		<item-type>Number:Temperature</item-type>
 		<label>Heat Source Inlet Temp.</label>
@@ -1961,9 +1954,9 @@
 		<state pattern="%.1f %unit%" min="-10" max="10" step="0.5"></state>
 	</channel-type>
 
-	<channel-type id="temperatureTargetHotWater_2">
+	<channel-type id="temperatureHotWaterTarget">
 		<item-type>Number:Temperature</item-type>
-		<label>Hot Water Temp.</label>
+		<label>Hot Water Target Temp.</label>
 		<category>Temperature</category>
 		<state pattern="%.1f %unit%" min="30" max="65" step="0.5"></state>
 	</channel-type>


### PR DESCRIPTION
temperatureHotWaterTarget channel is writable
temperatureTargetHotWater_2  channel doesn't exist in the binding

Signed-off-by: Martin Kurgi <martinkurgi@gmail.com>

