### PR TITLE
[resol] correct handling of system date/time field

### DIFF
--- a/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -144,6 +144,20 @@
 
 	</thing-type>
 
+	<channel-type id="weektime">
+		<item-type>DateTime</item-type>
+		<label>Time</label>
+		<description>Time and day of week.</description>
+		<category>Time</category>
+	</channel-type>
+
+	<channel-type id="datetime">
+		<item-type>DateTime</item-type>
+		<label>Time</label>
+		<description>Time and date.</description>
+		<category>Time</category>
+	</channel-type>
+
 	<channel-type id="None">
 		<item-type>Number</item-type>
 		<label>Any</label>

--- a/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.resol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -149,6 +149,14 @@
 		<label>Time</label>
 		<description>Time and day of week.</description>
 		<category>Time</category>
+		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="time">
+		<item-type>String</item-type>
+		<label>Time</label>
+		<category>Time</category>
+		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="datetime">
@@ -156,6 +164,7 @@
 		<label>Time</label>
 		<description>Time and date.</description>
 		<category>Time</category>
+		<state readOnly="true"/>
 	</channel-type>
 
 	<channel-type id="None">


### PR DESCRIPTION
Correct the handling of Date and Time fields in Packets on the VBUS to make these channels available and fix #10684 

Further discussion is here: https://community.openhab.org/t/resol-binding-stopped-working-in-recent-nightly-builds/122371/7

There is a jar of the fixed binding here: https://github.com/ramack/openhab-addons/blob/resolReleases/bundles/org.openhab.binding.resol/target/org.openhab.binding.resol-3.1.0-SNAPSHOT.jar?raw=true

@EjvindHald confirmed the fix so we can merge this bugfix.