### PR TITLE
[radiothermostat] Add job to set thermostat clock automatically from the binding

### DIFF
--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -42,7 +42,7 @@ The thing has a few configuration parameters:
 | isCT80          | Flag to enable additional features only available on the CT80 thermostat. Optional, the default is false.                                                                                                                                                       |
 | disableLogs     | Disable retrieval of run-time logs from the thermostat. Optional, the default is false.                                                                                                                                                                         |
 | setpointMode    | Controls temporary or absolute setpoint mode. In "temporary" mode the thermostat will temporarily maintain the given setpoint, returning to its program after a time. In "absolute" mode the thermostat will ignore its program maintaining the given setpoint. |
-| clockSync       | Flag to enable the binding to sync the internal clock on the thermostat to match the openHAB host's system clock. Use if the thermostat is not setup to connect to the manufacturer's cloud server.                                                             |
+| clockSync       | Flag to enable the binding to sync the internal clock on the thermostat to match the openHAB host's system clock. Use if the thermostat is not setup to connect to the manufacturer's cloud server. Sync occurs at binding startup and every hour thereafter.   |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.radiothermostat/README.md
+++ b/bundles/org.openhab.binding.radiothermostat/README.md
@@ -42,6 +42,7 @@ The thing has a few configuration parameters:
 | isCT80          | Flag to enable additional features only available on the CT80 thermostat. Optional, the default is false.                                                                                                                                                       |
 | disableLogs     | Disable retrieval of run-time logs from the thermostat. Optional, the default is false.                                                                                                                                                                         |
 | setpointMode    | Controls temporary or absolute setpoint mode. In "temporary" mode the thermostat will temporarily maintain the given setpoint, returning to its program after a time. In "absolute" mode the thermostat will ignore its program maintaining the given setpoint. |
+| clockSync       | Flag to enable the binding to sync the internal clock on the thermostat to match the openHAB host's system clock. Use if the thermostat is not setup to connect to the manufacturer's cloud server.                                                             |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatBindingConstants.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatBindingConstants.java
@@ -40,6 +40,7 @@ public class RadioThermostatBindingConstants {
     public static final String LOCAL = "local";
     public static final String PROPERTY_IP = "hostName";
     public static final String PROPERTY_ISCT80 = "isCT80";
+    public static final String JSON_TIME = "{\"day\":%s,\"hour\":%s,\"minute\":%s}";
 
     public static final String KEY_ERROR = "error";
 
@@ -48,6 +49,7 @@ public class RadioThermostatBindingConstants {
     public static final String RUNTIME_RESOURCE = "tstat/datalog";
     public static final String HUMIDITY_RESOURCE = "tstat/humidity";
     public static final String REMOTE_TEMP_RESOURCE = "tstat/remote_temp";
+    public static final String TIME_RESOURCE = "tstat/time";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_RTHERM = new ThingTypeUID(BINDING_ID, "rtherm");

--- a/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatConfiguration.java
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/java/org/openhab/binding/radiothermostat/internal/RadioThermostatConfiguration.java
@@ -28,5 +28,6 @@ public class RadioThermostatConfiguration {
     public @Nullable Integer logRefresh;
     public boolean isCT80 = false;
     public boolean disableLogs = false;
+    public boolean clockSync = false;
     public String setpointMode = "temporary";
 }

--- a/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.radiothermostat/src/main/resources/OH-INF/thing/thing-types.xml
@@ -68,7 +68,11 @@
 					<option value="temporary">Temporary</option>
 				</options>
 			</parameter>
-
+			<parameter name="clockSync" type="boolean">
+				<label>Enable Thermostat Clock Sync</label>
+				<description>Optional Flag to snyc the thermostat's clock with the host system clock</description>
+				<default>false</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
The goal of this PR is to add the ability for the binding to set the thermostat's clock automatically from the host's system time. This functionality is needed if the user does not connect their thermostat to the manufacturer's cloud service. It is also possible that the cloud service could be discontinued some day which would leave the user with no easy way to set the thermostat's clock.