### PR TITLE
[smhi] Catch exception that could cause binding to stop updating channels

### DIFF
--- a/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/SmhiConnector.java
+++ b/bundles/org.openhab.binding.smhi/src/main/java/org/openhab/binding/smhi/internal/SmhiConnector.java
@@ -15,6 +15,7 @@ package org.openhab.binding.smhi.internal;
 import static org.openhab.binding.smhi.internal.SmhiBindingConstants.*;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -25,6 +26,8 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonParseException;
 
 /**
  * Class for handling http requests to Smhi's API and return values.
@@ -88,7 +91,11 @@ public class SmhiConnector {
         logger.debug("Received response with status {} - {}", resp.getStatus(), resp.getReason());
         switch (resp.getStatus()) {
             case 200:
-                return Parser.parseTimeSeries(resp.getContentAsString());
+                try {
+                    return Parser.parseTimeSeries(resp.getContentAsString());
+                } catch (JsonParseException | DateTimeParseException e) {
+                    throw new SmhiException(e);
+                }
             case 400:
             case 404:
                 throw new PointOutOfBoundsException();


### PR DESCRIPTION
Signed-off-by: Anders Alfredsson <andersb86@gmail.com>

Discovered an issue where the binding would crash and stop updating if there was something wrong in the json received from the api. This fix catches these exceptions and sets the thing temporarily OFFLINE until a valid response is received.