### PR TITLE
[jdbc] Add support for TimescaleDB (#11090)

### DIFF
--- a/bundles/org.openhab.persistence.jdbc/README.md
+++ b/bundles/org.openhab.persistence.jdbc/README.md
@@ -16,6 +16,7 @@ The following databases are currently supported and tested:
 | [MySQL](https://www.mysql.com/)              | [mysql-connector-java-5.1.39.jar](https://mvnrepository.com/artifact/mysql/mysql-connector-java) |
 | [PostgreSQL](https://www.postgresql.org/)    | [postgresql-9.4.1209.jre7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
 | [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.16.1.jar](https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
+| [TimescaleDB](https://www.timescale.com/)    | [postgresql-9.4.1209.jre7.jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
 
 ## Table of Contents
 

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -248,6 +248,10 @@ public class JdbcBaseDAO {
         dbMeta = new DbMetaData();// get DB information
     }
 
+    public Properties getConnectionProperties() {
+        return new Properties(this.databaseProps);
+    }
+
     /**************
      * ITEMS DAOs *
      **************/

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/db/JdbcTimescaledbDAO.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.persistence.jdbc.db;
+
+import java.util.Properties;
+
+import org.knowm.yank.Yank;
+import org.openhab.persistence.jdbc.dto.ItemVO;
+import org.openhab.persistence.jdbc.utils.StringUtilsExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extended Database Configuration class. Class represents the extended database-specific configuration. Overrides and
+ * supplements the default settings from JdbcBaseDAO and JdbcPostgresqlDAO.
+ *
+ * @author Riccardo Nimser-Joseph - Initial contribution
+ */
+public class JdbcTimescaledbDAO extends JdbcPostgresqlDAO {
+    private final Logger logger = LoggerFactory.getLogger(JdbcTimescaledbDAO.class);
+
+    protected String sqlCreateHypertable;
+
+    public JdbcTimescaledbDAO() {
+        super();
+
+        initSqlQueries();
+    }
+
+    public Properties getDatabaseProperties() {
+        Properties properties = new Properties(this.databaseProps);
+
+        // Adjust the jdbc url since the service name 'timescaledb' is only used to differentiate the DAOs
+        if (properties.containsKey("jdbcUrl")) {
+            properties.put("jdbcUrl", properties.getProperty("jdbcUrl").replace("timescaledb", "postgresql"));
+        }
+
+        return properties;
+    }
+
+    public void doCreateItemTable(ItemVO vo) {
+        String sql;
+
+        sql = StringUtilsExt.replaceArrayMerge(this.sqlCreateItemTable,
+                new String[] { "#tableName#", "#dbType#", "#tablePrimaryKey#" },
+                new String[] { vo.getTableName(), vo.getDbType(), sqlTypes.get("tablePrimaryKey") });
+        this.logger.debug("JDBC::doCreateItemTable sql={}", sql);
+        Yank.execute(sql, null);
+
+        sql = StringUtilsExt.replaceArrayMerge(this.sqlCreateHypertable, new String[] { "#tableName#" },
+                new String[] { vo.getTableName() });
+        this.logger.debug("JDBC::doCreateItemTable sql={}", sql);
+        Yank.execute(sql, null);
+    }
+
+    private void initSqlQueries() {
+        this.logger.debug("JDBC::initSqlQueries: '{}'", this.getClass().getSimpleName());
+
+        this.sqlCreateHypertable = "SELECT create_hypertable('#tableName#', 'time')";
+    }
+}

--- a/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/org.openhab.persistence.jdbc/src/main/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -122,7 +122,7 @@ public class JdbcConfiguration {
 
         // set database type and database type class
         setDBDAOClass(parsedURL.getProperty("dbShortcut")); // derby, h2, hsqldb, mariadb, mysql, postgresql,
-                                                            // sqlite
+                                                            // sqlite, timescaledb
         // set user
         if (user != null && !user.isBlank()) {
             dBDAO.databaseProps.setProperty("dataSource.user", user);
@@ -322,7 +322,7 @@ public class JdbcConfiguration {
     }
 
     public Properties getHikariConfiguration() {
-        return dBDAO.databaseProps;
+        return dBDAO.getConnectionProperties();
     }
 
     public String getName() {


### PR DESCRIPTION
Signed-off-by: Riccardo Nimser-Joseph <github@nimric.de>

[jdbc] Add support for TimescaleDB

JDBC persistence writes and reads item states to and from a number of relational database systems that support Java Database Connectivity (JDBC). Since the stored data are time-series, a specialized database can provide an accelerated performance.