### PR TITLE
[linuxinput] use correct channelTypeUID for key-press channels

### DIFF
--- a/bundles/org.openhab.binding.linuxinput/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.linuxinput/src/main/resources/OH-INF/thing/thing-types.xml
@@ -30,7 +30,7 @@
 		<state readOnly="true"/>
 	</channel-type>
 
-	<channel-type id="keypress">
+	<channel-type id="key-press">
 		<item-type>Contact</item-type>
 		<label>Key Pressed</label>
 		<state readOnly="true"/>


### PR DESCRIPTION
Previously there was a mismatch between the UIDs used by the handler and
the one actually registered from the XML-file.
This lead to channels not showing up in the UI.
(See https://github.com/openhab/openhab-webui/issues/406 )

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>