### PR TITLE
[chamberlainmyq] Added new Close Error and Open Error Switch Items

### DIFF
--- a/bundles/org.openhab.binding.myq/README.md
+++ b/bundles/org.openhab.binding.myq/README.md
@@ -31,7 +31,9 @@ Once an account has been added, garage doors and lamps will automatically be dis
 | Channel       | Item Type     | Thing Type       | States                                                 |
 |---------------|---------------|------------------|--------------------------------------------------------|
 | status        | String        | garagedoor       | opening, closed, closing, stopped, transition, unknown |
-| rollershutter | Rollershutter | garagedoor       | UP, DOWN, 0%, 100%                                     |
+| rollershutter | Rollershutter | garagedoor       | UP, DOWN, 0%, 100%     
+| closeError    | Switch        | garagedoor       | ON (has error), OFF (doesn't have error)
+| openError     | Switch        | garagedoor       | ON (has error), OFF (doesn't have error)|
 | switch        | Switch        | garagedoor, lamp | ON (open), OFF (closed)
 
 ## Full Example
@@ -50,6 +52,8 @@ Bridge myq:account:home "MyQ Account" [ username="foo@bar.com", password="secret
 ```xtend
 String MyQGarageDoor1Status "Door Status [%s]" {channel = "myq:garagedoor:home:abcd12345:status"}
 Switch MyQGarageDoor1Switch "Door Switch [%s]" {channel = "myq:garagedoor:home:abcd12345:switch"}
+Switch MyQGarageDoor1CloseError "Door Close Error [%s]" {channel = "myq:garagedoor:home:abcd12345:closeError"}
+Switch MyQGarageDoor1OpenError "Door OpenError [%s]" {channel = "myq:garagedoor:home:abcd12345:openError"}
 Rollershutter MyQGarageDoor1Rollershutter "Door Rollershutter [%s]" {channel = "myq:garagedoor:home:abcd12345:rollershutter"}
 Switch MyQGarageDoorLamp "Lamp [%s]" {channel = "myq:lamp:home:efgh6789:switch"}
 }
@@ -61,7 +65,7 @@ Switch MyQGarageDoorLamp "Lamp [%s]" {channel = "myq:lamp:home:efgh6789:switch"}
 sitemap MyQ label="MyQ Demo Sitemap" {
   Frame label="Garage Door" {
     String item=MyQGarageDoor1Status
-    Switch item=MyQGarageDoor1Switch
+    Switch item=MyQGarageDoor1Switch    
     Rollershutter item=MyQGarageDoor1Rollershutter
   }                
 }

--- a/bundles/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/handler/MyQGarageDoorHandler.java
+++ b/bundles/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/handler/MyQGarageDoorHandler.java
@@ -112,6 +112,8 @@ public class MyQGarageDoorHandler extends BaseThingHandler implements MyQDeviceH
                     updateState("rollershutter", UnDefType.UNDEF);
                     break;
             }
+            updateState("closeerror", localState.state.isUnattendedCloseAllowed ? OnOffType.OFF : OnOffType.ON);
+            updateState("openerror", localState.state.isUnattendedOpenAllowed ? OnOffType.OFF : OnOffType.ON);
         }
     }
 

--- a/bundles/org.openhab.binding.myq/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.myq/src/main/resources/OH-INF/thing/thing-types.xml
@@ -19,6 +19,8 @@
 			<channel id="status" typeId="doorstatus"/>
 			<channel id="switch" typeId="doorswitch"/>
 			<channel id="rollershutter" typeId="doorrollershutter"/>
+			<channel id="closeerror" typeId="doorcloseerror"/>
+			<channel id="openerror" typeId="dooropenerror"/>
 		</channels>
 		<representation-property>serialNumber</representation-property>
 		<config-description-ref uri="thing-type:myq:garagedoor"/>
@@ -59,6 +61,16 @@
 	<channel-type id="doorrollershutter">
 		<item-type>Rollershutter</item-type>
 		<label>Garage Door Rollershutter</label>
+	</channel-type>
+	<channel-type id="doorcloseerror">
+		<item-type>Switch</item-type>
+		<label>Garage Door Close Error</label>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="dooropenerror">
+		<item-type>Switch</item-type>
+		<label>Garage Door Open Error</label>
+		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="lampswitch">
 		<item-type>Switch</item-type>


### PR DESCRIPTION
MyQ Garage Door may have a problem that prevents the door from being opened or closed. This is described in Chamberlain's website: [How to Resolve a Close Error in the myQ App
](https://support.chamberlaingroup.com/s/article/How-to-resolve-a-Close-error-in-the-myQ-app)
When the problem occurs, we would like to inform the user that there is a problem with the door.
The purpose of this Pull Request is to expose two new OpenHAB Switch Items:

1. closeError
2. openError

Each of the items will be ON when the error occurs in the door, and OFF when it doesn't occur.

The new Items can be used to inform the user that he has a problem with the Garage door.

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
