### PR TITLE
[metrics] Fix configuration PID and add file based configuration example

### DIFF
--- a/bundles/org.openhab.io.metrics/README.md
+++ b/bundles/org.openhab.io.metrics/README.md
@@ -1,9 +1,9 @@
 # Metrics service
 
-The metrics service provides 
+The metrics service provides:
 
 * an additional REST endpoint to retrieve openHAB core metrics from. This can be used as scrape target for pull-based monitoring systems like [Prometheus](https://prometheus.io/).
-* optionally configurable services to export openHAB core metrics to push-based monitoring systems like [InfluxDB](https://www.influxdata.com/). 
+* optionally configurable services to export openHAB core metrics to push-based monitoring systems like [InfluxDB](https://www.influxdata.com/).
 
 ## Precondition
 
@@ -38,7 +38,7 @@ The following configuration parameters can be set:
 | influxMetricsEnabled | Enable the Influx (www.influxdata.com) metrics. Further configuration of the InfluxDB instance necessary. | false         |
 | jmxMetricsEnabled    | Enable the Java Management Extensions (JMX) metrics.                                                      | false         |
 
-Refer to the corresponding monitoring system sections for monitoring system specific configuration parameters.  
+Refer to the corresponding monitoring system sections for monitoring system specific configuration parameters.
 
 ### Supported monitoring systems
 
@@ -90,16 +90,34 @@ You can monitor the JMX metrics using a tool like [JConsole](https://docs.oracle
 When the JMX exporter is enabled, the metrics will be available under the "metrics" MBean.
 JConsole and VisualVM will only be able to connect using JMX when openHAB is started in debug mode (use `start_debug.sh` or `start_debug.bat`).
 
+## Configuration file example
+
+The example below shows how to configure the Metrics service using a file.
+
+metrics.cfg:
+
+```java
+influxMetricsEnabled=true
+influxURL=https://influxdb
+influxDB=metrics
+influxUsername=openhab
+influxPassword=77QjHkoWZEdbvXe9FWsJ
+influxUpdateIntervalInSeconds=60
+
+jmxMetricsEnabled=false
+```
+
 ## Additional metric formats
 
 The metrics service was implemented using [Micrometer](https://micrometer.io), which supports a number of [monitoring systems](https://micrometer.io/docs) 
-It should be possible to add any of these, especially the ones using a pull mechanism ("scraping") like Prometheus does.     
+It should be possible to add any of these, especially the ones using a pull mechanism ("scraping") like Prometheus does.
 
 ## Grafana
 
 You can now visualize the results in Grafana. Micrometer provides a public [Grafana dashboard here](https://grafana.com/grafana/dashboards/4701). 
-I adapted it a little bit to include the openHAB metrics. You can download it here [Dashboard](doc/dashboard.json). 
-This has been tested with Prometheus - for other monitoring systems adaptions to the dashboard might be necessary.  
+I adapted it a little bit to include the openHAB metrics.
+You can download it here [Dashboard](doc/dashboard.json).
+This has been tested with Prometheus - for other monitoring systems adaptions to the dashboard might be necessary.
 
 Here are some screenshots: 
 

--- a/bundles/org.openhab.io.metrics/src/main/java/org/openhab/io/metrics/MetricsRestController.java
+++ b/bundles/org.openhab.io.metrics/src/main/java/org/openhab/io/metrics/MetricsRestController.java
@@ -56,7 +56,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  *
  * @author Robert Bach - Initial contribution
  */
-@Component(immediate = true, service = MetricsRestController.class)
+@Component(configurationPid = "org.openhab.metrics", immediate = true, service = MetricsRestController.class)
 @JaxrsResource
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @Path(MetricsRestController.PATH_METRICS)


### PR DESCRIPTION
The configuration PID is not defined so currently `org.openhab.io.metrics.MetricsRestController` is used.
Also added an example to the docs.

Fixes #11279

---

I went for a configuration PID similar to the persistence services so the `ConfigDispatcher` can also resolve the namespace to "org.openhab.metrics" if you use a `metrics.cfg` file and omit the namespace from settings keys (which does not work for bindings and several other addons) .