### PR TITLE
[openhabcloud] reconnect on connection errors

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/pom.xml
+++ b/bundles/org.openhab.io.openhabcloud/pom.xml
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>io.socket.socket.io-client</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>io.socket.engine.io-client</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/feature/feature.xml
@@ -9,8 +9,8 @@
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsr305/3.0.2_1</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.8.1_1</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.13.0_1</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/io.socket.socket.io-client/1.0.0</bundle>
-		<bundle dependency="true">mvn:org.openhab.osgiify/io.socket.engine.io-client/1.0.0</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/io.socket.socket.io-client/1.0.1</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/io.socket.engine.io-client/1.0.1</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.io.openhabcloud/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -231,10 +231,10 @@ public class CloudClient {
             public void call(Object... args) {
                 if (args[0] instanceof Exception) {
                     Exception e = (Exception) args[0];
-                    logger.warn("Socket.IO re-connect attempt error: {} {}", e.getClass().getSimpleName(),
+                    logger.debug("Socket.IO re-connect attempt error: {} {}", e.getClass().getSimpleName(),
                             e.getMessage());
                 } else {
-                    logger.warn("Socket.IO re-connect attempt error: {}", args[0]);
+                    logger.debug("Socket.IO re-connect attempt error: {}", args[0]);
                 }
             }
         }).on(Socket.EVENT_RECONNECT_FAILED, new Emitter.Listener() {

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -125,7 +125,7 @@ public class CloudClient {
     private Set<String> exposedItems;
 
     /**
-     * Backoff strategy for reconnecting on connect_error events
+     * Back-off strategy for reconnecting when manual reconnection is needed
      */
     private final Backoff reconnectBackoff = new Backoff();
 
@@ -263,9 +263,13 @@ public class CloudClient {
                         logger.error("Error during communication");
                     }
                 } else {
-                    // Socket.IO 1.x: 'error' event is emitted from Socket on connection errors that are not retried
+                    // We are not connected currently, manual reconnection is needed to keep trying to (re-)establish
+                    // connection.
                     //
-                    // In Socket.IO 2.x, Socket emits 'connect_error' event.
+                    // Socket.IO 1.x java client: 'error' event is emitted from Socket on connection errors that are not
+                    // retried, but also with error that are automatically retried. If we
+                    //
+                    // Note how this is different in Socket.IO 2.x java client, Socket emits 'connect_error' event.
                     // OBS: Don't get confused with Socket IO 2.x docs online, in 1.x connect_error is emitted also on
                     // errors that are retried by the library automatically!
                     long delay = reconnectBackoff.duration();

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -245,8 +245,7 @@ public class CloudClient {
         }).on(Socket.EVENT_DISCONNECT, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-
-                if (logger.isDebugEnabled() && args.length > 0) {
+                if (args.length > 0) {
                     logger.debug("Socket.IO disconnected: {}", args[0]);
                 } else {
                     logger.debug("Socket.IO disconnected");

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -174,6 +174,17 @@ public class CloudClient {
                     }
                 });
             }
+        }).on(Manager.EVENT_CONNECT_ERROR, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                // Try reconnecting on connection errors
+                if (logger.isDebugEnabled()) {
+                    logger.error("Error connecting to the openHAB Cloud instance: {}. Reconnecting.", args[0]);
+                } else {
+                    logger.error("Error connecting to the openHAB Cloud instance. Reconnecting.");
+                }
+                socket.close().connect();
+            }
         });
         socket.on(Socket.EVENT_CONNECT, new Emitter.Listener() {
             @Override

--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudClient.java
@@ -41,11 +41,13 @@ import org.openhab.core.OpenHAB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.socket.backo.Backoff;
 import io.socket.client.IO;
 import io.socket.client.Manager;
 import io.socket.client.Socket;
 import io.socket.emitter.Emitter;
 import io.socket.engineio.client.Transport;
+import io.socket.thread.EventThread;
 
 /**
  * This class provides communication between openHAB and the openHAB Cloud service.
@@ -123,6 +125,11 @@ public class CloudClient {
     private Set<String> exposedItems;
 
     /**
+     * Backoff strategy for reconnecting on connect_error events
+     */
+    private final Backoff reconnectBackoff = new Backoff();
+
+    /**
      * Constructor of CloudClient
      *
      * @param uuid openHAB's UUID to connect to the openHAB Cloud
@@ -139,6 +146,9 @@ public class CloudClient {
         this.remoteAccessEnabled = remoteAccessEnabled;
         this.exposedItems = exposedItems;
         this.jettyClient = httpClient;
+        reconnectBackoff.setMin(1000);
+        reconnectBackoff.setMax(30_000);
+        reconnectBackoff.setJitter(0.5);
     }
 
     /**
@@ -175,15 +185,23 @@ public class CloudClient {
                 });
             }
         }).on(Manager.EVENT_CONNECT_ERROR, new Emitter.Listener() {
+
             @Override
             public void call(Object... args) {
-                // Try reconnecting on connection errors
-                if (logger.isDebugEnabled()) {
-                    logger.error("Error connecting to the openHAB Cloud instance: {}. Reconnecting.", args[0]);
+                if (args.length > 0) {
+                    if (args[0] instanceof Exception) {
+                        Exception e = (Exception) args[0];
+                        logger.debug(
+                                "Error connecting to the openHAB Cloud instance: {} {}. Should reconnect automatically.",
+                                e.getClass().getSimpleName(), e.getMessage());
+                    } else {
+                        logger.debug(
+                                "Error connecting to the openHAB Cloud instance: {}. Should reconnect automatically.",
+                                args[0]);
+                    }
                 } else {
-                    logger.error("Error connecting to the openHAB Cloud instance. Reconnecting.");
+                    logger.debug("Error connecting to the openHAB Cloud instance. Should reconnect automatically.");
                 }
-                socket.close().connect();
             }
         });
         socket.on(Socket.EVENT_CONNECT, new Emitter.Listener() {
@@ -193,20 +211,83 @@ public class CloudClient {
                 isConnected = true;
                 onConnect();
             }
+        }).on(Socket.EVENT_CONNECTING, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                logger.debug("Socket.IO connecting");
+            }
+        }).on(Socket.EVENT_RECONNECTING, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                logger.debug("Socket.IO re-connecting (attempt {})", args[0]);
+            }
+        }).on(Socket.EVENT_RECONNECT, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                logger.debug("Socket.IO re-connected successfully (attempt {})", args[0]);
+            }
+        }).on(Socket.EVENT_RECONNECT_ERROR, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                if (args[0] instanceof Exception) {
+                    Exception e = (Exception) args[0];
+                    logger.warn("Socket.IO re-connect attempt error: {} {}", e.getClass().getSimpleName(),
+                            e.getMessage());
+                } else {
+                    logger.warn("Socket.IO re-connect attempt error: {}", args[0]);
+                }
+            }
+        }).on(Socket.EVENT_RECONNECT_FAILED, new Emitter.Listener() {
+            @Override
+            public void call(Object... args) {
+                logger.debug("Socket.IO re-connect attempts failed. Stopping reconnection.");
+            }
         }).on(Socket.EVENT_DISCONNECT, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                logger.debug("Socket.IO disconnected");
+
+                if (logger.isDebugEnabled() && args.length > 0) {
+                    logger.debug("Socket.IO disconnected: {}", args[0]);
+                } else {
+                    logger.debug("Socket.IO disconnected");
+                }
                 isConnected = false;
                 onDisconnect();
             }
         }).on(Socket.EVENT_ERROR, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                if (logger.isDebugEnabled()) {
-                    logger.error("Error connecting to the openHAB Cloud instance: {}", args[0]);
+                if (CloudClient.this.socket.connected()) {
+                    if (logger.isDebugEnabled() && args.length > 0) {
+                        logger.error("Error during communication: {}", args[0]);
+                    } else {
+                        logger.error("Error during communication");
+                    }
                 } else {
-                    logger.error("Error connecting to the openHAB Cloud instance");
+                    // Socket.IO 1.x: 'error' event is emitted from Socket on connection errors that are not retried
+                    //
+                    // In Socket.IO 2.x, Socket emits 'connect_error' event.
+                    // OBS: Don't get confused with Socket IO 2.x docs online, in 1.x connect_error is emitted also on
+                    // errors that are retried by the library automatically!
+                    long delay = reconnectBackoff.duration();
+                    // Try reconnecting on connection errors
+                    if (logger.isDebugEnabled() && args.length > 0) {
+                        if (args[0] instanceof Exception) {
+                            Exception e = (Exception) args[0];
+                            logger.error(
+                                    "Error connecting to the openHAB Cloud instance: {} {}. Reconnecting after {} ms.",
+                                    e.getClass().getSimpleName(), e.getMessage(), delay);
+                        } else {
+                            logger.error(
+                                    "Error connecting to the openHAB Cloud instance: {}. Reconnecting after {} ms.",
+                                    args[0], delay);
+                        }
+                    } else {
+                        logger.error("Error connecting to the openHAB Cloud instance. Reconnecting.");
+                    }
+                    socket.close();
+                    sleepSocketIO(delay);
+                    socket.connect();
                 }
             }
         }).on("request", new Emitter.Listener() {
@@ -235,6 +316,7 @@ public class CloudClient {
 
     public void onConnect() {
         logger.info("Connected to the openHAB Cloud service (UUID = {}, base URL = {})", this.uuid, this.localBaseUrl);
+        reconnectBackoff.reset();
         isConnected = true;
     }
 
@@ -588,5 +670,15 @@ public class CloudClient {
             logger.warn("Error forming response headers: {}", e.getMessage());
         }
         return headersJSON;
+    }
+
+    private void sleepSocketIO(long delay) {
+        EventThread.exec(() -> {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+
+            }
+        });
     }
 }


### PR DESCRIPTION
Requires https://github.com/openhab/openhab-osgiify/pull/28

Aiming to resolve issues like openhab/openhab-cloud#134 . Common workaround seems to be to restart the bundle, see https://community.openhab.org/t/myopenhab-service-not-working/121711/5 and https://community.openhab.org/t/connection-to-myopenhab-broken/73808/80.

According to documentation (albeit for 2.x Socket IO version) [1], reconnection is responsibility of the user on connect_error events. Indeed, default implementation ([1.0.0](https://github.com/socketio/socket.io-client-java/blob/45fd4fbdd8401ea63c30f6bbda266afd99df751f/src/main/java/io/socket/client/Manager.java#L248-L253) and [1.0.1](https://github.com/socketio/socket.io-client-java/blob/89ef9d09cee799ffb85e0252bcaf1993f9d49af9/src/main/java/io/socket/client/Manager.java#L252-L257)) only tries to reconnect if it is the first time we are connecting... **EDIT: ** please see https://github.com/openhab/openhab-addons/pull/11153#issuecomment-905567791 for more discussion how this behaves in socket io 1.x java client.


[1] Lifecycle diagram in https://socketio.github.io/socket.io-client-java/socket_instance.html

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
