### PR TITLE
[nikohomecontrol] Switch off hostname validation.

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NhcMqttConnection2.java
@@ -158,7 +158,7 @@ public class NhcMqttConnection2 implements MqttActionCallback {
     }
 
     private MqttBrokerConnection createMqttConnection() throws MqttException {
-        MqttBrokerConnection connection = new MqttBrokerConnection(cocoAddress, port, true, clientId);
+        MqttBrokerConnection connection = new MqttBrokerConnection(cocoAddress, port, true, false, clientId);
         connection.setTrustManagers(trustManagers);
         connection.setCredentials(profile, token);
         connection.setQos(1);


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

Depends on openhab-core [#2348](https://github.com/openhab/openhab-core/pull/2348)

The recent upgrade of hivemq introduces hostname validation for secure connections by default. This breaks the nikohomecontrol binding.
This change uses a new flag introduced in the openhab-core PR for the mqtt transport to disable this behaviour.

It can only be merged after the openhab-core PR.

See also conversation on the [forum](https://community.openhab.org/t/niko-home-control-energymeter-returning-undef/120959/11).