### PR TITLE
[hue] Make sure bridge status is set when returning from initialize

### DIFF
--- a/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/bundles/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/handler/HueBridgeHandler.java
@@ -685,6 +685,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 hueBridge = new HueBridge(ip, hueBridgeConfig.getPort(), hueBridgeConfig.getProtocol(), scheduler);
                 hueBridge.setTimeout(5000);
 
+                updateStatus(ThingStatus.UNKNOWN);
+
                 // Try a first connection that will fail, then try to authenticate,
                 // and finally change the bridge status to ONLINE
                 initJob = scheduler.submit(new PollingRunnable() {


### PR DESCRIPTION
I just experienced my bridge being in INITIALIZING state, although the handler successfully returned from the `initialize()` method.

Signed-off-by: Kai Kreuzer <kai@openhab.org>
