### PR TITLE
[tivo] Refresh persistent connection every 12 hours

### DIFF
--- a/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/TiVoBindingConstants.java
+++ b/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/TiVoBindingConstants.java
@@ -29,6 +29,7 @@ public class TiVoBindingConstants {
     public static final String BINDING_ID = "tivo";
     public static final int CONFIG_SOCKET_TIMEOUT_MS = 1000;
     public static final int INIT_POLLING_DELAY_S = 5;
+    public static final int POLLING_DELAY_12HR_S = 43200;
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_TIVO = new ThingTypeUID(BINDING_ID, "sckt");

--- a/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/handler/TiVoHandler.java
+++ b/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/handler/TiVoHandler.java
@@ -212,8 +212,9 @@ public class TiVoHandler extends BaseThingHandler {
         };
 
         if (tivoConfigData.isKeepConnActive()) {
-            // Run once
-            refreshJob = scheduler.schedule(runnable, INIT_POLLING_DELAY_S, TimeUnit.SECONDS);
+            // Run once every 12 hours to keep the connection from going stale
+            refreshJob = scheduler.scheduleWithFixedDelay(runnable, INIT_POLLING_DELAY_S, POLLING_DELAY_12HR_S,
+                    TimeUnit.SECONDS);
             logger.debug("Status collection '{}' will start in '{}' seconds.", getThing().getUID(),
                     INIT_POLLING_DELAY_S);
         } else if (tivoConfigData.doPollChanges()) {

--- a/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/service/TivoStatusProvider.java
+++ b/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/service/TivoStatusProvider.java
@@ -84,6 +84,13 @@ public class TivoStatusProvider {
             logger.debug(" statusRefresh '{}' - EXISTING status data - '{}'", tivoConfigData.getCfgIdentifier(),
                     tivoStatusData.toString());
         }
+
+        // this will close the connection and re-open every 12 hours
+        if (tivoConfigData.isKeepConnActive()) {
+            connTivoDisconnect();
+            doNappTime();
+        }
+
         connTivoConnect();
         doNappTime();
         if (!tivoConfigData.isKeepConnActive()) {


### PR DESCRIPTION
This PR fixes an issue with the Tivo binding while using the option to always keep the connection to the device open. The previous strategy was to keep the original socket connection open indefinitely. This works OK, but after several days the connection would die and the binding would not reconnect without restarting. Sometimes the device would not accept a new connection without being rebooted first. To alleviate these problems, the binding will now close and re-open the persistent connection every 12 hours .