### PR TITLE
 [homeconnect] Use getLinkedChannel rather than getThingChannel ...

### DIFF
--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/AbstractHomeConnectThingHandler.java
@@ -587,16 +587,16 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     protected void resetChannelsOnOfflineEvent() {
         logger.debug("Resetting channel states due to OFFLINE event. thing={}, haId={}", getThingLabel(),
                 getThingHaId());
-        getThingChannel(CHANNEL_POWER_STATE).ifPresent(channel -> updateState(channel.getUID(), OnOffType.OFF));
-        getThingChannel(CHANNEL_OPERATION_STATE).ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_DOOR_STATE).ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_LOCAL_CONTROL_ACTIVE_STATE)
+        getLinkedChannel(CHANNEL_POWER_STATE).ifPresent(channel -> updateState(channel.getUID(), OnOffType.OFF));
+        getLinkedChannel(CHANNEL_OPERATION_STATE).ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_DOOR_STATE).ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_LOCAL_CONTROL_ACTIVE_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_REMOTE_CONTROL_ACTIVE_STATE)
+        getLinkedChannel(CHANNEL_REMOTE_CONTROL_ACTIVE_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_REMOTE_START_ALLOWANCE_STATE)
+        getLinkedChannel(CHANNEL_REMOTE_START_ALLOWANCE_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_SELECTED_PROGRAM_STATE)
+        getLinkedChannel(CHANNEL_SELECTED_PROGRAM_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(), UnDefType.UNDEF));
     }
 
