### PR TITLE
[pushover] Provides the ability to specify a timeout in the config

### DIFF
--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -21,7 +21,7 @@ You are able to create multiple instances of this Thing to broadcast to differen
 | `sound`                 | text    | The default notification sound on target device (default: `default`) (see [supported notification sounds](https://pushover.net/api#sounds)).         |
 | `retry`                 | integer | The retry parameter specifies how often (in seconds) the Pushover servers will send the same notification to the user (default: `300`). **advanced** |
 | `expire`                | integer | The expire parameter specifies how long (in seconds) your notification will continue to be retried (default: `3600`). **advanced**                   |
-| `timeout`               | integer | The timeout parameter specifies maximum number of seconds a request to pushover can take. **advanced**                                               |
+| `timeout`               | integer | The timeout parameter specifies maximum number of seconds a request to Pushover can take. **advanced**                                               |
 
 The `retry` and `expire` parameters are only used for emergency-priority notifications.
 

--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -21,6 +21,7 @@ You are able to create multiple instances of this Thing to broadcast to differen
 | `sound`                 | text    | The default notification sound on target device (default: `default`) (see [supported notification sounds](https://pushover.net/api#sounds)).         |
 | `retry`                 | integer | The retry parameter specifies how often (in seconds) the Pushover servers will send the same notification to the user (default: `300`). **advanced** |
 | `expire`                | integer | The expire parameter specifies how long (in seconds) your notification will continue to be retried (default: `3600`). **advanced**                   |
+| `timeout`               | integer | The timeout parameter specifies maximum number of seconds a request to pushover can take. **advanced**                                               |
 
 The `retry` and `expire` parameters are only used for emergency-priority notifications.
 

--- a/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/config/PushoverAccountConfiguration.java
+++ b/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/config/PushoverAccountConfiguration.java
@@ -31,4 +31,5 @@ public class PushoverAccountConfiguration {
     public String sound = DEFAULT_SOUND;
     public int retry = 300;
     public int expire = 3600;
+    public int timeout = 10;
 }

--- a/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverAPIConnection.java
+++ b/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverAPIConnection.java
@@ -134,7 +134,8 @@ public class PushoverAPIConnection {
             throws PushoverCommunicationException, PushoverConfigurationException {
         logger.trace("Pushover request: {} - URL = '{}'", httpMethod, url);
         try {
-            final Request request = httpClient.newRequest(url).method(httpMethod).timeout(10, TimeUnit.SECONDS);
+            final Request request = httpClient.newRequest(url).method(httpMethod).timeout(config.timeout,
+                    TimeUnit.SECONDS);
 
             if (body != null) {
                 if (logger.isTraceEnabled()) {

--- a/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/config/config.xml
@@ -51,7 +51,7 @@
 		<parameter name="timeout" type="integer" min="0" max="10800" unit="s">
 			<advanced>true</advanced>
 			<label>Timeout</label>
-			<description>The timeout parameter specifies maximum number of seconds a request to pushover can
+			<description>The timeout parameter specifies maximum number of seconds a request to Pushover can
 				take.</description>
 			<default>10</default>
 		</parameter>

--- a/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/config/config.xml
@@ -48,6 +48,13 @@
 			<description>The expire parameter specifies how long your notification will continue to be retried.</description>
 			<default>3600</default>
 		</parameter>
+		<parameter name="timeout" type="integer" min="0" max="10800" unit="s">
+			<advanced>true</advanced>
+			<label>Timeout</label>
+			<description>The timeout parameter specifies maximum number of seconds a request to pushover can
+				take.</description>
+			<default>10</default>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>


### PR DESCRIPTION
[pushover] Provides the ability to specify a timeout in the config, instead of using hardcoded 10 seconds.

Provides the ability to specify a timeout in the config, instead of using hardcoded 10 seconds. On slower devices, and when sending a message with images, 10 seconds can be too short. This leads to a Timeout Exception.

An additional config parameter is added "timeout", with default value 10.

[pushover.zip](https://github.com/openhab/openhab-addons/files/6604591/pushover.zip)

