### PR TITLE
[somfytahoma] Fixed rssi channels creation & properties updating

### DIFF
--- a/bundles/org.openhab.binding.somfytahoma/README.md
+++ b/bundles/org.openhab.binding.somfytahoma/README.md
@@ -70,7 +70,7 @@ Please see the example below.
 | roller shutter, screen, venetian blind, garage door, awning, pergola, curtain | control                      | device controller which reacts to commands UP/DOWN/ON/OFF/OPEN/CLOSE/MY/STOP + closure 0-100                                |
 | window                                                                        | control                      | device controller which reacts to commands UP/DOWN/ON/OFF/OPEN/CLOSE/STOP + closure 0-100                                   |
 | silent roller shutter                                                         | silent_control               | similar to control channel but in silent mode                                                                               |
-| venetian blind, adjustable slats roller shutter, bioclimatic pergola           | orientation                  | percentual orientation of the blind's slats, it can have value 0-100. For IO Homecontrol devices only (non RTS)             |
+| venetian blind, adjustable slats roller shutter, bioclimatic pergola          | orientation                  | percentual orientation of the blind's slats, it can have value 0-100. For IO Homecontrol devices only (non RTS)             |
 | venetian blind, adjustable slats roller shutter                               | closure_orientation          | percentual closure and orientation of the blind's slats, it can have value 0-100. For IO Homecontrol devices only (non RTS) |
 | adjustable slats roller shutter                                               | rocker                       | used for setting the rocker position of the roller shutter, the only position allowing the slats control                    |
 | bioclimatic pergola                                                           | slats                        | slats state (open/closed)                                                                                                   |
@@ -129,7 +129,7 @@ You can list all the scenarios IDs with the following console command: `somfytah
 
 ### Remarks
 
-All things which have a RSSI (relative received signal) state, expose a channel "rssi".
+All things which have a RSSI (received signal strength indication) state, expose a channel "rssi".
 
 When a roller shutter-like thing receives STOP command, there are two possible behaviours
 

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/SomfyTahomaBindingConstants.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/SomfyTahomaBindingConstants.java
@@ -293,6 +293,7 @@ public class SomfyTahomaBindingConstants {
     public static final String TAHOMA_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36";
     public static final int TAHOMA_TIMEOUT = 5;
     public static final String UNAUTHORIZED = "Not logged in";
+    public static final int TYPE_NONE = 0;
     public static final int TYPE_PERCENT = 1;
     public static final int TYPE_DECIMAL = 2;
     public static final int TYPE_STRING = 3;

--- a/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBaseThingHandler.java
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/java/org/openhab/binding/somfytahoma/internal/handler/SomfyTahomaBaseThingHandler.java
@@ -47,6 +47,7 @@ import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -123,13 +124,15 @@ public abstract class SomfyTahomaBaseThingHandler extends BaseThingHandler {
     private void createRSSIChannel() {
         if (thing.getChannel(RSSI) == null) {
             logger.debug("{} Creating a rssi channel", url);
-            createChannel(RSSI, "Number", "RSSI Level");
+            ChannelTypeUID rssi = new ChannelTypeUID(BINDING_ID, "rssi");
+            createChannel(RSSI, "Number", "RSSI Level", rssi);
         }
     }
 
-    private void createChannel(String name, String type, String label) {
+    private void createChannel(String name, String type, String label, ChannelTypeUID channelType) {
         ThingBuilder thingBuilder = editThing();
-        Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), type).withLabel(label).build();
+        Channel channel = ChannelBuilder.create(new ChannelUID(thing.getUID(), name), type).withLabel(label)
+                .withType(channelType).build();
         thingBuilder.withChannel(channel);
         updateThing(thingBuilder.build());
     }
@@ -423,7 +426,7 @@ public abstract class SomfyTahomaBaseThingHandler extends BaseThingHandler {
         Map<String, String> properties = new HashMap<>();
         for (SomfyTahomaState state : states) {
             logger.trace("{} processing state: {} with value: {}", url, state.getName(), state.getValue());
-            properties.put(state.getName(), state.getValue().toString());
+            properties.put(state.getName(), TYPE_NONE != state.getType() ? state.getValue().toString() : "");
             if (RSSI_LEVEL_STATE.equals(state.getName())) {
                 // RSSI channel is a dynamic one
                 updateRSSIChannel(state);

--- a/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.somfytahoma/src/main/resources/OH-INF/thing/channels.xml
@@ -416,4 +416,12 @@
 			</options>
 		</state>
 	</channel-type>
+
+	<channel-type id="rssi">
+		<item-type>Number</item-type>
+		<label>RSSI</label>
+		<description>Relative received signal strength state</description>
+		<state pattern="%.1f" readOnly="true"/>
+	</channel-type>
+
 </thing:thing-descriptions>


### PR DESCRIPTION
This PR fixes two bugs relating to the Somfy Tahoma binding
- RSSI dynamic channel creation was not working since OH 3.x
- server side of the Somfy Tahoma cloud has started sending an empty value which was not interpretted correctly

Signed-off-by: Ondrej Pecta <opecta@gmail.com>
