### PR TITLE
[homematic] Added inverted info for rollershutters

### DIFF
--- a/bundles/org.openhab.binding.homematic/README.md
+++ b/bundles/org.openhab.binding.homematic/README.md
@@ -666,6 +666,15 @@ You have to delete the thing, start a scan and add it again.
 In case of problems in the discovery or if above mentioned error message appears in `openhab.log`, the size for the transmission buffer for the communication with the gateway is too small.
 The problem can be solved by increasing the `bufferSize` value in the bridge configuration.
 
+**Rollershutters are inverted**
+
+openHAB and the CCU are using different values for the same state of a rollershutter.
+Examples: HmIP-BROLL, HmIP-FROLL, HmIP-BBL, HmIP-FBL and HmIP-DRBLI4
+|         | Open | Closed |
+|---------|------|--------|
+| openHAB | 0%   | 100%   |
+| CCU     | 100% | 0%     |
+
 ### Debugging and Tracing
 
 If you want to see what's going on in the binding, switch the log level to DEBUG in the Karaf console


### PR DESCRIPTION
Hi there,

Currently openHAB and the CCU are using different values for the same state of a rollershutter.
This is not part of the docs and could confuse new users.
There are already posts in the community about this with workarounds like proxy items.

Added information about this under Troubleshooting and listed some examples.

Signed-off-by: Michael Bredehorn michael@bredehorn.nrw (github: bredmich)