### PR TITLE
[nuki] Adds another way to get the nukiId

### DIFF
--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -43,7 +43,7 @@ The following configuration options are available:
 
 | Parameter | Description                                                                                                                                                                                               | Comment       |
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| nukiId    | The `Nuki-ID` of the Nuki Smart Lock. It is a 8-digit hexadecimal string. Look it up on the sticker on the back of the Nuki Smart Lock (remove mounting plate). It can also be queried in the Nuki app (Sidebar > Manage my devices > Smart Lock > [Your lock] > Connection status, then tap anywhere on the screen)                                         | Required      |
+| nukiId    | The `Nuki-ID` of the Nuki Smart Lock. It is a 8-digit hexadecimal string. Look it up on the sticker on the back of the Nuki Smart Lock (remove mounting plate). It can also be retrieved in the Nuki app (Sidebar > Manage my devices > Smart Lock > [Your lock] > Connection status, then tap anywhere on the screen)                                         | Required      |
 | unlatch   | If set to `true` the Nuki Smart Lock will unlock the door but then also automatically pull the latch of the door lock. Usually, if the door hinges are correctly adjusted, the door will then swing open. | Default false |
 
 ## Supported Channels

--- a/bundles/org.openhab.binding.nuki/README.md
+++ b/bundles/org.openhab.binding.nuki/README.md
@@ -43,7 +43,7 @@ The following configuration options are available:
 
 | Parameter | Description                                                                                                                                                                                               | Comment       |
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| nukiId    | The `Nuki-ID` of the Nuki Smart Lock. It is a 8-digit hexadecimal string. Look it up on the sticker on the back of the Nuki Smart Lock (remove mounting plate).                                           | Required      |
+| nukiId    | The `Nuki-ID` of the Nuki Smart Lock. It is a 8-digit hexadecimal string. Look it up on the sticker on the back of the Nuki Smart Lock (remove mounting plate). It can also be queried in the Nuki app (Sidebar > Manage my devices > Smart Lock > [Your lock] > Connection status, then tap anywhere on the screen)                                         | Required      |
 | unlatch   | If set to `true` the Nuki Smart Lock will unlock the door but then also automatically pull the latch of the door lock. Usually, if the door hinges are correctly adjusted, the door will then swing open. | Default false |
 
 ## Supported Channels

--- a/bundles/org.openhab.binding.nuki/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nuki/src/main/resources/OH-INF/thing/thing-types.xml
@@ -53,7 +53,7 @@
 			<parameter name="nukiId" type="text" required="true">
 				<label>Nuki ID</label>
 				<description>The 8-digit hexadecimal string that identifies the Nuki Smart Lock. Look it up on the sticker on the
-					back of the Nuki Smart Lock (remove mounting plate).</description>
+					back of the Nuki Smart Lock (remove mounting plate). It can also be retrieved in the Nuki app (Sidebar > Manage my devices > Smart Lock > [Your lock] > Connection status, then tap anywhere on the screen)</description>
 			</parameter>
 			<parameter name="unlatch" type="boolean" required="false">
 				<label>Unlatch</label>


### PR DESCRIPTION
# Adds an alternate way to retrieve the nukiId

This updates the documentation with another way of retrieving the `nukiId` required for setup. This way is easier and does not require the user to remove the lock. 

EDIT: Also updates the UI


