### PR TITLE
Bump jsonpath dependency from 2.4.0 to 2.5.0

### DIFF
--- a/bundles/org.openhab.transform.jsonpath/pom.xml
+++ b/bundles/org.openhab.transform.jsonpath/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bump jsonpath dependency version

Signed-off-by: Alexander Falkenstern <alexander.falkenstern@gmail.com>
