### PR TITLE
[ihc] Improved command handling when controller is not ready

### DIFF
--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -212,6 +212,11 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
             return;
         }
 
+        if (thing.getStatus() != ThingStatus.ONLINE) {
+            logger.warn("Controller is not ONLINE state, abort resource value update for channel '{}'!", channelUID);
+            return;
+        }
+
         switch (channelUID.getId()) {
             case CHANNEL_CONTROLLER_STATE:
                 if (command.equals(RefreshType.REFRESH)) {

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -202,18 +202,19 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
         logger.debug("Received channel: {}, command: {}", channelUID, command);
 
         if (ihc == null) {
-            logger.warn("Connection is not initialized, abort resource value update for channel '{}'!", channelUID);
+            logger.debug("Connection is not initialized, aborting resource value update for channel '{}'!", channelUID);
             return;
         }
 
         if (ihc.getConnectionState() != ConnectionState.CONNECTED) {
-            logger.warn("Connection to controller is not open, abort resource value update for channel '{}'!",
+            logger.debug("Connection to controller is not open, aborting resource value update for channel '{}'!",
                     channelUID);
             return;
         }
 
         if (thing.getStatus() != ThingStatus.ONLINE) {
-            logger.warn("Controller is not ONLINE state, abort resource value update for channel '{}'!", channelUID);
+            logger.debug("Controller is not ONLINE, aborting resource value update for channel '{}'!",
+                    channelUID);
             return;
         }
 

--- a/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
+++ b/bundles/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/handler/IhcHandler.java
@@ -213,8 +213,7 @@ public class IhcHandler extends BaseThingHandler implements IhcEventListener {
         }
 
         if (thing.getStatus() != ThingStatus.ONLINE) {
-            logger.debug("Controller is not ONLINE, aborting resource value update for channel '{}'!",
-                    channelUID);
+            logger.debug("Controller is not ONLINE, aborting resource value update for channel '{}'!", channelUID);
             return;
         }
 


### PR DESCRIPTION
When connection from binding to IHC controller is open, but controller
is in programming state, things state is offline with special status to
indicate that binding can't send or receive any resource updates at the
moment. Things status check during command sending will prevent
unnecessary resource updates which will eventually fail and binding then
tries to restart the connection.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>
