### PR TITLE
[miele] Fix multicast and multi-protocol support (ZigBee/Wi-Fi)

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifier.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifier.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.miele.internal;
+
+/**
+ * The {@link FullyQualifiedApplianceIdentifier} class represents a fully qualified appliance identifier.
+ * Example: "hdm:ZigBee:0123456789abcdef#210"
+ *
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ */
+public class FullyQualifiedApplianceIdentifier {
+    private String uid;
+    private String protocol;
+    private String applianceId;
+
+    public FullyQualifiedApplianceIdentifier(String uid) {
+        this.uid = uid;
+
+        int separatorPosition = this.uid.lastIndexOf(':') + 1;
+        this.protocol = uid.substring(0, separatorPosition);
+        this.applianceId = uid.substring(separatorPosition);
+    }
+
+    public FullyQualifiedApplianceIdentifier(String applianceId, String protocol) {
+        this.uid = protocol + applianceId;
+        this.protocol = protocol;
+        this.applianceId = applianceId;
+    }
+
+    /**
+     * @return UID of appliance (e.g. "hdm:ZigBee:0123456789abcdef#210")
+     */
+    public String getUid() {
+        return this.uid;
+    }
+
+    /**
+     * @return Appliance ID without protocol adapter information (e.g. "0123456789abcdef#210")
+     */
+    public String getApplianceId() {
+        return this.applianceId;
+    }
+
+    public String getId() {
+        return this.getApplianceId().replaceAll("[^a-zA-Z0-9_]", "_");
+    }
+
+    /**
+     * @return Protocol prefix of fully qualified appliance identifier (e.g. "hdmi:ZigBee:"")
+     */
+    public String getProtocol() {
+        return this.protocol;
+    }
+}

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -21,6 +21,7 @@ import org.openhab.core.thing.ThingTypeUID;
  *
  * @author Karel Goderis - Initial contribution
  * @author Martin Lepsy - added constants for support of WiFi devices & protocol
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 @NonNullByDefault
 public class MieleBindingConstants {
@@ -28,9 +29,8 @@ public class MieleBindingConstants {
     public static final String BINDING_ID = "miele";
     public static final String APPLIANCE_ID = "uid";
     public static final String DEVICE_CLASS = "dc";
-    public static final String HDM_LAN = "hdm:LAN:";
-    public static final String HDM_ZIGBEE = "hdm:ZigBee:";
     public static final String PROTOCOL_PROPERTY_NAME = "protocol";
+    public static final String SERIAL_NUMBER_PROPERTY_NAME = "serialNumber";
 
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_XGW3000 = new ThingTypeUID(BINDING_ID, "xgw3000");

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -117,7 +117,8 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             }
 
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                    .withBridge(bridgeUID).withLabel((String) properties.get(DEVICE_CLASS)).build();
+                    .withBridge(bridgeUID).withLabel((String) properties.get(DEVICE_CLASS))
+                    .withRepresentationProperty(APPLIANCE_ID).build();
 
             thingDiscovered(discoveryResult);
         } else {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleApplianceDiscoveryService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.ApplianceStatusListener;
 import org.openhab.binding.miele.internal.handler.MieleApplianceHandler;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler;
@@ -42,6 +43,7 @@ import com.google.gson.JsonElement;
  *
  * @author Karel Goderis - Initial contribution
  * @author Martin Lepsy - Added protocol information in order so support WiFi devices
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class MieleApplianceDiscoveryService extends AbstractDiscoveryService implements ApplianceStatusListener {
 
@@ -101,8 +103,10 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
             ThingUID bridgeUID = mieleBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>(2);
 
-            properties.put(PROTOCOL_PROPERTY_NAME, appliance.getProtocol());
-            properties.put(APPLIANCE_ID, appliance.getApplianceId());
+            FullyQualifiedApplianceIdentifier applianceIdentifier = appliance.getApplianceIdentifier();
+            properties.put(PROTOCOL_PROPERTY_NAME, applianceIdentifier.getProtocol());
+            properties.put(APPLIANCE_ID, applianceIdentifier.getApplianceId());
+            properties.put(SERIAL_NUMBER_PROPERTY_NAME, appliance.getSerialNumber());
 
             for (JsonElement dc : appliance.DeviceClasses) {
                 String dcStr = dc.getAsString();
@@ -132,12 +136,17 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
     }
 
     @Override
-    public void onApplianceStateChanged(String uid, DeviceClassObject dco) {
+    public void onApplianceStateChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceClassObject dco) {
         // nothing to do
     }
 
     @Override
-    public void onAppliancePropertyChanged(String uid, DeviceProperty dp) {
+    public void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceProperty dp) {
+        // nothing to do
+    }
+
+    @Override
+    public void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp) {
         // nothing to do
     }
 
@@ -158,7 +167,7 @@ public class MieleApplianceDiscoveryService extends AbstractDiscoveryService imp
                     modelID.replaceAll("[^a-zA-Z0-9_]", "_").toLowerCase());
 
             if (getSupportedThingTypes().contains(thingTypeUID)) {
-                ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, appliance.getId());
+                ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, appliance.getApplianceIdentifier().getId());
                 return thingUID;
             } else {
                 return null;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/discovery/MieleMDNSDiscoveryParticipant.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Karel Goderis - Initial contribution
  * @author Martin Lepsy - Added check for Miele gateway for cleaner discovery
- *
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 @Component
 public class MieleMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant {
@@ -83,8 +83,7 @@ public class MieleMDNSDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 }
 
                 return DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withRepresentationProperty(MieleBindingConstants.HOST).withLabel("Miele XGW3000 Gateway")
-                        .build();
+                        .withRepresentationProperty(MieleBindingConstants.HOST).withLabel("Miele XGW3000").build();
             }
         }
         return null;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceClassObject;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceProperty;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.HomeDevice;
