### PR TITLE
[espmilight] Add color channels ability to trigger white LEDs

### DIFF
--- a/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/README.md
@@ -105,7 +105,7 @@ Note that the group 0 (or ALL group) is not autodiscovered as a thing and thus h
 | `dimmedCT` | Traditional globes grow warmer the more they are dimmed. Set this to 370, or leave blank to disable. | N | blank |
 | `oneTriggersNightMode` | Night mode is a much lower level of light and this feature allows it to be auto selected when your fader/slider moves to 1%. NOTE: Night mode by design locks out some controls of a physical remote, so this feature is disabled by default. | Y | false |
 | `powerFailsToMinimum` | If lights loose power from the power switch OR a power outage, they will default to using the lowest brightness if the light was turned off before the power failure occurred. | Y | true |
-| `whiteThreshold` | RGBW globes do not respond to saturation changes, so this feature allows you to specify a number that if the saturation drops below, it will trigger the white mode. -1 will disable this feature. | Y | 12 |
+| `whiteThreshold` | This feature allows you to use a color control to change to using the real white LEDs when the saturation is equal to, or below this threshold. -1 will disable this feature. | Y | 12 |
 
 ## Channels
 

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/discovery/EspMilightHubDiscoveryService.java
@@ -70,7 +70,7 @@ public class EspMilightHubDiscoveryService extends AbstractMQTTDiscovery {
                     String globeType = (cutTopic.substring(0, index));
                     String remoteGroupID = (cutTopic.substring(index + 1, index + 2));
                     // openHAB's framework has better code for handling groups then the firmware does
-                    if (!remoteGroupID.equals("0")) {// Users can manually add group 0 things if they wish
+                    if (!"0".equals(remoteGroupID)) {// Users can manually add group 0 things if they wish
                         publishDevice(connectionBridge, connection, topic, remoteCode, globeType, remoteGroupID);
                     }
                 }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -78,7 +78,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
     void changeChannel(String channel, State state) {
         updateState(new ChannelUID(channelPrefix + channel), state);
         // Remote code of 0 means that all channels need to follow this change.
-        if (remotesGroupID.equals("0")) {
+        if ("0".equals(remotesGroupID)) {
             switch (globeType) {
                 // These two are 8 channel remotes
                 case "fut091":
@@ -110,20 +110,20 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
         String bulbState = Helper.resolveJSON(messageJSON, "\"state\":\"", 3);
         String bulbLevel = Helper.resolveJSON(messageJSON, "\"level\":", 3);
         if (!bulbLevel.isEmpty()) {
-            if (bulbLevel.equals("0") || bulbState.equals("OFF")) {
+            if ("0".equals(bulbLevel) || "OFF".equals(bulbState)) {
                 changeChannel(CHANNEL_LEVEL, OnOffType.OFF);
                 tempBulbLevel = BigDecimal.ZERO;
             } else {
                 tempBulbLevel = new BigDecimal(bulbLevel);
                 changeChannel(CHANNEL_LEVEL, new PercentType(tempBulbLevel));
             }
-        } else if (bulbState.equals("ON") || bulbState.equals("OFF")) { // NOTE: Level is missing when this runs
+        } else if ("ON".equals(bulbState) || "OFF".equals(bulbState)) { // NOTE: Level is missing when this runs
             changeChannel(CHANNEL_LEVEL, OnOffType.valueOf(bulbState));
         }
         bulbMode = Helper.resolveJSON(messageJSON, "\"bulb_mode\":\"", 5);
         switch (bulbMode) {
             case "white":
-                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                if (!"cct".equals(globeType) && !"fut091".equals(globeType)) {
                     changeChannel(CHANNEL_BULB_MODE, new StringType("white"));
                     changeChannel(CHANNEL_COLOUR, new HSBType("0,0," + tempBulbLevel));
                     changeChannel(CHANNEL_DISCO_MODE, new StringType("None"));
@@ -149,7 +149,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 }
                 break;
             case "scene":
-                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                if (!"cct".equals(globeType) && !"fut091".equals(globeType)) {
                     changeChannel(CHANNEL_BULB_MODE, new StringType("scene"));
                 }
                 String bulbDiscoMode = Helper.resolveJSON(messageJSON, "\"mode\":", 1);
@@ -158,7 +158,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 }
                 break;
             case "night":
-                if (!globeType.equals("cct") && !globeType.equals("fut091")) {
+                if (!"cct".equals(globeType) && !"fut091".equals(globeType)) {
                     changeChannel(CHANNEL_BULB_MODE, new StringType("night"));
                     if (config.oneTriggersNightMode) {
                         changeChannel(CHANNEL_LEVEL, new PercentType("1"));
@@ -220,7 +220,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
                 turnOff();
                 return;
             } else if (config.whiteThreshold != -1 && hsb.getSaturation().intValue() <= config.whiteThreshold) {
-                sendMQTT("{\"command\":\"set_white\",\"level\":" + hsb.getBrightness().intValue() + "}");
+                sendMQTT("{\"command\":\"set_white\"}");// Can't send the command and level in the same message.
+                sendMQTT("{\"level\":" + hsb.getBrightness().intValue() + "}");
             } else {
                 sendMQTT("{\"state\":\"ON\",\"level\":" + hsb.getBrightness().intValue() + ",\"hue\":"
                         + hsb.getHue().intValue() + ",\"saturation\":" + hsb.getSaturation().intValue() + "}");
@@ -238,8 +239,8 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             }
             sendMQTT("{\"state\":\"ON\",\"level\":" + command + "}");
             savedLevel = percentType.toBigDecimal();
-            if ("rgb_cct".equals(globeType) || globeType.equals("fut089")) {
-                if (config.dimmedCT > 0 && bulbMode.equals("white")) {
+            if ("rgb_cct".equals(globeType) || "fut089".equals(globeType)) {
+                if (config.dimmedCT > 0 && "white".equals(bulbMode)) {
                     sendMQTT("{\"state\":\"ON\",\"color_temp\":" + autoColourTemp(savedLevel.intValue()) + "}");
                 }
             }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/java/org/openhab/binding/mqtt/espmilighthub/internal/handler/EspMilightHubHandler.java
@@ -219,13 +219,12 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             } else if (PercentType.ZERO.equals(hsb.getBrightness())) {
                 turnOff();
                 return;
-            } else if (config.whiteThreshold != -1 && hsb.getSaturation().intValue() <= config.whiteThreshold
-                    && "rgbw".equals(globeType)) {
-                sendMQTT("{\"command\":\"set_white\"}");
-                return;
+            } else if (config.whiteThreshold != -1 && hsb.getSaturation().intValue() <= config.whiteThreshold) {
+                sendMQTT("{\"command\":\"set_white\",\"level\":" + hsb.getBrightness().intValue() + "}");
+            } else {
+                sendMQTT("{\"state\":\"ON\",\"level\":" + hsb.getBrightness().intValue() + ",\"hue\":"
+                        + hsb.getHue().intValue() + ",\"saturation\":" + hsb.getSaturation().intValue() + "}");
             }
-            sendMQTT("{\"state\":\"ON\",\"level\":" + hsb.getBrightness().intValue() + ",\"hue\":"
-                    + hsb.getHue().intValue() + ",\"saturation\":" + hsb.getSaturation().intValue() + "}");
             savedLevel = hsb.getBrightness().toBigDecimal();
             return;
         } else if (command instanceof PercentType) {
@@ -239,7 +238,7 @@ public class EspMilightHubHandler extends BaseThingHandler implements MqttConnec
             }
             sendMQTT("{\"state\":\"ON\",\"level\":" + command + "}");
             savedLevel = percentType.toBigDecimal();
-            if (globeType.equals("rgb_cct") || globeType.equals("fut089")) {
+            if ("rgb_cct".equals(globeType) || globeType.equals("fut089")) {
                 if (config.dimmedCT > 0 && bulbMode.equals("white")) {
                     sendMQTT("{\"state\":\"ON\",\"color_temp\":" + autoColourTemp(savedLevel.intValue()) + "}");
                 }

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -47,6 +47,14 @@
 			<default>32</default>
 		</parameter>
 
+		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
+			<label>White Threshold</label>
+			<description>Saturation values below this value on a RGBW color control will trigger the white mode. -1 will disable
+				this feature.
+			</description>
+			<default>2</default>
+		</parameter>
+
 		<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
 			<label>Favourite White</label>
 			<description>When a shortcut triggers white mode, use this for the colour white.</description>

--- a/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.mqtt.espmilighthub/src/main/resources/OH-INF/config/config.xml
@@ -49,10 +49,11 @@
 
 		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
 			<label>White Threshold</label>
-			<description>Saturation values below this value on a RGBW color control will trigger the white mode. -1 will disable
+			<description>Saturation values at or below this value on a RGBW color control will trigger the white mode. -1 will
+				disable
 				this feature.
 			</description>
-			<default>2</default>
+			<default>6</default>
 		</parameter>
 
 		<parameter name="favouriteWhite" type="integer" required="true" min="153" max="370">
@@ -109,7 +110,8 @@
 
 		<parameter name="whiteThreshold" type="integer" required="true" min="-1" max="99">
 			<label>White Threshold</label>
-			<description>RGBW saturation changes, will trigger the white mode. -1 will disable this feature.
+			<description>Saturation values at or below this value on a RGBW color control will trigger the white mode. -1 will
+				disable this feature.
 			</description>
 			<default>12</default>
 		</parameter>


### PR DESCRIPTION
Before these changes with RGB and dual white globes you could not use the color gradients from a color element to switch back to using white LEDs. This change allows a user threshold to be specified where low SATURATION values will change to using the real white LEDs instead of a pastel colour. This is a big improvement as the openHAB colour indicator would show white when the globe was not white.

PR also contains minor refactoring to fix some compiler warnings.

Signed-off-by: Matthew Skinner <matt@pcmus.com>