### PR TITLE
[http] Fix parsing of Color RGB values

### DIFF
--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
@@ -109,9 +109,10 @@ public class ColorItemConverter extends AbstractTransformingItemConverter {
             if (matcher.matches()) {
                 switch (channelConfig.colorMode) {
                     case RGB:
-                        int r = Integer.parseInt(matcher.group(0));
-                        int g = Integer.parseInt(matcher.group(1));
-                        int b = Integer.parseInt(matcher.group(2));
+                        String[] channels = matcher.group(0).split(",");
+                        int r = Integer.parseInt(channels[0]);
+                        int g = Integer.parseInt(channels[1]);
+                        int b = Integer.parseInt(channels[2]);
                         newState = HSBType.fromRGB(r, g, b);
                         break;
                     case HSB:

--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
@@ -109,10 +109,10 @@ public class ColorItemConverter extends AbstractTransformingItemConverter {
             if (matcher.matches()) {
                 switch (channelConfig.colorMode) {
                     case RGB:
-                        String[] channels = matcher.group(0).split(",");
-                        int r = Integer.parseInt(channels[0]);
-                        int g = Integer.parseInt(channels[1]);
-                        int b = Integer.parseInt(channels[2]);
+                        int r = Integer.parseInt(matcher.group(1));
+                        int g = Integer.parseInt(matcher.group(2));
+                        int b = Integer.parseInt(matcher.group(3));
+
                         newState = HSBType.fromRGB(r, g, b);
                         break;
                     case HSB:

--- a/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
+++ b/bundles/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/converter/ColorItemConverter.java
@@ -112,7 +112,6 @@ public class ColorItemConverter extends AbstractTransformingItemConverter {
                         int r = Integer.parseInt(matcher.group(1));
                         int g = Integer.parseInt(matcher.group(2));
                         int b = Integer.parseInt(matcher.group(3));
-
                         newState = HSBType.fromRGB(r, g, b);
                         break;
                     case HSB:


### PR DESCRIPTION
When parsing RGB values from a http channel state request (in the form "0,1,2") there is an error like this one:

> Failed processing result for URL http://esp32dev2/get/color: For input string: "114,69,40"

Even though the input string "114,69,40" is supposed to be valid.
Which stems from RefreshingUrlCache.java:processResult after calling ColorItemConverter:toState. In the toState function the input is matched against the regex TRIPLE_MATCHER ("(\d+),(\d+),(\d+)") and then the r, g and b channels are set by matcher.group. The problem is that matcher.group returns which match was found, thus matcher.group(0) refers to the first three-digit pattern matching TRIPLE_MATCHER. Then matcher.group(1) has nothing to return as there is only one three-digit group.
Instead I have moved to only using matcher.group(0) and splitting it by the commas. Afterwards the state is parsed as expected.