### PR TITLE
[rfxcom] New sub types for undecoded messages

### DIFF
--- a/bundles/org.openhab.binding.rfxcom/README.md
+++ b/bundles/org.openhab.binding.rfxcom/README.md
@@ -1210,7 +1210,10 @@ Any messages that RFXCOM can receive but not decode.
         *   RTS - RTS
         *   SELECT\_PLUS - Select Plus
         *   HOME\_CONFORT - Home Confort
-
+        *   EDISIO - Edisio
+        *   HONEYWELL - Honeywell
+        *   FUNKBUS - Gira Funk-Bussystem
+        *   BYRONSX - Byron SX
 
 ### uv - RFXCOM UV/Temperature Sensor
 

--- a/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
+++ b/bundles/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
@@ -59,6 +59,10 @@ public class RFXComUndecodedRFMessage extends RFXComDeviceMessageImpl<RFXComUnde
         RTS(0x14),
         SELECT_PLUS(0x15),
         HOME_CONFORT(0x16),
+        EDISIO(0x17),
+        HONEYWELL(0x18),
+        FUNKBUS(0x19),
+        BYRONSX(0x1A),
 
         UNKNOWN(0xFF);
 
@@ -85,7 +89,7 @@ public class RFXComUndecodedRFMessage extends RFXComDeviceMessageImpl<RFXComUnde
     }
 
     public SubType subType;
-    public byte[] rawPayload = new byte[0];
+    public byte[] rawPayload;
 
     public RFXComUndecodedRFMessage() {
         super(UNDECODED_RF_MESSAGE);

--- a/bundles/org.openhab.binding.rfxcom/src/main/resources/OH-INF/thing/undecoded.xml
+++ b/bundles/org.openhab.binding.rfxcom/src/main/resources/OH-INF/thing/undecoded.xml
@@ -52,6 +52,10 @@
 					<option value="RTS">RTS</option>
 					<option value="SELECT_PLUS">Select Plus</option>
 					<option value="HOME_CONFORT">Home Confort</option>
+					<option value="EDISIO">Edisio</option>
+					<option value="HONEYWELL">Honeywell</option>
+					<option value="FUNKBUS">Gira Funk-Bussystem</option>
+					<option value="BYRONSX">Byron SX</option>
 				</options>
 			</parameter>
 		</config-description>


### PR DESCRIPTION
New subtypes have been added to the firmware, these are taken from the
RFXtrx SDK documentation.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
