### PR TITLE
[docs] MAP transformation text, add white space example

### DIFF
--- a/bundles/org.openhab.transform.map/README.md
+++ b/bundles/org.openhab.transform.map/README.md
@@ -19,15 +19,17 @@ key=value
 0=OFF
 ON=1
 OFF=0
+white\ space=showing escape
 =default
 ```
 
-| input      | output    |
-|------------|-----------|
-| `1`        | `ON`      |
-| `OFF`      | `0`       |
-| `key`      | `value`   |
-| `anything` | `default` |
+| input         | output         |
+|---------------|----------------|
+| `1`           | `ON`           |
+| `OFF`         | `0`            |
+| `key`         | `value`        |
+| `white space` | `using escape` |
+| `anything`    | `default`      |
 
 ## Usage as a Profile
 


### PR DESCRIPTION
Add simple white space escape example for MAP key

Signed-off-by: Ross Kennedy rossko@culzean.clara.co.uk

