### PR TITLE
Allow multi release JARs to resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <bnd.importpackage/>
     <bnd.exportpackage/>
-    <bnd.fixupmessages/>
+    <bnd.fixupmessages>"Classes found in the wrong directory"; is:=warning</bnd.fixupmessages>
     <bnd.includeresource>-${.}/NOTICE, -${.}/*.xsd</bnd.includeresource>
 
     <feature.directory>src/main/feature/feature.xml</feature.directory>


### PR DESCRIPTION
This allows bnd to resolve multi release jar files.

A number of people have posted they have troubles adding dependancies on the forum with this error.
`Classes found in the wrong directory: {META-INF/versions/9/module-info.class=module-info}`

Issue about it is here:
https://github.com/bndtools/bnd/issues/2227

An alternative fix is to add the following into each bindings pom.xml

```
  <properties>
    <bnd.fixupmessages>"Classes found in the wrong directory"; is:=warning</bnd.fixupmessages>
  </properties>
```

Not sure what the correct way to handle this is but these are two ways I have tested. The suggested way will mean any future people wont hit the error and can spend more time coding.

Signed-off-by: Matthew Skinner <matt@pcmus.com>