### PR TITLE
[squeezebox] Map player connection state to thing status

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/discovery/SqueezeBoxPlayerDiscoveryParticipant.java
@@ -211,4 +211,8 @@ public class SqueezeBoxPlayerDiscoveryParticipant extends AbstractDiscoveryServi
     @Override
     public void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand) {
     }
+
+    @Override
+    public void connectedStateChangeEvent(String mac, boolean connected) {
+    }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxNotificationListener.java
@@ -220,4 +220,8 @@ public final class SqueezeBoxNotificationListener implements SqueezeBoxPlayerEve
     @Override
     public void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand) {
     }
+
+    @Override
+    public void connectedStateChangeEvent(String mac, boolean connected) {
+    }
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxPlayerEventListener.java
@@ -82,4 +82,6 @@ public interface SqueezeBoxPlayerEventListener {
     void sourceChangeEvent(String mac, String source);
 
     void buttonsChangeEvent(String mac, String likeCommand, String unlikeCommand);
+
+    void connectedStateChangeEvent(String mac, boolean connected);
 }

--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -535,6 +536,8 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
         }
 
         private void handlePlayersList(String message) {
+            final Set<String> connectedPlayers = new HashSet<>();
+
             // Split out players
             String[] playersList = message.split("playerindex\\S*\\s");
             for (String playerParams : playersList) {
@@ -571,6 +574,10 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                         player.setName(parameter.substring(parameter.indexOf(":") + 1));
                     } else if (parameter.startsWith("model:")) {
                         player.setModel(parameter.substring(parameter.indexOf(":") + 1));
+                    } else if (parameter.startsWith("connected:")) {
+                        if ("1".equals(parameter.substring(parameter.indexOf(":") + 1))) {
+                            connectedPlayers.add(macAddress);
+                        }
                     }
                 }
 
@@ -587,6 +594,11 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     sendCommand(player.getMacAddress() + " status - 1 subscribe:10 tags:yagJlNKjc");
                 }
             }
+            for (final SqueezeBoxPlayer player : players.values()) {
+                final String mac = player.getMacAddress();
+                final boolean connected = connectedPlayers.contains(mac);
+                updatePlayer(listener -> listener.connectedStateChangeEvent(mac, connected));
+            }
         }
 
         private void handlePlayerUpdate(String message) {
@@ -601,6 +613,9 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
             // get the message type
             String messageType = messageParts[1];
             switch (messageType) {
+                case "client":
+                    handleClientMessage(mac, messageParts);
+                    break;
                 case "status":
                     handleStatusMessage(mac, messageParts);
                     break;
@@ -660,6 +675,26 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     logger.trace("Unhandled mixer message type '{}'", Arrays.toString(messageParts));
 
             }
+        }
+
+        private void handleClientMessage(final String mac, String[] messageParts) {
+            if (messageParts.length < 3) {
+                return;
+            }
+
+            String action = messageParts[2];
+            final boolean connected;
+
+            if ("new".equals(action) || "reconnect".equals(action)) {
+                connected = true;
+            } else if ("disconnect".equals(action) || "forget".equals(action)) {
+                connected = false;
+            } else {
+                logger.trace("Unhandled client message type '{}'", Arrays.toString(messageParts));
+                return;
+            }
+
+            updatePlayer(listener -> listener.connectedStateChangeEvent(mac, connected));
         }
 
         private void handleStatusMessage(final String mac, String[] messageParts) {


### PR DESCRIPTION
~~This read-only channel allows determining whether a given player is
currently connected to the server. This is useful for players which are
e.g. regularly without power.~~
Approach changed: a lack of connection (e.g. due to network or power outages) is now mapped to the thing status.
