### PR TITLE
[ihc] Support for TLSv1.2

### DIFF
--- a/bundles/org.openhab.binding.ihc/README.md
+++ b/bundles/org.openhab.binding.ihc/README.md
@@ -20,14 +20,15 @@ This binding supports one ThingType: `controller`.
 
 The `controller` Thing has the following configuration parameters:
 
-| Parameter                   | Description                                                                                                                  | Required | Default value |
-|-----------------------------|------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| hostname                    | Network/IP address of the IHC / ELKO controller without https prefix, but can contain TCP port if default port is not used.  | yes      |               |
-| username                    | User name to login to the IHC / ELKO controller.                                                                             | yes      |               |
-| password                    | Password to login to the IHC / ELKO controller.                                                                              | yes      |               |
-| timeout                     | Timeout in milliseconds to communicate to IHC / ELKO controller.                                                             | no       | 5000          |
-| loadProjectFile             | Load project file from controller.                                                                                           | no       | true          |
-| createChannelsAutomatically | Create channels automatically from project file. Project file loading parameter should be enabled as well.                   | no       | true          |
+| Parameter                   | Description                                                                                                                                                                                 | Required | Default value |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| hostname                    | Network/IP address of the IHC / ELKO controller without https prefix, but can contain TCP port if default port is not used.                                                                 | yes      |               |
+| username                    | User name to login to the IHC / ELKO controller.                                                                                                                                            | yes      |               |
+| password                    | Password to login to the IHC / ELKO controller.                                                                                                                                             | yes      |               |
+| timeout                     | Timeout in milliseconds to communicate to IHC / ELKO controller.                                                                                                                            | no       | 5000          |
+| loadProjectFile             | Load project file from controller.                                                                                                                                                          | no       | true          |
+| createChannelsAutomatically | Create channels automatically from project file. Project file loading parameter should be enabled as well.                                                                                  | no       | true          |
+| tlsVersion                  | TLS version used for controller communication. Choose `TLSv1` for older firmware versions and `TLSv1.2` for never versions (since fall 2021). `AUTO` mode try to recognize correct version. | no       | TLSv1         |
 
 
 ## Channels
