### PR TITLE
[gpio] Improved usability of pullupdown parameter on GPIO pin

### DIFF
--- a/bundles/org.openhab.binding.gpio/README.md
+++ b/bundles/org.openhab.binding.gpio/README.md
@@ -28,13 +28,17 @@ Note: if you are setting this up on a Raspberry Pi without `raspi-config` you ca
 sudo mkdir -p /etc/systemd/system/pigpiod.service.d/
 sudo nano /etc/systemd/system/pigpiod.service.d/public.conf
 ```
-      [Service]
-      ExecStart=
-      ExecStart=/usr/bin/pigpiod
+
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/pigpiod
+
 ```
 sudo systemctl daemon-reload
 ```
+
 Now that Remote GPIO is enabled, get the daemon going (even if installed with apt-get):
+
 ```
 sudo systemctl enable pigpiod 
 sudo systemctl start pigpiod
@@ -58,7 +62,7 @@ Note: If you are running Pigpio on same host as openHAB, then set host to **::1*
 Set the number of the pin in `gpioId`.
 If you want to invert the value, set `invert` to true.
 To prevent incorrect change events, you can adjust the `debouncingTime`.
-Using `pullupdown` you can enable pull up or pull down resistor (0 = Off, 1 = Pull Down, 2 = Pull Up).
+Using `pullupdown` you can enable pull up or pull down resistor (OFF = Off, DOWN = Pull Down, UP = Pull Up).
 
 ### GPIO digital output channel
 