@@ -22,24 +23,33 @@ import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.HomeDevice;
  * an appliance has been removed or added.
  *
  * @author Karel Goderis - Initial contribution
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public interface ApplianceStatusListener {
 
     /**
      * This method is called whenever the state of the given appliance has changed.
      *
-     * @param uid the UID of the aplliance that has changed
+     * @param applianceIdentifier the fully qualified identifier of the appliance that has changed
      * @param dco the POJO containing the new state (properties and/or operations)
      */
-    void onApplianceStateChanged(String uid, DeviceClassObject dco);
+    void onApplianceStateChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceClassObject dco);
 
     /**
      * This method is called whenever a "property" of the given appliance has changed.
      *
-     * @param uid the UID of the aplliance that has changed
+     * @param applianceIdentifier the fully qualified identifier of the appliance that has changed
      * @param dco the POJO containing the new state of the property
      */
-    void onAppliancePropertyChanged(String uid, DeviceProperty dp);
+    void onAppliancePropertyChanged(FullyQualifiedApplianceIdentifier applianceIdentifier, DeviceProperty dp);
+
+    /**
+     * This method is called whenever a "property" of the given appliance has changed.
+     *
+     * @param serialNumber The serial number of the appliance that has changed
+     * @param dco the POJO containing the new state of the property
+     */
+    void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp);
 
     /**
      * This method us called whenever an appliance is removed.

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -30,6 +32,7 @@ import com.google.gson.JsonElement;
  *
  * @author Stephan Esch - Initial contribution
  * @author Martin Lepsy - fixed handling of empty JSON results
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineChannelSelector> {
 
@@ -44,7 +47,9 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         CoffeeMachineChannelSelector selector = (CoffeeMachineChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -54,9 +59,9 @@ public class CoffeeMachineHandler extends MieleApplianceHandler<CoffeeMachineCha
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "switchOn");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOn");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "switchOff");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOff");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -31,6 +33,7 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSelector> {
 
@@ -45,7 +48,9 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         DishwasherChannelSelector selector = (DishwasherChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -55,9 +60,9 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -30,6 +32,7 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerChannelSelector> {
 
@@ -44,7 +47,9 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         FridgeFreezerChannelSelector selector = (FridgeFreezerChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -54,17 +59,17 @@ public class FridgeFreezerHandler extends MieleApplianceHandler<FridgeFreezerCha
                 switch (selector) {
                     case SUPERCOOL: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "startSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperCooling");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stopSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperCooling");
                         }
                         break;
                     }
                     case SUPERFREEZE: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "startSuperFreezing");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperFreezing");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stopSuperFreezing");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperFreezing");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -30,6 +32,7 @@ import com.google.gson.JsonElement;
  *
  * @author Karel Goderis - Initial contribution
  * @author Martin Lepsy - fixed handling of empty JSON results
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> {
 
@@ -44,7 +47,9 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         FridgeChannelSelector selector = (FridgeChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -54,15 +59,15 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
                 switch (selector) {
                     case SUPERCOOL: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "startSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperCooling");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stopSuperCooling");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperCooling");
                         }
                         break;
                     }
                     case START: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -30,7 +32,8 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
- */
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ **/
 public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
 
     private final Logger logger = LoggerFactory.getLogger(HoodHandler.class);
