### PR TITLE
[pushover] Add support to send an Image URL directly

### DIFF
--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -46,7 +46,7 @@ One has to pass a `null` value if it should be skipped or the default value for 
 
 - `sendMonospaceMessage(String message, @Nullable String title)` - This method is used to send a monospace message.
 
-- `sendAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType)` - This method is used to send a message with an attachment. It takes a local path or URL to the attachment (parameter `attachment` **mandatory**) and an optional `contentType` to define the content-type of the attachment (default: `image/jpeg`).
+- `sendAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType)` - This method is used to send a message with an attachment. It takes a local path or URL to the attachment (parameter `attachment` **mandatory**). Additionally you can pass a data URI scheme to this parameter. Optionally pass a `contentType` to define the content-type of the attachment (default: `image/jpeg` or guessed from image data).
 
 - `sendURLMessage(String message, @Nullable String title, String url, @Nullable String urlTitle)` - This method is used to send a message with an URL. A supplementary `url` to show with the message and a `urlTitle` for the URL, otherwise just the URL is shown.
 
@@ -74,6 +74,16 @@ demo.rules:
 val actions = getActions("pushover", "pushover:pushover-account:account")
 // send HTML message
 actions.sendHtmlMessage("Hello <font color='green'>World</font>!", "openHAB")
+```
+
+```java
+val actions = getActions("pushover", "pushover:pushover-account:account")
+// send message with attachment
+actions.sendAttachmentMessage("Hello World!", "openHAB", "/path/to/my-local-image.png", "image/png")
+actions.sendAttachmentMessage("Hello World!", "openHAB", "https://www.openhab.org/openhab-logo-square.png", null)
+actions.sendAttachmentMessage("Hello World!", "openHAB", "data:[<media type>][;base64],<data>", null)
+// in case you want to send the content of an Image Item (RawType)
+actions.sendAttachmentMessage("Hello World!", "openHAB", myImageItem.state.toFullString, null)
 ```
 
 ```java

--- a/bundles/org.openhab.binding.pushover/README.md
+++ b/bundles/org.openhab.binding.pushover/README.md
@@ -46,7 +46,7 @@ One has to pass a `null` value if it should be skipped or the default value for 
 
 - `sendMonospaceMessage(String message, @Nullable String title)` - This method is used to send a monospace message.
 
-- `sendAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType)` - This method is used to send a message with an attachment. It takes a (local) path to the attachment (parameter `attachment` **mandatory**) and an optional `contentType` to define the content-type of the attachment (default: `image/jpeg`).
+- `sendAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType)` - This method is used to send a message with an attachment. It takes a local path or URL to the attachment (parameter `attachment` **mandatory**) and an optional `contentType` to define the content-type of the attachment (default: `image/jpeg`).
 
 - `sendURLMessage(String message, @Nullable String title, String url, @Nullable String urlTitle)` - This method is used to send a message with an URL. A supplementary `url` to show with the message and a `urlTitle` for the URL, otherwise just the URL is shown.
 

