### PR TITLE
[deconz] Set "ontime" option only if thing has got an ONTIME channel

### DIFF
--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -282,13 +282,17 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                 return;
         }
 
-        Boolean newOn = newLightState.on;
-        if (newOn != null && !newOn) {
-            // if light shall be off, no other commands are allowed, so reset the new light state
-            newLightState.clear();
-            newLightState.on = false;
-        } else if (newOn != null && newOn) {
-            newLightState.ontime = onTime;
+        if (thing.getChannel(CHANNEL_ONTIME) != null) {
+            Boolean newOn = newLightState.on;
+            if (newOn != null && !newOn) {
+                // if light shall be off, no other commands are allowed, so reset the new light state
+                newLightState.clear();
+                newLightState.on = false;
+            } else if (newOn != null && newOn) {
+                newLightState.ontime = onTime;
+            }
+        } else {
+            newLightState.ontime = null;
         }
 
         sendCommand(newLightState, command, channelUID, () -> {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -96,7 +96,8 @@ public class LightThingHandler extends DeconzBaseThingHandler {
      */
     private LightState lightStateCache = new LightState();
     private LightState lastCommand = new LightState();
-    private int onTime = 0; // in 0.1s
+    @Nullable
+    private Integer onTime = null; // in 0.1s
     private String colorMode = "";
 
     // set defaults, we can override them later if we receive better values
@@ -282,17 +283,13 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                 return;
         }
 
-        if (thing.getChannel(CHANNEL_ONTIME) != null) {
-            Boolean newOn = newLightState.on;
-            if (newOn != null && !newOn) {
-                // if light shall be off, no other commands are allowed, so reset the new light state
-                newLightState.clear();
-                newLightState.on = false;
-            } else if (newOn != null && newOn) {
-                newLightState.ontime = onTime;
-            }
-        } else {
-            newLightState.ontime = null;
+        Boolean newOn = newLightState.on;
+        if (newOn != null && !newOn) {
+            // if light shall be off, no other commands are allowed, so reset the new light state
+            newLightState.clear();
+            newLightState.on = false;
+        } else if (newOn != null && newOn) {
+            newLightState.ontime = onTime;
         }
 
         sendCommand(newLightState, command, channelUID, () -> {


### PR DESCRIPTION
This PR corrects a problem (#10774) in the binding that currently makes it unusable for window coverings because no reall bypass exists.