### PR TITLE
[pulseaudio] Add "idle timeout" to Pulseaudio audio sink

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseaudioBindingConstants.java
@@ -53,6 +53,7 @@ public class PulseaudioBindingConstants {
     public static final String DEVICE_PARAMETER_NAME = "name";
     public static final String DEVICE_PARAMETER_AUDIO_SINK_ACTIVATION = "activateSimpleProtocolSink";
     public static final String DEVICE_PARAMETER_AUDIO_SINK_PORT = "simpleProtocolSinkPort";
+    public static final String DEVICE_PARAMETER_AUDIO_SINK_IDLE_TIMEOUT = "simpleProtocolSinkIdleTimeout";
 
     public static final String MODULE_SIMPLE_PROTOCOL_TCP_NAME = "module-simple-protocol-tcp";
     public static final int MODULE_SIMPLE_PROTOCOL_TCP_DEFAULT_PORT = 4711;

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
@@ -33,6 +33,15 @@
 				<description>Default Port to allocate for use by module-simple-protocol-tcp on the pulseaudio server</description>
 				<default>4711</default>
 			</parameter>
+			<parameter name="simpleProtocolSinkIdleTimeout" type="integer" required="false">
+				<label>Idle Timeout</label>
+				<description>Timeout in ms after which the connection will be closed when no stream is running.
+					This ensures that
+					your
+					speaker is not on all the time and the pulseaudio sink can go to idle mode.
+				</description>
+				<default>30000</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 

--- a/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/resources/OH-INF/thing/sink.xml
@@ -35,10 +35,8 @@
 			</parameter>
 			<parameter name="simpleProtocolSinkIdleTimeout" type="integer" required="false">
 				<label>Idle Timeout</label>
-				<description>Timeout in ms after which the connection will be closed when no stream is running.
-					This ensures that
-					your
-					speaker is not on all the time and the pulseaudio sink can go to idle mode.
+				<description>Timeout in ms after which the connection will be closed when no stream is running. This ensures that
+					your speaker is not on all the time and the pulseaudio sink can go to idle mode.
 				</description>
 				<default>30000</default>
 			</parameter>


### PR DESCRIPTION
## What?
This PR allows the Pulseaudio audio sink to disconnect after a configured period of being idle.
## Why?
I use Pulseaudio with a Raspberry and a speaker to announce events via TTS and noticed that the speaker never goes to sleep and constantly produces high pitch noise.
## Solution
After digging through the code the most obvious and simplest option was to disconnect immediately after a stream has finished. This worked initially but had a big drawback when issuing multiple "say" (TTS) commands in a row. There a new connection has been made for every "say" command which resulted in an overlap of the streams. This was not a problem previously because the same socket connection was used and the Pulseaudio server played this consecutively.
The solution I came up with is simple enough and works quite well. After each "thing save" and/or stream command a disconnect is scheduled with a configured delay (30s is the default). So for 30s a connection is reused and after that it will disconnect if no other stream started in the meantime.

If you have suggestions or notes, don't hesitate to approach me. 
Cheers and thanks!