### PR TITLE
[tivo] Fix thing staying offline after connection refresh

### DIFF
--- a/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/handler/TiVoHandler.java
+++ b/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/handler/TiVoHandler.java
@@ -115,6 +115,7 @@ public class TiVoHandler extends BaseThingHandler {
     }
 
     public void setStatusOffline() {
+        lastConnectionStatus = ConnectionStatus.UNKNOWN;
         this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                 "Power on device or check network configuration/connection.");
     }

--- a/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/service/TivoStatusProvider.java
+++ b/bundles/org.openhab.binding.tivo/src/main/java/org/openhab/binding/tivo/internal/service/TivoStatusProvider.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -441,7 +442,7 @@ public class TivoStatusProvider {
 
                     try {
                         receivedData = reader.readLine();
-                    } catch (SocketTimeoutException e) {
+                    } catch (SocketTimeoutException | SocketException e) {
                         // Do nothing. Just allow the thread to check if it has to stop.
                     }
 


### PR DESCRIPTION
This PR is a follow-on to #10824. It was discovered that after the connection refresh, the thing was showing as offline even though the connection was working. Please merge prior to the OH 3.1.0 final release if possible. @kaikreuzer 