### PR TITLE
[SenecHome] Catch and ignore malformed JSON

### DIFF
--- a/bundles/org.openhab.binding.senechome/pom.xml
+++ b/bundles/org.openhab.binding.senechome/pom.xml
@@ -14,11 +14,4 @@
 
   <name>openHAB Add-ons :: Bundles :: SenecHome Binding</name>
 
-  <dependencies>
-    <dependency>
-      <artifactId>json</artifactId>
-      <groupId>org.json</groupId>
-      <version>20180813</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/bundles/org.openhab.binding.senechome/pom.xml
+++ b/bundles/org.openhab.binding.senechome/pom.xml
@@ -14,4 +14,11 @@
 
   <name>openHAB Add-ons :: Bundles :: SenecHome Binding</name>
 
+  <dependencies>
+    <dependency>
+      <artifactId>json</artifactId>
+      <groupId>org.json</groupId>
+      <version>20180813</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.MalformedJsonException;
 
 /**
  * The {@link SenecHomeApi} class configures http client and
@@ -86,17 +87,22 @@ public class SenecHomeApi {
                 logger.trace("Got unexpected response code {}", response.getStatus());
                 throw new IOException("Got unexpected response code " + response.getStatus());
             }
-        } catch (JsonSyntaxException | InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (MalformedJsonException | JsonSyntaxException | InterruptedException | TimeoutException
+                | ExecutionException e) {
             logger.trace("Issue with getting SenecHomeResponse");
             logger.trace("location: {}", location);
             logger.trace("request: {}", request.toString());
             logger.trace("request.getHeaders: {}", request.getHeaders());
-            logger.trace("response: {}", response.toString());
-            logger.trace("response.getHeaders: {}", response.getHeaders());
-            if (response.getContent() == null) {
-                logger.trace("response.getContent is null");
+            if (response == null) {
+                logger.trace("response is null");
             } else {
-                logger.trace("response.getContentAsString: {}", response.getContentAsString());
+                logger.trace("response: {}", response.toString());
+                logger.trace("response.getHeaders: {}", response.getHeaders());
+                if (response.getContent() == null) {
+                    logger.trace("response.getContent is null");
+                } else {
+                    logger.trace("response.getContentAsString: {}", response.getContentAsString());
+                }
             }
             throw e;
         }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.stream.MalformedJsonException;
 
 /**
  * The {@link SenecHomeApi} class configures http client and
@@ -80,12 +81,17 @@ public class SenecHomeApi {
             response = request.method(HttpMethod.POST)
                     .content(new StringContentProvider(gson.toJson(new SenecHomeResponse()))).send();
             if (response.getStatus() == HttpStatus.OK_200) {
+                if (response.getContent() == null) {
+                    logger.warn("response.getContent is null");
+                } else {
+                    logger.info("response.getContentAsString: {}", response.getContentAsString());
+                }
                 return Objects.requireNonNull(gson.fromJson(response.getContentAsString(), SenecHomeResponse.class));
             } else {
                 logger.trace("Got unexpected response code {}", response.getStatus());
                 throw new IOException("Got unexpected response code " + response.getStatus());
             }
-        } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (MalformedJsonException | InterruptedException | TimeoutException | ExecutionException e) {
             logger.warn("Issue with getting SenecHomeResponse");
             logger.warn("location: {}", location);
             logger.warn("request: {}", request.toString());

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -27,16 +27,12 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.openhab.binding.senechome.internal.json.SenecHomeResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-import com.google.gson.stream.MalformedJsonException;
 
 /**
  * The {@link SenecHomeApi} class configures http client and
@@ -85,47 +81,24 @@ public class SenecHomeApi {
             response = request.method(HttpMethod.POST)
                     .content(new StringContentProvider(gson.toJson(new SenecHomeResponse()))).send();
             if (response.getStatus() == HttpStatus.OK_200) {
-                if (response.getContent() == null) {
-                    logger.warn("response.getContent is null");
-                } else {
-                    if (!isJSONValid(response.getContentAsString())) {
-                        logger.warn("Response is NO valid JSON: {}", response.getContentAsString());
-                    }
-                }
                 return Objects.requireNonNull(gson.fromJson(response.getContentAsString(), SenecHomeResponse.class));
             } else {
                 logger.trace("Got unexpected response code {}", response.getStatus());
                 throw new IOException("Got unexpected response code " + response.getStatus());
             }
-        } catch (JsonSyntaxException | MalformedJsonException | InterruptedException | TimeoutException
-                | ExecutionException e) {
-            logger.warn("Issue with getting SenecHomeResponse");
-            logger.warn("location: {}", location);
-            logger.warn("request: {}", request.toString());
-            logger.warn("request.getHeaders: {}", request.getHeaders());
-            logger.warn("response: {}", response.toString());
-            logger.warn("response.getHeaders: {}", response.getHeaders());
+        } catch (JsonSyntaxException | InterruptedException | TimeoutException | ExecutionException e) {
+            logger.trace("Issue with getting SenecHomeResponse");
+            logger.trace("location: {}", location);
+            logger.trace("request: {}", request.toString());
+            logger.trace("request.getHeaders: {}", request.getHeaders());
+            logger.trace("response: {}", response.toString());
+            logger.trace("response.getHeaders: {}", response.getHeaders());
             if (response.getContent() == null) {
-                logger.warn("response.getContent is null");
+                logger.trace("response.getContent is null");
             } else {
-                logger.warn("response.getContentAsString: {}", response.getContentAsString());
+                logger.trace("response.getContentAsString: {}", response.getContentAsString());
             }
             throw e;
         }
-    }
-
-    public boolean isJSONValid(String test) {
-        try {
-            new JSONObject(test);
-        } catch (JSONException ex) {
-            // edited, to include @Arthur's comment
-            // e.g. in case JSONArray is valid as well...
-            try {
-                new JSONArray(test);
-            } catch (JSONException ex1) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -75,14 +75,29 @@ public class SenecHomeApi {
         Request request = httpClient.newRequest(location);
         request.header(HttpHeader.ACCEPT, MimeTypes.Type.APPLICATION_JSON.asString());
         request.header(HttpHeader.CONTENT_TYPE, MimeTypes.Type.FORM_ENCODED.asString());
-        ContentResponse response = request.method(HttpMethod.POST)
-                .content(new StringContentProvider(gson.toJson(new SenecHomeResponse()))).send();
-
-        if (response.getStatus() == HttpStatus.OK_200) {
-            return Objects.requireNonNull(gson.fromJson(response.getContentAsString(), SenecHomeResponse.class));
-        } else {
-            logger.trace("Got unexpected response code {}", response.getStatus());
-            throw new IOException("Got unexpected response code " + response.getStatus());
+        ContentResponse response = null;
+        try {
+            response = request.method(HttpMethod.POST)
+                    .content(new StringContentProvider(gson.toJson(new SenecHomeResponse()))).send();
+            if (response.getStatus() == HttpStatus.OK_200) {
+                return Objects.requireNonNull(gson.fromJson(response.getContentAsString(), SenecHomeResponse.class));
+            } else {
+                logger.trace("Got unexpected response code {}", response.getStatus());
+                throw new IOException("Got unexpected response code " + response.getStatus());
+            }
+        } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
+            logger.warn("Issue with getting SenecHomeResponse");
+            logger.warn("location: {}", location);
+            logger.warn("request: {}", request.toString());
+            logger.warn("request.getHeaders: {}", request.getHeaders());
+            logger.warn("response: {}", response.toString());
+            logger.warn("response.getHeaders: {}", response.getHeaders());
+            if (response.getContent() == null) {
+                logger.warn("response.getContent is null");
+            } else {
+                logger.warn("response.getContentAsString: {}", response.getContentAsString());
+            }
+            throw e;
         }
     }
 }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeApi.java
@@ -89,21 +89,21 @@ public class SenecHomeApi {
             }
         } catch (MalformedJsonException | JsonSyntaxException | InterruptedException | TimeoutException
                 | ExecutionException e) {
-            logger.trace("Issue with getting SenecHomeResponse");
-            logger.trace("location: {}", location);
-            logger.trace("request: {}", request.toString());
-            logger.trace("request.getHeaders: {}", request.getHeaders());
+            String errorMessage = "\nlocation: " + location;
+            errorMessage += "\nrequest: " + request.toString();
+            errorMessage += "\nrequest.getHeaders: " + request.getHeaders();
             if (response == null) {
-                logger.trace("response is null");
+                errorMessage += "\nresponse: null";
             } else {
-                logger.trace("response: {}", response.toString());
-                logger.trace("response.getHeaders: {}", response.getHeaders());
+                errorMessage += "\nresponse: " + response.toString();
+                errorMessage += "\nresponse.getHeaders: " + response.getHeaders();
                 if (response.getContent() == null) {
-                    logger.trace("response.getContent is null");
+                    errorMessage += "\nresponse.getContent is null";
                 } else {
-                    logger.trace("response.getContentAsString: {}", response.getContentAsString());
+                    errorMessage += "\nresponse.getContentAsString: " + response.getContentAsString();
                 }
             }
+            logger.trace("Issue with getting SenecHomeResponse\n{}", errorMessage);
             throw e;
         }
     }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -121,8 +121,9 @@ public class SenecHomeHandler extends BaseThingHandler {
     }
 
     public @Nullable Boolean refreshState() {
+        SenecHomeResponse response = null;
         try {
-            SenecHomeResponse response = senecHomeApi.getStatistics();
+            response = senecHomeApi.getStatistics();
             logger.trace("received {}", response);
 
             BigDecimal pvLimitation = new BigDecimal(100).subtract(getSenecValue(response.limitation.powerLimitation))
@@ -280,6 +281,7 @@ public class SenecHomeHandler extends BaseThingHandler {
             errorCounter = 0;
             updateStatus(ThingStatus.ONLINE);
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
+            logger.warn("Faulty response: {}", response.toString());
             logger.warn("Error refreshing source '{}'", getThing().getUID(), e);
             if (errorCounter < 3)
                 errorCounter++;

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.core.types.RefreshType.REFRESH;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
@@ -51,8 +50,6 @@ import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.gson.stream.MalformedJsonException;
 
 /**
  * The {@link SenecHomeHandler} is responsible for handling commands, which are
@@ -279,8 +276,7 @@ public class SenecHomeHandler extends BaseThingHandler {
             updateGridPowerValues(getSenecValue(response.grid.currentGridValue));
 
             updateStatus(ThingStatus.ONLINE);
-        } catch (IOException | InterruptedException | TimeoutException | ExecutionException | SocketTimeoutException
-                | MalformedJsonException e) {
+        } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
             logger.warn("Error refreshing source '{}'", getThing().getUID(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Could not connect to Senec web interface:" + e.getMessage());

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.core.types.RefreshType.REFRESH;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
@@ -50,6 +51,8 @@ import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.stream.MalformedJsonException;
 
 /**
  * The {@link SenecHomeHandler} is responsible for handling commands, which are
@@ -276,7 +279,8 @@ public class SenecHomeHandler extends BaseThingHandler {
             updateGridPowerValues(getSenecValue(response.grid.currentGridValue));
 
             updateStatus(ThingStatus.ONLINE);
-        } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
+        } catch (IOException | InterruptedException | TimeoutException | ExecutionException | SocketTimeoutException
+                | MalformedJsonException e) {
             logger.warn("Error refreshing source '{}'", getThing().getUID(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                     "Could not connect to Senec web interface:" + e.getMessage());

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -281,7 +281,11 @@ public class SenecHomeHandler extends BaseThingHandler {
             errorCounter = 0;
             updateStatus(ThingStatus.ONLINE);
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
-            logger.warn("Faulty response: {}", response.toString());
+            if (response == null) {
+                logger.warn("Faulty response: is null");
+            } else {
+                logger.warn("Faulty response: {}", response.toString());
+            }
             logger.warn("Error refreshing source '{}'", getThing().getUID(), e);
             if (errorCounter < 3)
                 errorCounter++;

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -281,9 +281,9 @@ public class SenecHomeHandler extends BaseThingHandler {
             updateStatus(ThingStatus.ONLINE);
         } catch (JsonSyntaxException | IOException | InterruptedException | TimeoutException | ExecutionException e) {
             if (response == null) {
-                logger.warn("Faulty response: is null");
+                logger.trace("Faulty response: is null");
             } else {
-                logger.warn("Faulty response: {}", response.toString());
+                logger.trace("Faulty response: {}", response.toString());
             }
             logger.warn("Error refreshing source '{}'", getThing().getUID(), e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,


### PR DESCRIPTION
Hello,

this PR shall fix Issue #10025 .

### The Issue
Some Senec Home Devices do respond with a broken JSON. One example

Good:
```json
        "POWER_RATIO_L3": "u3_00000064",
        "PV_MISSING": "u8_03",
        "P_TOTAL": "fl_C2EA7EFB",
        "STATE_INT": [
            "u3_00000110",
            "u3_00000110"
        ],
        "TYPE": "u8_A0"
    },
    "ENERGY": {
        "CAPTESTMODULE": [
            "fl_00000000",
            "fl_00000000",
            "fl_00000000",
            "fl_00000000"
        ],
        "GUI_BAT_DATA_COLLECTED": "u8_01",
        "GUI_BAT_DATA_CURRENT": "fl_BD8F5C29",
        "GUI_BAT_DATA_FUEL_CHARGE": "fl_00000000",
```

Malformed:
```json
        "POWER_RATIO_L3": "u3_00000064",
        "PV_MISS",
        "GUI_BAT_DATA_FUEL_CHARGE": "fl_00000000",
```

This was leading to an exception:
> 2021-04-30 19:58:54.904 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
> com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Expected ':' at line 1 column 1009 path $.PV1.PV_MISS
>         at com.google.gson.Gson.fromJson(Gson.java:947) ~[?:?]
>         at com.google.gson.Gson.fromJson(Gson.java:897) ~[?:?]
>         at com.google.gson.Gson.fromJson(Gson.java:846) ~[?:?]
>         at com.google.gson.Gson.fromJson(Gson.java:817) ~[?:?]
>         at org.openhab.binding.senechome.internal.SenecHomeApi.getStatistics(SenecHomeApi.java:97) ~[?:?]
>         at org.openhab.binding.senechome.internal.SenecHomeHandler.refreshState(SenecHomeHandler.java:126) ~[?:?]
>         at org.openhab.core.cache.ExpiringCache.refreshValue(ExpiringCache.java:101) ~[?:?]
>         at org.openhab.core.cache.ExpiringCache.getValue(ExpiringCache.java:72) ~[?:?]
>         at org.openhab.binding.senechome.internal.SenecHomeHandler.refresh(SenecHomeHandler.java:120) ~[?:?]
>         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
>         at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
>         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
>         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
>         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
>         at java.lang.Thread.run(Thread.java:834) [?:?]
> Caused by: com.google.gson.stream.MalformedJsonException: Expected ':' at line 1 column 1009 path $.PV1.PV_MISS
>         at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1564) ~[?:?]
>         at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:531) ~[?:?]
>         at com.google.gson.stream.JsonReader.skipValue(JsonReader.java:1233) ~[?:?]
>         at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:220) ~[?:?]
>         at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[?:?]
>         at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[?:?]
>         at com.google.gson.Gson.fromJson(Gson.java:932) ~[?:?]

### The Fix:
The JsonSyntaxException was not catched. And this was crashing the SenecHome Binding without recovery. Now the Exeption is catched, the Binding is set offline. The malformed JSON is ignored. But next cycle the Binding will recover itself.

### JARs
These Jars were build by the Jenkins Test Job
[org.openhab.binding.senechome-3.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab-addons/files/6447207/org.openhab.binding.senechome-3.1.0-SNAPSHOT.zip)



Cheers

PS: A huge thank you to @Puddingkuchen , together we could identify and fix the Issue