### PR TITLE
Update Jackson version to 2.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bnd.version>5.3.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
-    <jackson.version>2.12.2</jackson.version>
+    <jackson.version>2.12.3</jackson.version>
     <karaf.version>4.3.1</karaf.version>
     <netty.version>4.1.63.Final</netty.version>
     <sat.version>0.11.1</sat.version>


### PR DESCRIPTION
This is the version used in the feature provided by openhab-core.

Depends https://github.com/openhab/openhab-core/pull/2357