### PR TITLE
[mielecloud] Increase timeout for integration tests

### DIFF
--- a/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
+++ b/itests/org.openhab.binding.mielecloud.tests/src/main/java/org/openhab/binding/mielecloud/internal/handler/AbstractMieleThingHandlerTest.java
@@ -129,6 +129,12 @@ public abstract class AbstractMieleThingHandlerTest extends JavaOSGiTest {
         return Objects.requireNonNull(itemRegistry);
     }
 
+    @Override
+    protected void waitForAssert(Runnable assertion) {
+        // Use a larger timeout to avoid test failures in the CI build.
+        waitForAssert(assertion, 2 * DFL_TIMEOUT, 2 * DFL_SLEEP_TIME);
+    }
+
     private void setUpThingRegistry() {
         thingRegistry = getService(ThingRegistry.class, ThingRegistry.class);
         assertNotNull(thingRegistry, "Thing registry is missing");


### PR DESCRIPTION
Increases the integration test timeout to avoid failures in the CI build, see #11283.