### PR TITLE
[irobot] fix unstable test

### DIFF
--- a/bundles/org.openhab.binding.irobot/src/test/java/org/openhab/binding/irobot/internal/handler/RoombaHandlerTest.java
+++ b/bundles/org.openhab.binding.irobot/src/test/java/org/openhab/binding/irobot/internal/handler/RoombaHandlerTest.java
@@ -75,7 +75,7 @@ public class RoombaHandlerTest {
         config.put("ipaddress", RoombaHandlerTest.IP_ADDRESS);
         config.put("password", RoombaHandlerTest.PASSWORD);
         Mockito.when(thing.getConfiguration()).thenReturn(config);
-        Mockito.when(thing.getStatusInfo())
+        Mockito.lenient().when(thing.getStatusInfo())
                 .thenReturn(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE, "mocked"));
         Mockito.lenient().when(thing.getUID()).thenReturn(new ThingUID("mocked", "irobot", "uid"));
 


### PR DESCRIPTION
Fix UnnecessaryStubbingException in RoombaHandlerTest.

Fixes #10954 and #10956

Signed-off-by: Florian Binder <fb@java4.info>