### PR TITLE
Hueemulation: Fix xy change response

### DIFF
--- a/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/response/HueSuccessResponseStateChanged.java
+++ b/bundles/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/dto/response/HueSuccessResponseStateChanged.java
@@ -13,7 +13,9 @@
 package org.openhab.io.hueemulation.internal.dto.response;
 
 import java.lang.reflect.Type;
+import java.util.List;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
@@ -64,6 +66,9 @@ public class HueSuccessResponseStateChanged extends HueSuccessResponse {
             }
             if (product.value instanceof String) {
                 jObj.addProperty(product.relURI, (String) product.value);
+            }
+            if (product.value instanceof List) {
+                jObj.add(product.relURI, new Gson().toJsonTree(product.value));
             }
             return jObj;
         }

--- a/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
+++ b/bundles/org.openhab.io.hueemulation/src/test/java/org/openhab/io/hueemulation/internal/rest/LightsAndGroupsTests.java
@@ -306,6 +306,7 @@ public class LightsAndGroupsTests {
                 .put(Entity.json(body));
         assertEquals(200, response.getStatus());
         assertThat(response.readEntity(String.class), containsString("success"));
+        assertThat(response.readEntity(String.class), containsString("xy"));
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).on, is(true));
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).bri, is(200));
         assertThat(((HueStateColorBulb) cs.ds.lights.get("2").state).xy[0], is(0.5119));


### PR DESCRIPTION
Fixes the following problem mentioned in #10691 :
- In HueSuccessResponseStateChanged.java the serializer for lists is missing, so when setting xy the response is missing that it changed xy