### PR TITLE
Correctly disable unstable test

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
+++ b/bundles/org.openhab.binding.homematic/src/test/java/org/openhab/binding/homematic/internal/communicator/virtual/ButtonDatapointTest.java
@@ -17,8 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.homematic.internal.misc.HomematicClientException;
 import org.openhab.binding.homematic.internal.misc.HomematicConstants;
@@ -93,7 +93,7 @@ public class ButtonDatapointTest extends JavaTest {
     }
 
     @Test
-    @Ignore(value = "Test is unstable see #10753")
+    @Disabled(value = "Test is unstable see #10753")
     public void testDoublePress() throws IOException, HomematicClientException, InterruptedException {
         HmDatapoint shortPressDp = createPressDatapoint("PRESS_SHORT", Boolean.TRUE);
         HmDatapoint buttonVirtualDatapoint = getButtonVirtualDatapoint(shortPressDp);


### PR DESCRIPTION
The test was disabled using a JUnit4 annotation, which didn't show any effect and thus our builds kept failing due to this unstable test.

https://github.com/openhab/openhab-addons/issues/10753

Signed-off-by: Kai Kreuzer <kai@openhab.org>
