### PR TITLE
[pulseaudio] Fix playing time with pulseaudio sink (#11170)

### DIFF
--- a/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
+++ b/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/handler/PulseaudioHandler.java
@@ -231,24 +231,28 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
                     // refresh to get the current volume level
                     bridge.getClient().update();
                     device = bridge.getDevice(name);
-                    savedVolume = device.getVolume();
+                    int oldVolume = device.getVolume();
+                    int newVolume = oldVolume;
                     if (command.equals(IncreaseDecreaseType.INCREASE)) {
-                        savedVolume = Math.min(100, savedVolume + 5);
+                        newVolume = Math.min(100, oldVolume + 5);
                     }
                     if (command.equals(IncreaseDecreaseType.DECREASE)) {
-                        savedVolume = Math.max(0, savedVolume - 5);
+                        newVolume = Math.max(0, oldVolume - 5);
                     }
-                    bridge.getClient().setVolumePercent(device, savedVolume);
-                    updateState = new PercentType(savedVolume);
+                    bridge.getClient().setVolumePercent(device, newVolume);
+                    updateState = new PercentType(newVolume);
+                    savedVolume = newVolume;
                 } else if (command instanceof PercentType) {
                     DecimalType volume = (DecimalType) command;
                     bridge.getClient().setVolumePercent(device, volume.intValue());
                     updateState = (PercentType) command;
+                    savedVolume = volume.intValue();
                 } else if (command instanceof DecimalType) {
                     // set volume
                     DecimalType volume = (DecimalType) command;
                     bridge.getClient().setVolume(device, volume.intValue());
                     updateState = (DecimalType) command;
+                    savedVolume = volume.intValue();
                 }
             } else if (channelUID.getId().equals(MUTE_CHANNEL)) {
                 if (command instanceof OnOffType) {
@@ -318,6 +322,7 @@ public class PulseaudioHandler extends BaseThingHandler implements DeviceStatusL
         AbstractAudioDeviceConfig device = bridge.getDevice(name);
         bridge.getClient().setVolumePercent(device, volume);
         updateState(VOLUME_CHANNEL, new PercentType(volume));
+        savedVolume = volume;
     }
 
     @Override


### PR DESCRIPTION
Fixes #11170 by introducing an intelligent Thread.sleep (getting the duration of the sound if possible, then wait the appropriate time for letting the sound play).

Also fix a minor issue with the last volume not propertly saved.

And fix some minor warnings by using final local variable.

Signed-off-by: Gwendal ROULLEAU <gwendal.roulleau@gmail.com>

[Link to jar](https://github.com/dalgwen/openhab-addons/releases/tag/3.2.0-SNAPSHOT_pulseaudio_11170)