### PR TITLE
[danfossairunit] Add channel descriptions and categories

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/README.md
+++ b/bundles/org.openhab.binding.danfossairunit/README.md
@@ -27,8 +27,8 @@ These are the available configuration parameters:
 | manual_fan_speed | main | Dimmer | RW | Value to control the fan speed when in MANUAL mode (10 steps) |
 | supply_fan_speed | main | Number | RO | Current rotation of the fan supplying air to the rooms (in rpm) |
 | extract_fan_speed | main | Number | RO | Current rotation of the fan extracting air from the rooms (in rpm) |
-| supply_fan_step | main | Dimmer | RO | Current 10-step setting of the fan supplying air to the rooms |
-| extract_fan_step | main | Dimmer | RO | Current 10-step setting of the fan extracting air from the rooms |
+| supply_fan_step | main | Dimmer | RO | Current step setting of the fan supplying air to the rooms |
+| extract_fan_step | main | Dimmer | RO | Current step setting of the fan extracting air from the rooms |
 | boost | main | Switch | RW | Enables fan boost  |
 | night_cooling | main | Switch | RW | Enables night cooling  |
 | room_temp | temps | Number | RO | Temperature of the air in the room of the Air Dial  |

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -128,6 +128,7 @@
 	<channel-type id="currentTime">
 		<item-type>DateTime</item-type>
 		<label>Current Time</label>
+		<category>Time</category>
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="mode">
@@ -146,26 +147,31 @@
 	<channel-type id="manualFanSpeed">
 		<item-type>Dimmer</item-type>
 		<label>Manual Fan Speed</label>
+		<category>Fan</category>
 		<state step="10" min="0" max="100"/>
 	</channel-type>
 	<channel-type id="supplyFanSpeed">
 		<item-type>Number</item-type>
 		<label>Supply Fan Speed</label>
+		<category>Fan</category>
 		<state pattern="%.0f rpm" readOnly="true" min="0"/>
 	</channel-type>
 	<channel-type id="extractFanSpeed">
 		<item-type>Number</item-type>
 		<label>Extract Fan Speed</label>
+		<category>Fan</category>
 		<state pattern="%.0f rpm" readOnly="true" min="0"/>
 	</channel-type>
 	<channel-type id="supplyFanStep">
 		<item-type>Dimmer</item-type>
 		<label>Supply Fan Step</label>
+		<category>Fan</category>
 		<state step="10" min="0" max="100" readOnly="true"/>
 	</channel-type>
 	<channel-type id="extractFanStep">
 		<item-type>Dimmer</item-type>
 		<label>Extract Fan Step</label>
+		<category>Fan</category>
 		<state step="10" min="0" max="100" readOnly="true"/>
 	</channel-type>
 	<channel-type id="percentage">
@@ -192,6 +198,7 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
 		<description>Current temperature</description>
+		<category>Temperature</category>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -113,7 +113,7 @@
 	<channel-group-type id="service">
 		<label>Service</label>
 		<channels>
-			<channel id="battery_life" typeId="percentage">
+			<channel id="battery_life" typeId="system.battery-level">
 				<label>Battery Life</label>
 				<description>Remaining Air Dial Battery Level</description>
 			</channel>

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -128,13 +128,14 @@
 	<channel-type id="currentTime">
 		<item-type>DateTime</item-type>
 		<label>Current Time</label>
+		<description>Current time reported by the air unit</description>
 		<category>Time</category>
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="mode">
 		<item-type>String</item-type>
 		<label>Mode</label>
-		<description>Off, Demand, Manual, Program</description>
+		<description>Operation mode of the air unit: Off, Demand, Manual, Program</description>
 		<state>
 			<options>
 				<option value="DEMAND">Demand</option>
@@ -147,30 +148,35 @@
 	<channel-type id="manualFanSpeed">
 		<item-type>Dimmer</item-type>
 		<label>Manual Fan Speed</label>
+		<description>Controls 10-step setting of the fan when operation mode is manual</description>
 		<category>Fan</category>
 		<state step="10" min="0" max="100"/>
 	</channel-type>
 	<channel-type id="supplyFanSpeed">
 		<item-type>Number</item-type>
 		<label>Supply Fan Speed</label>
+		<description>Current rotation of the fan supplying air to the rooms</description>
 		<category>Fan</category>
 		<state pattern="%.0f rpm" readOnly="true" min="0"/>
 	</channel-type>
 	<channel-type id="extractFanSpeed">
 		<item-type>Number</item-type>
 		<label>Extract Fan Speed</label>
+		<description>Current rotation of the fan extracting air from the rooms</description>
 		<category>Fan</category>
 		<state pattern="%.0f rpm" readOnly="true" min="0"/>
 	</channel-type>
 	<channel-type id="supplyFanStep">
 		<item-type>Dimmer</item-type>
 		<label>Supply Fan Step</label>
+		<description>Current step setting of the fan supplying air to the rooms</description>
 		<category>Fan</category>
 		<state step="10" min="0" max="100" readOnly="true"/>
 	</channel-type>
 	<channel-type id="extractFanStep">
 		<item-type>Dimmer</item-type>
 		<label>Extract Fan Step</label>
+		<description>Current step setting of the fan extracting air from the rooms</description>
 		<category>Fan</category>
 		<state step="10" min="0" max="100" readOnly="true"/>
 	</channel-type>


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Changes:
- Use system default channel type for battery level.
- Add channel categories where applicable.
- Add missing channel descriptions.
- Fix two channel descriptions (also in README) as they are not 10-step.

Semantic tags postponed until further investigated and to avoid conflict with #11121.