### PR TITLE
[bsblan] Support quantity types for "number-value" channel

### DIFF
--- a/bundles/org.openhab.binding.bsblan/src/main/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverter.java
+++ b/bundles/org.openhab.binding.bsblan/src/main/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverter.java
@@ -21,6 +21,7 @@ import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterDTO;
 import org.openhab.binding.bsblan.internal.handler.BsbLanParameterHandler;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
@@ -134,8 +135,13 @@ public class BsbLanParameterConverter {
     }
 
     private static @Nullable String getValueForNumberValueChannel(Command command) {
+        if (command instanceof QuantityType<?>) {
+            // the target unit is yet unknown, so just use the value as is (without converting based on the unit)
+            QuantityType<?> quantity = (QuantityType<?>) command;
+            return String.valueOf(quantity.doubleValue());
+        }
         // check if numeric
-        if (command.toString().matches("-?\\d+(\\.\\d+)?")) {
+        else if (command.toString().matches("-?\\d+(\\.\\d+)?")) {
             return command.toString();
         }
         LOGGER.warn("Command '{}' is not a valid number value", command);

--- a/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
+++ b/bundles/org.openhab.binding.bsblan/src/test/java/org/openhab/binding/bsblan/internal/helper/BsbLanParameterConverterTests.java
@@ -20,7 +20,10 @@ import org.junit.jupiter.api.Test;
 import org.openhab.binding.bsblan.internal.api.dto.BsbLanApiParameterDTO;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.types.State;
 
 /**
@@ -219,11 +222,14 @@ public class BsbLanParameterConverterTests {
     public void testGetValueForNumberValueChannel() {
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.ON), "1");
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, OnOffType.OFF), "0");
-        assertEquals(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(42)), "42");
-        assertEquals(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(22.5)), "22.5");
+        assertEquals("42", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(42)));
+        assertEquals("22.5", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new DecimalType(22.5)));
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE,
                 new StringType("Not a number value")));
         assertNull(BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new StringType("")));
+        assertEquals("75", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE, new PercentType(75)));
+        assertEquals("22.5", BsbLanParameterConverter.getValue(PARAMETER_CHANNEL_NUMBER_VALUE,
+                new QuantityType<>(22.5, SIUnits.CELSIUS)));
     }
 
     @Test


### PR DESCRIPTION
When using items of e.g. type `Number:Temperature` (e.g. for room temperature setpoint) changing the item's value is not possible because the internal conversion of the binding fails.

```
2021-09-08 21:55:00.715 [WARN ] [rnal.helper.BsbLanParameterConverter] - Command '23 °C' is not a valid number value
2021-09-08 21:55:00.718 [WARN ] [ernal.handler.BsbLanParameterHandler] - Channel 'number-value' is read only or conversion failed. Ignoring command
```

This change solves this issue.

Signed-off-by: Schraffl Peter <p.schraffl@gmx.at>
