### PR TITLE
[miele] Fix broken things file support.

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -143,8 +143,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
     @Override
     public void onApplianceStateChanged(String UID, DeviceClassObject dco) {
-        String myUID = (getThing().getProperties().get(PROTOCOL_PROPERTY_NAME))
-                + (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String myUID = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
         String modelID = StringUtils.right(dco.DeviceClass,
                 dco.DeviceClass.length() - new String("com.miele.xgw3000.gateway.hdm.deviceclasses.Miele").length());
 
@@ -167,8 +166,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
 
     @Override
     public void onAppliancePropertyChanged(String UID, DeviceProperty dp) {
-        String myUID = (getThing().getProperties().get(PROTOCOL_PROPERTY_NAME))
-                + (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String myUID = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
 
         if (myUID.equals(UID)) {
             try {
@@ -230,7 +228,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     @Override
     public void onApplianceRemoved(HomeDevice appliance) {
         if (uid != null) {
-            if (uid.equals(appliance.UID)) {
+            if (uid.equals(appliance.getApplianceId())) {
                 updateStatus(ThingStatus.OFFLINE);
             }
         }
@@ -239,7 +237,11 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
     @Override
     public void onApplianceAdded(HomeDevice appliance) {
         if (uid != null) {
-            if (uid.equals(appliance.UID)) {
+            if (uid.equals(appliance.getApplianceId())) {
+                Map<String, String> properties = editProperties();
+                properties.put(PROTOCOL_PROPERTY_NAME, appliance.getProtocol());
+                updateProperties(properties);
+
                 updateStatus(ThingStatus.ONLINE);
             }
         }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -266,8 +266,14 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
 
                             for (Thing appliance : getThing().getThings()) {
                                 if (appliance.getStatus() == ThingStatus.ONLINE) {
-                                    String UID = appliance.getProperties().get(PROTOCOL_PROPERTY_NAME)
-                                            + (String) appliance.getConfiguration().getProperties().get(APPLIANCE_ID);
+                                    String applianceId = (String) appliance.getConfiguration().getProperties()
+                                            .get(APPLIANCE_ID);
+                                    String protocol = appliance.getProperties().get(PROTOCOL_PROPERTY_NAME);
+                                    if (protocol == null) {
+                                        logger.error("Protocol property is missing for {}", applianceId);
+                                        continue;
+                                    }
+                                    String UID = protocol + applianceId;
 
                                     Object[] args = new Object[2];
                                     args[0] = UID;
@@ -280,7 +286,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                                 DeviceClassObject dco = gson.fromJson(obj, DeviceClassObject.class);
 
                                                 for (ApplianceStatusListener listener : applianceStatusListeners) {
-                                                    listener.onApplianceStateChanged(UID, dco);
+                                                    listener.onApplianceStateChanged(applianceId, dco);
                                                 }
                                             } catch (Exception e) {
                                                 logger.debug("An exception occurred while quering an appliance : '{}'",


### PR DESCRIPTION
Fixes #8877

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

This is a MVP bugfix for broken support of things files.

This is an alternative solution to #8902 where protocol information is kept as a property instead of being added to configuration. This has the advantage of being transparent for users, i.e. no need to configure anything.

From code perspective protocol is kept as either **ZigBee** or **LAN** without introducing further protocol confusion by adding a third option (**Wi-Fi**) being mapped to LAN.

PR can be merged as-is for fixing the root cause, in which case I plan to provide another PR for simplifying and abstracting the protocol (as separate issue). In case of impatience from my side, I might also consider adding more commits into this PR. Let me know what you think.

Manual testing performed for:
- ZigBee device configured through UI.
- ZigBee device configured through file.
- Wi-Fi device configured through UI.
- Wi-Fi device configured through file.