### PR TITLE
[influxdb] Use item instead of _measurement for influxdbV2 (#10325) 

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -81,8 +81,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])"));
     }
 
     @Test
@@ -114,8 +114,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         String expectedQueryV2 = String.format(
                 "from(bucket:\"origin\")\n\t" + "|> range(start:%s, stop:%s)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])",
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])",
                 INFLUX2_DATE_FORMATTER.format(now.toInstant()), INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
         assertThat(queryV2, equalTo(expectedQueryV2));
     }
@@ -132,8 +132,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])\n\t"
                         + "|> filter(fn: (r) => (r[\"_field\"] == \"value\" and r[\"_value\"] <= 90))"));
     }
 
@@ -147,9 +147,10 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(query, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem LIMIT 10 OFFSET 20;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t" + "|> limit(n:10, offset:20)"));
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])\n\t" + "|> limit(n:10, offset:20)"));
     }
 
     @Test
@@ -163,8 +164,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])\n\t"
                         + "|> sort(desc:false, columns:[\"_time\"])"));
     }
 
@@ -194,9 +195,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"measurementName\")\n\t"
                         + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\", \"item\"])"));
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])"));
 
         when(metadataRegistry.get(metadataKey))
                 .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
@@ -207,7 +207,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
-                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_time\", \"_value\", \"item\"])"));
     }
 }


### PR DESCRIPTION
# Use item instead of _measurement for influxdbV2 (#10325)

## DESCRIPTION
There is a problem when using aliases in influxdb.persist and the naming of measurements. See #10325.
 
This PR removes the dependency on the _measurement and instead uses the item tag for selecting values/series from influx. As the item names are unique, this should (hopefully :-)) work as before.

I can't really see the requirement of defining a _measurement manually. Normally each series has the same _measurement name as the item name, unless an alias is used (in influxdb.persist) - then the alias will be used as _measurement instead. The item name/tag will be the same in both cases. So why not use the item tag directly when selecting from influx?

The documentation will have to be updated as well - but the PR should probably be discussed before that.
