### PR TITLE
[LuxtronikHeatpump] Adds additional setting for heating limit temperature

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/README.md
+++ b/bundles/org.openhab.binding.luxtronikheatpump/README.md
@@ -266,6 +266,7 @@ The following channels are also writable:
 | comfortCoolingMode | Number |   | Comfort cooling mode |
 | temperatureComfortCoolingATRelease | Number:Temperature |   | Comfort cooling AT release |
 | temperatureComfortCoolingATReleaseTarget | Number:Temperature |   | Comfort cooling AT release target |
+| temperatureHeatingLimit | Number:Temperature |   | Temperature Heating Limit |
 | comfortCoolingATExcess | Number:Time |   | AT Excess |
 | comfortCoolingATUndercut | Number:Time |   | AT undercut |
 

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/LuxtronikHeatpumpHandler.java
@@ -163,6 +163,7 @@ public class LuxtronikHeatpumpHandler extends BaseThingHandler {
             case CHANNEL_EINST_KUCFTL_AKT:
             case CHANNEL_SOLLWERT_KUCFTL_AKT:
             case CHANNEL_SOLL_BWS_AKT:
+            case CHANNEL_EINST_HEIZGRENZE_TEMP:
                 float temperature = ((DecimalType) command).floatValue();
                 value = (int) (temperature * 10);
                 break;

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/enums/HeatpumpChannel.java
@@ -1299,6 +1299,13 @@ public enum HeatpumpChannel {
             true, HeatpumpVisibility.KUHLUNG),
 
     /**
+     * Temperature heating limit
+     * (original: Temperatur Heizgrenze)
+     */
+    CHANNEL_EINST_HEIZGRENZE_TEMP(700, "temperatureHeatingLimit", NumberItem.class, SIUnits.CELSIUS, true,
+            HeatpumpVisibility.HEIZUNG),
+
+    /**
      * AT Excess
      * (original: AT-Überschreitung)
      */

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/i18n/luxtronikheatpump_de.properties
@@ -287,6 +287,7 @@ channel-type.luxtronikheatpump.comfortCoolingMode.state.option.0 = Aus
 channel-type.luxtronikheatpump.comfortCoolingMode.state.option.1 = Auto
 channel-type.luxtronikheatpump.temperatureComfortCoolingATRelease.label = Comfort Kühlung AT-Freigabe
 channel-type.luxtronikheatpump.temperatureComfortCoolingATReleaseTarget.label = Comfort Kühlung AT-Freigabe Sollwert
+channel-type.luxtronikheatpump.temperatureHeatingLimit.label = Temperatur Heizgrenze
 channel-type.luxtronikheatpump.comfortCoolingATExcess.label = AT-Überschreitung
 channel-type.luxtronikheatpump.comfortCoolingATUndercut.label = AT-Unterschreitung
 

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -2063,7 +2063,7 @@
 
 	<channel-type id="temperatureHeatingLimit">
 		<item-type>Number:Temperature</item-type>
-		<label>Temperature Heatling Limit</label>
+		<label>Temperature Heating Limit</label>
 		<category>Temperature</category>
 		<state pattern="%.1f %unit%"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/channels.xml
@@ -2061,6 +2061,13 @@
 		<state pattern="%.1f %unit%"></state>
 	</channel-type>
 
+	<channel-type id="temperatureHeatingLimit">
+		<item-type>Number:Temperature</item-type>
+		<label>Temperature Heatling Limit</label>
+		<category>Temperature</category>
+		<state pattern="%.1f %unit%"></state>
+	</channel-type>
+
 	<channel-type id="comfortCoolingATExcess">
 		<item-type>Number:Time</item-type>
 		<label>AT Excess</label>

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/resources/OH-INF/thing/thing-types.xml
@@ -226,6 +226,7 @@
 			<channel id="thermalDisinfectionPermanent" typeId="thermalDisinfectionPermanent"/>
 			<channel id="temperatureComfortCoolingATRelease" typeId="temperatureComfortCoolingATRelease"/>
 			<channel id="temperatureComfortCoolingATReleaseTarget" typeId="temperatureComfortCoolingATReleaseTarget"/>
+			<channel id="temperatureHeatingLimit" typeId="temperatureHeatingLimit"/>
 			<channel id="comfortCoolingATExcess" typeId="comfortCoolingATExcess"/>
 			<channel id="comfortCoolingATUndercut" typeId="comfortCoolingATUndercut"/>
 		</channels>


### PR DESCRIPTION
The binding for luxtronik based heatpumps currently doesn't provider a channel for setting/reading the heating limit temperature ("Heizgrenze" in German).

This was requested on the forum: https://community.openhab.org/t/migration-of-novelan-luxtronic-binding-to-openhab2/70743/130?u=sgiehl