### PR TITLE
[unifi] Fixed 404 error with reconnect and no default value set for UniFiOS Checkbox

### DIFF
--- a/bundles/org.openhab.binding.unifi/README.md
+++ b/bundles/org.openhab.binding.unifi/README.md
@@ -29,6 +29,7 @@ The following table describes the Bridge configuration parameters:
 | ------------------------ | ---------------------------------------------- |--------- | ------- |
 | host                     | Hostname of IP address of the UniFi Controller | Required | -       |
 | port                     | Port of the UniFi Controller                   | Required | -       |
+| UniFi OS                 | If the UniFi Controller is running on UniFi OS | Required | false   |
 | username                 | The username to access the UniFi Controller    | Required | -       |
 | password                 | The password to access the UniFi Controller    | Required | -       |
 | refresh                  | Refresh interval in seconds                    | Optional | 10      |

--- a/bundles/org.openhab.binding.unifi/README.md
+++ b/bundles/org.openhab.binding.unifi/README.md
@@ -29,7 +29,7 @@ The following table describes the Bridge configuration parameters:
 | ------------------------ | ---------------------------------------------- |--------- | ------- |
 | host                     | Hostname of IP address of the UniFi Controller | Required | -       |
 | port                     | Port of the UniFi Controller                   | Required | -       |
-| UniFi OS                 | If the UniFi Controller is running on UniFi OS | Required | false   |
+| unifios                  | If the UniFi Controller is running on UniFi OS | Required | false   |
 | username                 | The username to access the UniFi Controller    | Required | -       |
 | password                 | The password to access the UniFi Controller    | Required | -       |
 | refresh                  | Refresh interval in seconds                    | Optional | 10      |
@@ -107,7 +107,7 @@ The `reconnect` channel allows you to force a client to reconnect. Sending `ON` 
 things/unifi.things
 
 ```
-Bridge unifi:controller:home "UniFi Controller" [ host="unifi", port=8443, username="$username", password="$password", refresh=10 ] {
+Bridge unifi:controller:home "UniFi Controller" [ host="unifi", port=8443, unifios=false, username="$username", password="$password", refresh=10 ] {
 	Thing wirelessClient matthewsPhone "Matthew's iPhone" [ cid="$cid", site="default", considerHome=180 ]
 }
 ```

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
@@ -94,7 +94,10 @@ public class UniFiController {
     // Public API
 
     public void start() throws UniFiException {
-        obtainCsrfToken();
+        if(unifios) {
+            obtainCsrfToken();
+        }
+
         login();
     }
 

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
@@ -94,6 +94,7 @@ public class UniFiController {
     // Public API
 
     public void start() throws UniFiException {
+        obtainCsrfToken();
         login();
     }
 
@@ -101,9 +102,15 @@ public class UniFiController {
         logout();
     }
 
-    public void login() throws UniFiException {
+    public void obtainCsrfToken() throws UniFiException {
         csrfToken = "";
 
+        UniFiControllerRequest<Void> req = newRequest(Void.class);
+        req.setPath("/");
+        executeRequest(req);
+    }
+
+    public void login() throws UniFiException {
         UniFiControllerRequest<Void> req = newRequest(Void.class);
         req.setPath(unifios ? "/api/auth/login" : "/api/login");
         req.setBodyParameter("username", username);

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
@@ -94,7 +94,7 @@ public class UniFiController {
     // Public API
 
     public void start() throws UniFiException {
-        if(unifios) {
+        if (unifios) {
             obtainCsrfToken();
         }
 

--- a/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.unifi/src/main/resources/OH-INF/thing/thing-types.xml
@@ -24,6 +24,7 @@
 			<parameter name="unifios" type="boolean" required="true">
 				<label>UniFi OS</label>
 				<description>If the UniFi Controller is running on UniFi OS.</description>
+				<default>false</default>
 			</parameter>
 			<parameter name="username" type="text" required="true">
 				<label>Username</label>


### PR DESCRIPTION
This should fix: #8388 and #10935

This PR adds the following:
- Fixes the 404 error
- Sets a default value for the UniFi OS checkbox (false)
- Adds a bit of documentation