### PR TITLE
Update README.md - [insteon] Channel Type is switch not broadcastOnOff

### DIFF
--- a/bundles/org.openhab.binding.insteon/README.md
+++ b/bundles/org.openhab.binding.insteon/README.md
@@ -748,7 +748,7 @@ The format is `broadcastOnOff#X` where X is the group that you want to be able t
 Bridge insteon:network:home [port="/dev/ttyUSB0"] {
   Thing device AABBCC             [address="AA.BB.CC", productKey="0x000045"] {
     Channels:
-      Type broadcastOnOff : broadcastOnOff#2
+      Type switch : broadcastOnOff#2
   }
 }
 
@@ -803,7 +803,7 @@ A typical example would be a switch configured to broadcast to a group, and one 
 Bridge insteon:network:home [port="/dev/ttyUSB0"] {
   Thing device AABBCC [address="AA.BB.CC", productKey="0x000045"] {
     Channels:
-      Type broadcastOnOff : broadcastOnOff#3 [related="AA.BB.DD"]
+      Type switch : broadcastOnOff#3 [related="AA.BB.DD"]
   }
   Thing device AABBDD [address="AA.BB.DD", productKey="F00.00.11"]
 }


### PR DESCRIPTION
[insteon] - Channel Type is switch not broadcastOnOff


<!-- TITLE -->

[insteon] - Channel Type is switch not broadcastOnOff
<!-- DESCRIPTION -->

The examples for broadcastOnOff are incorrect as the channel type shown is broadcastOnOff as opposed to switch.  This problem seems to have crept into the 3.x Insteon binding documentation.  The 2.5 Insteon binding documentations shows the channel type as switch.

I've opened 2 pull requests for this issue to cover both the 3.0.1 and 3.0.2 Insteon binding information.

Regards,
Burzin