### PR TITLE
[zway] Change minimum polling interval to 1 second.

### DIFF
--- a/bundles/org.openhab.binding.zway/src/main/resources/OH-INF/config/bridge-config.xml
+++ b/bundles/org.openhab.binding.zway/src/main/resources/OH-INF/config/bridge-config.xml
@@ -52,7 +52,7 @@
 			<description>Password to access the Z-Way server.</description>
 		</parameter>
 
-		<parameter name="pollingInterval" groupName="binding" type="integer" required="false" min="60" max="3600"
+		<parameter name="pollingInterval" groupName="binding" type="integer" required="false" min="1" max="3600"
 			unit="s">
 			<label>Polling Interval</label>
 			<description>Refresh device states and registration from Z-Way server.</description>


### PR DESCRIPTION
Hi,

when using the Z-Way binding there is a significant delay in receiving a new value as there are no events in the Z-Way API, but instead there is constant polling to detect change. For example the Z-Wave Frontend shows constant requests to ``/ZAutomation/api/v1/devices?since=[timestamp]`` as seen here:
![nBK8goS](https://user-images.githubusercontent.com/23010137/129613813-44f7dc99-93a7-4ed0-9432-4653e2d506f8.png)
As you can see by the timestamp in the request URL, they are being sent every 1-2 seconds, while the openHAB binding allows a polling interval from 60 seconds to the default 1 hour. Since the Z-Wave interface does such frequent polling I believe it is appropiate for openHAB to at least support the same. I am unsure whether the default 1 hour interval is appropiate, so I left it unchanged.
I have found #8264 mentioning the same thing, but there is no activity there.

Thank you.