### PR TITLE
Update README.md

### DIFF
--- a/bundles/org.openhab.binding.insteon/README.md
+++ b/bundles/org.openhab.binding.insteon/README.md
@@ -748,7 +748,7 @@ The format is `broadcastOnOff#X` where X is the group that you want to be able t
 Bridge insteon:network:home [port="/dev/ttyUSB0"] {
   Thing device AABBCC             [address="AA.BB.CC", productKey="0x000045"] {
     Channels:
-      Type broadcastOnOff : broadcastOnOff#2
+      Type switch : broadcastOnOff#2
   }
 }
 


### PR DESCRIPTION
<!-- TITLE -->
[insteon] - broadcastOnOff example is incorrect.   The channel type is switch, not broadcastOnOff

<!-- DESCRIPTION -->
The Insteon binding for openhab 3.x has a broadcastOnOff category.  However, I believe the example is incorrect.   The channel type is switch, not broadcastOnOff.   This typo seems to have crept into the 3.x binding information.  Archived versions show the channel type correctly.


Regards,
Burzin
Burzin