### PR TITLE
[danfossairunit] Change Humidity channel type from Number to Number:Dimensionless

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/README.md
+++ b/bundles/org.openhab.binding.danfossairunit/README.md
@@ -31,9 +31,9 @@ These are the available configuration parameters:
 | extract_fan_step | main | Dimmer | RO | Current 10-step setting of the fan extracting air from the rooms |
 | boost | main | Switch | RW | Enables fan boost  |
 | night_cooling | main | Switch | RW | Enables night cooling  |
-| room_temp | temps | Number | RO | Temperature of the air in the room of the Air Dial  |
-| room_temp_calculated | temps | Number | RO | Calculated Room Temperature  |
-| outdoor_temp | temps | Number | RO | Temperature of the air outside  |
+| room_temp | temps | Number:Temperature | RO | Temperature of the air in the room of the Air Dial  |
+| room_temp_calculated | temps | Number:Temperature | RO | Calculated Room Temperature  |
+| outdoor_temp | temps | Number:Temperature | RO | Temperature of the air outside  |
 | humidity | humidity | Number:Dimensionless | RO | Current relative humidity measured by the unit  |
 | bypass | recuperator | Switch | RW | Disables the heat exchange. Useful in summer when room temperature is above target and outside temperature is below target.  |
 | supply_temp | recuperator | Number | RO | Temperature of air which is passed to the rooms  |

--- a/bundles/org.openhab.binding.danfossairunit/README.md
+++ b/bundles/org.openhab.binding.danfossairunit/README.md
@@ -34,7 +34,7 @@ These are the available configuration parameters:
 | room_temp | temps | Number | RO | Temperature of the air in the room of the Air Dial  |
 | room_temp_calculated | temps | Number | RO | Calculated Room Temperature  |
 | outdoor_temp | temps | Number | RO | Temperature of the air outside  |
-| humidity | humidity | Number | RO | Humidity  |
+| humidity | humidity | Number:Dimensionless | RO | Current relative humidity measured by the unit  |
 | bypass | recuperator | Switch | RW | Disables the heat exchange. Useful in summer when room temperature is above target and outside temperature is below target.  |
 | supply_temp | recuperator | Number | RO | Temperature of air which is passed to the rooms  |
 | extract_temp | recuperator | Number | RO | Temperature of the air as extracted from the rooms  |

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
@@ -23,6 +23,7 @@ import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -33,6 +34,7 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.Command;
 
 /**
@@ -191,9 +193,9 @@ public class DanfossAirUnit {
         return getBoolean(REGISTER_1_READ, BYPASS) ? OnOffType.ON : OnOffType.OFF;
     }
 
-    public DecimalType getHumidity() throws IOException {
+    public QuantityType<Dimensionless> getHumidity() throws IOException {
         BigDecimal value = BigDecimal.valueOf(asPercentByte(getByte(REGISTER_1_READ, HUMIDITY)));
-        return new DecimalType(value.setScale(1, RoundingMode.HALF_UP));
+        return new QuantityType<>(value.setScale(1, RoundingMode.HALF_UP), Units.PERCENT);
     }
 
     public QuantityType<Temperature> getRoomTemperature() throws IOException, UnexpectedResponseValueException {

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -84,7 +84,9 @@
 	<channel-group-type id="humidity">
 		<label>Humidity</label>
 		<channels>
-			<channel id="humidity" typeId="humidity"/>
+			<channel id="humidity" typeId="humidity">
+				<description>Current relative humidity measured by the unit</description>
+			</channel>
 		</channels>
 	</channel-group-type>
 	<channel-group-type id="recuperator">
@@ -175,7 +177,7 @@
 		<state pattern="%.0f %%" readOnly="true" min="0" max="100"/>
 	</channel-type>
 	<channel-type id="humidity">
-		<item-type>Number</item-type>
+		<item-type>Number:Dimensionless</item-type>
 		<label>Humidity</label>
 		<category>Humidity</category>
 		<tags>


### PR DESCRIPTION
Fixes #9755

Change channel humidity#humidity to Number:Dimensionless to correctly express and format relative humidity as percent.

As effect, items tracking this channel can be seen in logs like:
[INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'DanfossHRV_Humidity' changed from 59.2 % to 59.6 %

As opposed to previous behaviour:
[INFO ] [openhab.event.ItemStateChangedEvent ] - Item 'DanfossHRV_Humidity' changed from 59.2 to 59.6

With a properly defined item without any custom formatting:
`Number:Dimensionless DanfossHRV_Humidity "Relative humidity" <humidity> ["Measurement", "Humidity"] { channel = "danfossairunit:airunit:a2:humidity#humidity" }`

Sitemaps can format value correctly:
`Text item=DanfossHRV_Humidity`

Previously something like this was needed for Number item:
`Text item=DanfossHRV_Humidity label="Relative humidity [%s %%]"`

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>