### PR TITLE
[magentatv] Fix: Start UPNP listener to catch power off button, thing id in log

### DIFF
--- a/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/handler/MagentaTVControl.java
+++ b/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/handler/MagentaTVControl.java
@@ -57,7 +57,7 @@ public class MagentaTVControl {
     }
 
     public MagentaTVControl(MagentaTVDynamicConfig config, MagentaTVNetwork network, HttpClient httpClient) {
-        thingId = config.getFriendlyName();
+        this.thingId = config.getFriendlyName();
         this.network = network;
         this.oauth = new MagentaTVOAuth(httpClient);
         this.config = config;
@@ -69,6 +69,10 @@ public class MagentaTVControl {
 
     public boolean isInitialized() {
         return initialized;
+    }
+
+    public void setThingId(String thingId) {
+        this.thingId = thingId;
     }
 
     /**

--- a/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/handler/MagentaTVHandler.java
+++ b/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/handler/MagentaTVHandler.java
@@ -141,6 +141,7 @@ public class MagentaTVHandler extends BaseThingHandler implements MagentaTVListe
     private void initializeThing() {
         String errorMessage = "";
         try {
+            config.setFriendlyName(getThing().getLabel().toString());
             if (config.getUDN().isEmpty()) {
                 // get UDN from device name
                 String uid = this.getThing().getUID().getAsString();
@@ -321,6 +322,7 @@ public class MagentaTVHandler extends BaseThingHandler implements MagentaTVListe
     protected void connectReceiver() throws MagentaTVException {
         if (control.checkDev()) {
             updateThingProperties();
+            control.setThingId(config.getFriendlyName());
             manager.registerDevice(config.getUDN(), config.getTerminalID(), config.getIpAddress(), this);
             control.subscribeEventChannel();
             control.sendPairingRequest();

--- a/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/network/MagentaTVPoweroffListener.java
+++ b/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/network/MagentaTVPoweroffListener.java
@@ -114,7 +114,6 @@ public class MagentaTVPoweroffListener extends Thread {
     }
 
     public boolean isStarted() {
-        // return socket.isBound();
         return started;
     }
 

--- a/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/network/MagentaTVPoweroffListener.java
+++ b/bundles/org.openhab.binding.magentatv/src/main/java/org/openhab/binding/magentatv/internal/network/MagentaTVPoweroffListener.java
@@ -46,6 +46,7 @@ public class MagentaTVPoweroffListener extends Thread {
     protected final MulticastSocket socket;
     protected @Nullable NetworkInterface networkInterface;
     protected byte[] buf = new byte[256];
+    private boolean started = false;
 
     public MagentaTVPoweroffListener(MagentaTVHandlerFactory handlerFactory,
             @Nullable NetworkInterface networkInterface) throws IOException {
@@ -61,6 +62,7 @@ public class MagentaTVPoweroffListener extends Thread {
     public void start() {
         if (!isStarted()) {
             logger.debug("Listening to SSDP shutdown messages");
+            started = true;
             super.start();
         }
     }
@@ -112,18 +114,20 @@ public class MagentaTVPoweroffListener extends Thread {
     }
 
     public boolean isStarted() {
-        return socket.isBound();
+        // return socket.isBound();
+        return started;
     }
 
     /**
      * Make sure the socket gets closed
      */
     public void close() {
-        if (isStarted()) {
+        if (started) { // if (isStarted()) {
             logger.debug("No longer listening to SSDP messages");
             if (!socket.isClosed()) {
                 socket.close();
             }
+            started = false;
         }
     }
 


### PR DESCRIPTION
This PR fixes a small bug, which didn't started the UPnP listener. This is used to catch the situation where the receiver is switch off with the physical power button