### PR TITLE
[ipcamera] Fix ipcamera.jpg can return an old picture

### DIFF
--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -139,7 +140,7 @@ public class IpCameraHandler extends BaseThingHandler {
     public @Nullable Ffmpeg ffmpegSnapshot = null;
     public boolean streamingAutoFps = false;
     public boolean motionDetected = false;
-
+    public Instant currentSnapshotTime = Instant.now();
     private @Nullable ScheduledFuture<?> cameraConnectionJob = null;
     private @Nullable ScheduledFuture<?> pollCameraJob = null;
     private @Nullable ScheduledFuture<?> snapshotJob = null;
@@ -662,6 +663,7 @@ public class IpCameraHandler extends BaseThingHandler {
             }
         } finally {
             lockCurrentSnapshot.unlock();
+            currentSnapshotTime = Instant.now();
         }
 
         if (updateImageChannel) {

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/handler/IpCameraHandler.java
@@ -696,7 +696,7 @@ public class IpCameraHandler extends BaseThingHandler {
         sendHttpGET(mjpegUri);
     }
 
-    void openChannel(Channel channel, String httpRequestURL) {
+    private void openChannel(Channel channel, String httpRequestURL) {
         ChannelTracking tracker = channelTrackingMap.get(httpRequestURL);
         if (tracker != null && !tracker.getReply().isEmpty()) {// We need to keep the stored reply
             tracker.setChannel(channel);
@@ -1478,13 +1478,7 @@ public class IpCameraHandler extends BaseThingHandler {
      *
      */
     void pollCameraRunnable() {
-        // Snapshot should be first to keep consistent time between shots
-        if (streamingAutoFps) {
-            if (!snapshotPolling && !ffmpegSnapshotGeneration) {
-                // Dont need to poll if creating from RTSP stream with FFmpeg or we are polling at full rate already.
-                sendHttpGET(snapshotUri);
-            }
-        } else if (!snapshotUri.isEmpty() && !snapshotPolling) {// we need to check camera is still online.
+        if (!snapshotUri.isEmpty() && !snapshotPolling) {// we need to check camera is still online.
             checkCameraConnection();
         }
         // NOTE: Use lowPriorityRequests if get request is not needed every poll.

--- a/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
+++ b/bundles/org.openhab.binding.ipcamera/src/main/java/org/openhab/binding/ipcamera/internal/servlet/IpCameraServlet.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletResponse;
 
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Matthew Skinner - Initial contribution
  */
 @NonNullByDefault
+@WebServlet(asyncSupported = true)
 public abstract class IpCameraServlet extends HttpServlet {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes an issue now that the binding is not polling the snapshot anymore where the jpg could return an old image from cache.

Precompiled jar can be downloaded here:
http://pcmus.com/openhab/IpCameraBinding/

Signed-off-by: Matthew Skinner <matt@pcmus.com>