@@ -44,7 +47,9 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         HoodChannelSelector selector = (HoodChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -54,15 +59,15 @@ public class HoodHandler extends MieleApplianceHandler<HoodChannelSelector> {
                 switch (selector) {
                     case LIGHT: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "startLighting");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startLighting");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stopLighting");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopLighting");
                         }
                         break;
                     }
                     case STOP: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.common.NamedThreadFactory;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -71,7 +72,8 @@ import com.google.gson.JsonParser;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - Fixed lifecycle issues
  * @author Martin Lepsy - Added protocol information to support WiFi devices & some refactoring for HomeDevice
- */
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ **/
 public class MieleBridgeHandler extends BaseBridgeHandler {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_XGW3000);
@@ -103,8 +105,6 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     // Data structures to de-JSONify whatever Miele appliances are sending us
     public class HomeDevice {
 
-        private static final String PROTOCOL_LAN = "LAN";
-
         public String Name;
         public String Status;
         public String ParentUID;
@@ -121,17 +121,12 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         HomeDevice() {
         }
 
-        public String getId() {
-            return getApplianceId().replaceAll("[^a-zA-Z0-9_]", "_");
+        public FullyQualifiedApplianceIdentifier getApplianceIdentifier() {
+            return new FullyQualifiedApplianceIdentifier(this.UID);
         }
 
-        public String getProtocol() {
-            return ProtocolAdapterName.equals(PROTOCOL_LAN) ? HDM_LAN : HDM_ZIGBEE;
-        }
-
-        public String getApplianceId() {
-            return ProtocolAdapterName.equals(PROTOCOL_LAN) ? StringUtils.right(UID, UID.length() - HDM_LAN.length())
-                    : StringUtils.right(UID, UID.length() - HDM_ZIGBEE.length());
+        public String getSerialNumber() {
+            return Properties.get("serial.number").getAsString();
         }
     }
 
@@ -269,14 +264,11 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                     String applianceId = (String) appliance.getConfiguration().getProperties()
                                             .get(APPLIANCE_ID);
                                     String protocol = appliance.getProperties().get(PROTOCOL_PROPERTY_NAME);
-                                    if (protocol == null) {
-                                        logger.error("Protocol property is missing for {}", applianceId);
-                                        continue;
-                                    }
-                                    String UID = protocol + applianceId;
+                                    var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId,
+                                            protocol);
 
                                     Object[] args = new Object[2];
-                                    args[0] = UID;
+                                    args[0] = applianceIdentifier.getUid();
                                     args[1] = true;
                                     JsonElement result = invokeRPC("HDAccess/getDeviceClassObjects", args);
 
@@ -286,7 +278,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                                 DeviceClassObject dco = gson.fromJson(obj, DeviceClassObject.class);
 
                                                 for (ApplianceStatusListener listener : applianceStatusListeners) {
-                                                    listener.onApplianceStateChanged(applianceId, dco);
+                                                    listener.onApplianceStateChanged(applianceIdentifier, dco);
                                                 }
                                             } catch (Exception e) {
                                                 logger.debug("An exception occurred while quering an appliance : '{}'",
@@ -384,7 +376,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                         packet.getPort());
 
                                 DeviceProperty dp = new DeviceProperty();
-                                String uid = null;
+                                String id = null;
 
                                 String[] parts = StringUtils.split(event, "&");
                                 for (String p : parts) {
@@ -399,14 +391,27 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                             break;
                                         }
                                         case "id": {
-                                            uid = subparts[1];
+                                            id = subparts[1];
                                             break;
                                         }
                                     }
                                 }
 
-                                for (ApplianceStatusListener listener : applianceStatusListeners) {
-                                    listener.onAppliancePropertyChanged(uid, dp);
+                                if (id == null) {
+                                    continue;
+                                }
+
+                                // In XGW 3000 firmware 2.03 this was changed from UID (hdm:ZigBee:0123456789abcdef#210)
+                                // to serial number (001234567890)
+                                if (id.startsWith("hdm:")) {
+                                    for (ApplianceStatusListener listener : applianceStatusListeners) {
+                                        listener.onAppliancePropertyChanged(new FullyQualifiedApplianceIdentifier(id),
+                                                dp);
+                                    }
+                                } else {
+                                    for (ApplianceStatusListener listener : applianceStatusListeners) {
+                                        listener.onAppliancePropertyChanged(id, dp);
+                                    }
                                 }
                             } catch (SocketTimeoutException e) {
                                 try {
@@ -440,14 +445,11 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
         }
     };
 
