### PR TITLE
[hdpowerview] Add new signal strength channel

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -80,6 +80,7 @@ All of these channels appear in the binding, but only those which have a physica
 | vane           | Dimmer                   | The degree of opening of the slats or vanes. Setting this to a non-zero value will first move the shade `position` fully down, since the slats or vanes can only have a defined state if the shade is in its down position -- see [Interdependency between Channel positions](#Interdependency-between-Channel-positions). |
 | lowBattery     | Switch                   | Indicates ON when the battery level of the shade is low, as determined by the hub's internal rules. |
 | batteryVoltage | Number:ElectricPotential | Battery voltage reported by the shade. |
+| signalStrength | Number                   | Signal strength (0 for no or unknown signal, 1 for weak, 2 for average, 3 for good or 4 for excellent) |
 
 ### Roller Shutter Up/Down Position vs. Open/Close State
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -38,10 +38,11 @@ public class HDPowerViewBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_SHADE_POSITION = "position";
+    public static final String CHANNEL_SHADE_SECONDARY_POSITION = "secondary";
     public static final String CHANNEL_SHADE_VANE = "vane";
     public static final String CHANNEL_SHADE_LOW_BATTERY = "lowBattery";
     public static final String CHANNEL_SHADE_BATTERY_VOLTAGE = "batteryVoltage";
-    public static final String CHANNEL_SHADE_SECONDARY_POSITION = "secondary";
+    public static final String CHANNEL_SHADE_SIGNAL_STRENGTH = "signalStrength";
 
     public static final String CHANNELTYPE_SCENE_ACTIVATE = "scene-activate";
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/api/responses/Shades.java
@@ -50,6 +50,7 @@ public class Shades {
         public boolean batteryIsLow;
         public @Nullable ShadePosition positions;
         public @Nullable Boolean timedOut;
+        public int signalStrength;
 
         public String getName() {
             return new String(Base64.getDecoder().decode(name));

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -30,6 +30,7 @@ import org.openhab.binding.hdpowerview.internal.api.ShadePosition;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shade;
 import org.openhab.binding.hdpowerview.internal.api.responses.Shades.ShadeData;
 import org.openhab.binding.hdpowerview.internal.config.HDPowerViewShadeConfiguration;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
@@ -138,6 +139,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
             updateBindingStates(shadeData.positions);
             updateState(CHANNEL_SHADE_LOW_BATTERY, shadeData.batteryStatus < 2 ? OnOffType.ON : OnOffType.OFF);
             updateState(CHANNEL_SHADE_BATTERY_VOLTAGE, new QuantityType<>(shadeData.batteryStrength / 10, Units.VOLT));
+            updateState(CHANNEL_SHADE_SIGNAL_STRENGTH, new DecimalType(shadeData.signalStrength));
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         }

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
@@ -49,6 +49,7 @@
 			<channel id="vane" typeId="shade-vane"/>
 			<channel id="lowBattery" typeId="system.low-battery"/>
 			<channel id="batteryVoltage" typeId="battery-voltage"/>
+			<channel id="signalStrength" typeId="system.signal-strength"/>
 		</channels>
 
 		<properties>

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
@@ -355,6 +355,8 @@ public class HDPowerViewJUnitTests {
 
             pos = shadePos.getState(PRIMARY_ACTUATOR, VANE_COORDS);
             assertEquals(UnDefType.class, pos.getClass());
+
+            assertEquals(4, shadeData.signalStrength);
         } catch (JsonParseException e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
Fixes #11197

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

This adds a new signalStrength channel to the Hunter Douglas PowerView binding. See #11197 