### PR TITLE
[miele] Fix IllegalArgumentException when using oven channel 'type'

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -88,7 +88,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             }
         }
 
-        throw new IllegalArgumentException("Not valid value selector");
+        throw new IllegalArgumentException(String.format("Not valid value selector: %s", valueSelectorText));
     }
 
     public ApplianceChannelSelector getValueSelectorFromMieleID(String valueSelectorText)
@@ -99,7 +99,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
             }
         }
 
-        throw new IllegalArgumentException("Not valid value selector");
+        throw new IllegalArgumentException(String.format("Not valid value selector: %s", valueSelectorText));
     }
 
     @Override

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -46,6 +46,7 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE("state", "state", StringType.class, false),
     PROGRAMID("programId", "program", StringType.class, false),
+    PROGRAMTYPE("programType", "type", StringType.class, false),
     PROGRAMPHASE("phase", "phase", StringType.class, false),
     START_TIME("startTime", "start", DateTimeType.class, false) {
         @Override


### PR DESCRIPTION
Fixes #11286

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

See issue description. Channel **type** for ovens was not fully implemented, so would throw exception when item was linked.