### PR TITLE
[tr064] Added representation property for Things

### DIFF
--- a/bundles/org.openhab.binding.tr064/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,6 +7,8 @@
 	<bridge-type id="generic">
 		<label>Generic CPE</label>
 
+		<representation-property>host</representation-property>
+
 		<config-description>
 			<parameter name="host" type="text" required="true">
 				<label>Host</label>
@@ -32,6 +34,8 @@
 	<bridge-type id="fritzbox">
 		<label>FritzBox</label>
 		<description>A physical FritzBox Device.</description>
+
+		<representation-property>host</representation-property>
 
 		<config-description>
 			<parameter name="host" type="text" required="true">
@@ -109,6 +113,8 @@
 		<label>Sub-Device</label>
 		<description>A virtual sub-device.</description>
 
+		<representation-property>uuid</representation-property>
+
 		<config-description>
 			<parameter name="uuid" type="text" required="true">
 				<label>UUID</label>
@@ -129,6 +135,8 @@
 		</supported-bridge-type-refs>
 		<label>Sub-Device (LAN)</label>
 		<description>A virtual Sub-Device (LAN).</description>
+
+		<representation-property>uuid</representation-property>
 
 		<config-description>
 			<parameter name="uuid" type="text" required="true">


### PR DESCRIPTION
- Added representation property for Things

See https://community.openhab.org/t/tr-064-binding-inbox-notification-after-manual-adding-fritzbox/123977

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
