### PR TITLE
[venstarthermostat] Venstar thermostat away mode enhancement

### DIFF
--- a/bundles/org.openhab.binding.venstarthermostat/README.md
+++ b/bundles/org.openhab.binding.venstarthermostat/README.md
@@ -43,6 +43,8 @@ After adding the Inbox item, enter the user name and password from the physical 
 
 | Channel            | Type               | Description                  | Notes                                                  |
 |--------------------|--------------------|------------------------------|--------------------------------------------------------|
+| awayMode           | String             | Home or Away Mode            |                                                        |
+| awayModeRaw        | Number             | Away Mode Raw (Read Only)    | 0 (Home) 1 (Away)                                      |
 | systemMode         | String             | System Mode                  |                                                        |
 | systemModeRaw      | Number             | System Mode Raw (Read Only)  | 0 (Off) 1 (Heat) 2 (Cool) 3 (Auto)                     |
 | systemState        | String             | System State (Read Only)     |                                                        |
@@ -72,6 +74,7 @@ Number:Temperature Guest_HVAC_CoolSetpoint  "Cool Setpoint [%d °F]" {channel="v
 Number Guest_HVAC_Mode                      "Mode [%s]"             {channel="venstarthermostat:colorTouchThermostat:001122334455:systemMode"}
 Number Guest_HVAC_Humidity                  "Humidity [%d %%]"      {channel="venstarthermostat:colorTouchThermostat:001122334455:humidity"}
 Number Guest_HVAC_State                     "State [%s]"            {channel="venstarthermostat:colorTouchThermostat:001122334455:systemState"}
+Number Guest_Away_Mode                      "Mode [%s]"             {channel="venstarthermostat:colorTouchThermostat:001122334455:awayMode"}
 ```
 
 ### thermostat.sitemap
@@ -83,6 +86,7 @@ sitemap demo label="Venstar Color Thermostat Demo"
     Setpoint item=Guest_HVAC_HeatSetpoint minValue=50 maxValue=99
     Setpoint item=Guest_HVAC_CoolSetpoint minValue=50 maxValue=99
     Switch item=Guest_HVAC_Mode mappings=[off=Off,heat=Heat,cool=Cool,auto=Auto]
+    Switch item=Guest_Away_Mode mappings=[home=Home,away=Away]
     Text item=Guest_HVAC_State
    }
 }

--- a/bundles/org.openhab.binding.venstarthermostat/pom.xml
+++ b/bundles/org.openhab.binding.venstarthermostat/pom.xml
@@ -3,6 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>

--- a/bundles/org.openhab.binding.venstarthermostat/pom.xml
+++ b/bundles/org.openhab.binding.venstarthermostat/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/VenstarThermostatBindingConstants.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/VenstarThermostatBindingConstants.java
@@ -23,6 +23,7 @@ import org.openhab.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author William Welliver - Initial contribution
+ * @author Matthew Davies - added awayMode and awayModeRaw to include thermostat away mode in binding
  */
 @NonNullByDefault
 public class VenstarThermostatBindingConstants {
@@ -44,6 +45,8 @@ public class VenstarThermostatBindingConstants {
     public final static String CHANNEL_SYSTEM_MODE = "systemMode";
     public final static String CHANNEL_SYSTEM_STATE_RAW = "systemStateRaw";
     public final static String CHANNEL_SYSTEM_MODE_RAW = "systemModeRaw";
+    public final static String CHANNEL_AWAY_MODE="awayMode";
+    public final static String CHANNEL_AWAY_MODE_RAW="awayModeRaw";
 
     public final static String CONFIG_USERNAME = "username";
     public final static String CONFIG_PASSWORD = "password";

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/VenstarThermostatBindingConstants.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/VenstarThermostatBindingConstants.java
@@ -45,8 +45,8 @@ public class VenstarThermostatBindingConstants {
     public final static String CHANNEL_SYSTEM_MODE = "systemMode";
     public final static String CHANNEL_SYSTEM_STATE_RAW = "systemStateRaw";
     public final static String CHANNEL_SYSTEM_MODE_RAW = "systemModeRaw";
-    public final static String CHANNEL_AWAY_MODE="awayMode";
-    public final static String CHANNEL_AWAY_MODE_RAW="awayModeRaw";
+    public final static String CHANNEL_AWAY_MODE = "awayMode";
+    public final static String CHANNEL_AWAY_MODE_RAW = "awayModeRaw";
 
     public final static String CONFIG_USERNAME = "username";
     public final static String CONFIG_PASSWORD = "password";

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayMode.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayMode.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.venstarthermostat.internal.model;
+
+/**
+ * The {@link VenstarSystemMode} represents the value of the system mode returned
+ * from the REST API.
+ *
+ * @author Matthew Davies - created new class to add away mode to binding
+ */
+public enum VenstarAwayMode {
+    HOME(0, "home", "Home"),
+    AWAY(1, "away", "Away");
+
+    private int mode;
+    private String name;
+    private String friendlyName;
+
+    VenstarAwayMode(int mode, String name, String friendlyName) {
+        this.mode = mode;
+        this.name = name;
+        this.friendlyName = friendlyName;
+    }
+
+    public int mode() {
+        return mode;
+    }
+
+    public String modeName() {
+        return name;
+    }
+
+    public String friendlyName() {
+        return friendlyName;
+    }
+
+    public static VenstarAwayMode fromInt(int mode) {
+        for (VenstarAwayMode sm : values()) {
+            if (sm.mode == mode) {
+                return sm;
+            }
+        }
+
+        throw (new IllegalArgumentException("Invalid away mode " + mode));
+    }
+}

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayMode.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayMode.java
@@ -45,9 +45,9 @@ public enum VenstarAwayMode {
     }
 
     public static VenstarAwayMode fromInt(int mode) {
-        for (VenstarAwayMode sm : values()) {
-            if (sm.mode == mode) {
-                return sm;
+        for (VenstarAwayMode am : values()) {
+            if (am.mode == mode) {
+                return am;
             }
         }
 

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayModeSerializer.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarAwayModeSerializer.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.venstarthermostat.internal.model;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * The {@link VenstarSystemModeSerializer} parses system mode values
+ * from the REST API JSON.
+ *
+ * @author Matthew Davies - created new class to include away mode in binding
+ */
+public class VenstarAwayModeSerializer implements JsonDeserializer<VenstarAwayMode> {
+    @Override
+    public VenstarAwayMode deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2)
+            throws JsonParseException {
+        int key = element.getAsInt();
+        return VenstarAwayMode.fromInt(key);
+    }
+}

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarInfoData.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarInfoData.java
@@ -16,6 +16,7 @@ package org.openhab.binding.venstarthermostat.internal.model;
  * The {@link VenstarInfoData} represents a thermostat state from the REST API.
  *
  * @author William Welliver - Initial contribution
+ * @author Matthew Davies - added VenstarAwayMode to include away mode in binding
  */
 public class VenstarInfoData {
     double cooltemp;
@@ -23,18 +24,20 @@ public class VenstarInfoData {
 
     VenstarSystemState state;
     VenstarSystemMode mode;
+    VenstarAwayMode away;
     int tempunits;
 
     public VenstarInfoData() {
         super();
     }
 
-    public VenstarInfoData(double cooltemp, double heattemp, VenstarSystemState state, VenstarSystemMode mode) {
+    public VenstarInfoData(double cooltemp, double heattemp, VenstarSystemState state, VenstarSystemMode mode,VenstarAwayMode away) {
         super();
         this.cooltemp = cooltemp;
         this.heattemp = heattemp;
         this.state = state;
         this.mode = mode;
+        this.away=away;
     }
 
     public double getCooltemp() {
@@ -75,5 +78,11 @@ public class VenstarInfoData {
 
     public void setTempunits(int tempunits) {
         this.tempunits = tempunits;
+    }
+    public VenstarAwayMode getAway() {
+        return away;
+    }
+    public void setAwayMode(VenstarAwayMode away) {
+        this.away=away;
     }
 }

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarInfoData.java
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/java/org/openhab/binding/venstarthermostat/internal/model/VenstarInfoData.java
@@ -31,13 +31,14 @@ public class VenstarInfoData {
         super();
     }
 
-    public VenstarInfoData(double cooltemp, double heattemp, VenstarSystemState state, VenstarSystemMode mode,VenstarAwayMode away) {
+    public VenstarInfoData(double cooltemp, double heattemp, VenstarSystemState state, VenstarSystemMode mode,
+            VenstarAwayMode away) {
         super();
         this.cooltemp = cooltemp;
         this.heattemp = heattemp;
         this.state = state;
         this.mode = mode;
-        this.away=away;
+        this.away = away;
     }
 
     public double getCooltemp() {
@@ -79,10 +80,12 @@ public class VenstarInfoData {
     public void setTempunits(int tempunits) {
         this.tempunits = tempunits;
     }
+
     public VenstarAwayMode getAway() {
         return away;
     }
+
     public void setAwayMode(VenstarAwayMode away) {
-        this.away=away;
+        this.away = away;
     }
 }

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -21,7 +21,7 @@
 			<channel id="systemStateRaw" typeId="systemStateRaw"/>
 			<channel id="awayMode" typeId="awayMode"/>
 			<channel id="awayModeRaw" typeId="awayModeRaw"/>
-        </channels>
+		</channels>
 
 		<properties>
 			<property name="uuid"></property>
@@ -69,26 +69,26 @@
 		<description>Current System Operating Mode, as an integer number</description>
 		<state readOnly="true"/>
 	</channel-type>
-	
-    <channel-type id="awayMode">
-        <item-type>String</item-type>
-        <label>Away Mode</label>
-        <description>Current Away Mode</description>
-        <state readOnly="false">
-            <options>
-                <option value="home">Home</option>
-                <option value="away">Away</option>
-            </options>
-        </state>
-    </channel-type>
 
-    <channel-type id="awayModeRaw" advanced="true">
-        <item-type>Number</item-type>
-        <label>Away Mode (Raw)</label>
-        <description>Current Away Mode, as an integer number</description>
-        <state readOnly="true"/>
-    </channel-type>
-    
+	<channel-type id="awayMode">
+		<item-type>String</item-type>
+		<label>Away Mode</label>
+		<description>Current Away Mode</description>
+		<state readOnly="false">
+			<options>
+				<option value="home">Home</option>
+				<option value="away">Away</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="awayModeRaw" advanced="true">
+		<item-type>Number</item-type>
+		<label>Away Mode (Raw)</label>
+		<description>Current Away Mode, as an integer number</description>
+		<state readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="systemState">
 		<item-type>String</item-type>
 		<label>System State</label>

--- a/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.venstarthermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -19,7 +19,9 @@
 			<channel id="coolingSetpoint" typeId="coolingSetpoint"/>
 			<channel id="systemState" typeId="systemState"/>
 			<channel id="systemStateRaw" typeId="systemStateRaw"/>
-		</channels>
+			<channel id="awayMode" typeId="awayMode"/>
+			<channel id="awayModeRaw" typeId="awayModeRaw"/>
+        </channels>
 
 		<properties>
 			<property name="uuid"></property>
@@ -67,7 +69,26 @@
 		<description>Current System Operating Mode, as an integer number</description>
 		<state readOnly="true"/>
 	</channel-type>
+	
+    <channel-type id="awayMode">
+        <item-type>String</item-type>
+        <label>Away Mode</label>
+        <description>Current Away Mode</description>
+        <state readOnly="false">
+            <options>
+                <option value="home">Home</option>
+                <option value="away">Away</option>
+            </options>
+        </state>
+    </channel-type>
 
+    <channel-type id="awayModeRaw" advanced="true">
+        <item-type>Number</item-type>
+        <label>Away Mode (Raw)</label>
+        <description>Current Away Mode, as an integer number</description>
+        <state readOnly="true"/>
+    </channel-type>
+    
 	<channel-type id="systemState">
 		<item-type>String</item-type>
 		<label>System State</label>


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<[venstarthermostat] Add away mode channel in binding>

<This PR adds the Away Mode available via the thermostat local API to the Venstar thermostat binding. The Away Mode is a String channel. It allows the Away Mode to be seen in the UI and also changed as a setting with two options (away or home). It has been tested using the demo app in Eclipse IDE. https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/addons/bundles/org.openhab.binding.venstarthermostat/3.1.0-SNAPSHOT/>

Closes #10707