### PR TITLE
[homematic] Fix UI enumeration of HM-MOD-EM-8 channels

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandlerFactory.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/handler/HomematicThingHandlerFactory.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.homematic.internal.HomematicBindingConstants.*
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.homematic.internal.type.HomematicChannelTypeProvider;
 import org.openhab.binding.homematic.internal.type.HomematicTypeGenerator;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.net.NetworkAddressService;
@@ -40,13 +41,16 @@ import org.osgi.service.component.annotations.Reference;
 public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
 
     private final HomematicTypeGenerator typeGenerator;
+    private final HomematicChannelTypeProvider channelTypeProvider;
     private final NetworkAddressService networkAddressService;
     private final HttpClient httpClient;
 
     @Activate
     public HomematicThingHandlerFactory(@Reference HomematicTypeGenerator typeGenerator,
+            @Reference HomematicChannelTypeProvider channelTypeProvider,
             @Reference NetworkAddressService networkAddressService, @Reference HttpClientFactory httpClientFactory) {
         this.typeGenerator = typeGenerator;
+        this.channelTypeProvider = channelTypeProvider;
         this.networkAddressService = networkAddressService;
         this.httpClient = httpClientFactory.getCommonHttpClient();
     }
@@ -62,7 +66,7 @@ public class HomematicThingHandlerFactory extends BaseThingHandlerFactory {
             return new HomematicBridgeHandler((Bridge) thing, typeGenerator,
                     networkAddressService.getPrimaryIpv4HostAddress(), httpClient);
         } else {
-            return new HomematicThingHandler(thing);
+            return new HomematicThingHandler(thing, channelTypeProvider);
         }
     }
 }

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -250,7 +250,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
     /**
      * Creates the ChannelType for the given datapoint.
      */
-    private ChannelType createChannelType(HmDatapoint dp, ChannelTypeUID channelTypeUID) {
+    public static ChannelType createChannelType(HmDatapoint dp, ChannelTypeUID channelTypeUID) {
         ChannelType channelType;
         if (dp.getName().equals(DATAPOINT_NAME_LOWBAT) || dp.getName().equals(DATAPOINT_NAME_LOWBAT_IP)) {
             channelType = DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_LOW_BATTERY;


### PR DESCRIPTION
The set of available HM-MOD-EM-8 channels varies depending on the
function a given channel is configured to use, which is why for those
devices we can't determine a static ThingType, but instead must populate
the thing channels on initialization. The existing code already handled
that case, but missed registering channel types for the dynamically
generated channels, which is why those channels were not shown in main
UI.

(Original code introduced in #3140)