### PR TITLE
[wled] Add semantic tag.

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -57,7 +57,8 @@
 		<description>Allows you to exit FX mode and use the LEDS like a normal light</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 


### PR DESCRIPTION
Add a semantic tag so the model can auto display how many lights are on in each location.

Signed-off-by: Matthew Skinner <matt@pcmus.com>