### PR TITLE
[gpio] Added parameter for pull up/down resistor and other improvements

### DIFF
--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -56,6 +56,7 @@ In openHAB, set `host` to the address of the pi and the `port` to the port of pi
 Set the number of the pin in `gpioId`.
 If you want to invert the value, set `invert` to true.
 To prevent incorrect change events, you can adjust the `debouncingTime`.
+Using `pullupdown` you can enable pull up or pull down resistor (0 = Off, 1 = Pull Down, 2 = Pull Up).
 
 ### GPIO digital output channel
 

--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -34,13 +34,15 @@ sudo nano /etc/systemd/system/pigpiod.service.d/public.conf
 ```
 sudo systemctl daemon-reload
 ```
-Now that Remote GPIO is enabled, get the daemon going:
+Now that Remote GPIO is enabled, get the daemon going (even if installed with apt-get):
 ```
 sudo systemctl enable pigpiod 
 sudo systemctl start pigpiod
 ```
 
 In openHAB, set `host` to the address of the pi and the `port` to the port of pigpio (default: 8888).
+
+Note: If you are running Pigpio on same host as OpenHab, then set host to **::1**.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -79,7 +79,7 @@ Thing gpio:pigpio-remote:sample-pi-1 "Sample-Pi 1" [host="192.168.2.36", port=88
 Thing gpio:pigpio-remote:sample-pi-2 "Sample-Pi 2" [host="192.168.2.37", port=8888] {
     Channels:
         Type pigpio-digital-input : sample-input-3 [ gpioId=16, debouncingTime=20]
-        Type pigpio-digital-input : sample-input-4 [ gpioId=17, invert=true, debouncingTime=5]
+        Type pigpio-digital-input : sample-input-4 [ gpioId=17, invert=true, debouncingTime=5, pullupdown=2]
         Type pigpio-digital-output : sample-output-2 [ gpioId=4, invert=true]
 }
 ```

--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -42,7 +42,7 @@ sudo systemctl start pigpiod
 
 In openHAB, set `host` to the address of the pi and the `port` to the port of pigpio (default: 8888).
 
-Note: If you are running Pigpio on same host as OpenHab, then set host to **::1**.
+Note: If you are running Pigpio on same host as openHAB, then set host to **::1**.
 
 ## Channels
 

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/configuration/GPIOInputConfiguration.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/configuration/GPIOInputConfiguration.java
@@ -25,4 +25,10 @@ public class GPIOInputConfiguration extends GPIOConfiguration {
      * Time in ms to double check if value hasn't changed
      */
     public int debouncingTime = 10;
+
+    /**
+     * Setup a pullup resistor on the GPIO pin
+     * 0 = PI_PUD_OFF, 1 = PI_PUD_DOWN, 2 = PI_PUD_UP
+     */
+    public int pullupdown = 0;
 }

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
@@ -62,6 +62,8 @@ public class PigpioDigitalInputHandler implements ChannelHandler {
             Date thisChange = new Date();
             scheduler.schedule(() -> afterDebounce(thisChange), configuration.debouncingTime, TimeUnit.MILLISECONDS);
         });
+        Integer pullupdown = configuration.pullupdown;
+        jPigpio.gpioSetPullUpDown(gpio.getPin(), pullupdown);
     }
 
     private void afterDebounce(Date thisChange) {

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
@@ -56,7 +56,7 @@ public class PigpioDigitalInputHandler implements ChannelHandler {
         if (gpioId == null) {
             throw new NoGpioIdException();
         }
-        gpio = new GPIO(jPigpio, gpioId, 1);
+        gpio = new GPIO(jPigpio, gpioId, JPigpio.PI_INPUT);
         jPigpio.gpioSetAlertFunc(gpio.getPin(), (gpio, level, tick) -> {
             lastChanged = new Date();
             Date thisChange = new Date();

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalOutputHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalOutputHandler.java
@@ -62,7 +62,7 @@ public class PigpioDigitalOutputHandler implements ChannelHandler {
         if (gpioId == null) {
             throw new NoGpioIdException();
         }
-        this.gpio = new GPIO(jPigpio, gpioId, 0);
+        this.gpio = new GPIO(jPigpio, gpioId, JPigpio.PI_OUTPUT);
     }
 
     @Override

--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
@@ -50,6 +50,17 @@
 				<default>10</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="pullupdown" type="integer" min="0" max="2">
+				<label>Pull Up/Down resistor</label>
+				<description>Configure Pull Up/Down resistor of GPIO pin</description>
+				<options>
+					<option value="0">Off</option>
+					<option value="1">Pull Down</option>
+					<option value="2">Pull Up</option>
+				</options>
+				<limitToOptions>true</limitToOptions>
+				<default>0</default>
+			</parameter>
 		</config-description>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
@@ -51,8 +51,8 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="pullupdown" type="integer" min="0" max="2">
-				<label>Pull Up/Down resistor</label>
-				<description>Configure Pull Up/Down resistor of GPIO pin</description>
+				<label>Pull Up/Down Resistor</label>
+				<description>Configure Pull Up/Down Resistor of GPIO pin</description>
 				<options>
 					<option value="0">Off</option>
 					<option value="1">Pull Down</option>


### PR DESCRIPTION
*[gpio] Added parameter for pull up/down resistor for GPIO binding*

Changes:

- Added Pull Up/Down parameter to input GPIO pin configuration
- GPIO pin mode set with library constant instead of integer
- Updated README.md of binding (added information about new parameter)
- Improved README.md of binding with some additional info
- Also ran static code analysis
- Tested on my setup, no problems detected

Most of changes were implemeted by @sjoerdtakken ([Forum post](https://community.openhab.org/t/gpio-new-gpio-binding-for-oh3/113943/33), [His repo with changes](https://wordpressvonmorgen.dd-dns.de/pigpio/)), but not commited to this repo. 

Here is compiled version: [org.openhab.binding.gpio-3.1.0.zip](https://github.com/openhab/openhab-addons/files/6566972/org.openhab.binding.gpio-3.1.0.zip)