@@ -81,7 +85,7 @@ Thing gpio:pigpio-remote:sample-pi-1 "Sample-Pi 1" [host="192.168.2.36", port=88
 Thing gpio:pigpio-remote:sample-pi-2 "Sample-Pi 2" [host="192.168.2.37", port=8888] {
     Channels:
         Type pigpio-digital-input : sample-input-3 [ gpioId=16, debouncingTime=20]
-        Type pigpio-digital-input : sample-input-4 [ gpioId=17, invert=true, debouncingTime=5, pullupdown=2]
+        Type pigpio-digital-input : sample-input-4 [ gpioId=17, invert=true, debouncingTime=5, pullupdown="UP"]
         Type pigpio-digital-output : sample-output-2 [ gpioId=4, invert=true]
 }
 ```

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/GPIOBindingConstants.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/GPIOBindingConstants.java
@@ -21,6 +21,7 @@ import org.openhab.core.thing.type.ChannelTypeUID;
  * used across the whole binding.
  *
  * @author Nils Bauer - Initial contribution
+ * @author Martin Dagarin - Pull Up/Down GPIO pin
  */
 @NonNullByDefault
 public class GPIOBindingConstants {
@@ -41,6 +42,12 @@ public class GPIOBindingConstants {
     public static final String INVERT = "invert";
     public static final String DEBOUNCING_TIME = "debouncing_time";
     public static final String STRICT_DEBOUNCING = "debouncing_strict";
+    public static final String PULLUPDOWN_RESISTOR = "pullupdown";
+
+    // Pull Up/Down modes
+    public static final String PUD_OFF = "OFF";
+    public static final String PUD_DOWN = "DOWN";
+    public static final String PUD_UP = "UP";
 
     // GPIO config properties
     public static final String GPIO_ID = "gpioId";

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/InvalidPullUpDownException.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/InvalidPullUpDownException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.gpio.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Is thrown when invalid GPIO pin Pull Up/Down resistor configuration is set
+ *
+ * @author Martin Dagarin - Initial contribution
+ */
+@NonNullByDefault
+public class InvalidPullUpDownException extends Exception {
+    private static final long serialVersionUID = -1281107134439928767L;
+}

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/configuration/GPIOInputConfiguration.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/configuration/GPIOInputConfiguration.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * The {@link GPIOInputConfiguration} class contains fields mapping thing configuration parameters.
  *
  * @author Nils Bauer - Initial contribution
+ * @author Martin Dagarin - Pull Up/Down GPIO pin
  */
 @NonNullByDefault
 public class GPIOInputConfiguration extends GPIOConfiguration {
@@ -28,7 +29,7 @@ public class GPIOInputConfiguration extends GPIOConfiguration {
 
     /**
      * Setup a pullup resistor on the GPIO pin
-     * 0 = PI_PUD_OFF, 1 = PI_PUD_DOWN, 2 = PI_PUD_UP
+     * OFF = PI_PUD_OFF, DOWN = PI_PUD_DOWN, UP = PI_PUD_UP
      */
-    public int pullupdown = 0;
+    public String pullupdown = "OFF";
 }

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioDigitalInputHandler.java
@@ -18,6 +18,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.gpio.internal.GPIOBindingConstants;
+import org.openhab.binding.gpio.internal.InvalidPullUpDownException;
 import org.openhab.binding.gpio.internal.NoGpioIdException;
 import org.openhab.binding.gpio.internal.configuration.GPIOInputConfiguration;
 import org.openhab.core.library.types.OnOffType;
@@ -36,6 +38,7 @@ import eu.xeli.jpigpio.PigpioException;
  *
  * @author Nils Bauer - Initial contribution
  * @author Jan N. Klug - Channel redesign
+ * @author Martin Dagarin - Pull Up/Down GPIO pin
  */
 @NonNullByDefault
 public class PigpioDigitalInputHandler implements ChannelHandler {
@@ -49,12 +52,22 @@ public class PigpioDigitalInputHandler implements ChannelHandler {
 
     public PigpioDigitalInputHandler(GPIOInputConfiguration configuration, JPigpio jPigpio,
             ScheduledExecutorService scheduler, Consumer<State> updateStatus)
-            throws PigpioException, NoGpioIdException {
+            throws PigpioException, InvalidPullUpDownException, NoGpioIdException {
         this.configuration = configuration;
         this.updateStatus = updateStatus;
         Integer gpioId = configuration.gpioId;
         if (gpioId == null) {
             throw new NoGpioIdException();
+        }
+        Integer pullupdown = JPigpio.PI_PUD_OFF;
+        String pullupdownStr = configuration.pullupdown.toUpperCase();
+        if (pullupdownStr.equals(GPIOBindingConstants.PUD_DOWN)) {
+            pullupdown = JPigpio.PI_PUD_DOWN;
+        } else if (pullupdownStr.equals(GPIOBindingConstants.PUD_UP)) {
+            pullupdown = JPigpio.PI_PUD_UP;
+        } else {
+            if (!pullupdownStr.equals(GPIOBindingConstants.PUD_OFF))
+                throw new InvalidPullUpDownException();
         }
         gpio = new GPIO(jPigpio, gpioId, JPigpio.PI_INPUT);
         jPigpio.gpioSetAlertFunc(gpio.getPin(), (gpio, level, tick) -> {
@@ -62,7 +75,6 @@ public class PigpioDigitalInputHandler implements ChannelHandler {
             Date thisChange = new Date();
             scheduler.schedule(() -> afterDebounce(thisChange), configuration.debouncingTime, TimeUnit.MILLISECONDS);
         });
-        Integer pullupdown = configuration.pullupdown;
         jPigpio.gpioSetPullUpDown(gpio.getPin(), pullupdown);
     }
 

--- a/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioRemoteHandler.java
+++ b/bundles/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/handler/PigpioRemoteHandler.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.gpio.internal.InvalidPullUpDownException;
 import org.openhab.binding.gpio.internal.NoGpioIdException;
 import org.openhab.binding.gpio.internal.configuration.GPIOInputConfiguration;
 import org.openhab.binding.gpio.internal.configuration.GPIOOutputConfiguration;
@@ -105,6 +106,8 @@ public class PigpioRemoteHandler extends BaseThingHandler {
                 }
             } catch (PigpioException e) {
                 logger.warn("Failed to initialize {}: {}", channelUID, e.getMessage());
+            } catch (InvalidPullUpDownException e) {
+                logger.warn("Failed to initialize {}: Invalid Pull Up/Down resistor configuration", channelUID);
             } catch (NoGpioIdException e) {
                 logger.warn("Failed to initialize {}: GpioId is not set", channelUID);
             }

--- a/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
+++ b/bundles/org.openhab.binding.gpio/src/main/resources/OH-INF/thing/pigpio-remote.xml
@@ -50,16 +50,16 @@
 				<default>10</default>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="pullupdown" type="integer" min="0" max="2">
+			<parameter name="pullupdown" type="text">
 				<label>Pull Up/Down Resistor</label>
 				<description>Configure Pull Up/Down Resistor of GPIO pin</description>
 				<options>
-					<option value="0">Off</option>
-					<option value="1">Pull Down</option>
-					<option value="2">Pull Up</option>
+					<option value="OFF">Off</option>
+					<option value="DOWN">Pull Down</option>
+					<option value="UP">Pull Up</option>
 				</options>
 				<limitToOptions>true</limitToOptions>
-				<default>0</default>
+				<default>OFF</default>
 			</parameter>
 		</config-description>
 	</channel-type>


### PR DESCRIPTION
Follow-up pull request to pull request #10782, changed usage of pullupdown parameter, instead of numeric parameter is now text parameter with "constants" OFF, DOWN, UP.

-  Signed off commits
-  Checked with mvn spotless:apply
-  Tested on my instance, no errors detected.

Signed-off-by: Martin <martin.dagarin@gmail.com>