### PR TITLE
[LuxtronikHeatpump] Fix/update channels for setting hot water target temperature

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
@@ -162,6 +162,7 @@ public class LuxtronikHeatpumpHandler extends BaseThingHandler {
             case CHANNEL_EINST_BWS_AKT:
             case CHANNEL_EINST_KUCFTL_AKT:
             case CHANNEL_SOLLWERT_KUCFTL_AKT:
+            case CHANNEL_SOLL_BWS_AKT:
                 float temperature = ((DecimalType) command).floatValue();
                 value = (int) (temperature * 10);
                 break;

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
@@ -1204,10 +1204,10 @@ public enum HeatpumpChannel {
             HeatpumpVisibility.HEIZUNG),
 
     /**
-     * Hot water temperature
-     * (original: Warmwasser Soll Temperatur)
+     * Coverage Heat pump (Hot Water)
+     * (original: Deckung Wärmepumpe)
      */
-    CHANNEL_EINST_BWS_AKT(2, "temperatureHotWaterTarget", NumberItem.class, SIUnits.CELSIUS, true,
+    CHANNEL_EINST_BWS_AKT(2, "temperatureHotWaterCoverage", NumberItem.class, SIUnits.CELSIUS, true,
             HeatpumpVisibility.BRAUWASSER),
 
     /**
@@ -1270,6 +1270,13 @@ public enum HeatpumpChannel {
      */
     CHANNEL_EINST_BWTDI_AKT_AL(27, "thermalDisinfectionPermanent", SwitchItem.class, null, true,
             HeatpumpVisibility.THERMDESINFEKT),
+
+    /**
+     * Hot water target temperature
+     * (original: Warmwasser Soll Temperatur)
+     */
+    CHANNEL_SOLL_BWS_AKT(105, "temperatureHotWaterTarget", NumberItem.class, SIUnits.CELSIUS, true,
+            HeatpumpVisibility.BRAUWASSER),
 
     /**
      * Comfort cooling mode

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
@@ -26,6 +26,7 @@ channel-type.luxtronikheatpump.temperatureOutside.label = Außentemp.
 channel-type.luxtronikheatpump.temperatureOutsideMean.label = Durchschnittstemp. Außen über 24 h (Funktion Heizgrenze)
 channel-type.luxtronikheatpump.temperatureHotWater.label = Warmwasser Ist-Temp.
 channel-type.luxtronikheatpump.temperatureHotWaterTarget.label = Warmwasser Soll-Temp.
+channel-type.luxtronikheatpump.temperatureHotWaterCoverage.label = Warmwasser Deckung WP
 channel-type.luxtronikheatpump.temperatureHeatSourceInlet.label = Wärmequellen-Eintrittstemp.
 channel-type.luxtronikheatpump.temperatureHeatSourceOutlet.label = Wärmequellen-Austrittstemp.
 channel-type.luxtronikheatpump.temperatureMixingCircuit1Flow.label = Mischkreis 1 Vorlauftemp.

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -1954,9 +1954,9 @@
 		<state pattern="%.1f %unit%" min="-10" max="10" step="0.5"></state>
 	</channel-type>
 
-	<channel-type id="temperatureHotWaterTarget">
+	<channel-type id="temperatureHotWaterCoverage">
 		<item-type>Number:Temperature</item-type>
-		<label>Hot Water Target Temp.</label>
+		<label>Coverage Hot Water Temp.</label>
 		<category>Temperature</category>
 		<state pattern="%.1f %unit%" min="30" max="65" step="0.5"></state>
 	</channel-type>
@@ -2027,6 +2027,13 @@
 	<channel-type id="thermalDisinfectionPermanent" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Thermal Disinfection (Permanent)</label>
+	</channel-type>
+
+	<channel-type id="temperatureHotWaterTarget">
+		<item-type>Number:Temperature</item-type>
+		<label>Hot Water Target Temp.</label>
+		<category>Temperature</category>
+		<state pattern="%.1f %unit%" min="30" max="65" step="0.5"></state>
 	</channel-type>
 
 	<channel-type id="comfortCoolingMode">

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,6 +16,7 @@
 			<channel id="temperatureOutsideMean" typeId="temperatureOutsideMean"/>
 			<channel id="temperatureHotWater" typeId="temperatureHotWater"/>
 			<channel id="temperatureHotWaterTarget" typeId="temperatureHotWaterTarget"/>
+			<channel id="temperatureHotWaterCoverage" typeId="temperatureHotWaterCoverage"/>
 			<channel id="temperatureHeatSourceInlet" typeId="temperatureHeatSourceInlet"/>
 			<channel id="temperatureHeatSourceOutlet" typeId="temperatureHeatSourceOutlet"/>
 			<channel id="temperatureMixingCircuit1Flow" typeId="temperatureMixingCircuit1Flow"/>


### PR DESCRIPTION
Based on some feedback on the forum (https://community.openhab.org/t/migration-of-novelan-luxtronic-binding-to-openhab2/70743/118) we were able to figure out, that the socket parameter used to set the hot water target temperature actually was not fully correct.

The former implementation was based on the binding for OpenHAB2, so seems it had been "wrong" there already.

It seems the socket parameter `2` used to set the hot water target temperature actually sets a value called coverage heat pump ("Deckung WP") in the heat pump control, which seems to be a value related to the hot water target temperature.
The hot water target temperature seems to be set by parameter `105`, which automatically also updates parameter `2` to the same value. (While setting `2`, doesn't update `105`)