### PR TITLE
[mqtt.homie] Workaround for #10839. DateTime and Duration

### DIFF
--- a/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/PropertyAttributes.java
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/java/org/openhab/binding/mqtt/homie/internal/homie300/PropertyAttributes.java
@@ -29,6 +29,7 @@ import org.openhab.binding.mqtt.generic.mapping.TopicPrefix;
 @TopicPrefix
 public class PropertyAttributes extends AbstractMqttAttributeClass {
     // Lower-case enum value names required. Those are identifiers for the MQTT/homie protocol.
+    // https://homieiot.github.io/specification/#payload
     public enum DataTypeEnum {
         unknown,
         integer_,
@@ -36,7 +37,9 @@ public class PropertyAttributes extends AbstractMqttAttributeClass {
         boolean_,
         string_,
         enum_,
-        color_
+        color_,
+        datetime_,
+        duration_
     }
 
     public String name = "";

--- a/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/config/homie-channel-config.xml
+++ b/bundles/org.openhab.binding.mqtt.homie/src/main/resources/OH-INF/config/homie-channel-config.xml
@@ -42,6 +42,8 @@
 				<option value="string_">String</option>
 				<option value="enum_">Enumeration</option>
 				<option value="color_">Colour</option>
+				<option value="datetime_">DateTime</option>
+				<option value="duration_">Duration</option>
 			</options>
 		</parameter>
 	</config-description>


### PR DESCRIPTION
This commit adds support for DateTime and Duration payload. Duration is a workaround only. Duration will be displayed as it is like "P0DT0H10M9S". Maybe a DurationType and DurationItem needs be added to "openhab.core".
