### PR TITLE
[openwebnet] shutter position is set UNDEF after reboot

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -140,10 +140,10 @@ Devices support some of the following channels:
 For Percent commands and position feedback to work correctly, the `shutterRun` Thing config parameter must be configured equal to the time (in ms) to go from full UP to full DOWN.
 It's possible to enter a value manually or set `shutterRun=AUTO` (default) to calibrate `shutterRun` automatically: in this case a *UP >> DOWN >> Position%* cycle will be performed automatically the first time a Percent command is sent to the shutter.
 
-- if `shutterRun` is not set, or is set to AUTO but calibration has not been performed yet, then position estimation will remain `UNDEFINED`
-- if `shutterRun` is wrongly set higher than the actual runtime, then position estimation will remain `UNDEFINED`: try to reduce shutterRun until you find the right value
+- if `shutterRun` is not set, or is set to `AUTO` but calibration has not been performed yet, then position estimation will remain `UNDEF` (undefined)
+- if `shutterRun` is wrongly set higher than the actual runtime, then position estimation will remain `UNDEF`: try to reduce shutterRun until you find the right value
 - before adding/configuring roller shutter Things it is suggested to have all roller shutters `UP`, otherwise the Percent command won’t work until the roller shutter is fully rolled up
-- if the gateways gets disconnected the binding cannot estimate anymore the shutter positions: just roll the shutter all `UP` or `DOWN` and its position will be estimated again
+- if OH is restarted the binding does not know if a shutter position has changed in the meantime, so its position will be `UNDEF`. Move the shutter all `UP`/`DOWN` to synchronize again its position with the binding
 - the shutter position is estimated based on UP/DOWN timing: an error of ±2% is normal
 
 ## Full Example

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetAutomationHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetAutomationHandler.java
@@ -87,7 +87,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
     private int shutterRun = SHUTTER_RUN_UNDEFINED;
     private static final String AUTO_CALIBRATION = "AUTO";
 
-    private long startedMovingAt = -1;
+    private long startedMovingAtTS = -1; // timestamp when device started moving UP/DOWN
     private int movingState = MOVING_STATE_UNKNOWN;
     private int positionEstimation = POSITION_UNKNOWN;
     private @Nullable ScheduledFuture<?> moveSchedule;
@@ -351,7 +351,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
         } else if (msg.isStop()) {
             long stoppedAt = System.currentTimeMillis();
             if (calibrating == CALIBRATION_GOING_DOWN && shutterRun == SHUTTER_RUN_UNDEFINED) {
-                shutterRun = (int) (stoppedAt - startedMovingAt);
+                shutterRun = (int) (stoppedAt - startedMovingAtTS);
                 logger.debug("& {} & CALIBRATION - reached DOWN ---> shutterRun={}", deviceWhere, shutterRun);
                 updateMovingState(MOVING_STATE_STOPPED);
                 logger.debug("& {} & CALIBRATION - COMPLETED, now going to {}%", deviceWhere, positionRequested);
@@ -393,19 +393,19 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
     private void updateMovingState(int newState) {
         if (movingState == MOVING_STATE_STOPPED) {
             if (newState != MOVING_STATE_STOPPED) { // moving after stop
-                startedMovingAt = System.currentTimeMillis();
+                startedMovingAtTS = System.currentTimeMillis();
                 synchronized (DATE_FORMATTER) {
-                    logger.debug("# {} # MOVING {} - startedMovingAt={} - {}", deviceWhere, newState, startedMovingAt,
-                            DATE_FORMATTER.format(new Date(startedMovingAt)));
+                    logger.debug("# {} # MOVING {} - startedMovingAt={} - {}", deviceWhere, newState, startedMovingAtTS,
+                            DATE_FORMATTER.format(new Date(startedMovingAtTS)));
                 }
             }
         } else { // we were moving
             updatePosition();
             if (newState != MOVING_STATE_STOPPED) { // moving after moving, take new timestamp
-                startedMovingAt = System.currentTimeMillis();
+                startedMovingAtTS = System.currentTimeMillis();
                 synchronized (DATE_FORMATTER) {
-                    logger.debug("# {} # MOVING {} - startedMovingAt={} - {}", deviceWhere, newState, startedMovingAt,
-                            DATE_FORMATTER.format(new Date(startedMovingAt)));
+                    logger.debug("# {} # MOVING {} - startedMovingAt={} - {}", deviceWhere, newState, startedMovingAtTS,
+                            DATE_FORMATTER.format(new Date(startedMovingAtTS)));
                 }
             }
             // cancel the schedule
@@ -424,8 +424,9 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
      */
     private void updatePosition() {
         int newPos = POSITION_UNKNOWN;
-        if (shutterRun > 0) {// we have shutterRun defined, let's calculate new positionEstimation
-            long movedTime = System.currentTimeMillis() - startedMovingAt;
+        if (shutterRun > 0 && startedMovingAtTS != -1) {// we have shutterRun and startedMovingAtTS defined, let's
+                                                        // calculate new positionEstimation
+            long movedTime = System.currentTimeMillis() - startedMovingAtTS;
             logger.debug("# {} # current positionEstimation={} movedTime={}", deviceWhere, positionEstimation,
                     movedTime);
             int movedSteps = Math.round((float) movedTime / shutterRun * POSITION_MAX_STEPS);


### PR DESCRIPTION
With this change after OH reboot position remains UNDEF since the binding does not know anymore the real position of the shutter. Users should move the shutter full UP/DOWN to re-synchronize with the real position again.
Fixes #10662 

Signed-off-by: Massimo Valla <mvcode00@gmail.com>
