### PR TITLE
[modbus] DEVELOPERS.md: fix jamod dependency in demo app

### DIFF
--- a/bundles/org.openhab.binding.modbus/DEVELOPERS.md
+++ b/bundles/org.openhab.binding.modbus/DEVELOPERS.md
@@ -20,8 +20,8 @@ When configuring dependencies in `openhab-distro/launch/app/pom.xml`, add all de
     <scope>runtime</scope>
 </dependency>
 <dependency>
-    <groupId>org.openhab.osgiify</groupId>
-    <artifactId>net.wimpi.jamod</artifactId>
+    <groupId>net.wimpi</groupId>
+    <artifactId>jamod</artifactId>
     <version>1.2.4.OH</version>
     <scope>runtime</scope>
 </dependency>

--- a/bundles/org.openhab.binding.modbus/DEVELOPERS.md
+++ b/bundles/org.openhab.binding.modbus/DEVELOPERS.md
@@ -14,8 +14,8 @@ When configuring dependencies in `openhab-distro/launch/app/pom.xml`, add all de
     <scope>runtime</scope>
 </dependency>
 <dependency>
-    <groupId>org.openhab.addons.bundles</groupId>
-    <artifactId>org.openhab.io.transport.modbus</artifactId>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.io.transport.modbus</artifactId>
     <version>${project.version}</version>
     <scope>runtime</scope>
 </dependency>


### PR DESCRIPTION
As discussed in #8551. See comment from fwolter at Sep 23 2020.:
https://github.com/openhab/openhab-addons/issues/8551#issuecomment-697237105

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
