### PR TITLE
[epsonprojector] Update readme configuration section

### DIFF
--- a/bundles/org.openhab.binding.epsonprojector/README.md
+++ b/bundles/org.openhab.binding.epsonprojector/README.md
@@ -21,14 +21,18 @@ All settings are through thing configuration parameters.
 
 The `projector-serial` thing has the following configuration parameters:
 
-- _serialPort_: Serial port device name that is connected to the Epson projector to control, e.g. COM1 on Windows, /dev/ttyS0 on Linux or /dev/tty.PL2303-0000103D on Mac
-- _pollingInterval_: Polling interval in seconds to update channel states | 5-60 seconds; default 10 seconds
+| Parameter       | Name             | Description                                                                                                                                                | Required |
+|-----------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| serialPort      | Serial Port      | Serial port device name that is connected to the Epson projector to control, e.g. COM1 on Windows, /dev/ttyS0 on Linux or /dev/tty.PL2303-0000103D on Mac. | yes      |
+| pollingInterval | Polling Interval | Polling interval in seconds to update channel states, range 5-60 seconds; default 10 seconds.                                                              | no       |
 
 The `projector-tcp` thing has the following configuration parameters:
 
-- _host_: IP address for the projector or serial over IP device
-- _port_: Port for the projector or serial over IP device; default 3629 for projectors with built-in ethernet connector or Wi-Fi
-- _pollingInterval_: Polling interval in seconds to update channel states | 5-60 seconds; default 10 seconds
+| Parameter       | Name             | Description                                                                                                             | Required |
+|-----------------|------------------|-------------------------------------------------------------------------------------------------------------------------|----------|
+| host            | Host Name        | Host Name or IP address for the projector or serial over IP device.                                                     | yes      |
+| port            | Port             | Port for the projector or serial over IP device; default 3629 for projectors with built-in ethernet connector or Wi-Fi. | yes      |
+| pollingInterval | Polling Interval | Polling interval in seconds to update channel states, range 5-60 seconds; default 10 seconds.                           | no       |
 
 Some notes:
 
@@ -87,12 +91,12 @@ Some notes:
 
 things/epson.things:
 
-```java
+```
 // serial port connection
 epsonprojector:projector-serial:hometheater "Projector" [ serialPort="COM5", pollingInterval=10 ]
 
 // direct IP or serial over IP connection
-epsonprojector:projector-tcp:hometheater "Projector"  [ host="192.168.0.10", port=3629, pollingInterval=10 ]
+epsonprojector:projector-tcp:hometheater "Projector" [ host="192.168.0.10", port=3629, pollingInterval=10 ]
 
 ```
 

--- a/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.epsonprojector/src/main/resources/OH-INF/thing/thing-types.xml
@@ -46,7 +46,7 @@
 				<description>Serial Port to Use for Connecting to the Epson Projector</description>
 			</parameter>
 			<parameter name="pollingInterval" type="integer" min="5" max="60" unit="s" required="false">
-				<label>Polling interval</label>
+				<label>Polling Interval</label>
 				<description>Configures How Often to Poll the Projector for Updates (5-60; Default 10)</description>
 				<default>10</default>
 			</parameter>
@@ -104,7 +104,7 @@
 				<default>3629</default>
 			</parameter>
 			<parameter name="pollingInterval" type="integer" min="5" max="60" unit="s" required="false">
-				<label>Polling interval</label>
+				<label>Polling Interval</label>
 				<description>Configures How Often to Poll the Projector for Updates (5-60; Default 10)</description>
 				<default>10</default>
 			</parameter>


### PR DESCRIPTION
Update configuration section in README to use tables per comments in the benqprojector PR.