@@ -148,7 +149,7 @@ Will send TOGGLE (ON/OFF) command to Dimmer test item when short button press is
 ### example.things
 
 ```xtend
-ihc:controller:elko [ hostname="192.168.1.2", username="openhab", password="secret", timeout=5000, loadProjectFile=true, createChannelsAutomatically=false ] {
+ihc:controller:elko [ hostname="192.168.1.2", username="openhab", password="secret", timeout=5000, loadProjectFile=true, createChannelsAutomatically=false, tlsVersion="TLSv1" ] {
     Channels:
         Type switch                : my_test_switch  "My Test Switch"          [ resourceId=3988827 ]
         Type contact               : my_test_contact "My Test Contact"         [ resourceId=3988827 ]

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/config/IhcConfiguration.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/config/IhcConfiguration.java
@@ -24,11 +24,12 @@ public class IhcConfiguration {
     public int timeout;
     public boolean loadProjectFile;
     public boolean createChannelsAutomatically;
+    public String tlsVersion;
 
     @Override
     public String toString() {
         return "[" + "hostname=" + hostname + ", username=" + username + ", password=******" + ", timeout=" + timeout
                 + ", loadProjectFile=" + loadProjectFile + ", createChannelsAutomatically="
-                + createChannelsAutomatically + "]";
+                + createChannelsAutomatically + ", tlsVersion=" + tlsVersion + "]";
     }
 }

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -50,6 +50,7 @@ import org.openhab.binding.ihc.internal.ws.datatypes.WSSystemInfo;
 import org.openhab.binding.ihc.internal.ws.datatypes.WSTimeManagerSettings;
 import org.openhab.binding.ihc.internal.ws.exeptions.ConversionException;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
+import org.openhab.binding.ihc.internal.ws.exeptions.IhcFatalExecption;
 import org.openhab.binding.ihc.internal.ws.projectfile.IhcEnumValue;
 import org.openhab.binding.ihc.internal.ws.projectfile.ProjectFileUtils;
 import org.openhab.binding.ihc.internal.ws.resourcevalues.WSBooleanValue;
@@ -534,7 +535,7 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
             setConnectingState(true);
             logger.debug("Connecting to IHC / ELKO LS controller [hostname='{}', username='{}'].", conf.hostname,
                     conf.username);
-            ihc = new IhcClient(conf.hostname, conf.username, conf.password, conf.timeout);
+            ihc = new IhcClient(conf.hostname, conf.username, conf.password, conf.timeout, conf.tlsVersion);
             ihc.openConnection();
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                     "Initializing communication to the IHC / ELKO controller");
@@ -883,6 +884,11 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
                 }
                 connect();
                 setReconnectRequest(false);
+            } catch (IhcFatalExecption e) {
+                logger.warn("Can't open connection to controller {}", e.getMessage());
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                setReconnectRequest(false);
+                return;
             } catch (IhcExecption e) {
                 logger.debug("Can't open connection to controller {}", e.getMessage());
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/exeptions/IhcFatalExecption.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/exeptions/IhcFatalExecption.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ihc.internal.ws.exeptions;
+
+/**
+ * Exception for handling fatal communication errors to controller.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class IhcFatalExecption extends IhcExecption {
+
+    private static final long serialVersionUID = -8107948791816894352L;
+
+    public IhcFatalExecption() {
+    }
+
+    public IhcFatalExecption(String message) {
+        super(message);
+    }
+
+    public IhcFatalExecption(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IhcFatalExecption(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/exeptions/IhcTlsExecption.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/exeptions/IhcTlsExecption.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.ihc.internal.ws.exeptions;
+
+/**
+ * Exception for handling TLS communication errors to controller.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class IhcTlsExecption extends IhcFatalExecption {
+
+    private static final long serialVersionUID = -1366186910684967044L;
+
+    public IhcTlsExecption() {
+    }
+
+    public IhcTlsExecption(String message) {
+        super(message);
+    }
+
+    public IhcTlsExecption(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IhcTlsExecption(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
@@ -33,6 +33,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.openhab.binding.ihc.internal.ws.exeptions.IhcFatalExecption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,83 +59,91 @@ public class IhcConnectionPool {
 
     private HttpClientBuilder httpClientBuilder;
     private HttpClientContext localContext;
+    private String tlsVersion = "TLSv1";
 
-    public IhcConnectionPool() {
+    public IhcConnectionPool() throws IhcFatalExecption {
+        this("TLSv1");
+    }
+
+    public IhcConnectionPool(String tlsVersion) throws IhcFatalExecption {
+        if (!tlsVersion.isEmpty()) {
+            this.tlsVersion = tlsVersion;
+        }
         init();
     }
 
-    private void init() {
-        // Create a local instance of cookie store
-        cookieStore = new BasicCookieStore();
-
-        // Create local HTTP context
-        localContext = HttpClientContext.create();
-
-        // Bind custom cookie store to the local context
-        localContext.setCookieStore(cookieStore);
-
-        httpClientBuilder = HttpClientBuilder.create();
-
-        // Setup a Trust Strategy that allows all certificates.
-
-        logger.debug("Initialize SSL context");
-
-        // Create a trust manager that does not validate certificate chains, but accept all.
-        TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return null;
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] certs, String authType) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                logger.trace("Trusting server cert: {}", certs[0].getIssuerDN());
-            }
-        } };
-
-        // Install the all-trusting trust manager
-
+    private void init() throws IhcFatalExecption {
         try {
-            // Controller supports only SSLv3 and TLSv1
-            sslContext = SSLContext.getInstance("TLSv1");
+
+            // Create a local instance of cookie store
+            cookieStore = new BasicCookieStore();
+
+            // Create local HTTP context
+            localContext = HttpClientContext.create();
+
+            // Bind custom cookie store to the local context
+            localContext.setCookieStore(cookieStore);
+
+            httpClientBuilder = HttpClientBuilder.create();
+
+            // Setup a Trust Strategy that allows all certificates.
+
+            logger.debug("Initialize SSL context");
+
+            // Create a trust manager that does not validate certificate chains, but accept all.
+            TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    logger.trace("Trusting server cert: {}", certs[0].getIssuerDN());
+                }
+            } };
+
+            // Install the all-trusting trust manager
+
+            // Old controller FW supports only SSLv3 and TLSv1, never controller TLSv1.2
+            sslContext = SSLContext.getInstance(tlsVersion);
+            logger.debug("Using TLS version {}", sslContext.getProtocol());
             sslContext.init(null, trustAllCerts, new SecureRandom());
-        } catch (NoSuchAlgorithmException e) {
-            logger.warn("Exception", e);
-        } catch (KeyManagementException e) {
-            logger.warn("Exception", e);
+
+            // Controller accepts only HTTPS connections and because normally IP address are used on home network rather
+            // than DNS names, create custom host name verifier.
+            HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+
+                @Override
+                public boolean verify(String arg0, SSLSession arg1) {
+                    logger.trace("HostnameVerifier: arg0 = {}, arg1 = {}", arg0, arg1);
+                    return true;
+                }
+            };
+
+            // Create an SSL Socket Factory, to use our weakened "trust strategy"
+            SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                    new String[] { tlsVersion }, null, hostnameVerifier);
+
+            Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory> create()
+                    .register("https", sslSocketFactory).build();
+
+            // Create connection-manager using our Registry. Allows multi-threaded use
+            PoolingHttpClientConnectionManager connMngr = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+
+            // Increase max connection counts
+            connMngr.setMaxTotal(20);
+            connMngr.setDefaultMaxPerRoute(6);
+
+            httpClientBuilder.setConnectionManager(connMngr);
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new IhcFatalExecption(e);
         }
-
-        // Controller accepts only HTTPS connections and because normally IP address are used on home network rather
-        // than DNS names, create custom host name verifier.
-        HostnameVerifier hostnameVerifier = new HostnameVerifier() {
-
-            @Override
-            public boolean verify(String arg0, SSLSession arg1) {
-                logger.trace("HostnameVerifier: arg0 = {}, arg1 = {}", arg0, arg1);
-                return true;
-            }
-        };
-
-        // Create an SSL Socket Factory, to use our weakened "trust strategy"
-        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
-                new String[] { "TLSv1" }, null, hostnameVerifier);
-
-        Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory> create()
-                .register("https", sslSocketFactory).build();
-
-        // Create connection-manager using our Registry. Allows multi-threaded use
-        PoolingHttpClientConnectionManager connMngr = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
-
-        // Increase max connection counts
-        connMngr.setMaxTotal(20);
-        connMngr.setDefaultMaxPerRoute(6);
-
-        httpClientBuilder.setConnectionManager(connMngr);
     }
 
     public HttpClient getHttpClient() {

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
@@ -34,6 +34,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcFatalExecption;
+import org.openhab.binding.ihc.internal.ws.exeptions.IhcTlsExecption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,8 +142,10 @@ public class IhcConnectionPool {
             connMngr.setDefaultMaxPerRoute(6);
 
             httpClientBuilder.setConnectionManager(connMngr);
-        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+        } catch (KeyManagementException e) {
             throw new IhcFatalExecption(e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IhcTlsExecption(e);
         }
     }
 

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcConnectionPool.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 public class IhcConnectionPool {
 
     private final Logger logger = LoggerFactory.getLogger(IhcConnectionPool.class);
+    private static final String DEFAULT_TLS_VER = "TLSv1";
 
     /**
      * Controller TLS certificate is self signed, which means that certificate
@@ -60,10 +61,10 @@ public class IhcConnectionPool {
 
     private HttpClientBuilder httpClientBuilder;
     private HttpClientContext localContext;
-    private String tlsVersion = "TLSv1";
+    private String tlsVersion = DEFAULT_TLS_VER;
 
     public IhcConnectionPool() throws IhcFatalExecption {
-        this("TLSv1");
+        this(DEFAULT_TLS_VER);
     }
 
     public IhcConnectionPool(String tlsVersion) throws IhcFatalExecption {

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcHttpsClient.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/ws/http/IhcHttpsClient.java
@@ -20,6 +20,8 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.ClientProtocolException;
@@ -29,6 +31,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.openhab.binding.ihc.internal.ws.exeptions.IhcExecption;
+import org.openhab.binding.ihc.internal.ws.exeptions.IhcTlsExecption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +75,8 @@ public abstract class IhcHttpsClient {
         setRequestProperty(requestProperties);
         try {
             return sendQ(query, timeout);
+        } catch (SSLHandshakeException e) {
+            throw new IhcTlsExecption(e);
         } catch (NoHttpResponseException | SocketTimeoutException e) {
             try {
                 logger.debug("No response received, resend query");

--- a/bundles/org.openhab.binding.ihc/src/main/resources/OH-INF/thing/controller.xml
+++ b/bundles/org.openhab.binding.ihc/src/main/resources/OH-INF/thing/controller.xml
@@ -62,11 +62,12 @@
 			<parameter name="tlsVersion" type="text" required="false">
 				<label>TLS version</label>
 				<description>TLS version used for controller communication. Choose TLSv1 for older firmware versions and TLSv1.2 for
-					never versions.</description>
+					never versions (since fall 2021). Auto mode try to recognize correct version.</description>
 				<default>TLSv1</default>
 				<options>
 					<option value="TLSv1">TLSv1</option>
 					<option value="TLSv1.2">TLSv1.2</option>
+					<option value="AUTO">Auto</option>
 				</options>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.ihc/src/main/resources/OH-INF/thing/controller.xml
+++ b/bundles/org.openhab.binding.ihc/src/main/resources/OH-INF/thing/controller.xml
@@ -59,6 +59,16 @@
 					well.</description>
 				<default>true</default>
 			</parameter>
+			<parameter name="tlsVersion" type="text" required="false">
+				<label>TLS version</label>
+				<description>TLS version used for controller communication. Choose TLSv1 for older firmware versions and TLSv1.2 for
+					never versions.</description>
+				<default>TLSv1</default>
+				<options>
+					<option value="TLSv1">TLSv1</option>
+					<option value="TLSv1.2">TLSv1.2</option>
+				</options>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
So far IHC controller have supported only TLSv1. As TLSv1 is already deprecated and upcoming IHC controller FW version will introduce support for TLSv1.2. This change introduce TLSv1.2 support for the binding. TLS version is selectable to be backward compatible for older controller versions.

Communication error handling is also improved e.g. because of wrong password or if Java environment doesn't support required TLS version. When fatal communication error occurs, binding will not hammer controller with retries as it need user actions.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
