### PR TITLE
[influxdb] Fix issue #10464 Problem querying old historical data

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConfiguration.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConfiguration.java
@@ -14,6 +14,7 @@ package org.openhab.persistence.influxdb.internal;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -61,7 +62,7 @@ public class InfluxDBConfiguration {
         token = (String) config.getOrDefault(TOKEN_PARAM, "");
         databaseName = (String) config.getOrDefault(DATABASE_PARAM, "openhab");
         retentionPolicy = (String) config.getOrDefault(RETENTION_POLICY_PARAM, "autogen");
-        version = parseInfluxVersion(config.getOrDefault(VERSION_PARAM, InfluxDBVersion.V1.name()));
+        version = parseInfluxVersion((String) config.getOrDefault(VERSION_PARAM, InfluxDBVersion.V1.name()));
 
         replaceUnderscore = getConfigBooleanValue(config, REPLACE_UNDERSCORE_PARAM, false);
         addCategoryTag = getConfigBooleanValue(config, ADD_CATEGORY_TAG_PARAM, false);
@@ -80,9 +81,9 @@ public class InfluxDBConfiguration {
         }
     }
 
-    private InfluxDBVersion parseInfluxVersion(@Nullable Object value) {
+    private InfluxDBVersion parseInfluxVersion(@Nullable String value) {
         try {
-            return InfluxDBVersion.valueOf((String) value);
+            return Optional.ofNullable(value).map(InfluxDBVersion::valueOf).orElse(InfluxDBVersion.UNKNOWN);
         } catch (RuntimeException e) {
             logger.warn("Invalid version {}", value);
             return InfluxDBVersion.UNKNOWN;

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtils.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBStateConvertUtils.java
@@ -93,7 +93,7 @@ public class InfluxDBStateConvertUtils {
      * @return the state of the item represented by the itemName parameter, else the string value of
      *         the Object parameter
      */
-    public static State objectToState(Object value, String itemName, @Nullable ItemRegistry itemRegistry) {
+    public static State objectToState(@Nullable Object value, String itemName, @Nullable ItemRegistry itemRegistry) {
         State state = null;
         if (itemRegistry != null) {
             try {
@@ -111,9 +111,10 @@ public class InfluxDBStateConvertUtils {
         return state;
     }
 
-    public static State objectToState(Object value, Item itemToSetState) {
+    public static State objectToState(@Nullable Object value, Item itemToSetState) {
         String valueStr = String.valueOf(value);
 
+        @Nullable
         Item item = itemToSetState;
         if (item instanceof GroupItem) {
             item = ((GroupItem) item).getBaseItem();

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBVersion.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBVersion.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.persistence.influxdb.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * InfluxDB version
  *
  * @author Joan Pujol Espinar - Initial contribution
  */
+@NonNullByDefault
 public enum InfluxDBVersion {
     V1,
     V2,

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxRow.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxRow.java
@@ -15,6 +15,7 @@ package org.openhab.persistence.influxdb.internal;
 import java.time.Instant;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Row data returned from database query
@@ -25,9 +26,9 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class InfluxRow {
     private final String itemName;
     private final Instant time;
-    private final Object value;
+    private final @Nullable Object value;
 
-    public InfluxRow(Instant time, String itemName, Object value) {
+    public InfluxRow(Instant time, String itemName, @Nullable Object value) {
         this.time = time;
         this.itemName = itemName;
         this.value = value;
@@ -41,7 +42,7 @@ public class InfluxRow {
         return itemName;
     }
 
-    public Object getValue() {
+    public @Nullable Object getValue() {
         return value;
     }
 }


### PR DESCRIPTION
Fixes issue #10464

Problem was introduced in #9943 and it's reproducible with historical Influx1 data that was generated with addon version <3.0.0 that didn't store item tag in points.


Generated binary to test:

[org.openhab.persistence.influxdb-3.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab-addons/files/6468951/org.openhab.persistence.influxdb-3.1.0-SNAPSHOT.zip)

