### PR TITLE
[zoneminder] Fixes API structural change relating to the location of event counts

### DIFF
--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/dto/EventSummaryDTO.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/dto/EventSummaryDTO.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zoneminder.internal.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The {@link EventSummaryDTO} contains event counts for the monitor. If this object
+ * doesn't exist in the JSON response, the event counts will be in the monitor object.
+ *
+ * @author Mark Hilbush - Initial contribution
+ */
+public class EventSummaryDTO {
+
+    /**
+     * Number of events in last hour
+     */
+    @SerializedName("HourEvents")
+    public String hourEvents;
+
+    /**
+     * Number of events in last day
+     */
+    @SerializedName("DayEvents")
+    public String dayEvents;
+
+    /**
+     * Number of events in last week
+     */
+    @SerializedName("WeekEvents")
+    public String weekEvents;
+
+    /**
+     * Number of events in last month
+     */
+    @SerializedName("MonthEvents")
+    public String monthEvents;
+
+    /**
+     * Total number of events
+     */
+    @SerializedName("TotalEvents")
+    public String totalEvents;
+}

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/dto/MonitorItemDTO.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/dto/MonitorItemDTO.java
@@ -32,4 +32,10 @@ public class MonitorItemDTO {
      */
     @SerializedName("Monitor_Status")
     public MonitorStatusDTO monitorStatus;
+
+    /**
+     * Event counts
+     */
+    @SerializedName("Event_Summary")
+    public EventSummaryDTO eventSummary;
 }

--- a/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
+++ b/bundles/org.openhab.binding.zoneminder/src/main/java/org/openhab/binding/zoneminder/internal/handler/ZmBridgeHandler.java
@@ -41,6 +41,7 @@ import org.openhab.binding.zoneminder.internal.ZmStateDescriptionOptionsProvider
 import org.openhab.binding.zoneminder.internal.config.ZmBridgeConfig;
 import org.openhab.binding.zoneminder.internal.discovery.MonitorDiscoveryService;
 import org.openhab.binding.zoneminder.internal.dto.EventDTO;
+import org.openhab.binding.zoneminder.internal.dto.EventSummaryDTO;
 import org.openhab.binding.zoneminder.internal.dto.EventsDTO;
 import org.openhab.binding.zoneminder.internal.dto.MonitorDTO;
 import org.openhab.binding.zoneminder.internal.dto.MonitorItemDTO;
@@ -302,23 +303,20 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
         }
         try {
             String response = executeGet(buildUrl("/api/monitors.json"));
-            MonitorsDTO monitors = GSON.fromJson(response, MonitorsDTO.class);
-            if (monitors != null && monitors.monitorItems != null) {
+            MonitorsDTO monitorsDTO = GSON.fromJson(response, MonitorsDTO.class);
+            if (monitorsDTO != null && monitorsDTO.monitorItems != null) {
                 List<StateOption> options = new ArrayList<>();
-                for (MonitorItemDTO monitorItem : monitors.monitorItems) {
-                    MonitorDTO m = monitorItem.monitor;
-                    MonitorStatusDTO mStatus = monitorItem.monitorStatus;
-                    if (m != null && mStatus != null) {
-                        Monitor monitor = new Monitor(m.id, m.name, m.function, m.enabled, mStatus.status);
-                        monitor.setHourEvents(m.hourEvents);
-                        monitor.setDayEvents(m.dayEvents);
-                        monitor.setWeekEvents(m.weekEvents);
-                        monitor.setMonthEvents(m.monthEvents);
-                        monitor.setTotalEvents(m.totalEvents);
-                        monitor.setImageUrl(buildStreamUrl(m.id, STREAM_IMAGE));
-                        monitor.setVideoUrl(buildStreamUrl(m.id, STREAM_VIDEO));
+                for (MonitorItemDTO monitorItemDTO : monitorsDTO.monitorItems) {
+                    MonitorDTO monitorDTO = monitorItemDTO.monitor;
+                    MonitorStatusDTO monitorStatusDTO = monitorItemDTO.monitorStatus;
+                    if (monitorDTO != null && monitorStatusDTO != null) {
+                        Monitor monitor = new Monitor(monitorDTO.id, monitorDTO.name, monitorDTO.function,
+                                monitorDTO.enabled, monitorStatusDTO.status);
+                        extractEventCounts(monitor, monitorItemDTO);
+                        monitor.setImageUrl(buildStreamUrl(monitorDTO.id, STREAM_IMAGE));
+                        monitor.setVideoUrl(buildStreamUrl(monitorDTO.id, STREAM_VIDEO));
                         monitorList.add(monitor);
-                        options.add(new StateOption(m.id, "Monitor " + m.id));
+                        options.add(new StateOption(monitorDTO.id, "Monitor " + monitorDTO.id));
                     }
                     stateDescriptionProvider
                             .setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_IMAGE_MONITOR_ID), options);
@@ -338,6 +336,30 @@ public class ZmBridgeHandler extends BaseBridgeHandler {
             logger.debug("Bridge: JsonSyntaxException: {}", e.getMessage(), e);
         }
         return monitorList;
+    }
+
+    private void extractEventCounts(Monitor monitor, MonitorItemDTO monitorItemDTO) {
+        /*
+         * The Zoneminder API changed in version 1.36.x such that the event counts moved from the
+         * monitor object to a new event summary object. Therefore, if the event summary object
+         * exists in the JSON response, pull the event counts from that object, otherwise get the
+         * counts from the monitor object.
+         */
+        if (monitorItemDTO.eventSummary != null) {
+            EventSummaryDTO eventSummaryDTO = monitorItemDTO.eventSummary;
+            monitor.setHourEvents(eventSummaryDTO.hourEvents);
+            monitor.setDayEvents(eventSummaryDTO.dayEvents);
+            monitor.setWeekEvents(eventSummaryDTO.weekEvents);
+            monitor.setMonthEvents(eventSummaryDTO.monthEvents);
+            monitor.setTotalEvents(eventSummaryDTO.totalEvents);
+        } else {
+            MonitorDTO monitorDTO = monitorItemDTO.monitor;
+            monitor.setHourEvents(monitorDTO.hourEvents);
+            monitor.setDayEvents(monitorDTO.dayEvents);
+            monitor.setWeekEvents(monitorDTO.weekEvents);
+            monitor.setMonthEvents(monitorDTO.monthEvents);
+            monitor.setTotalEvents(monitorDTO.totalEvents);
+        }
     }
 
     @SuppressWarnings("null")


### PR DESCRIPTION
Zoneminder changed the structure of their API response in version 1.36.x. They moved the event counts from the monitor object to a new event summary object. This change accounts for both situations.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
