### PR TITLE
[hdpowerview] Add new battery level channel

### DIFF
--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -79,6 +79,7 @@ All of these channels appear in the binding, but only those which have a physica
 | secondary      | Rollershutter            | The vertical position of the secondary rail (if any). Its function is basically identical to the `position` channel above -- but see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). |
 | vane           | Dimmer                   | The degree of opening of the slats or vanes. Setting this to a non-zero value will first move the shade `position` fully down, since the slats or vanes can only have a defined state if the shade is in its down position -- see [Interdependency between Channel positions](#Interdependency-between-Channel-positions). |
 | lowBattery     | Switch                   | Indicates ON when the battery level of the shade is low, as determined by the hub's internal rules. |
+| batteryLevel   | Number                   | Battery level (33% = low, 67% = medium, 100% = high)
 | batteryVoltage | Number:ElectricPotential | Battery voltage reported by the shade. |
 | signalStrength | Number                   | Signal strength (0 for no or unknown signal, 1 for weak, 2 for average, 3 for good or 4 for excellent) |
 

--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -74,7 +74,7 @@ If it is a dual action (top-down plus bottom-up) shade, there is also a roller s
 All of these channels appear in the binding, but only those which have a physical implementation in the shade, will have any physical effect.
 
 | Channel        | Item Type                | Description |
-|----------------|--------------------------|------------|
+|----------------|--------------------------|-------------|
 | position       | Rollershutter            | The vertical position of the shade's rail -- see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). Up/Down commands will move the rail completely up or completely down. Percentage commands will move the rail to an intermediate position. Stop commands will halt any current movement of the rail. |
 | secondary      | Rollershutter            | The vertical position of the secondary rail (if any). Its function is basically identical to the `position` channel above -- but see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). |
 | vane           | Dimmer                   | The degree of opening of the slats or vanes. Setting this to a non-zero value will first move the shade `position` fully down, since the slats or vanes can only have a defined state if the shade is in its down position -- see [Interdependency between Channel positions](#Interdependency-between-Channel-positions). |

--- a/bundles/org.openhab.binding.hdpowerview/README.md
+++ b/bundles/org.openhab.binding.hdpowerview/README.md
@@ -79,7 +79,7 @@ All of these channels appear in the binding, but only those which have a physica
 | secondary      | Rollershutter            | The vertical position of the secondary rail (if any). Its function is basically identical to the `position` channel above -- but see [next chapter](#Roller-Shutter-Up/Down-Position-vs.-Open/Close-State). |
 | vane           | Dimmer                   | The degree of opening of the slats or vanes. Setting this to a non-zero value will first move the shade `position` fully down, since the slats or vanes can only have a defined state if the shade is in its down position -- see [Interdependency between Channel positions](#Interdependency-between-Channel-positions). |
 | lowBattery     | Switch                   | Indicates ON when the battery level of the shade is low, as determined by the hub's internal rules. |
-| batteryLevel   | Number                   | Battery level (33% = low, 67% = medium, 100% = high)
+| batteryLevel   | Number                   | Battery level (10% = low, 50% = medium, 100% = high)
 | batteryVoltage | Number:ElectricPotential | Battery voltage reported by the shade. |
 | signalStrength | Number                   | Signal strength (0 for no or unknown signal, 1 for weak, 2 for average, 3 for good or 4 for excellent) |
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/HDPowerViewBindingConstants.java
@@ -41,6 +41,7 @@ public class HDPowerViewBindingConstants {
     public static final String CHANNEL_SHADE_SECONDARY_POSITION = "secondary";
     public static final String CHANNEL_SHADE_VANE = "vane";
     public static final String CHANNEL_SHADE_LOW_BATTERY = "lowBattery";
+    public static final String CHANNEL_SHADE_BATTERY_LEVEL = "batteryLevel";
     public static final String CHANNEL_SHADE_BATTERY_VOLTAGE = "batteryVoltage";
     public static final String CHANNEL_SHADE_SIGNAL_STRENGTH = "signalStrength";
 

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -161,10 +161,10 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         int mappedValue;
         switch (batteryStatus) {
             case 1: // Low
-                mappedValue = 33;
+                mappedValue = 10;
                 break;
             case 2: // Medium
-                mappedValue = 67;
+                mappedValue = 50;
                 break;
             case 3: // High
             case 4: // Plugged in

--- a/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/java/org/openhab/binding/hdpowerview/internal/handler/HDPowerViewShadeHandler.java
@@ -137,7 +137,7 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
         if (shadeData != null) {
             updateStatus(ThingStatus.ONLINE);
             updateBindingStates(shadeData.positions);
-            updateState(CHANNEL_SHADE_LOW_BATTERY, shadeData.batteryStatus == 1 ? OnOffType.ON : OnOffType.OFF);
+            updateBatteryLevel(shadeData.batteryStatus);
             updateState(CHANNEL_SHADE_BATTERY_VOLTAGE, new QuantityType<>(shadeData.batteryStrength / 10, Units.VOLT));
             updateState(CHANNEL_SHADE_SIGNAL_STRENGTH, new DecimalType(shadeData.signalStrength));
         } else {
@@ -155,6 +155,26 @@ public class HDPowerViewShadeHandler extends AbstractHubbedThingHandler {
             updateState(CHANNEL_SHADE_VANE, UnDefType.UNDEF);
             updateState(CHANNEL_SHADE_SECONDARY_POSITION, UnDefType.UNDEF);
         }
+    }
+
+    private void updateBatteryLevel(int batteryStatus) {
+        int mappedValue;
+        switch (batteryStatus) {
+            case 1: // Low
+                mappedValue = 33;
+                break;
+            case 2: // Medium
+                mappedValue = 67;
+                break;
+            case 3: // High
+            case 4: // Plugged in
+                mappedValue = 100;
+                break;
+            default: // No status available (0) or invalid
+                return;
+        }
+        updateState(CHANNEL_SHADE_LOW_BATTERY, batteryStatus == 1 ? OnOffType.ON : OnOffType.OFF);
+        updateState(CHANNEL_SHADE_BATTERY_LEVEL, new DecimalType(mappedValue));
     }
 
     private void moveShade(ActuatorClass actuatorClass, CoordinateSystem coordSys, int newPercent) {

--- a/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.hdpowerview/src/main/resources/OH-INF/thing/thing-types.xml
@@ -48,6 +48,7 @@
 			</channel>
 			<channel id="vane" typeId="shade-vane"/>
 			<channel id="lowBattery" typeId="system.low-battery"/>
+			<channel id="batteryLevel" typeId="system.battery-level"/>
 			<channel id="batteryVoltage" typeId="battery-voltage"/>
 			<channel id="signalStrength" typeId="system.signal-strength"/>
 		</channels>

--- a/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/java/org/openhab/binding/hdpowerview/HDPowerViewJUnitTests.java
@@ -356,6 +356,8 @@ public class HDPowerViewJUnitTests {
             pos = shadePos.getState(PRIMARY_ACTUATOR, VANE_COORDS);
             assertEquals(UnDefType.class, pos.getClass());
 
+            assertEquals(3, shadeData.batteryStatus);
+
             assertEquals(4, shadeData.signalStrength);
         } catch (JsonParseException e) {
             fail(e.getMessage());

--- a/bundles/org.openhab.binding.hdpowerview/src/test/resources/duette.json
+++ b/bundles/org.openhab.binding.hdpowerview/src/test/resources/duette.json
@@ -6,8 +6,8 @@
 		{
 			"id": 63778,
 			"type": 8,
-			"batteryStatus": 0,
-			"batteryStrength": 0,
+			"batteryStatus": 3,
+			"batteryStrength": 168,
 			"roomId": 891,
 			"firmware": {
 				"revision": 1,


### PR DESCRIPTION
Fixes #11205

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

This adds a new channel **batteryLevel** of standard type _system.battery-level_ extracting as much data as possible from the Hunter Douglas PowerView Hub. This is quite limited as only three different values are available: low, medium or high. Previously it was only possible through channel **lowBattery** to deduct if level was either low or medium/high. In the future this channel could be improved by calculations taking voltage into consideration also.

Also fixes a regression from #11201 where "no status available" when **lowBattery** was ON would lead to **lowBattery** being reset to OFF.