### PR TITLE
Fix build and improve exception handling

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/DimmerItemConverter.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/DimmerItemConverter.java
@@ -92,7 +92,7 @@ public class DimmerItemConverter extends AbstractTransformingItemConverter {
                     value = PercentType.ZERO.toBigDecimal();
                 }
                 newState = new PercentType(value);
-            } catch (NumberFormatException e) {
+            } catch (IllegalArgumentException e) {
                 // ignore
             }
         }

--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/NumberItemConverter.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/NumberItemConverter.java
@@ -14,8 +14,6 @@ package org.openhab.binding.http.internal.converter;
 
 import java.util.function.Consumer;
 
-import javax.measure.format.MeasurementParseException;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.http.internal.config.HttpChannelConfig;
@@ -62,7 +60,7 @@ public class NumberItemConverter extends AbstractTransformingItemConverter {
                         return new QuantityType<>(trimmedValue);
                     }
                 }
-            } catch (IllegalArgumentException | MeasurementParseException e) {
+            } catch (IllegalArgumentException e) {
                 // finally failed
             }
         }

--- a/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/handler/IAqualinkHandler.java
+++ b/bundles/org.openhab.binding.iaqualink/src/main/java/org/openhab/binding/iaqualink/internal/handler/IAqualinkHandler.java
@@ -457,7 +457,7 @@ public class IAqualinkHandler extends BaseThingHandler {
                 default:
                     return StringType.valueOf(value);
             }
-        } catch (NumberFormatException e) {
+        } catch (IllegalArgumentException e) {
             return UnDefType.UNDEF;
         }
     }

--- a/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/logic/CommandTag.java
+++ b/bundles/org.openhab.binding.icalendar/src/main/java/org/openhab/binding/icalendar/internal/logic/CommandTag.java
@@ -46,8 +46,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class CommandTag {
 
-    private static final List<Class<? extends Command>> otherCommandTypes = Arrays.asList(DecimalType.class,
-            QuantityType.class, OnOffType.class, OpenClosedType.class, UpDownType.class, HSBType.class,
+    private static final List<Class<? extends Command>> otherCommandTypes = Arrays.asList(HSBType.class,
+            DecimalType.class, QuantityType.class, OnOffType.class, OpenClosedType.class, UpDownType.class,
             PlayPauseType.class, RewindFastforwardType.class, StringType.class);
 
     private static final List<Class<? extends Command>> percentCommandType = Arrays.asList(PercentType.class);

--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -159,8 +159,8 @@ public class WLedHandler extends BaseThingHandler {
                 updateState(CHANNEL_SECONDARY_WHITE,
                         new PercentType(secondaryWhite.divide(BIG_DECIMAL_2_55, RoundingMode.HALF_UP)));
             }
-        } catch (NumberFormatException e) {
-            logger.warn("NumberFormatException when parsing the WLED colour and white fields:{}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            logger.warn("IllegalArgumentException when parsing the WLED colour and white fields:{}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoItemValueConverter.java
+++ b/bundles/org.openhab.io.neeo/src/main/java/org/openhab/io/neeo/internal/NeeoItemValueConverter.java
@@ -250,7 +250,7 @@ public class NeeoItemValueConverter {
                     default:
                         break;
                 }
-            } catch (NumberFormatException e) {
+            } catch (IllegalArgumentException e) {
                 // do nothing - let it go to the other cases
             }
         }

--- a/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/ScaleTransformationService.java
+++ b/bundles/org.openhab.transform.scale/src/main/java/org/openhab/transform/scale/internal/ScaleTransformationService.java
@@ -122,7 +122,7 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
             try {
                 final QuantityType<?> quantity = new QuantityType<>(source);
                 return formatResult(data, source, quantity.toBigDecimal());
-            } catch (NumberFormatException e2) {
+            } catch (IllegalArgumentException e2) {
                 String nonNumeric = data.get(null);
                 if (nonNumeric != null) {
                     return nonNumeric;


### PR DESCRIPTION
The PercentType and QuantityType can also throw an IllegalArgumentException.
The MeasurementParseException is no longer thrown.

Related to https://github.com/openhab/openhab-core/pull/2365