### PR TITLE
[influxdb] Fix for influxdbv1 retention and table names containing keywords or special chars

### DIFF
--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
@@ -122,7 +122,7 @@ public class Influx1FilterCriteriaQueryCreatorImpl implements FilterCriteriaQuer
         if (escapeTableName) {
             Appender.appendName("\"" + tableName + "\"", sb);
         } else {
-            sb.append("\"" + tableName + "\"");
+            sb.append(tableName);
         }
         return sb.toString();
     }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
@@ -117,12 +117,12 @@ public class Influx1FilterCriteriaQueryCreatorImpl implements FilterCriteriaQuer
 
     private String fullQualifiedTableName(String retentionPolicy, String tableName, boolean escapeTableName) {
         StringBuilder sb = new StringBuilder();
-        Appender.appendName(retentionPolicy, sb);
+        Appender.appendName("\"" + retentionPolicy + "\"", sb);
         sb.append(".");
         if (escapeTableName) {
-            Appender.appendName(tableName, sb);
+            Appender.appendName("\"" + tableName + "\"", sb);
         } else {
-            sb.append(tableName);
+            sb.append("\"" + tableName + "\"");
         }
         return sb.toString();
     }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
@@ -117,10 +117,10 @@ public class Influx1FilterCriteriaQueryCreatorImpl implements FilterCriteriaQuer
 
     private String fullQualifiedTableName(String retentionPolicy, String tableName, boolean escapeTableName) {
         StringBuilder sb = new StringBuilder();
-        Appender.appendName("\"" + retentionPolicy + "\"", sb);
+        sb.append('"').append(retentionPolicy).append('"');
         sb.append(".");
         if (escapeTableName) {
-            Appender.appendName("\"" + tableName + "\"", sb);
+            sb.append('"').append(tableName).append('"');
         } else {
             sb.append(tableName);
         }

--- a/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/influx1/Influx1FilterCriteriaQueryCreatorImpl.java
@@ -19,7 +19,6 @@ import static org.openhab.persistence.influxdb.internal.InfluxDBStateConvertUtil
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.influxdb.dto.Query;
-import org.influxdb.querybuilder.Appender;
 import org.influxdb.querybuilder.BuiltQuery;
 import org.influxdb.querybuilder.Select;
 import org.influxdb.querybuilder.Where;

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -76,7 +76,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         FilterCriteria criteria = createBaseCriteria();
 
         String queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
+        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\";"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
@@ -91,7 +91,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setOrdering(null);
 
         String queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin./.*/;"));
+        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"/.*/\";"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)"));
@@ -107,7 +107,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
 
         String queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
         String expectedQueryV1 = String.format(
-                "SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem WHERE time >= '%s' AND time <= '%s';",
+                "SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\" WHERE time >= '%s' AND time <= '%s';",
                 now.toInstant(), tomorrow.toInstant());
         assertThat(queryV1, equalTo(expectedQueryV1));
 
@@ -127,7 +127,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setState(new PercentType(90));
 
         String query = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(query, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem WHERE value <= 90;"));
+        assertThat(query,
+                equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\" WHERE value <= 90;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
@@ -144,7 +145,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setPageSize(10);
 
         String query = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(query, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem LIMIT 10 OFFSET 20;"));
+        assertThat(query,
+                equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\" LIMIT 10 OFFSET 20;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
@@ -158,7 +160,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setOrdering(FilterCriteria.Ordering.ASCENDING);
 
         String query = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(query, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem ORDER BY time ASC;"));
+        assertThat(query,
+                equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\" ORDER BY time ASC;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
@@ -189,7 +192,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
 
         String queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV1, equalTo(
-                "SELECT \"value\"::field,\"item\"::tag FROM origin.measurementName WHERE item = 'sampleItem';"));
+                "SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"measurementName\" WHERE item = 'sampleItem';"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,
@@ -202,7 +205,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
                 .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
 
         queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
+        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"sampleItem\";"));
 
         queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2,

--- a/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.openhab.persistence.influxdb/src/test/java/org/openhab/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -91,7 +91,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         criteria.setOrdering(null);
 
         String queryV1 = instanceV1.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\".\"/.*/\";"));
+        assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM \"origin\"./.*/;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)"));


### PR DESCRIPTION
Bugfix for using itemnames beginning with numbers or having retention namnes beginning with numbers
Also solves if using old db where retention was named default wich is now a influxQL keyword

Resolves #9790
Resolves #10398

Added doubleqoutes for retention and table name as documentation for influxQL states
https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#identifiers


