### PR TITLE
Ignore spotless errors on binding creation

### DIFF
--- a/bundles/create_openhab_binding_skeleton.cmd
+++ b/bundles/create_openhab_binding_skeleton.cmd
@@ -19,7 +19,7 @@ SET GithubUser=%~3
 
 call :LoCase BindingIdInLowerCase
 
-call mvn -s archetype-settings.xml archetype:generate -N -DarchetypeGroupId=org.openhab.core.tools.archetypes -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding -DarchetypeVersion=%OpenhabVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase% -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%OpenhabVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%" -DgithubUser="%GithubUser%"
+call mvn -s archetype-settings.xml archetype:generate -N -Dspotless.check.skip=true -DarchetypeGroupId=org.openhab.core.tools.archetypes -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding -DarchetypeVersion=%OpenhabVersion% -DgroupId=org.openhab.binding -DartifactId=org.openhab.binding.%BindingIdInLowerCase% -Dpackage=org.openhab.binding.%BindingIdInLowerCase% -Dversion=%OpenhabVersion% -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -DvendorName=openHAB -Dnamespace=org.openhab -Dauthor="%Author%" -DgithubUser="%GithubUser%"
 
 COPY ..\src\etc\NOTICE org.openhab.binding.%BindingIdInLowerCase%\
 

--- a/bundles/create_openhab_binding_skeleton.sh
+++ b/bundles/create_openhab_binding_skeleton.sh
@@ -11,6 +11,7 @@ author=$2
 githubUser=$3
 
 mvn -s archetype-settings.xml archetype:generate -N \
+  -Dspotless.check.skip=true \
   -DarchetypeGroupId=org.openhab.core.tools.archetypes \
   -DarchetypeArtifactId=org.openhab.core.tools.archetypes.binding \
   -DarchetypeVersion=$openHABVersion \


### PR DESCRIPTION
Currently spotless errors are occuring when I try to create a new binding with the skeleton scripts. Sure the root cause of this should be fixed, anyhow I think it's a bad smell to annoy new binding developers with this directly on their very first step.

Signed-off-by: Patrick Fink <mail@pfink.de>