### PR TITLE
[telegram] Fixes exceptions that stop rules/actions from finishing

### DIFF
--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -324,20 +324,20 @@ public class TelegramHandler extends BaseThingHandler {
                             update.callbackQuery().data());
                 }
             }
-            updateChannel(LASTMESSAGETEXT, lastMessageText != null ? new StringType(lastMessageText) : UnDefType.NULL);
+            updateChannel(CHATID, chatId != null ? new StringType(chatId.toString()) : UnDefType.NULL);
+            updateChannel(REPLYID, replyId != null ? new StringType(replyId) : UnDefType.NULL);
             updateChannel(LASTMESSAGEURL, lastMessageURL != null ? new StringType(lastMessageURL) : UnDefType.NULL);
-            updateChannel(LASTMESSAGEDATE, lastMessageDate != null
-                    ? new DateTimeType(
-                            ZonedDateTime.ofInstant(Instant.ofEpochSecond(lastMessageDate.intValue()), ZoneOffset.UTC))
-                    : UnDefType.NULL);
             updateChannel(LASTMESSAGENAME, (lastMessageFirstName != null || lastMessageLastName != null)
                     ? new StringType((lastMessageFirstName != null ? lastMessageFirstName + " " : "")
                             + (lastMessageLastName != null ? lastMessageLastName : ""))
                     : UnDefType.NULL);
             updateChannel(LASTMESSAGEUSERNAME,
                     lastMessageUsername != null ? new StringType(lastMessageUsername) : UnDefType.NULL);
-            updateChannel(CHATID, chatId != null ? new StringType(chatId.toString()) : UnDefType.NULL);
-            updateChannel(REPLYID, replyId != null ? new StringType(replyId) : UnDefType.NULL);
+            updateChannel(LASTMESSAGETEXT, lastMessageText != null ? new StringType(lastMessageText) : UnDefType.NULL);
+            updateChannel(LASTMESSAGEDATE, lastMessageDate != null
+                    ? new DateTimeType(
+                            ZonedDateTime.ofInstant(Instant.ofEpochSecond(lastMessageDate.intValue()), ZoneOffset.UTC))
+                    : UnDefType.NULL);
         }
         return UpdatesListener.CONFIRMED_UPDATES_ALL;
     }

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/TelegramHandler.java
@@ -156,7 +156,7 @@ public class TelegramHandler extends BaseThingHandler {
         }
 
         OkHttpClient.Builder prepareConnection = new OkHttpClient.Builder().connectTimeout(75, TimeUnit.SECONDS)
-                .readTimeout(75, TimeUnit.SECONDS);
+                .writeTimeout(75, TimeUnit.SECONDS).readTimeout(75, TimeUnit.SECONDS);
 
         String proxyHost = config.getProxyHost();
         Integer proxyPort = config.getProxyPort();

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -135,7 +135,7 @@ public class TelegramActions implements ThingActions {
             }
             Integer messageId = localHandler.removeMessageId(chatId, replyId);
             if (messageId == null) {
-                logger.warn("messageId could not be found for chatId {} and replyId {}", messageId, chatId, replyId);
+                logger.warn("messageId could not be found for chatId {} and replyId {}", chatId, replyId);
                 return false;
             }
             logger.debug("remove messageId {} for chatId {} and replyId {}", messageId, chatId, replyId);

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -243,7 +243,7 @@ public class TelegramActions implements ThingActions {
             try {
                 retMessage = localHandler.execute(sendMessage);
             } catch (Exception e) {
-                logger.warn("Exception occured whilst sending message:{}",e.getMessage());
+                logger.warn("Exception occured whilst sending message:{}", e.getMessage());
             }
             if (!evaluateResponse(retMessage)) {
                 return false;

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -134,6 +134,10 @@ public class TelegramActions implements ThingActions {
                 }
             }
             Integer messageId = localHandler.removeMessageId(chatId, replyId);
+            if (messageId == null) {
+                logger.warn("messageId could not be found for chatId {} and replyId {}", messageId, chatId, replyId);
+                return false;
+            }
             logger.debug("remove messageId {} for chatId {} and replyId {}", messageId, chatId, replyId);
 
             EditMessageReplyMarkup editReplyMarkup = new EditMessageReplyMarkup(chatId, messageId.intValue())

--- a/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
+++ b/bundles/org.openhab.binding.telegram/src/main/java/org/openhab/binding/telegram/internal/action/TelegramActions.java
@@ -239,7 +239,12 @@ public class TelegramActions implements ThingActions {
                     logger.warn("replyId {} must not contain spaces. ReplyMarkup will be ignored.", replyId);
                 }
             }
-            SendResponse retMessage = localHandler.execute(sendMessage);
+            SendResponse retMessage = null;
+            try {
+                retMessage = localHandler.execute(sendMessage);
+            } catch (Exception e) {
+                logger.warn("Exception occured whilst sending message:{}",e.getMessage());
+            }
             if (!evaluateResponse(retMessage)) {
                 return false;
             }


### PR DESCRIPTION
+ Fixes a NPE causing action/rule to not complete, reported on forum here https://community.openhab.org/t/solved-telegram-sendtelegramanswer-works-but-error-in-log-file-null-in-xxx/126039/14

+ Possible fix for #11102 which is a SocketTimeoutException that causes an action to not complete.

+ Closes #11048 Where the order that channels are updated can causes rule complexity and prone to errors.

Signed-off-by: Matthew Skinner <matt@pcmus.com>