@@ -792,43 +792,43 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     }
 
     protected EventHandler defaultElapsedProgramTimeEventHandler() {
-        return event -> getThingChannel(CHANNEL_ELAPSED_PROGRAM_TIME)
+        return event -> getLinkedChannel(CHANNEL_ELAPSED_PROGRAM_TIME)
                 .ifPresent(channel -> updateState(channel.getUID(), new QuantityType<>(event.getValueAsInt(), SECOND)));
     }
 
     protected EventHandler defaultPowerStateEventHandler() {
         return event -> {
-            getThingChannel(CHANNEL_POWER_STATE).ifPresent(
+            getLinkedChannel(CHANNEL_POWER_STATE).ifPresent(
                     channel -> updateState(channel.getUID(), OnOffType.from(STATE_POWER_ON.equals(event.getValue()))));
 
             if (STATE_POWER_ON.equals(event.getValue())) {
                 getThingChannel(CHANNEL_SELECTED_PROGRAM_STATE).ifPresent(c -> updateChannel(c.getUID()));
             } else {
                 resetProgramStateChannels(true);
-                getThingChannel(CHANNEL_SELECTED_PROGRAM_STATE)
+                getLinkedChannel(CHANNEL_SELECTED_PROGRAM_STATE)
                         .ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
             }
         };
     }
 
     protected EventHandler defaultDoorStateEventHandler() {
-        return event -> getThingChannel(CHANNEL_DOOR_STATE).ifPresent(channel -> updateState(channel.getUID(),
+        return event -> getLinkedChannel(CHANNEL_DOOR_STATE).ifPresent(channel -> updateState(channel.getUID(),
                 STATE_DOOR_OPEN.equals(event.getValue()) ? OpenClosedType.OPEN : OpenClosedType.CLOSED));
     }
 
     protected EventHandler defaultOperationStateEventHandler() {
         return event -> {
             String value = event.getValue();
-            getThingChannel(CHANNEL_OPERATION_STATE).ifPresent(channel -> updateState(channel.getUID(),
+            getLinkedChannel(CHANNEL_OPERATION_STATE).ifPresent(channel -> updateState(channel.getUID(),
                     value == null ? UnDefType.UNDEF : new StringType(mapStringType(value))));
 
             if (STATE_OPERATION_FINISHED.equals(value)) {
-                getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
+                getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
                         .ifPresent(c -> updateState(c.getUID(), new QuantityType<>(100, PERCENT)));
-                getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE)
+                getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE)
                         .ifPresent(c -> updateState(c.getUID(), new QuantityType<>(0, SECOND)));
             } else if (STATE_OPERATION_RUN.equals(value)) {
-                getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
+                getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
                         .ifPresent(c -> updateState(c.getUID(), new QuantityType<>(0, PERCENT)));
                 getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateChannel(c.getUID()));
             } else if (STATE_OPERATION_READY.equals(value)) {
@@ -840,7 +840,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     protected EventHandler defaultActiveProgramEventHandler() {
         return event -> {
             String value = event.getValue();
-            getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(channel -> updateState(channel.getUID(),
+            getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(channel -> updateState(channel.getUID(),
                     value == null ? UnDefType.UNDEF : new StringType(mapStringType(value))));
             if (value == null) {
                 resetProgramStateChannels(false);
@@ -851,7 +851,7 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     protected EventHandler updateProgramOptionsAndActiveProgramStateEventHandler() {
         return event -> {
             String value = event.getValue();
-            getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(channel -> updateState(channel.getUID(),
+            getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(channel -> updateState(channel.getUID(),
                     value == null ? UnDefType.UNDEF : new StringType(mapStringType(value))));
             if (value == null) {
                 resetProgramStateChannels(false);
@@ -874,34 +874,34 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     }
 
     protected EventHandler defaultEventPresentStateEventHandler(String channelId) {
-        return event -> getThingChannel(channelId).ifPresent(channel -> updateState(channel.getUID(),
+        return event -> getLinkedChannel(channelId).ifPresent(channel -> updateState(channel.getUID(),
                 OnOffType.from(!STATE_EVENT_PRESENT_STATE_OFF.equals(event.getValue()))));
     }
 
     protected EventHandler defaultBooleanEventHandler(String channelId) {
-        return event -> getThingChannel(channelId)
+        return event -> getLinkedChannel(channelId)
                 .ifPresent(channel -> updateState(channel.getUID(), OnOffType.from(event.getValueAsBoolean())));
     }
 
     protected EventHandler defaultRemainingProgramTimeEventHandler() {
-        return event -> getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE)
+        return event -> getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(), new QuantityType<>(event.getValueAsInt(), SECOND)));
     }
 
     protected EventHandler defaultSelectedProgramStateEventHandler() {
-        return event -> getThingChannel(CHANNEL_SELECTED_PROGRAM_STATE)
+        return event -> getLinkedChannel(CHANNEL_SELECTED_PROGRAM_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue())));
     }
 
     protected EventHandler defaultAmbientLightColorStateEventHandler() {
-        return event -> getThingChannel(CHANNEL_AMBIENT_LIGHT_COLOR_STATE)
+        return event -> getLinkedChannel(CHANNEL_AMBIENT_LIGHT_COLOR_STATE)
                 .ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue())));
     }
 
     protected EventHandler defaultAmbientLightCustomColorStateEventHandler() {
-        return event -> getThingChannel(CHANNEL_AMBIENT_LIGHT_CUSTOM_COLOR_STATE).ifPresent(channel -> {
+        return event -> getLinkedChannel(CHANNEL_AMBIENT_LIGHT_CUSTOM_COLOR_STATE).ifPresent(channel -> {
             String value = event.getValue();
             if (value != null) {
                 updateState(channel.getUID(), mapColor(value));
@@ -979,12 +979,12 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
     }
 
     protected EventHandler defaultPercentQuantityTypeEventHandler(String channelId) {
-        return event -> getThingChannel(channelId).ifPresent(
+        return event -> getLinkedChannel(channelId).ifPresent(
                 channel -> updateState(channel.getUID(), new QuantityType<>(event.getValueAsInt(), PERCENT)));
     }
 
     protected EventHandler defaultPercentHandler(String channelId) {
-        return event -> getThingChannel(channelId)
+        return event -> getLinkedChannel(channelId)
                 .ifPresent(channel -> updateState(channel.getUID(), new PercentType(event.getValueAsInt())));
     }
 
@@ -1030,18 +1030,18 @@ public abstract class AbstractHomeConnectThingHandler extends BaseThingHandler i
                     if (enabled) {
                         // brightness
                         Data brightnessData = apiClient.get().getAmbientLightBrightnessState(getThingHaId());
-                        getThingChannel(CHANNEL_AMBIENT_LIGHT_BRIGHTNESS_STATE)
+                        getLinkedChannel(CHANNEL_AMBIENT_LIGHT_BRIGHTNESS_STATE)
                                 .ifPresent(channel -> updateState(channel.getUID(),
                                         new PercentType(brightnessData.getValueAsInt())));
 
                         // color
                         Data colorData = apiClient.get().getAmbientLightColorState(getThingHaId());
-                        getThingChannel(CHANNEL_AMBIENT_LIGHT_COLOR_STATE).ifPresent(
+                        getLinkedChannel(CHANNEL_AMBIENT_LIGHT_COLOR_STATE).ifPresent(
                                 channel -> updateState(channel.getUID(), new StringType(colorData.getValue())));
 
                         // custom color
                         Data customColorData = apiClient.get().getAmbientLightCustomColorState(getThingHaId());
-                        getThingChannel(CHANNEL_AMBIENT_LIGHT_CUSTOM_COLOR_STATE).ifPresent(channel -> {
+                        getLinkedChannel(CHANNEL_AMBIENT_LIGHT_CUSTOM_COLOR_STATE).ifPresent(channel -> {
                             String value = customColorData.getValue();
                             if (value != null) {
                                 updateState(channel.getUID(), mapColor(value));

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectCoffeeMakerHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectCoffeeMakerHandler.java
@@ -72,7 +72,7 @@ public class HomeConnectCoffeeMakerHandler extends AbstractHomeConnectThingHandl
         // register coffee maker specific SSE event handlers
         handlers.put(EVENT_PROGRAM_PROGRESS, event -> {
             if (event.getValue() == null || event.getValueAsInt() == 0) {
-                getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
+                getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE)
                         .ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
             } else {
                 defaultPercentQuantityTypeEventHandler(CHANNEL_PROGRAM_PROGRESS_STATE).handle(event);
@@ -97,7 +97,7 @@ public class HomeConnectCoffeeMakerHandler extends AbstractHomeConnectThingHandl
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectCooktopHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectCooktopHandler.java
@@ -89,6 +89,6 @@ public class HomeConnectCooktopHandler extends AbstractHomeConnectThingHandler {
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectDishwasherHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectDishwasherHandler.java
@@ -94,8 +94,8 @@ public class HomeConnectDishwasherHandler extends AbstractHomeConnectThingHandle
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectDryerHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectDryerHandler.java
@@ -83,8 +83,9 @@ public class HomeConnectDryerHandler extends AbstractHomeConnectThingHandler {
 
         // register dryer specific event handlers
         handlers.put(EVENT_DRYER_DRYING_TARGET,
-                event -> getThingChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(channel -> updateState(channel.getUID(),
-                        event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
+                event -> getLinkedChannel(CHANNEL_DRYER_DRYING_TARGET)
+                        .ifPresent(channel -> updateState(channel.getUID(),
+                                event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
     }
 
     @Override
@@ -116,11 +117,11 @@ public class HomeConnectDryerHandler extends AbstractHomeConnectThingHandler {
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         if (offline) {
-            getThingChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         }
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectFridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectFridgeFreezerHandler.java
@@ -12,16 +12,7 @@
  */
 package org.openhab.binding.homeconnect.internal.handler;
 
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.CHANNEL_DOOR_STATE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.CHANNEL_FREEZER_SETPOINT_TEMPERATURE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.CHANNEL_FREEZER_SUPER_MODE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.CHANNEL_REFRIGERATOR_SETPOINT_TEMPERATURE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.CHANNEL_REFRIGERATOR_SUPER_MODE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.EVENT_DOOR_STATE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.EVENT_FREEZER_SETPOINT_TEMPERATURE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.EVENT_FREEZER_SUPER_MODE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.EVENT_FRIDGE_SETPOINT_TEMPERATURE;
-import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.EVENT_FRIDGE_SUPER_MODE;
+import static org.openhab.binding.homeconnect.internal.HomeConnectBindingConstants.*;
 
 import java.util.Map;
 import java.util.Optional;
@@ -130,11 +121,11 @@ public class HomeConnectFridgeFreezerHandler extends AbstractHomeConnectThingHan
 
         // register fridge/freezer specific event handlers
         handlers.put(EVENT_FREEZER_SETPOINT_TEMPERATURE,
-                event -> getThingChannel(CHANNEL_FREEZER_SETPOINT_TEMPERATURE)
+                event -> getLinkedChannel(CHANNEL_FREEZER_SETPOINT_TEMPERATURE)
                         .ifPresent(channel -> updateState(channel.getUID(),
                                 new QuantityType<>(event.getValueAsInt(), mapTemperature(event.getUnit())))));
         handlers.put(EVENT_FRIDGE_SETPOINT_TEMPERATURE,
-                event -> getThingChannel(CHANNEL_REFRIGERATOR_SETPOINT_TEMPERATURE)
+                event -> getLinkedChannel(CHANNEL_REFRIGERATOR_SETPOINT_TEMPERATURE)
                         .ifPresent(channel -> updateState(channel.getUID(),
                                 new QuantityType<>(event.getValueAsInt(), mapTemperature(event.getUnit())))));
     }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectHoodHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectHoodHandler.java
@@ -85,7 +85,7 @@ public class HomeConnectHoodHandler extends AbstractHomeConnectThingHandler {
                             boolean enabled = data.getValueAsBoolean();
                             if (enabled) {
                                 Data brightnessData = apiClient.get().getFunctionalLightBrightnessState(getThingHaId());
-                                getThingChannel(CHANNEL_FUNCTIONAL_LIGHT_BRIGHTNESS_STATE)
+                                getLinkedChannel(CHANNEL_FUNCTIONAL_LIGHT_BRIGHTNESS_STATE)
                                         .ifPresent(channel -> updateState(channel.getUID(),
                                                 new PercentType(brightnessData.getValueAsInt())));
                             }
@@ -120,7 +120,7 @@ public class HomeConnectHoodHandler extends AbstractHomeConnectThingHandler {
 
         // register hood specific SSE event handlers
         handlers.put(EVENT_HOOD_INTENSIVE_LEVEL,
-                event -> getThingChannel(CHANNEL_HOOD_INTENSIVE_LEVEL).ifPresent(channel -> {
+                event -> getLinkedChannel(CHANNEL_HOOD_INTENSIVE_LEVEL).ifPresent(channel -> {
                     String hoodIntensiveLevel = event.getValue();
                     if (hoodIntensiveLevel != null) {
                         updateState(channel.getUID(), new StringType(mapStageStringType(hoodIntensiveLevel)));
@@ -129,7 +129,7 @@ public class HomeConnectHoodHandler extends AbstractHomeConnectThingHandler {
                     }
                 }));
         handlers.put(EVENT_HOOD_VENTING_LEVEL,
-                event -> getThingChannel(CHANNEL_HOOD_VENTING_LEVEL).ifPresent(channel -> {
+                event -> getLinkedChannel(CHANNEL_HOOD_VENTING_LEVEL).ifPresent(channel -> {
                     String hoodVentingLevel = event.getValue();
                     if (hoodVentingLevel != null) {
                         updateState(channel.getUID(), new StringType(mapStageStringType(hoodVentingLevel)));
@@ -269,9 +269,9 @@ public class HomeConnectHoodHandler extends AbstractHomeConnectThingHandler {
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_HOOD_INTENSIVE_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_HOOD_VENTING_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_HOOD_INTENSIVE_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_HOOD_VENTING_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 
     private StateOption createVentingStateOption(String optionKey) {

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectOvenHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectOvenHandler.java
@@ -114,32 +114,32 @@ public class HomeConnectOvenHandler extends AbstractHomeConnectThingHandler {
             }
         });
         handlers.put(EVENT_POWER_STATE, event -> {
-            getThingChannel(CHANNEL_POWER_STATE).ifPresent(
+            getLinkedChannel(CHANNEL_POWER_STATE).ifPresent(
                     channel -> updateState(channel.getUID(), OnOffType.from(STATE_POWER_ON.equals(event.getValue()))));
 
             if (STATE_POWER_ON.equals(event.getValue())) {
                 updateChannels();
             } else {
                 resetProgramStateChannels(true);
-                getThingChannel(CHANNEL_SELECTED_PROGRAM_STATE)
+                getLinkedChannel(CHANNEL_SELECTED_PROGRAM_STATE)
                         .ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-                getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-                getThingChannel(CHANNEL_SETPOINT_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-                getThingChannel(CHANNEL_DURATION).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+                getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+                getLinkedChannel(CHANNEL_SETPOINT_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+                getLinkedChannel(CHANNEL_DURATION).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
             }
         });
 
         handlers.put(EVENT_OVEN_CAVITY_TEMPERATURE, event -> {
             manuallyUpdateCavityTemperature = false;
-            getThingChannel(CHANNEL_OVEN_CURRENT_CAVITY_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
+            getLinkedChannel(CHANNEL_OVEN_CURRENT_CAVITY_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
                     new QuantityType<>(event.getValueAsInt(), mapTemperature(event.getUnit()))));
         });
 
         handlers.put(EVENT_SETPOINT_TEMPERATURE,
-                event -> getThingChannel(CHANNEL_SETPOINT_TEMPERATURE)
+                event -> getLinkedChannel(CHANNEL_SETPOINT_TEMPERATURE)
                         .ifPresent(channel -> updateState(channel.getUID(),
                                 new QuantityType<>(event.getValueAsInt(), mapTemperature(event.getUnit())))));
-        handlers.put(EVENT_DURATION, event -> getThingChannel(CHANNEL_DURATION).ifPresent(
+        handlers.put(EVENT_DURATION, event -> getLinkedChannel(CHANNEL_DURATION).ifPresent(
                 channel -> updateState(channel.getUID(), new QuantityType<>(event.getValueAsInt(), SECOND))));
     }
 
@@ -214,8 +214,8 @@ public class HomeConnectOvenHandler extends AbstractHomeConnectThingHandler {
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ELAPSED_PROGRAM_TIME).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ELAPSED_PROGRAM_TIME).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectWasherDryerHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectWasherDryerHandler.java
@@ -103,26 +103,27 @@ public class HomeConnectWasherDryerHandler extends AbstractHomeConnectThingHandl
 
         // register washer specific event handlers
         handlers.put(EVENT_WASHER_TEMPERATURE,
-                event -> getThingChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
         handlers.put(EVENT_WASHER_SPIN_SPEED,
-                event -> getThingChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
         // register dryer specific event handlers
         handlers.put(EVENT_DRYER_DRYING_TARGET,
-                event -> getThingChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(channel -> updateState(channel.getUID(),
-                        event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
+                event -> getLinkedChannel(CHANNEL_DRYER_DRYING_TARGET)
+                        .ifPresent(channel -> updateState(channel.getUID(),
+                                event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
     }
 
     @Override
     protected boolean isChannelLinkedToProgramOptionNotFullySupportedByApi() {
-        return (getThingChannel(CHANNEL_WASHER_VARIO_PERFECT).isPresent() && isLinked(CHANNEL_WASHER_VARIO_PERFECT))
-                || (getThingChannel(CHANNEL_WASHER_LESS_IRONING).isPresent() && isLinked(CHANNEL_WASHER_LESS_IRONING))
-                || (getThingChannel(CHANNEL_WASHER_PRE_WASH).isPresent() && isLinked(CHANNEL_WASHER_PRE_WASH))
-                || (getThingChannel(CHANNEL_WASHER_RINSE_PLUS).isPresent() && isLinked(CHANNEL_WASHER_RINSE_PLUS))
-                || (getThingChannel(CHANNEL_WASHER_SOAK).isPresent() && isLinked(CHANNEL_WASHER_SOAK))
-                || (getThingChannel(CHANNEL_PROGRAM_ENERGY).isPresent() && isLinked(CHANNEL_PROGRAM_ENERGY))
-                || (getThingChannel(CHANNEL_PROGRAM_WATER).isPresent() && isLinked(CHANNEL_PROGRAM_WATER));
+        return getLinkedChannel(CHANNEL_WASHER_VARIO_PERFECT).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_LESS_IRONING).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_PRE_WASH).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_RINSE_PLUS).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_SOAK).isPresent()
+                || getLinkedChannel(CHANNEL_PROGRAM_ENERGY).isPresent()
+                || getLinkedChannel(CHANNEL_PROGRAM_WATER).isPresent();
     }
 
     @Override
@@ -162,20 +163,20 @@ public class HomeConnectWasherDryerHandler extends AbstractHomeConnectThingHandl
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         if (offline) {
-            getThingChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_VARIO_PERFECT).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_LESS_IRONING).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_PRE_WASH).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_RINSE_PLUS).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_SOAK).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_PROGRAM_ENERGY).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_PROGRAM_WATER).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_VARIO_PERFECT).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_LESS_IRONING).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_PRE_WASH).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_RINSE_PLUS).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_SOAK).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_PROGRAM_ENERGY).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_PROGRAM_WATER).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_DRYER_DRYING_TARGET).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         }
     }
 }

--- a/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectWasherHandler.java
+++ b/bundles/org.openhab.binding.homeconnect/src/main/java/org/openhab/binding/homeconnect/internal/handler/HomeConnectWasherHandler.java
@@ -109,16 +109,16 @@ public class HomeConnectWasherHandler extends AbstractHomeConnectThingHandler {
 
         // register washer specific event handlers
         handlers.put(EVENT_WASHER_TEMPERATURE,
-                event -> getThingChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
         handlers.put(EVENT_WASHER_SPIN_SPEED,
-                event -> getThingChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
         handlers.put(EVENT_WASHER_IDOS_1_DOSING_LEVEL,
-                event -> getThingChannel(CHANNEL_WASHER_IDOS1_LEVEL).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_IDOS1_LEVEL).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
         handlers.put(EVENT_WASHER_IDOS_2_DOSING_LEVEL,
-                event -> getThingChannel(CHANNEL_WASHER_IDOS2_LEVEL).ifPresent(channel -> updateState(channel.getUID(),
+                event -> getLinkedChannel(CHANNEL_WASHER_IDOS2_LEVEL).ifPresent(channel -> updateState(channel.getUID(),
                         event.getValue() == null ? UnDefType.UNDEF : new StringType(event.getValue()))));
     }
 
@@ -165,15 +165,14 @@ public class HomeConnectWasherHandler extends AbstractHomeConnectThingHandler {
 
     @Override
     protected boolean isChannelLinkedToProgramOptionNotFullySupportedByApi() {
-        return (getThingChannel(CHANNEL_WASHER_IDOS1).isPresent() && isLinked(CHANNEL_WASHER_IDOS1))
-                || (getThingChannel(CHANNEL_WASHER_IDOS2).isPresent() && isLinked(CHANNEL_WASHER_IDOS2))
-                || (getThingChannel(CHANNEL_WASHER_VARIO_PERFECT).isPresent() && isLinked(CHANNEL_WASHER_VARIO_PERFECT))
-                || (getThingChannel(CHANNEL_WASHER_LESS_IRONING).isPresent() && isLinked(CHANNEL_WASHER_LESS_IRONING))
-                || (getThingChannel(CHANNEL_WASHER_PRE_WASH).isPresent() && isLinked(CHANNEL_WASHER_PRE_WASH))
-                || (getThingChannel(CHANNEL_WASHER_RINSE_PLUS).isPresent() && isLinked(CHANNEL_WASHER_RINSE_PLUS))
-                || (getThingChannel(CHANNEL_WASHER_SOAK).isPresent() && isLinked(CHANNEL_WASHER_SOAK))
-                || (getThingChannel(CHANNEL_PROGRAM_ENERGY).isPresent() && isLinked(CHANNEL_PROGRAM_ENERGY))
-                || (getThingChannel(CHANNEL_PROGRAM_WATER).isPresent() && isLinked(CHANNEL_PROGRAM_WATER));
+        return getLinkedChannel(CHANNEL_WASHER_IDOS1).isPresent() || getLinkedChannel(CHANNEL_WASHER_IDOS2).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_VARIO_PERFECT).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_LESS_IRONING).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_PRE_WASH).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_RINSE_PLUS).isPresent()
+                || getLinkedChannel(CHANNEL_WASHER_SOAK).isPresent()
+                || getLinkedChannel(CHANNEL_PROGRAM_ENERGY).isPresent()
+                || getLinkedChannel(CHANNEL_PROGRAM_WATER).isPresent();
     }
 
     @Override
@@ -217,23 +216,23 @@ public class HomeConnectWasherHandler extends AbstractHomeConnectThingHandler {
     @Override
     protected void resetProgramStateChannels(boolean offline) {
         super.resetProgramStateChannels(offline);
-        getThingChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-        getThingChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_REMAINING_PROGRAM_TIME_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_PROGRAM_PROGRESS_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+        getLinkedChannel(CHANNEL_ACTIVE_PROGRAM_STATE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         if (offline) {
-            getThingChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_IDOS1_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_IDOS2_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_IDOS1).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_IDOS2).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_VARIO_PERFECT).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_LESS_IRONING).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_PRE_WASH).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_RINSE_PLUS).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_WASHER_SOAK).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_PROGRAM_ENERGY).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
-            getThingChannel(CHANNEL_PROGRAM_WATER).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_TEMPERATURE).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_SPIN_SPEED).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_IDOS1_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_IDOS2_LEVEL).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_IDOS1).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_IDOS2).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_VARIO_PERFECT).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_LESS_IRONING).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_PRE_WASH).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_RINSE_PLUS).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_WASHER_SOAK).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_PROGRAM_ENERGY).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
+            getLinkedChannel(CHANNEL_PROGRAM_WATER).ifPresent(c -> updateState(c.getUID(), UnDefType.UNDEF));
         }
     }
 }


### PR DESCRIPTION
when the purpose is only to call the method updateState

Signed-off-by: Laurent Garnier <lg.hc@free.fr>