### PR TITLE
[kostalinverter] Fix using binding together with z-wave binding

### DIFF
--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/config/SecondGeneration.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/config/SecondGeneration.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
-	<config-description uri="thing-type:kostalpiko1020_config">
+	<config-description uri="thing-type:kostalinverter:kostalpiko1020">
 		<parameter name="url" type="text" required="true">
 			<label>IP Address</label>
 			<description>IP address of the inverter.</description>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/config/ThirdGeneration.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/config/ThirdGeneration.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
-	<config-description uri="thing-type:kostalplenticorepikoiq_config">
+	<config-description uri="thing-type:kostalinverter:plenticorepikoiq">
 		<parameter name="url" type="text" required="true">
 			<context>network-address</context>
 			<label>IP Address / Hostname</label>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKO1020.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKO1020.xml
@@ -74,6 +74,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalpiko1020_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:kostalpiko1020"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ100.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ100.xml
@@ -68,6 +68,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ42.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ42.xml
@@ -68,6 +68,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ55.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ55.xml
@@ -68,6 +68,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ70.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ70.xml
@@ -68,6 +68,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ85.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PIKOIQ85.xml
@@ -68,6 +68,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHBATTERY.xml
@@ -81,6 +81,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS100WITHOUTBATTERY.xml
@@ -73,6 +73,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHBATTERY.xml
@@ -81,6 +81,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS42WITHOUTBATTERY.xml
@@ -73,6 +73,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHBATTERY.xml
@@ -81,6 +81,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS55WITHOUTBATTERY.xml
@@ -73,6 +73,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHBATTERY.xml
@@ -81,6 +81,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS70WITHOUTBATTERY.xml
@@ -73,6 +73,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHBATTERY.xml
@@ -81,6 +81,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHOUTBATTERY.xml
+++ b/bundles/org.openhab.binding.kostalinverter/src/main/resources/OH-INF/thing/PLENTICOREPLUS85WITHOUTBATTERY.xml
@@ -73,6 +73,6 @@
 		<properties>
 			<property name="vendor">KOSTAL Solar Electric GmbH</property>
 		</properties>
-		<config-description-ref uri="thing-type:kostalplenticorepikoiq_config"/>
+		<config-description-ref uri="thing-type:kostalinverter:plenticorepikoiq"/>
 	</thing-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Fixes using the kostalinverter binding together with the z-wave binding (#7090)

According to the [example in the documentation](https://www.openhab.org/docs/developer/bindings/config-xml.html#xml-structure-for-configuration-descriptions)  the kostalinverter binding seems to use an invalid format for the `config-description` URI. The value must consist of three parts separated by `:` and not just two.

The z-wave binding expects this format and crashes when an invalid one is given.

I verified the fix by building a new JAR and dropping it into my openHAB 3.1.0 instance.

This solution is similar to the one proposed in #7090, but I used the binding name as the first identifier and not already a name related to the config or thing itself.