### PR TITLE
[tesla] Prevent NPE

### DIFF
--- a/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
+++ b/bundles/org.openhab.binding.tesla/src/main/java/org/openhab/binding/tesla/internal/handler/TeslaVehicleHandler.java
@@ -560,7 +560,9 @@ public class TeslaVehicleHandler extends BaseThingHandler {
                 }
 
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
-                eventClient.close();
+                if (eventClient != null) {
+                    eventClient.close();
+                }
             } else if ((System.currentTimeMillis() - apiIntervalTimestamp) > 1000
                     * TeslaAccountHandler.API_ERROR_INTERVAL_SECONDS) {
                 logger.trace("Resetting the error counter. ({} errors in the last interval)", apiIntervalErrors);


### PR DESCRIPTION
This NPE causes the scheduled task to crash, so that the whole binding stops working.

Signed-off-by: Kai Kreuzer <kai@openhab.org>