### PR TITLE
[deconz] make lightgroup switch off if brightness is set to 0

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/GroupThingHandler.java
@@ -129,8 +129,8 @@ public class GroupThingHandler extends DeconzBaseThingHandler {
         }
 
         Integer bri = newGroupAction.bri;
-        if (bri != null && bri > 0) {
-            newGroupAction.on = true;
+        if (bri != null) {
+            newGroupAction.on = (bri > 0);
         }
 
         sendCommand(newGroupAction, command, channelUID, null);


### PR DESCRIPTION
fixes https://github.com/openhab/openhab-addons/issues/10320 ,
applies same  handling as for lights