-    public JsonElement invokeOperation(String UID, String modelID, String methodName) {
-        return invokeOperation(UID, modelID, methodName, HDM_ZIGBEE);
-    }
-
-    public JsonElement invokeOperation(String UID, String modelID, String methodName, String protocol) {
+    public JsonElement invokeOperation(FullyQualifiedApplianceIdentifier applianceIdentifier, String modelID,
+            String methodName) {
         if (getThing().getStatus() == ThingStatus.ONLINE) {
             Object[] args = new Object[4];
-            args[0] = protocol + UID;
+            args[0] = applianceIdentifier.getUid();
             args[1] = "com.miele.xgw3000.gateway.hdm.deviceclasses.Miele" + modelID;
             args[2] = methodName;
             args[3] = null;

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.miele.internal.handler;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
 import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -32,6 +33,7 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
  */
 public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
 
@@ -46,8 +48,9 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
-        String protocol = (String) getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         OvenChannelSelector selector = (OvenChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -57,15 +60,15 @@ public class OvenHandler extends MieleApplianceHandler<OvenChannelSelector> {
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "switchOn", protocol);
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOn");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "switchOff", protocol);
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "switchOff");
                         }
                         break;
                     }
                     case STOP: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stop", protocol);
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -31,7 +33,8 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
- */
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ **/
 public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannelSelector> {
 
     private final Logger logger = LoggerFactory.getLogger(TumbleDryerHandler.class);
@@ -45,7 +48,9 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         TumbleDryerChannelSelector selector = (TumbleDryerChannelSelector) getValueSelectorFromChannelID(channelID);
         JsonElement result = null;
@@ -55,9 +60,9 @@ public class TumbleDryerHandler extends MieleApplianceHandler<TumbleDryerChannel
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -13,7 +13,9 @@
 package org.openhab.binding.miele.internal.handler;
 
 import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
 
+import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -31,7 +33,8 @@ import com.google.gson.JsonElement;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - fixed handling of REFRESH commands
  * @author Martin Lepsy - fixed handling of empty JSON results
- */
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ **/
 public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineChannelSelector> {
 
     private final Logger logger = LoggerFactory.getLogger(WashingMachineHandler.class);
@@ -45,7 +48,9 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
         super.handleCommand(channelUID, command);
 
         String channelID = channelUID.getId();
-        String uid = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String applianceId = (String) getThing().getConfiguration().getProperties().get(APPLIANCE_ID);
+        String protocol = getThing().getProperties().get(PROTOCOL_PROPERTY_NAME);
+        var applianceIdentifier = new FullyQualifiedApplianceIdentifier(applianceId, protocol);
 
         WashingMachineChannelSelector selector = (WashingMachineChannelSelector) getValueSelectorFromChannelID(
                 channelID);
@@ -56,9 +61,9 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
                 switch (selector) {
                     case SWITCH: {
                         if (command.equals(OnOffType.ON)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "start");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "start");
                         } else if (command.equals(OnOffType.OFF)) {
-                            result = bridgeHandler.invokeOperation(uid, modelID, "stop");
+                            result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stop");
                         }
                         break;
                     }

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -76,7 +76,7 @@
 	<channel-type id="stop" advanced="false">
 		<item-type>Switch</item-type>
 		<label>Stop</label>
-		<description>Stop the hood</description>
+		<description>Stop the appliance</description>
 	</channel-type>
 
 	<channel-type id="step" advanced="true">

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/coffeemachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/coffeemachine.xml
@@ -22,6 +22,8 @@
 			<channel id="switch" typeId="switch"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/dishwasher.xml
@@ -25,6 +25,8 @@
 			<channel id="switch" typeId="switch"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
@@ -22,6 +22,8 @@
 			<channel id="start" typeId="switch"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
@@ -27,6 +27,8 @@
 			<channel id="start" typeId="switch"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hob.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hob.xml
@@ -35,6 +35,8 @@
 			<channel id="plate6time" typeId="time"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hood.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/hood.xml
@@ -20,6 +20,8 @@
 			<channel id="stop" typeId="stop"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
@@ -31,6 +31,8 @@
 			<channel id="switch" typeId="switch"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/tumbledryer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/tumbledryer.xml
@@ -27,6 +27,8 @@
 			<channel id="step" typeId="step"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -28,6 +28,8 @@
 			<channel id="spinningspeed" typeId="spinningspeed"/>
 		</channels>
 
+		<representation-property>uid</representation-property>
+
 		<config-description>
 			<parameter name="uid" type="text" required="true">
 				<label>ID</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/xgw3000.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/xgw3000.xml
@@ -13,6 +13,8 @@
 			<property name="vendor">Miele</property>
 		</properties>
 
+		<representation-property>ipAddress</representation-property>
+
 		<config-description>
 			<parameter name="ipAddress" type="text" required="true">
 				<context>network-address</context>

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifierTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/FullyQualifiedApplianceIdentifierTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.miele.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.core.test.java.JavaTest;
+
+/**
+ * This class provides test cases for {@link
+ * org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier}
+ *
+ * @author Jacob Laursen - Fixed multicast and protocol support (ZigBee/LAN)
+ */
+public class FullyQualifiedApplianceIdentifierTest extends JavaTest {
+
+    @Test
+    public void getUidWhenConstructedFromUidReturnsUid() {
+        var identifier = new FullyQualifiedApplianceIdentifier("hdm:ZigBee:0123456789abcdef#210");
+        assertEquals("hdm:ZigBee:0123456789abcdef#210", identifier.getUid());
+    }
+
+    @Test
+    public void getUidWhenConstructedFromApplianceIdAndProtocolReturnsUid() {
+        var identifier = new FullyQualifiedApplianceIdentifier("0123456789abcdef#210", "hdm:LAN:");
+        assertEquals("hdm:LAN:0123456789abcdef#210", identifier.getUid());
+    }
+
+    @Test
+    public void getApplianceIdWhenConstructedFromUidReturnsApplianceId() {
+        var identifier = new FullyQualifiedApplianceIdentifier("hdm:ZigBee:0123456789abcdef#210");
+        assertEquals("0123456789abcdef#210", identifier.getApplianceId());
+    }
+
+    @Test
+    public void getApplianceIdWhenConstructedFromApplianceIdAndProtocolReturnsApplianceId() {
+        var identifier = new FullyQualifiedApplianceIdentifier("0123456789abcdef#210", "hdm:LAN:");
+        assertEquals("0123456789abcdef#210", identifier.getApplianceId());
+    }
+
+    @Test
+    public void getIdWhenConstructedFromUidReturnsProtocol() {
+        var identifier = new FullyQualifiedApplianceIdentifier("hdm:ZigBee:0123456789abcdef#210");
+        assertEquals("0123456789abcdef_210", identifier.getId());
+    }
+
+    @Test
+    public void getIdWhenConstructedFromApplianceIdAndProtocolReturnsProtocol() {
+        var identifier = new FullyQualifiedApplianceIdentifier("0123456789abcdef#210", "hdm:LAN:");
+        assertEquals("0123456789abcdef_210", identifier.getId());
+    }
+
+    @Test
+    public void getProtocolWhenConstructedFromUidReturnsProtocol() {
+        var identifier = new FullyQualifiedApplianceIdentifier("hdm:ZigBee:0123456789abcdef#210");
+        assertEquals("hdm:ZigBee:", identifier.getProtocol());
+    }
+
+    @Test
+    public void getProtocolWhenConstructedFromApplianceIdAndProtocolReturnsProtocol() {
+        var identifier = new FullyQualifiedApplianceIdentifier("0123456789abcdef#210", "hdm:LAN:");
+        assertEquals("hdm:LAN:", identifier.getProtocol());
+    }
+}


### PR DESCRIPTION
Fixes #11242

Fixes #11243

Fixes #11252

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

This PR fixes issues related to protocol support and broken multicast support. This is a continuation of #11218 which was a quickfix, while this one is more in-depth and trying to fix root cause, but with full backwards configuration compatibility:
- Protocol specification is no longer parsed/interpreted, but simply concatenated with configured appliance ID's which unfortunately are without this. This makes it also forwards-compatible with any new protocol.
- Hardcoded ZigBee protocol for all handlers except oven has been fixed, so that actions for Wi-Fi devices will now work.

Also fixed multicast support which was broken by an XGW 3000 firmware upgrade in 2016. This fix is backwards compatible, so if anyone is using firmware prior to 2.03, it will also work.

Last, fixed auto-discovery finding already configured things through things files.

Manual testing performed for:
- ZigBee device configured through UI.
- ZigBee device configured through file.
- Wi-Fi device configured through UI.
- Wi-Fi device configured through file.

See also #8902 