### PR TITLE
[rfxcom] Add support for TFA 30.3233.1 rainmeter

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -882,6 +882,7 @@ A Rain device
         *   RAIN4 - UPM RG700
         *   RAIN5 - WS2300
         *   RAIN6 - La Crosse TX5
+        *   RAIN9 - TFA 30.3233.1
 
 ### rfxsensor - RFXCOM RFXSensor 
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComRainMessage.java
@@ -38,7 +38,9 @@ public class RFXComRainMessage extends RFXComBatteryDeviceMessage<RFXComRainMess
         RAIN4(4),
         RAIN5(5),
         RAIN6(6),
-        RAIN7(7);
+        RAIN7(7),
+        RAIN8(8),
+        RAIN9(9);
 
         private final int subType;
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/OH-INF/thing/rain.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/OH-INF/thing/rain.xml
@@ -38,6 +38,7 @@
 					<option value="RAIN4">UPM RG700</option>
 					<option value="RAIN5">WS2300</option>
 					<option value="RAIN6">La Crosse TX5</option>
+					<option value="RAIN9">TFA 30.3233.1</option>
 				</options>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
In a recent [Firmware Update](http://blog.rfxcom.com/) to the RFXCOM family of transievers, support for the TFA 30.3233.1 rain sensor has been added.

The meter is identified as the subtype RAIN9. This leads to an error due to 9 being out of range of the enumerator mapping the subtypes to models/manufacturers in the configuration.

This PR adds the relevant entries to the message parser. I can confirm that the sensor is detected and works with these changes.