### PR TITLE
[ahawastecollection] Change loglevel from warn to debug

### DIFF
--- a/bundles/org.openhab.binding.ahawastecollection/src/main/java/org/openhab/binding/ahawastecollection/internal/AhaWasteCollectionHandler.java
+++ b/bundles/org.openhab.binding.ahawastecollection/src/main/java/org/openhab/binding/ahawastecollection/internal/AhaWasteCollectionHandler.java
@@ -176,7 +176,7 @@ public class AhaWasteCollectionHandler extends BaseThingHandler {
     private void updateChannels(final Map<WasteType, CollectionDate> collectionDates) {
         for (final Channel channel : this.getThing().getChannels()) {
 
-        	final WasteType wasteType = getWasteTypeByChannel(channel.getUID().getId());
+            final WasteType wasteType = getWasteTypeByChannel(channel.getUID().getId());
 
             final CollectionDate collectionDate = collectionDates.get(wasteType);
             if (collectionDate == null) {

--- a/bundles/org.openhab.binding.ahawastecollection/src/main/java/org/openhab/binding/ahawastecollection/internal/AhaWasteCollectionHandler.java
+++ b/bundles/org.openhab.binding.ahawastecollection/src/main/java/org/openhab/binding/ahawastecollection/internal/AhaWasteCollectionHandler.java
@@ -175,11 +175,12 @@ public class AhaWasteCollectionHandler extends BaseThingHandler {
      */
     private void updateChannels(final Map<WasteType, CollectionDate> collectionDates) {
         for (final Channel channel : this.getThing().getChannels()) {
-            final WasteType wasteType = getWasteTypeByChannel(channel.getUID().getId());
+
+        	final WasteType wasteType = getWasteTypeByChannel(channel.getUID().getId());
 
             final CollectionDate collectionDate = collectionDates.get(wasteType);
             if (collectionDate == null) {
-                this.logger.warn("No collection dates found for waste type: {}", wasteType);
+                this.logger.debug("No collection dates found for waste type: {}", wasteType);
                 continue;
             }
 


### PR DESCRIPTION
Changed the loglevel to debug, if no collection times for an specific waste type was found.

Fixes #10786

