### PR TITLE
[linuxinput] Handle all kinds of buttons

### DIFF
--- a/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/evdev4j/EvdevDevice.java
+++ b/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/evdev4j/EvdevDevice.java
@@ -189,7 +189,7 @@ public class EvdevDevice implements Closeable {
 
     public Collection<Key> enumerateKeys() {
         int minKey = 0;
-        int maxKey = 255 - 1;
+        int maxKey = lib.event_type_get_max(EvdevLibrary.Type.KEY.intValue());
         List<Key> result = new ArrayList<>();
         for (int i = minKey; i <= maxKey; i++) {
             if (has(EvdevLibrary.Type.KEY, i)) {
@@ -214,6 +214,11 @@ public class EvdevDevice implements Closeable {
 
         public String getName() {
             return lib.event_code_get_name(EvdevLibrary.Type.KEY.intValue(), code);
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(code);
         }
     }
 

--- a/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/evdev4j/jnr/EvdevLibrary.java
+++ b/bundles/org.openhab.binding.linuxinput/src/main/java/org/openhab/binding/linuxinput/internal/evdev4j/jnr/EvdevLibrary.java
@@ -98,6 +98,8 @@ public interface EvdevLibrary {
 
     int enable_event_type(@In Handle handle, int type);
 
+    int event_type_get_max(int type);
+
     int disable_event_type(@In Handle handle, int type);
 
     boolean has_event_code(@In Handle handle, int type, int code);


### PR DESCRIPTION
Previously only the basic keyboard buttons where handled.
Now all buttons known to Linux, or rather libevdev are reported.

Reported-in: https://community.openhab.org/t/linuxinput-binding-and-mouse-capture/122612
Reported-in: https://github.com/t-8ch/binding-linuxinput/issues/5

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>