### PR TITLE
[avmfritz] Invert opening level of HAN-FUN blinds, when a command switch is set to ON

### DIFF
--- a/bundles/org.openhab.binding.avmfritz/README.md
+++ b/bundles/org.openhab.binding.avmfritz/README.md
@@ -156,6 +156,11 @@ If the FRITZ!Powerline 546E is added via auto-discovery it determines its own `a
 
 - `ain` (mandatory), no default (AIN number of the device)
 
+### HAN-FUN Blinds
+
+- `ain` (mandatory), no default (AIN number of the device)
+- `invertLevel` (mandatory), default false (Set this to true to invert the shutter level to match the openHAB standard, where 0 = closed, 100 = open)
+
 ### Finding The AIN
 
 The AIN (actor identification number) can be found in the FRITZ!Box interface -> Home Network -> SmartHome. When opening the details view for a device with the edit button, the AIN is shown. Use the AIN without the blank.

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzHandlerFactory.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/AVMFritzHandlerFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.avmfritz.internal.handler.AVMFritzButtonHandler;
+import org.openhab.binding.avmfritz.internal.handler.AVMFritzHanFunBlindsHandler;
 import org.openhab.binding.avmfritz.internal.handler.AVMFritzHeatingDeviceHandler;
 import org.openhab.binding.avmfritz.internal.handler.AVMFritzHeatingGroupHandler;
 import org.openhab.binding.avmfritz.internal.handler.BoxHandler;
@@ -76,6 +77,8 @@ public class AVMFritzHandlerFactory extends BaseThingHandlerFactory {
             return new BoxHandler((Bridge) thing, httpClient, commandDescriptionProvider);
         } else if (PL546E_STANDALONE_THING_TYPE.equals(thingTypeUID)) {
             return new Powerline546EHandler((Bridge) thing, httpClient, commandDescriptionProvider);
+        } else if (HAN_FUN_BLINDS_THING_TYPE.equals(thingTypeUID)) {
+            return new AVMFritzHanFunBlindsHandler(thing);
         } else if (SUPPORTED_BUTTON_THING_TYPES_UIDS.contains(thingTypeUID)) {
             return new AVMFritzButtonHandler(thing);
         } else if (SUPPORTED_HEATING_THING_TYPES.contains(thingTypeUID)) {

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/config/AVMFritzHanFunBlindsConfiguration.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/config/AVMFritzHanFunBlindsConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.avmfritz.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Bean holding configuration data for a HAN-FUN blind.
+ *
+ * @author Ulrich Mertin - Initial contribution
+ */
+@NonNullByDefault
+public class AVMFritzHanFunBlindsConfiguration extends AVMFritzDeviceConfiguration {
+
+    public @Nullable Boolean invertLevel;
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append("[identifier=").append(ain).append(", invertLevel=").append(invertLevel)
+                .append("]").toString();
+    }
+}

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzBaseThingHandler.java
@@ -33,25 +33,20 @@ import org.openhab.binding.avmfritz.internal.dto.DeviceModel;
 import org.openhab.binding.avmfritz.internal.dto.HeatingModel;
 import org.openhab.binding.avmfritz.internal.dto.HeatingModel.NextChangeModel;
 import org.openhab.binding.avmfritz.internal.dto.HumidityModel;
-import org.openhab.binding.avmfritz.internal.dto.LevelcontrolModel;
 import org.openhab.binding.avmfritz.internal.dto.PowerMeterModel;
 import org.openhab.binding.avmfritz.internal.dto.SimpleOnOffModel;
 import org.openhab.binding.avmfritz.internal.dto.SwitchModel;
 import org.openhab.binding.avmfritz.internal.dto.TemperatureModel;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaStatusListener;
 import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
-import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaSetBlindTargetCallback.BlindCommand;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
-import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
-import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.StringType;
-import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Bridge;
@@ -155,9 +150,6 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
                 if (deviceModel.isHANFUNAlarmSensor()) {
                     updateHANFUNAlarmSensor(deviceModel.getAlert());
                 }
-                if (deviceModel.isHANFUNBlinds()) {
-                    updateLevelcontrol(deviceModel.getLevelcontrol());
-                }
             }
         }
     }
@@ -182,12 +174,6 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
         if (humidityModel != null) {
             updateThingChannelState(CHANNEL_HUMIDITY,
                     new QuantityType<>(humidityModel.getRelativeHumidity(), Units.PERCENT));
-        }
-    }
-
-    protected void updateLevelcontrol(@Nullable LevelcontrolModel levelcontrolModel) {
-        if (levelcontrolModel != null) {
-            updateThingChannelState(CHANNEL_ROLLERSHUTTER, new PercentType(levelcontrolModel.getLevelPercentage()));
         }
     }
 
@@ -446,29 +432,6 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
                     }
                 }
                 break;
-            case CHANNEL_ROLLERSHUTTER:
-                if (command instanceof StopMoveType) {
-                    StopMoveType rollershutterCommand = (StopMoveType) command;
-                    if (StopMoveType.STOP.equals(rollershutterCommand)) {
-                        fritzBox.setBlind(ain, BlindCommand.STOP);
-                    } else {
-                        logger.debug("Received unknown rollershutter StopMove command MOVE");
-                    }
-                } else if (command instanceof UpDownType) {
-                    UpDownType rollershutterCommand = (UpDownType) command;
-                    if (UpDownType.UP.equals(rollershutterCommand)) {
-                        fritzBox.setBlind(ain, BlindCommand.OPEN);
-                    } else {
-                        fritzBox.setBlind(ain, BlindCommand.CLOSE);
-                    }
-                } else if (command instanceof PercentType) {
-                    PercentType rollershutterCommand = (PercentType) command;
-                    BigDecimal levelpercentage = rollershutterCommand.toBigDecimal();
-                    fritzBox.setLevelpercentage(ain, levelpercentage);
-                } else {
-                    logger.debug("Received unknown rollershutter command type '{}'", command.toString());
-                }
-                break;
             default:
                 logger.debug("Received unknown channel {}", channelId);
                 break;
@@ -515,7 +478,7 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
      *
      * @return The web interface object
      */
-    private @Nullable FritzAhaWebInterface getWebInterface() {
+    protected @Nullable FritzAhaWebInterface getWebInterface() {
         Bridge bridge = getBridge();
         if (bridge != null) {
             BridgeHandler handler = bridge.getHandler();
@@ -529,7 +492,7 @@ public abstract class AVMFritzBaseThingHandler extends BaseThingHandler implemen
     /**
      * Handles a refresh command.
      */
-    private void handleRefreshCommand() {
+    protected void handleRefreshCommand() {
         Bridge bridge = getBridge();
         if (bridge != null) {
             BridgeHandler handler = bridge.getHandler();

--- a/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzHanFunBlindsHandler.java
+++ b/bundles/org.openhab.binding.avmfritz/src/main/java/org/openhab/binding/avmfritz/internal/handler/AVMFritzHanFunBlindsHandler.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.avmfritz.internal.handler;
+
+import static org.openhab.binding.avmfritz.internal.AVMFritzBindingConstants.CHANNEL_ROLLERSHUTTER;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.avmfritz.internal.config.AVMFritzHanFunBlindsConfiguration;
+import org.openhab.binding.avmfritz.internal.dto.AVMFritzBaseModel;
+import org.openhab.binding.avmfritz.internal.dto.DeviceModel;
+import org.openhab.binding.avmfritz.internal.dto.LevelcontrolModel;
+import org.openhab.binding.avmfritz.internal.hardware.FritzAhaWebInterface;
+import org.openhab.binding.avmfritz.internal.hardware.callbacks.FritzAhaSetBlindTargetCallback.BlindCommand;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.library.types.UpDownType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for a HAN-FUN blind. Handles commands, which are sent to one of the channels.
+ *
+ * @author Ulrich Mertin - Initial contribution
+ */
+@NonNullByDefault
+public class AVMFritzHanFunBlindsHandler extends DeviceHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(AVMFritzHanFunBlindsHandler.class);
+
+    private @Nullable Boolean invertLevel;
+
+    public AVMFritzHanFunBlindsHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        final AVMFritzHanFunBlindsConfiguration config = getConfigAs(AVMFritzHanFunBlindsConfiguration.class);
+        this.invertLevel = config.invertLevel;
+        super.initialize();
+    }
+
+    @Override
+    public void onDeviceUpdated(ThingUID thingUID, AVMFritzBaseModel device) {
+        if (thing.getUID().equals(thingUID)) {
+            DeviceModel deviceModel = (DeviceModel) device;
+            super.onDeviceUpdated(thingUID, deviceModel);
+            logger.debug("Update blind '{}' with device model: {}", thingUID, device);
+            LevelcontrolModel levelcontrol = deviceModel.getLevelcontrol();
+            if (invertLevel != null && invertLevel.booleanValue()) {
+                BigDecimal oldLevelPercentage = levelcontrol.getLevelPercentage();
+                BigDecimal newLevelPercentage = BigDecimal.valueOf(100L).subtract(oldLevelPercentage);
+                logger.debug("Inverting level of blind {}: {} -> {}", thingUID, oldLevelPercentage, newLevelPercentage);
+                levelcontrol.setLevelPercentage(newLevelPercentage);
+            }
+            updateLevelcontrol(levelcontrol);
+        }
+    }
+
+    protected void updateLevelcontrol(@Nullable LevelcontrolModel levelcontrolModel) {
+        if (levelcontrolModel != null) {
+            updateThingChannelState(CHANNEL_ROLLERSHUTTER, new PercentType(levelcontrolModel.getLevelPercentage()));
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        String channelId = channelUID.getIdWithoutGroup();
+        logger.debug("Handle command '{}' for blind channel {}", command, channelId);
+        if (command == RefreshType.REFRESH) {
+            handleRefreshCommand();
+            return;
+        }
+        if (command != RefreshType.REFRESH) {
+            FritzAhaWebInterface fritzBox = getWebInterface();
+            if (fritzBox == null) {
+                logger.debug("Cannot handle command '{}' because connection is missing", command);
+                return;
+            }
+            String ain = getIdentifier();
+            if (ain == null) {
+                logger.debug("Cannot handle command '{}' because AIN is missing", command);
+                return;
+            }
+            if (channelId.equals(CHANNEL_ROLLERSHUTTER)) {
+                if (command instanceof StopMoveType) {
+                    StopMoveType rollershutterCommand = (StopMoveType) command;
+                    if (StopMoveType.STOP.equals(rollershutterCommand)) {
+                        fritzBox.setBlind(ain, BlindCommand.STOP);
+                    } else {
+                        logger.debug("Received unknown rollershutter StopMove command MOVE");
+                    }
+                } else if (command instanceof UpDownType) {
+                    UpDownType rollershutterCommand = (UpDownType) command;
+                    if (UpDownType.UP.equals(rollershutterCommand)) {
+                        fritzBox.setBlind(ain, BlindCommand.OPEN);
+                    } else {
+                        fritzBox.setBlind(ain, BlindCommand.CLOSE);
+                    }
+                } else if (command instanceof PercentType) {
+                    PercentType rollershutterCommand = (PercentType) command;
+                    BigDecimal levelpercentage = rollershutterCommand.toBigDecimal();
+                    if (invertLevel != null && invertLevel.booleanValue()) {
+                        BigDecimal newLevelPercentage = BigDecimal.valueOf(100L).subtract(levelpercentage);
+                        logger.debug("Inverting level of blind channel {}: {} -> {}", channelUID, levelpercentage,
+                                newLevelPercentage);
+                        fritzBox.setLevelpercentage(ain, newLevelPercentage);
+                    } else {
+                        fritzBox.setLevelpercentage(ain, levelpercentage);
+                    }
+                } else {
+                    logger.debug("Received unknown rollershutter command type '{}'", command.toString());
+                }
+            } else {
+                logger.debug("Received unknown channel {}", channelId);
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/config/config.xml
@@ -128,6 +128,18 @@
 		</parameter>
 	</config-description>
 
+	<config-description uri="thing-type:avmfritz:hanfunblinds">
+		<parameter name="ain" type="text" required="true">
+			<label>AIN</label>
+			<description>The AHA id (AIN) that identifies one specific FRITZ! device.</description>
+		</parameter>
+		<parameter name="invertLevel" type="boolean" required="true">
+			<label>Invert Level</label>
+			<description>Set this to true to invert the shutter level to match the openHAB standard (0 = closed, 100 = open)</description>
+			<default>false</default>
+		</parameter>
+	</config-description>
+
 	<config-description uri="thing-type:avmfritz:fritzgroup">
 		<parameter name="ain" type="text" required="true">
 			<label>AIN</label>

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/i18n/avmfritz_de.properties
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/i18n/avmfritz_de.properties
@@ -117,6 +117,9 @@ thing-type.config.avmfritz.fritzdevice.ain.description = Die AHA ID (AIN) zur Id
 
 thing-type.config.avmfritz.fritzgroup.ain.description = Die AHA ID (AIN) zur Identifikation der FRITZ! Gruppe.
 
+thing-type.config.avmfritz.hanfunblinds.ain.description = Die AHA ID (AIN) zur Identifikation des FRITZ! Gerätes.
+thing-type.config.avmfritz.hanfunblinds.invertLevel.description = Wenn dieser Wert auf wahr gesetzt ist, wird der Öffnungsgrad des Rollladens invertiert, um dem openHAB-Standard (0 = geschlossen, 100 = offen) zu entsprechen.
+
 # channel group types
 channel-group-type.avmfritz.button.label = Taste
 

--- a/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.avmfritz/src/main/resources/OH-INF/thing/thing-types.xml
@@ -292,7 +292,7 @@
 
 		<representation-property>ain</representation-property>
 
-		<config-description-ref uri="thing-type:avmfritz:fritzdevice"/>
+		<config-description-ref uri="thing-type:avmfritz:hanfunblinds"/>
 	</thing-type>
 
 	<thing-type id="HAN_FUN_ON_OFF">


### PR DESCRIPTION
While openHAB generally interprets a blind opening level of 0% as fully closed and 100% as fully open, the HAN-FUN blinds interpret the values vice versa. This leads to the need to convert the values in rules and to wrong representation of the opening levels in widgets.
So I have implemented a command switch 'invertLevel' for the HAN-FUN Blind device type. If this switch is set to ON, the opening level of the blind is inverted (i.e. newValue is 100 - oldValue) both when reading the state and when sending commands.