--- a/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverConfigurationException.java
+++ b/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverConfigurationException.java
@@ -20,7 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public class PushoverConfigurationException extends RuntimeException {
+public class PushoverConfigurationException extends IllegalArgumentException {
 
     private static final long serialVersionUID = 1L;
 

--- a/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverMessageBuilder.java
+++ b/bundles/org.openhab.binding.pushover/src/main/java/org/openhab/binding/pushover/internal/connection/PushoverMessageBuilder.java
@@ -14,7 +14,8 @@ package org.openhab.binding.pushover.internal.connection;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,6 +25,8 @@ import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.util.MultiPartContentProvider;
 import org.eclipse.jetty.client.util.PathContentProvider;
 import org.eclipse.jetty.client.util.StringContentProvider;
+import org.openhab.core.io.net.http.HttpUtil;
+import org.openhab.core.library.types.RawType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +58,7 @@ public class PushoverMessageBuilder {
     private static final int MAX_MESSAGE_LENGTH = 1024;
     private static final int MAX_TITLE_LENGTH = 250;
     private static final int MAX_DEVICE_LENGTH = 25;
-    private static final List<Integer> VALID_PRIORITY_LIST = Arrays.asList(-2, -1, 0, 1, 2);
+    private static final List<Integer> VALID_PRIORITY_LIST = List.of(-2, -1, 0, 1, 2);
     private static final int DEFAULT_PRIORITY = 0;
     public static final int EMERGENCY_PRIORITY = 2;
     private static final int MIN_RETRY_SECONDS = 30;
@@ -239,18 +242,36 @@ public class PushoverMessageBuilder {
         }
 
         if (attachment != null) {
-            File file = new File(attachment);
-            if (!file.exists()) {
-                throw new IllegalArgumentException(
-                        String.format("Skip sending the message as file '%s' does not exist.", attachment));
-            }
-            try {
-                body.addFilePart(MESSAGE_KEY_ATTACHMENT, file.getName(),
-                        new PathContentProvider(contentType, file.toPath()), null);
-            } catch (IOException e) {
-                logger.debug("IOException occurred - skip sending message: {}", e.getLocalizedMessage(), e);
-                throw new PushoverCommunicationException(
-                        String.format("Skip sending the message: %s", e.getLocalizedMessage()), e);
+            if (attachment.startsWith("http")) {
+                RawType content = HttpUtil.downloadImage(attachment, 10000);
+                if (content == null) {
+                    throw new IllegalArgumentException(
+                            String.format("Skip sending the message as content '%s' does not exist.", attachment));
+                }
+                try {
+                    Path tmpFile = Files.createTempFile("pushover-", ".tmp");
+                    Files.write(tmpFile, content.getBytes());
+                    body.addFilePart(MESSAGE_KEY_ATTACHMENT, tmpFile.toFile().getName(),
+                            new PathContentProvider(contentType, tmpFile), null);
+                } catch (IOException e) {
+                    logger.debug("IOException occurred - skip sending message: {}", e.getLocalizedMessage(), e);
+                    throw new PushoverCommunicationException(
+                            String.format("Skip sending the message: %s", e.getLocalizedMessage()), e);
+                }
+            } else {
+                File file = new File(attachment);
+                if (!file.exists()) {
+                    throw new IllegalArgumentException(
+                            String.format("Skip sending the message as file '%s' does not exist.", attachment));
+                }
+                try {
+                    body.addFilePart(MESSAGE_KEY_ATTACHMENT, file.getName(),
+                            new PathContentProvider(contentType, file.toPath()), null);
+                } catch (IOException e) {
+                    logger.debug("IOException occurred - skip sending message: {}", e.getLocalizedMessage(), e);
+                    throw new PushoverCommunicationException(
+                            String.format("Skip sending the message: %s", e.getLocalizedMessage()), e);
+                }
             }
         }
 

--- a/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/i18n/pushover.properties
+++ b/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/i18n/pushover.properties
@@ -32,7 +32,7 @@ sendMonospaceMessageActionDescription = This method is used to send a monospace 
 sendAttachmentMessageActionLabel = send a plain text message with an attachment
 sendAttachmentMessageActionDescription = This method is used to send a message with an attachment.
 sendMessageActionInputAttachmentLabel = Attachment
-sendMessageActionInputAttachmentDescription = A (local) path to the attachment.
+sendMessageActionInputAttachmentDescription = Local path or URL to the attachment.
 sendMessageActionInputContentTypeLabel = Content Type
 sendMessageActionInputContentTypeDescription = The content type of the attachment. Defaults to "image/jpeg".
 

--- a/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/i18n/pushover_de.properties
+++ b/bundles/org.openhab.binding.pushover/src/main/resources/OH-INF/i18n/pushover_de.properties
@@ -57,7 +57,7 @@ sendMonospaceMessageActionDescription = Action zum Versenden einer monospace-Nac
 sendAttachmentMessageActionLabel = eine Textnachricht mit Anhang senden
 sendAttachmentMessageActionDescription = Action zum Versenden einer Textnachricht mit Anhang.
 sendMessageActionInputAttachmentLabel = Anhang
-sendMessageActionInputAttachmentDescription = Lokaler Pfad zum Anhang.
+sendMessageActionInputAttachmentDescription = Lokaler Pfad oder URL zum Anhang.
 sendMessageActionInputContentTypeLabel = Content-Type
 sendMessageActionInputContentTypeDescription = Der Content-Type für den Anhang. Default: "image/jpeg".
 


### PR DESCRIPTION
- Added support to send an Image URL directly

Closes #9340

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
