### PR TITLE
[bsblan] Several configuration parameters are not visible in Main UI

### DIFF
--- a/bundles/org.openhab.binding.bsblan/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.bsblan/src/main/resources/OH-INF/thing/bridge.xml
@@ -7,7 +7,12 @@
 	<bridge-type id="bridge">
 		<label>BSB-LAN Bridge</label>
 		<description>A bridge to connect a BSB-LAN device</description>
+
 		<config-description>
+			<parameter-group name="network">
+				<label>Network Settings</label>
+			</parameter-group>
+
 			<parameter name="host" type="text" required="true" groupName="network">
 				<context>network-address</context>
 				<label>Host</label>

--- a/bundles/org.openhab.binding.bsblan/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.bsblan/src/main/resources/OH-INF/thing/thing-types.xml
@@ -23,16 +23,20 @@
 		</channels>
 
 		<config-description>
+			<parameter-group name="change-requests">
+				<label>Change Requests</label>
+			</parameter-group>
+
 			<parameter name="id" type="integer" required="true">
 				<label>Parameter ID</label>
 				<description>Specific parameter identifier</description>
 			</parameter>
-			<parameter name="setId" type="integer" required="false" groupName="Change Requests">
+			<parameter name="setId" type="integer" required="false" groupName="change-requests">
 				<label>Parameter Set-ID</label>
 				<description>Parameter identifier used for change requests. Defaults to the value of Parameter ID</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="setType" type="text" required="false" groupName="Change Requests">
+			<parameter name="setType" type="text" required="false" groupName="change-requests">
 				<label>Message Type</label>
 				<description>Message type used for change requests. Defaults to SET.</description>
 				<default>SET</default>


### PR DESCRIPTION
The main UI in OH3 seems to not show configuration parameters of Things when `groupName` is specified but the related `parameter-group` node is missing in the definition XML.
Could possibly be a change in behavior compared to the OH 2.5 (?) UI?

A similar issue has already been discussed here: [V2 vs V3 - Option Parameter not showing](https://community.openhab.org/t/solved-v2-vs-v3-option-parameter-not-showing/115685/3)

Signed-off-by: Schraffl Peter <p.schraffl@gmx.at>