### PR TITLE
[danfossairunit] Renamed channel manual_fan_speed to manual_fan_step for consistency.

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/README.md
+++ b/bundles/org.openhab.binding.danfossairunit/README.md
@@ -24,7 +24,7 @@ These are the available configuration parameters:
 |---|---|---|---|---|
 | current_time | main | DateTime | RO | Current time reported by the air unit.  |
 | mode | main | String | RW | Value to control the operation mode of the air unit. One of DEMAND, PROGRAM, MANUAL and OFF  |
-| manual_fan_speed | main | Dimmer | RW | Value to control the fan speed when in MANUAL mode (10 steps) |
+| manual_fan_step | main | Dimmer | RW | Value to control the fan step when in MANUAL mode (10 steps) |
 | supply_fan_speed | main | Number | RO | Current rotation of the fan supplying air to the rooms (in rpm) |
 | extract_fan_speed | main | Number | RO | Current rotation of the fan extracting air from the rooms (in rpm) |
 | supply_fan_step | main | Dimmer | RO | Current step setting of the fan supplying air to the rooms |
@@ -34,7 +34,7 @@ These are the available configuration parameters:
 | room_temp | temps | Number:Temperature | RO | Temperature of the air in the room of the Air Dial  |
 | room_temp_calculated | temps | Number:Temperature | RO | Calculated Room Temperature  |
 | outdoor_temp | temps | Number:Temperature | RO | Temperature of the air outside  |
