### PR TITLE
[irobot] Minor readme corrections

### DIFF
--- a/bundles/org.openhab.binding.irobot/README.md
+++ b/bundles/org.openhab.binding.irobot/README.md
@@ -21,6 +21,8 @@ receive the password and go ONLINE.
 
 After you've done this procedure you can write the password somewhere in case if you need to reconfigure your binding. It's
 not known, however, whether the password is eternal or can change during factory reset.
+If you have issues getting the password make sure there are no other devices like your smartphone communicating with the robot.
+You can also try using the python scripts from (https://github.com/NickWaterton/Roomba980-Python) to get the password. 
 
 ## Thing Configuration
 
@@ -166,7 +168,7 @@ The easiest way to determine the pmapId and region_ids is to monitor the last_co
 irobot.things:
 
 ```
-irobot:roomba:my_roomba [ ipaddress="192.168.0.5", password="xxxxxxxx" ]
+Thing irobot:roomba:my_roomba [ ipaddress="192.168.0.5", password="xxxxxxxx" ]
 ```
 
 irobot.items:


### PR DESCRIPTION
Minor documentation clarification originally described here https://community.openhab.org/t/irobot-9xx-on-openhab/17774/196
by original author. I had to spend some hours because I did not find the information buried in the thread initially.
Signed-off-by: Kennet Nielsen <kennetn@gmail.com>