### PR TITLE
[squeezebox] Fixes volume parsing when volume string is a float

### DIFF
--- a/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
+++ b/bundles/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/handler/SqueezeBoxServerHandler.java
@@ -646,7 +646,7 @@ public class SqueezeBoxServerHandler extends BaseBridgeHandler {
                     String volumeStringValue = decode(messageParts[3]);
                     updatePlayer(listener -> {
                         try {
-                            int volume = Integer.parseInt(volumeStringValue);
+                            int volume = Math.round(Float.parseFloat(volumeStringValue));
 
                             // Check if we received a relative volume change, or an absolute
                             // volume value.


### PR DESCRIPTION
Fixes #11144 

Signed-off-by: Mark Hilbush <mark@hilbush.com>
