### PR TITLE
[influxdb] Fix queries with InfluxDB 2.0 with data migrated from InfluxDB1 without item tags

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConstants.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBConstants.java
@@ -32,4 +32,5 @@ public class InfluxDBConstants {
     public static final String TAG_CATEGORY_NAME = "category";
     public static final String TAG_TYPE_NAME = "type";
     public static final String TAG_LABEL_NAME = "label";
+    public static final String FIELD_MEASUREMENT_NAME = "_measurement";
 }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/Influx2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx2/Influx2FilterCriteriaQueryCreatorImpl.java
@@ -66,10 +66,18 @@ public class Influx2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQuer
         String itemName = criteria.getItemName();
         if (itemName != null) {
             String measurementName = calculateMeasurementName(itemName);
+            boolean needsToUseItemTagName = !measurementName.equals(itemName);
+
             flux = flux.filter(measurement().equal(measurementName));
-            if (!measurementName.equals(itemName)) {
-                flux = flux.filter(tag("item").equal(itemName));
+            if (needsToUseItemTagName) {
+                flux = flux.filter(tag(TAG_ITEM_NAME).equal(itemName));
             }
+
+            if (needsToUseItemTagName)
+                flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2,
+                        TAG_ITEM_NAME });
+            else
+                flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2 });
         }
 
         if (criteria.getState() != null && criteria.getOperator() != null) {

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -79,8 +79,10 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")"));
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
     }
 
     @Test
@@ -112,7 +114,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         String expectedQueryV2 = String.format(
                 "from(bucket:\"origin\")\n\t" + "|> range(start:%s, stop:%s)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")",
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])",
                 INFLUX2_DATE_FORMATTER.format(now.toInstant()), INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
         assertThat(queryV2, equalTo(expectedQueryV2));
     }
@@ -130,6 +133,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
                         + "|> filter(fn: (r) => (r[\"_field\"] == \"value\" and r[\"_value\"] <= 90))"));
     }
 
@@ -144,7 +148,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t" + "|> limit(n:10, offset:20)"));
+                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t" + "|> limit(n:10, offset:20)"));
     }
 
     @Test
@@ -159,6 +164,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
                         + "|> sort(desc:false, columns:[\"_time\"])"));
     }
 
@@ -189,7 +195,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"measurementName\")\n\t"
-                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")"));
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\", \"item\"])"));
 
         when(metadataRegistry.get(metadataKey))
                 .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
@@ -198,7 +205,9 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
 
         queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")"));
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
     }
 }


### PR DESCRIPTION
Fixes bug in queries with InfluxDB 2.0 that had data migrated from InfluxDB 1.0 with old versions of the addon that didn't put item tag name.

In that case, the result contained several group keys and could give bad results, for example in sort queries like `deltaSince` that failed because sort was applied per series and not for all the results.

Completes work done on #10888 to cover all casuistic.

There isn't any open issue but the problem was commented on in that thread
https://community.openhab.org/t/influx-db2-openhab-3-1m5-deltasince-start-of-day-not-working-when-lines-without-item-name-in-database-from-openhab-2-5/123546/26
