### PR TITLE
[homematic] Provide additional null pointer checks

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -355,7 +355,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                         Number defaultValue = (Number) dp.getDefaultValue();
                         Number maxValue = dp.getMaxValue();
                         // some datapoints can have a default value that is greater than the maximum value
-                        if (defaultValue.doubleValue() > maxValue.doubleValue()) {
+                        if (defaultValue != null && maxValue != null && 
+                                defaultValue.doubleValue() > maxValue.doubleValue()) {
                             maxValue = defaultValue;
                         }
                         builder.withMinimum(MetadataUtils.createBigDecimal(dp.getMinValue()));

--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -169,8 +169,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     ChannelGroupTypeUID groupTypeUID = UidUtils.generateChannelGroupTypeUID(channel);
                     ChannelGroupType groupType = channelGroupTypeProvider.getInternalChannelGroupType(groupTypeUID);
                     if (groupType == null || device.isGatewayExtras()) {
-                        String groupLabel = String.format("%s",
-                                MiscUtils.capitalize(channel.getType().replace("_", " ")));
+                        String groupLabel = String.format("%s", channel.getType() == null ? null
+                                : MiscUtils.capitalize(channel.getType().replace("_", " ")));
                         groupType = ChannelGroupTypeBuilder.instance(groupTypeUID, groupLabel)
                                 .withChannelDefinitions(channelDefinitions).build();
                         channelGroupTypeProvider.addChannelGroupType(groupType);
@@ -355,8 +355,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                         Number defaultValue = (Number) dp.getDefaultValue();
                         Number maxValue = dp.getMaxValue();
                         // some datapoints can have a default value that is greater than the maximum value
-                        if (defaultValue != null && maxValue != null && 
-                                defaultValue.doubleValue() > maxValue.doubleValue()) {
+                        if (defaultValue != null && maxValue != null
+                                && defaultValue.doubleValue() > maxValue.doubleValue()) {
                             maxValue = defaultValue;
                         }
                         builder.withMinimum(MetadataUtils.createBigDecimal(dp.getMinValue()));


### PR DESCRIPTION
This PR fixes a problem that was introduced with version openHAB 3.1.

Signed-off-by: Martin Herbst <develop@mherbst.de>