### PR TITLE
[miio] fix discovery issue for devices with dot in ID

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
@@ -233,7 +233,7 @@ public class MiIoDiscovery extends AbstractDiscoveryService {
     }
 
     private void submitDiscovery(String ip, String token, String id, String label, String country, boolean isOnline) {
-        ThingUID uid = new ThingUID(THING_TYPE_MIIO, id);
+        ThingUID uid = new ThingUID(THING_TYPE_MIIO, id.replace(".", "_"));
         DiscoveryResultBuilder dr = DiscoveryResultBuilder.create(uid).withProperty(PROPERTY_HOST_IP, ip)
                 .withProperty(PROPERTY_DID, id);
         if (IGNORED_TOKENS.contains(token)) {


### PR DESCRIPTION
Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>

avoid error
```
18:19:51.732 [ERROR] [internal.DiscoveryServiceRegistryImpl] - Cannot trigger scan for thing types '[miio:vacuum, miio:unsupported, miio:basic, miio:generic]' on 'MiIoDiscovery'!
java.lang.IllegalArgumentException: ID segment 'lumi.158d0001e09bdb' contains invalid characters. Each segment of the ID must match the pattern [\w-]*.
        at org.openhab.core.common.AbstractUID.validateSegment(AbstractUID.java:98) ~[?:?]
        at org.openhab.core.common.AbstractUID.<init>(AbstractUID.java:76) ~[?:?]
        at org.openhab.core.common.AbstractUID.<init>(AbstractUID.java:59) ~[?:?]
        at org.openhab.core.thing.UID.<init>(UID.java:57) ~[?:?]
        at org.openhab.core.thing.ThingUID.<init>(ThingUID.java:47) ~[?:?]
        at org.openhab.binding.miio.internal.discovery.MiIoDiscovery.submitDiscovery(MiIoDiscovery.java:236) ~[?:?]
        at org.openhab.binding.miio.internal.discovery.MiIoDiscovery.cloudDiscovery(MiIoDiscovery.java:201) ~[?:?]
        at org.openhab.binding.miio.internal.discovery.MiIoDiscovery.startScan(MiIoDiscovery.java:158) ~[?:?]
 
```
