### PR TITLE
[nikobus] removed required=true for parameters with default value

### DIFF
--- a/bundles/org.openhab.binding.nikobus/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.nikobus/src/main/resources/OH-INF/config/config.xml
@@ -9,7 +9,7 @@
 			<label>Command</label>
 			<description>Command to send</description>
 		</parameter>
-		<parameter name="delay" type="integer" required="true" min="0" unit="ms">
+		<parameter name="delay" type="integer" min="0" unit="ms">
 			<label>Delay</label>
 			<description>Delay in milliseconds before triggered</description>
 			<default>0</default>
@@ -21,7 +21,7 @@
 	</config-description>
 
 	<config-description uri="push-button:trigger-button:config">
-		<parameter name="threshold" type="integer" required="true" min="0" unit="ms">
+		<parameter name="threshold" type="integer" min="0" unit="ms">
 			<label>Threshold</label>
 			<description>Long-press threshold in milliseconds</description>
 			<default>1000</default>


### PR DESCRIPTION
Based on [feedback](https://community.openhab.org/t/nikobus-v2/80241/296) from some users it seems `required=true` should not be set for parameters that have a default value, as stated [here](https://community.openhab.org/t/nikobus-v2/80241/300), otherwise one can have problems when restarting OH.

Signed-off-by: Boris Krivonog boris.krivonog@inova.si
