### PR TITLE
[deconz] Changed default color mode for color commands to XY

### DIFF
--- a/bundles/org.openhab.binding.deconz/README.md
+++ b/bundles/org.openhab.binding.deconz/README.md
@@ -89,7 +89,7 @@ The transition time is the time to move between two states and is configured in 
 The resolution provided is 1/10s.
 If no value is provided, the default value of the device is used.
 
-`extendedcolorlight` and `colorlight` have different modes for setting the color.
+`extendedcolorlight`, `colorlight` and `lightgroup` have different modes for setting the color.
 Some devices accept only XY, others HSB, others both modes and the binding tries to autodetect the correct mode.
 If this fails, the advanced `colormode` parameter can be set to `xy` or `hs`.
 

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/GroupAction.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/dto/GroupAction.java
@@ -33,14 +33,16 @@ public class GroupAction {
     public @Nullable Integer ct;
     public double @Nullable [] xy;
     public @Nullable String alert;
+    public @Nullable String colormode;
     public @Nullable String effect;
     public @Nullable Integer colorloopspeed;
     public @Nullable Integer transitiontime;
 
     @Override
     public String toString() {
-        return "GroupAction{" + "on=" + on + ", toggle=" + toggle + ", bri=" + bri + ", hue=" + hue + ", sat=" + sat
-                + ", ct=" + ct + ", xy=" + Arrays.toString(xy) + ", alert='" + alert + '\'' + ", effect='" + effect
-                + '\'' + ", colorloopspeed=" + colorloopspeed + ", transitiontime=" + transitiontime + '}';
+        return "GroupAction{on=" + on + ", toggle=" + toggle + ", bri=" + bri + ", hue=" + hue + ", sat=" + sat
+                + ", ct=" + ct + ", xy=" + Arrays.toString(xy) + ", alert='" + alert + "', colormode='" + colormode
+                + "', effect='" + effect + "', colorloopspeed=" + colorloopspeed + ", transitiontime=" + transitiontime
+                + "}";
     }
 }

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/LightThingHandler.java
@@ -210,19 +210,19 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                     }
                 } else if (command instanceof HSBType) {
                     HSBType hsbCommand = (HSBType) command;
-                    if ("xy".equals(colorMode)) {
+                    // XY color is the implicit default: Use XY color mode if i) no color mode is set or ii) if the bulb
+                    // is in CT mode or iii) already in XY mode. Only if the bulb is in HS mode, use this one.
+                    if ("hs".equals(colorMode)) {
+                        newLightState.hue = (int) (hsbCommand.getHue().doubleValue() * HUE_FACTOR);
+                        newLightState.sat = Util.fromPercentType(hsbCommand.getSaturation());
+                    } else {
                         PercentType[] xy = hsbCommand.toXY();
                         if (xy.length < 2) {
                             logger.warn("Failed to convert {} to xy-values", command);
                         }
                         newLightState.xy = new double[] { xy[0].doubleValue() / 100.0, xy[1].doubleValue() / 100.0 };
-                        newLightState.bri = Util.fromPercentType(hsbCommand.getBrightness());
-                    } else {
-                        // default is colormode "hs" (used when colormode "hs" is set or colormode is unknown)
-                        newLightState.bri = Util.fromPercentType(hsbCommand.getBrightness());
-                        newLightState.hue = (int) (hsbCommand.getHue().doubleValue() * HUE_FACTOR);
-                        newLightState.sat = Util.fromPercentType(hsbCommand.getSaturation());
                     }
+                    newLightState.bri = Util.fromPercentType(hsbCommand.getBrightness());
                 } else if (command instanceof PercentType) {
                     newLightState.bri = Util.fromPercentType((PercentType) command);
                 } else if (command instanceof DecimalType) {

--- a/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
+++ b/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/ThingConfig.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ThingConfig {
     public String id = "";
-    public int lastSeenPolling = 1440;
     public @Nullable Double transitiontime;
     public String colormode = "";
+    public int lastSeenPolling = 1440;
 }

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/config/config.xml
@@ -10,23 +10,23 @@
 			<context>network-address</context>
 			<description>IP address or host name of deCONZ interface.</description>
 		</parameter>
-		<parameter name="httpPort" type="integer" required="false" min="1" max="65535">
+		<parameter name="httpPort" type="integer" min="1" max="65535">
 			<label>HTTP Port</label>
 			<description>Port of the deCONZ HTTP interface.</description>
 			<default>80</default>
 		</parameter>
-		<parameter name="port" type="integer" required="false" min="1" max="65535">
+		<parameter name="port" type="integer" min="1" max="65535">
 			<label>Websocket Port</label>
 			<description>Port of the deCONZ Websocket.</description>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="apikey" type="text" required="false">
+		<parameter name="apikey" type="text">
 			<label>API Key</label>
 			<context>password</context>
 			<description>If no API Key is provided, a new one will be requested. You need to authorize the access on the deCONZ
 				web interface.</description>
 		</parameter>
-		<parameter name="timeout" type="integer" required="false" unit="ms" min="0">
+		<parameter name="timeout" type="integer" unit="ms" min="0">
 			<label>Timeout</label>
 			<description>Timeout for asynchronous HTTP requests (in milliseconds).</description>
 			<advanced>true</advanced>
@@ -52,7 +52,7 @@
 			<label>Device ID</label>
 			<description>The deCONZ bridge assigns an integer number ID to each device.</description>
 		</parameter>
-		<parameter name="transitiontime" type="decimal" required="false" min="0" unit="s">
+		<parameter name="transitiontime" type="decimal" min="0" unit="s">
 			<label>Transition Time</label>
 			<description>Time to move between two states. If empty, the default of the device is used. Resolution is 1/10 second.</description>
 		</parameter>
@@ -63,11 +63,11 @@
 			<label>Device ID</label>
 			<description>The deCONZ bridge assigns an integer number ID to each device.</description>
 		</parameter>
-		<parameter name="transitiontime" type="decimal" required="false" min="0" unit="s">
+		<parameter name="transitiontime" type="decimal" min="0" unit="s">
 			<label>Transition Time</label>
 			<description>Time to move between two states. If empty, the default of the device is used. Resolution is 1/10 second.</description>
 		</parameter>
-		<parameter name="colormode" type="text" required="false">
+		<parameter name="colormode" type="text">
 			<label>Color Mode</label>
 			<description>Override the default color mode (auto-detect)</description>
 			<options>
@@ -78,4 +78,19 @@
 		</parameter>
 	</config-description>
 
+	<config-description uri="thing-type:deconz:lightgroup">
+		<parameter name="id" type="text" required="true">
+			<label>Device ID</label>
+			<description>The deCONZ bridge assigns an integer number ID to each group.</description>
+		</parameter>
+		<parameter name="colormode" type="text">
+			<label>Color Mode</label>
+			<description>Override the default color mode (auto-detect)</description>
+			<options>
+				<option value="hs">HSB</option>
+				<option value="xy">XY</option>
+			</options>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
@@ -21,7 +21,7 @@
 
 		<representation-property>uid</representation-property>
 
-		<config-description-ref uri="thing-type:deconz:sensor"/>
+		<config-description-ref uri="thing-type:deconz:lightgroup"/>
 	</thing-type>
 
 	<channel-type id="all_on">


### PR DESCRIPTION
- Changed default color mode for color commands to XY

See https://github.com/openhab/openhab-addons/issues/11031#issuecomment-883324344
Similar to https://github.com/openhab/openhab-addons/pull/10608

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
