### PR TITLE
[ipcamera] Fix bugs, IndexOutOfBoundsException and remove sleep.

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/onvif/OnvifConnection.java
@@ -27,6 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -110,6 +112,7 @@ public class OnvifConnection {
     }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
+    private ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(2);
     private @Nullable Bootstrap bootstrap;
     private EventLoopGroup mainEventLoopGroup = new NioEventLoopGroup();
     private String ipAddress = "";
@@ -162,129 +165,138 @@ public class OnvifConnection {
         }
     }
 
-    String getXml(RequestType requestType) {
-        switch (requestType) {
-            case AbsoluteMove:
-                return "<AbsoluteMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><Position><PanTilt x=\""
-                        + currentPanCamValue + "\" y=\"" + currentTiltCamValue
-                        + "\" space=\"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\">\n"
-                        + "</PanTilt>\n" + "<Zoom x=\"" + currentZoomCamValue
-                        + "\" space=\"http://www.onvif.org/ver10/tptz/ZoomSpaces/PositionGenericSpace\">\n"
-                        + "</Zoom>\n" + "</Position>\n"
-                        + "<Speed><PanTilt x=\"0.1\" y=\"0.1\" space=\"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\"></PanTilt><Zoom x=\"1.0\" space=\"http://www.onvif.org/ver10/tptz/ZoomSpaces/ZoomGenericSpeedSpace\"></Zoom>\n"
-                        + "</Speed></AbsoluteMove>";
-            case AddPTZConfiguration: // not tested to work yet
-                return "<AddPTZConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><ConfigurationToken>"
-                        + ptzConfigToken + "</ConfigurationToken></AddPTZConfiguration>";
-            case ContinuousMoveLeft:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><PanTilt x=\"-0.5\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case ContinuousMoveRight:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><PanTilt x=\"0.5\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case ContinuousMoveUp:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><PanTilt x=\"0\" y=\"-0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case ContinuousMoveDown:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><PanTilt x=\"0\" y=\"0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case Stop:
-                return "<Stop xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><PanTilt>true</PanTilt><Zoom>true</Zoom></Stop>";
-            case ContinuousMoveIn:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><Zoom x=\"0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case ContinuousMoveOut:
-                return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Velocity><Zoom x=\"-0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
-            case CreatePullPointSubscription:
-                return "<CreatePullPointSubscription xmlns=\"http://www.onvif.org/ver10/events/wsdl\"><InitialTerminationTime>PT600S</InitialTerminationTime></CreatePullPointSubscription>";
-            case GetCapabilities:
-                return "<GetCapabilities xmlns=\"http://www.onvif.org/ver10/device/wsdl\"><Category>All</Category></GetCapabilities>";
+    private String getXml(RequestType requestType) {
+        try {
+            switch (requestType) {
+                case AbsoluteMove:
+                    return "<AbsoluteMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><Position><PanTilt x=\""
+                            + currentPanCamValue + "\" y=\"" + currentTiltCamValue
+                            + "\" space=\"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\">\n"
+                            + "</PanTilt>\n" + "<Zoom x=\"" + currentZoomCamValue
+                            + "\" space=\"http://www.onvif.org/ver10/tptz/ZoomSpaces/PositionGenericSpace\">\n"
+                            + "</Zoom>\n" + "</Position>\n"
+                            + "<Speed><PanTilt x=\"0.1\" y=\"0.1\" space=\"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\"></PanTilt><Zoom x=\"1.0\" space=\"http://www.onvif.org/ver10/tptz/ZoomSpaces/ZoomGenericSpeedSpace\"></Zoom>\n"
+                            + "</Speed></AbsoluteMove>";
+                case AddPTZConfiguration: // not tested to work yet
+                    return "<AddPTZConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><ConfigurationToken>"
+                            + ptzConfigToken + "</ConfigurationToken></AddPTZConfiguration>";
+                case ContinuousMoveLeft:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><PanTilt x=\"-0.5\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case ContinuousMoveRight:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><PanTilt x=\"0.5\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case ContinuousMoveUp:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><PanTilt x=\"0\" y=\"-0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case ContinuousMoveDown:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><PanTilt x=\"0\" y=\"0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case Stop:
+                    return "<Stop xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><PanTilt>true</PanTilt><Zoom>true</Zoom></Stop>";
+                case ContinuousMoveIn:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><Zoom x=\"0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case ContinuousMoveOut:
+                    return "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Velocity><Zoom x=\"-0.5\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Velocity></ContinuousMove>";
+                case CreatePullPointSubscription:
+                    return "<CreatePullPointSubscription xmlns=\"http://www.onvif.org/ver10/events/wsdl\"><InitialTerminationTime>PT600S</InitialTerminationTime></CreatePullPointSubscription>";
+                case GetCapabilities:
+                    return "<GetCapabilities xmlns=\"http://www.onvif.org/ver10/device/wsdl\"><Category>All</Category></GetCapabilities>";
 
-            case GetDeviceInformation:
-                return "<GetDeviceInformation xmlns=\"http://www.onvif.org/ver10/device/wsdl\"/>";
-            case GetProfiles:
-                return "<GetProfiles xmlns=\"http://www.onvif.org/ver10/media/wsdl\"/>";
-            case GetServiceCapabilities:
-                return "<GetServiceCapabilities xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"></GetServiceCapabilities>";
-            case GetSnapshotUri:
-                return "<GetSnapshotUri xmlns=\"http://www.onvif.org/ver10/media/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetSnapshotUri>";
-            case GetStreamUri:
-                return "<GetStreamUri xmlns=\"http://www.onvif.org/ver10/media/wsdl\"><StreamSetup><Stream xmlns=\"http://www.onvif.org/ver10/schema\">RTP-Unicast</Stream><Transport xmlns=\"http://www.onvif.org/ver10/schema\"><Protocol>RTSP</Protocol></Transport></StreamSetup><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetStreamUri>";
-            case GetSystemDateAndTime:
-                return "<GetSystemDateAndTime xmlns=\"http://www.onvif.org/ver10/device/wsdl\"/>";
-            case Subscribe:
-                return "<Subscribe xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"><ConsumerReference><Address>http://"
-                        + ipCameraHandler.hostIp + ":" + ipCameraHandler.cameraConfig.getServerPort()
-                        + "/OnvifEvent</Address></ConsumerReference></Subscribe>";
-            case Unsubscribe:
-                return "<Unsubscribe xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"></Unsubscribe>";
-            case PullMessages:
-                return "<PullMessages xmlns=\"http://www.onvif.org/ver10/events/wsdl\"><Timeout>PT8S</Timeout><MessageLimit>1</MessageLimit></PullMessages>";
-            case GetEventProperties:
-                return "<GetEventProperties xmlns=\"http://www.onvif.org/ver10/events/wsdl\"/>";
-            case RelativeMoveLeft:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><PanTilt x=\"0.05000000\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case RelativeMoveRight:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><PanTilt x=\"-0.05000000\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case RelativeMoveUp:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><PanTilt x=\"0\" y=\"0.100000000\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case RelativeMoveDown:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><PanTilt x=\"0\" y=\"-0.100000000\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case RelativeMoveIn:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><Zoom x=\"0.0240506344\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case RelativeMoveOut:
-                return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex)
-                        + "</ProfileToken><Translation><Zoom x=\"-0.0240506344\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
-            case Renew:
-                return "<Renew xmlns=\"http://docs.oasis-open.org/wsn/b-2\"><TerminationTime>PT1M</TerminationTime></Renew>";
-            case GetConfigurations:
-                return "<GetConfigurations xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"></GetConfigurations>";
-            case GetConfigurationOptions:
-                return "<GetConfigurationOptions xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ConfigurationToken>"
-                        + ptzConfigToken + "</ConfigurationToken></GetConfigurationOptions>";
-            case GetConfiguration:
-                return "<GetConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><PTZConfigurationToken>"
-                        + ptzConfigToken + "</PTZConfigurationToken></GetConfiguration>";
-            case SetConfiguration:// not tested to work yet
-                return "<SetConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><PTZConfiguration><NodeToken>"
-                        + ptzNodeToken
-                        + "</NodeToken><DefaultAbsolutePantTiltPositionSpace>AbsolutePanTiltPositionSpace</DefaultAbsolutePantTiltPositionSpace><DefaultAbsoluteZoomPositionSpace>AbsoluteZoomPositionSpace</DefaultAbsoluteZoomPositionSpace></PTZConfiguration></SetConfiguration>";
-            case GetNodes:
-                return "<GetNodes xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"></GetNodes>";
-            case GetStatus:
-                return "<GetStatus xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetStatus>";
-            case GotoPreset:
-                return "<GotoPreset xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><PresetToken>"
-                        + presetTokens.get(presetTokenIndex) + "</PresetToken></GotoPreset>";
-            case GetPresets:
-                return "<GetPresets xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
-                        + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetPresets>";
+                case GetDeviceInformation:
+                    return "<GetDeviceInformation xmlns=\"http://www.onvif.org/ver10/device/wsdl\"/>";
+                case GetProfiles:
+                    return "<GetProfiles xmlns=\"http://www.onvif.org/ver10/media/wsdl\"/>";
+                case GetServiceCapabilities:
+                    return "<GetServiceCapabilities xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"></GetServiceCapabilities>";
+                case GetSnapshotUri:
+                    return "<GetSnapshotUri xmlns=\"http://www.onvif.org/ver10/media/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetSnapshotUri>";
+                case GetStreamUri:
+                    return "<GetStreamUri xmlns=\"http://www.onvif.org/ver10/media/wsdl\"><StreamSetup><Stream xmlns=\"http://www.onvif.org/ver10/schema\">RTP-Unicast</Stream><Transport xmlns=\"http://www.onvif.org/ver10/schema\"><Protocol>RTSP</Protocol></Transport></StreamSetup><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetStreamUri>";
+                case GetSystemDateAndTime:
+                    return "<GetSystemDateAndTime xmlns=\"http://www.onvif.org/ver10/device/wsdl\"/>";
+                case Subscribe:
+                    return "<Subscribe xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"><ConsumerReference><Address>http://"
+                            + ipCameraHandler.hostIp + ":" + ipCameraHandler.cameraConfig.getServerPort()
+                            + "/OnvifEvent</Address></ConsumerReference></Subscribe>";
+                case Unsubscribe:
+                    return "<Unsubscribe xmlns=\"http://docs.oasis-open.org/wsn/b-2/\"></Unsubscribe>";
+                case PullMessages:
+                    return "<PullMessages xmlns=\"http://www.onvif.org/ver10/events/wsdl\"><Timeout>PT8S</Timeout><MessageLimit>1</MessageLimit></PullMessages>";
+                case GetEventProperties:
+                    return "<GetEventProperties xmlns=\"http://www.onvif.org/ver10/events/wsdl\"/>";
+                case RelativeMoveLeft:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><PanTilt x=\"0.05000000\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case RelativeMoveRight:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><PanTilt x=\"-0.05000000\" y=\"0\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case RelativeMoveUp:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><PanTilt x=\"0\" y=\"0.100000000\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case RelativeMoveDown:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><PanTilt x=\"0\" y=\"-0.100000000\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case RelativeMoveIn:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><Zoom x=\"0.0240506344\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case RelativeMoveOut:
+                    return "<RelativeMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex)
+                            + "</ProfileToken><Translation><Zoom x=\"-0.0240506344\" xmlns=\"http://www.onvif.org/ver10/schema\"/></Translation></RelativeMove>";
+                case Renew:
+                    return "<Renew xmlns=\"http://docs.oasis-open.org/wsn/b-2\"><TerminationTime>PT1M</TerminationTime></Renew>";
+                case GetConfigurations:
+                    return "<GetConfigurations xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"></GetConfigurations>";
+                case GetConfigurationOptions:
+                    return "<GetConfigurationOptions xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ConfigurationToken>"
+                            + ptzConfigToken + "</ConfigurationToken></GetConfigurationOptions>";
+                case GetConfiguration:
+                    return "<GetConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><PTZConfigurationToken>"
+                            + ptzConfigToken + "</PTZConfigurationToken></GetConfiguration>";
+                case SetConfiguration:// not tested to work yet
+                    return "<SetConfiguration xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><PTZConfiguration><NodeToken>"
+                            + ptzNodeToken
+                            + "</NodeToken><DefaultAbsolutePantTiltPositionSpace>AbsolutePanTiltPositionSpace</DefaultAbsolutePantTiltPositionSpace><DefaultAbsoluteZoomPositionSpace>AbsoluteZoomPositionSpace</DefaultAbsoluteZoomPositionSpace></PTZConfiguration></SetConfiguration>";
+                case GetNodes:
+                    return "<GetNodes xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"></GetNodes>";
+                case GetStatus:
+                    return "<GetStatus xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetStatus>";
+                case GotoPreset:
+                    return "<GotoPreset xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken><PresetToken>"
+                            + presetTokens.get(presetTokenIndex) + "</PresetToken></GotoPreset>";
+                case GetPresets:
+                    return "<GetPresets xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\"><ProfileToken>"
+                            + mediaProfileTokens.get(mediaProfileIndex) + "</ProfileToken></GetPresets>";
+            }
+        } catch (IndexOutOfBoundsException e) {
+            if (!isConnected) {
+                logger.debug("IndexOutOfBoundsException occured, camera is not connected via ONVIF: {}",
+                        e.getMessage());
+            } else {
+                logger.debug("IndexOutOfBoundsException occured, {}", e.getMessage());
+            }
         }
         return "notfound";
     }
@@ -805,6 +817,10 @@ public class OnvifConnection {
     }
 
     public void sendPTZRequest(RequestType requestType) {
+        if (!isConnected) {
+            logger.debug("ONVIF was not connected when a PTZ request was made, connecting now");
+            connect(usingEvents);
+        }
         sendOnvifRequest(requestBuilder(requestType, ptzXAddr));
     }
 
@@ -823,26 +839,28 @@ public class OnvifConnection {
         return isConnected;
     }
 
-    public void disconnect() {
-        if (usingEvents && isConnected) {
-            sendOnvifRequest(requestBuilder(RequestType.Unsubscribe, subscriptionXAddr));
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-            }
-        }
+    private void cleanup() {
+        mainEventLoopGroup.shutdownGracefully();
         isConnected = false;
-        presetTokens.clear();
-        mediaProfileTokens.clear();
         if (!mainEventLoopGroup.isShutdown()) {
             try {
                 mainEventLoopGroup.awaitTermination(3, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
-                logger.info("Onvif was not shutdown correctly due to being interrupted");
+                logger.warn("ONVIF was not cleanly shutdown, due to being interrupted");
             } finally {
+                logger.debug("Eventloop is shutdown:{}", mainEventLoopGroup.isShutdown());
                 mainEventLoopGroup = new NioEventLoopGroup();
                 bootstrap = null;
             }
         }
+        threadPool.shutdown();
+    }
+
+    public void disconnect() {
+        if (usingEvents && isConnected && !mainEventLoopGroup.isShuttingDown()) {
+            sendOnvifRequest(requestBuilder(RequestType.Unsubscribe, subscriptionXAddr));
+        }
+        // Some cameras may continue to send event callbacks even when they cant reach a server.
+        threadPool.schedule(this::cleanup, 500, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
Changes are to:
1. Fix a reported bug (via the forum) where a IndexOutOfBoundsException is thrown when the binding sends a PTZ request before ONVIF is fully connected.
2. Remove the use of sleep and to change to using threadpool.
3. Fixes a bug that can happen when a camera keeps sending ONVIF events even after the handler is destroyed.

Signed-off-by: Matthew Skinner <matt@pcmus.com>