### PR TITLE
[homeconnect] Fix invalid authorization header during Server-Sent Events (SSE) client creation

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectStreamingRequestFilter.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HomeConnectStreamingRequestFilter.java
@@ -16,11 +16,15 @@ import java.io.IOException;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Inserts Authorization header for requests on the streaming REST API.
@@ -28,10 +32,11 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Laurent Garnier - Initial contribution
  */
 @NonNullByDefault
-public class HomeConnectStreamingRequestFilter implements ClientRequestFilter {
+public class HomeConnectStreamingRequestFilter implements ClientRequestFilter, ClientResponseFilter {
 
     private static final String TEXT_EVENT_STREAM = "text/event-stream";
 
+    private final Logger logger = LoggerFactory.getLogger(HomeConnectStreamingRequestFilter.class);
     private final String authorizationHeader;
 
     public HomeConnectStreamingRequestFilter(String authorizationHeader) {
@@ -45,6 +50,25 @@ public class HomeConnectStreamingRequestFilter implements ClientRequestFilter {
             headers.putSingle(HttpHeaders.AUTHORIZATION, authorizationHeader);
             headers.putSingle(HttpHeaders.CACHE_CONTROL, "no-cache");
             headers.putSingle(HttpHeaders.ACCEPT, TEXT_EVENT_STREAM);
+        }
+    }
+
+    @Override
+    public void filter(@Nullable ClientRequestContext requestContext, @Nullable ClientResponseContext responseContext)
+            throws IOException {
+        if (logger.isDebugEnabled() && requestContext != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("SSE connection: ");
+            sb.append(requestContext.getUri()).append("\n");
+            requestContext.getHeaders()
+                    .forEach((name, value) -> sb.append("> ").append(name).append(": ").append(value).append("\n"));
+
+            if (responseContext != null) {
+                responseContext.getHeaders()
+                        .forEach((name, value) -> sb.append("< ").append(name).append(": ").append(value).append("\n"));
+            }
+
+            logger.debug("{}", sb);
         }
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
@@ -60,6 +60,8 @@ public class HttpHelper {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final JsonParser JSON_PARSER = new JsonParser();
     private static final Map<String, Bucket> BUCKET_MAP = new HashMap<>();
+    private static final Object AUTHORIZATION_HEADER_MONITOR = new Object();
+    private static final Object BUCKET_MONITOR = new Object();
 
     private static @Nullable String lastAccessToken = null;
 
@@ -90,7 +92,7 @@ public class HttpHelper {
 
     public static String getAuthorizationHeader(OAuthClientService oAuthClientService)
             throws AuthorizationException, CommunicationException {
-        synchronized ("authorizationHeader") {
+        synchronized (AUTHORIZATION_HEADER_MONITOR) {
             try {
                 AccessTokenResponse accessTokenResponse = oAuthClientService.getAccessTokenResponse();
                 // refresh the token if it's about to expire
@@ -133,20 +135,22 @@ public class HttpHelper {
         return JSON_PARSER.parse(json);
     }
 
-    private static synchronized Bucket getBucket(String clientId) {
-        Bucket bucket = null;
-        if (BUCKET_MAP.containsKey(clientId)) {
-            bucket = BUCKET_MAP.get(clientId);
-        }
+    private static Bucket getBucket(String clientId) {
+        synchronized (BUCKET_MONITOR) {
+            Bucket bucket = null;
+            if (BUCKET_MAP.containsKey(clientId)) {
+                bucket = BUCKET_MAP.get(clientId);
+            }
 
-        if (bucket == null) {
-            bucket = Bucket4j.builder()
-                    // allows 50 tokens per minute (added 10 second buffer)
-                    .addLimit(classic(50, intervally(50, Duration.ofSeconds(70))).withInitialTokens(40))
-                    // but not often then 50 tokens per second
-                    .addLimit(classic(10, intervally(10, Duration.ofSeconds(1)))).build();
-            BUCKET_MAP.put(clientId, bucket);
+            if (bucket == null) {
+                bucket = Bucket4j.builder()
+                        // allows 50 tokens per minute (added 10 second buffer)
+                        .addLimit(classic(50, intervally(50, Duration.ofSeconds(70))).withInitialTokens(40))
+                        // but not often then 50 tokens per second
+                        .addLimit(classic(10, intervally(10, Duration.ofSeconds(1)))).build();
+                BUCKET_MAP.put(clientId, bucket);
+            }
+            return bucket;
         }
-        return bucket;
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/client/HttpHelper.java
@@ -109,6 +109,9 @@ public class HttpHelper {
                             accessTokenResponse.getCreatedOn().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
                 }
                 lastAccessToken = accessTokenResponse.getAccessToken();
+
+                LoggerFactory.getLogger(HttpHelper.class).debug("Current access token: {}",
+                        accessTokenResponse.getAccessToken());
                 return BEARER + accessTokenResponse.getAccessToken();
             } else {
                 LoggerFactory.getLogger(HttpHelper.class).error("No access token available! Fatal error.");


### PR DESCRIPTION
An obsolete filter was used during the creation of an SSE client. The client used an incorrect authorization header.

Signed-off-by: Jonas Brüstel <jonas@bruestel.net>