-| humidity | humidity | Number:Dimensionless | RO | Current relative humidity measured by the unit  |
+| humidity | humidity | Number:Dimensionless | RO | Current relative humidity measured by the air unit  |
 | bypass | recuperator | Switch | RW | Disables the heat exchange. Useful in summer when room temperature is above target and outside temperature is below target.  |
 | supply_temp | recuperator | Number | RO | Temperature of air which is passed to the rooms  |
 | extract_temp | recuperator | Number | RO | Temperature of the air as extracted from the rooms  |

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/Channel.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/Channel.java
@@ -28,8 +28,11 @@ public enum Channel {
 
     CHANNEL_CURRENT_TIME("current_time", ChannelGroup.MAIN, DanfossAirUnit::getCurrentTime),
     CHANNEL_MODE("mode", ChannelGroup.MAIN, DanfossAirUnit::getMode, DanfossAirUnit::setMode),
-    CHANNEL_MANUAL_FAN_SPEED("manual_fan_speed", ChannelGroup.MAIN, DanfossAirUnit::getManualFanSpeed,
-            DanfossAirUnit::setManualFanSpeed),
+    // Backwards compatibility as channel was renamed from manual_fan_speed to manual_fan_step.
+    CHANNEL_MANUAL_FAN_SPEED("manual_fan_speed", ChannelGroup.MAIN, DanfossAirUnit::getManualFanStep,
+            DanfossAirUnit::setManualFanStep),
+    CHANNEL_MANUAL_FAN_STEP("manual_fan_step", ChannelGroup.MAIN, DanfossAirUnit::getManualFanStep,
+            DanfossAirUnit::setManualFanStep),
     CHANNEL_EXTRACT_FAN_SPEED("extract_fan_speed", ChannelGroup.MAIN, DanfossAirUnit::getExtractFanSpeed),
     CHANNEL_SUPPLY_FAN_SPEED("supply_fan_speed", ChannelGroup.MAIN, DanfossAirUnit::getSupplyFanSpeed),
     CHANNEL_EXTRACT_FAN_STEP("extract_fan_step", ChannelGroup.MAIN, DanfossAirUnit::getExtractFanStep),

--- a/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/java/org/openhab/binding/danfossairunit/internal/DanfossAirUnit.java
@@ -161,7 +161,7 @@ public class DanfossAirUnit {
         return new StringType(Mode.values()[getByte(REGISTER_1_READ, MODE)].name());
     }
 
-    public PercentType getManualFanSpeed() throws IOException {
+    public PercentType getManualFanStep() throws IOException {
         return new PercentType(BigDecimal.valueOf(getByte(REGISTER_1_READ, MANUAL_FAN_SPEED_STEP) * 10));
     }
 
@@ -242,7 +242,7 @@ public class DanfossAirUnit {
         return new DateTimeType(timestamp);
     }
 
-    public PercentType setManualFanSpeed(Command cmd) throws IOException {
+    public PercentType setManualFanStep(Command cmd) throws IOException {
         return setPercentTypeRegister(cmd, MANUAL_FAN_SPEED_STEP);
     }
 

--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -48,6 +48,7 @@
 		<channels>
 			<channel id="current_time" typeId="currentTime"/>
 			<channel id="mode" typeId="mode"/>
+			<channel id="manual_fan_step" typeId="manualFanStep"/>
 			<channel id="manual_fan_speed" typeId="manualFanSpeed"/>
 			<channel id="supply_fan_speed" typeId="supplyFanSpeed"/>
 			<channel id="extract_fan_speed" typeId="extractFanSpeed"/>
@@ -85,7 +86,7 @@
 		<label>Humidity</label>
 		<channels>
 			<channel id="humidity" typeId="humidity">
-				<description>Current relative humidity measured by the unit</description>
+				<description>Current relative humidity measured by the air unit</description>
 			</channel>
 		</channels>
 	</channel-group-type>
@@ -147,10 +148,17 @@
 			</options>
 		</state>
 	</channel-type>
-	<channel-type id="manualFanSpeed">
+	<channel-type id="manualFanStep">
+		<item-type>Dimmer</item-type>
+		<label>Manual Fan Step</label>
+		<description>Controls 10-step setting of the fan when operation mode is manual</description>
+		<category>Fan</category>
+		<state step="10" min="0" max="100"/>
+	</channel-type>
+	<channel-type id="manualFanSpeed" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Manual Fan Speed</label>
-		<description>Controls 10-step setting of the fan when operation mode is manual</description>
+		<description>Deprecated, please use Manual Fan Step instead. This channel will be removed in a later version.</description>
 		<category>Fan</category>
 		<state step="10" min="0" max="100"/>
 	</channel-type>


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fixes #10621

Binding can read fan speeds (in rpm) and read/control fan steps (in percent or steps). The channel used to control fan step (10 steps) is named "manual_fan_speed". This is misleading as it's actually a step.

I noticed when reconfiguring in files:

```
Dimmer DanfossHRV_Main_ManualFanSpeed <fan> (DanfossHRV) ["Control"] { channel = "danfossairunit:airunit:a2:main#manual_fan_speed" }
Number DanfossHRV_Main_SupplyFanSpeed <fan> (DanfossHRV) ["Measurement"] { channel = "danfossairunit:airunit:a2:main#supply_fan_speed" }
Number DanfossHRV_Main_ExtractFanSpeed <fan> (DanfossHRV) ["Measurement"] { channel = "danfossairunit:airunit:a2:main#extract_fan_speed" }
Dimmer DanfossHRV_Main_SupplyFanStep <fan> (DanfossHRV) ["Measurement"] { channel = "danfossairunit:airunit:a2:main#supply_fan_step" }
Dimmer DanfossHRV_Main_ExtractFanStep <fan> (DanfossHRV) ["Measurement"] { channel = "danfossairunit:airunit:a2:main#extract_fan_step" }
```

supply_fan_speed and extract_fan_speed are speed in rpm while supply_fan_step and extract_fan_step are steps in percent.

manual_fan_speed is also "step", but named "speed".

As renaming a channel is a breaking change, I'm not sure how to deal with it in the best way. In this PR I have kept the original channel and hidden it as "Advanced" with a deprecation description. I couldn't find a way to still support it, but completely hide it. This would be cleaner in the UI, and if possible, old channel could be supported for years, while current approach probably should be cleaned sooner.