### PR TITLE
[mail] Add support for e-mail headers

### DIFF
--- a/bundles/org.openhab.binding.mail/README.md
+++ b/bundles/org.openhab.binding.mail/README.md
@@ -127,3 +127,23 @@ val List<String> attachmentUrlList = newArrayList(
 val mailActions = getActions("mail","mail:smtp:sampleserver")
 mailActions.sendHtmlMail("mail@example.com", "Test subject", "<h1>Header</h1>This is the mail content.", attachmentUrlList)
 ```
+
+## Mail Headers
+
+The binding allows one to add custom e-mail headers to messages that it sends.
+For example if you want e-mails sent by this binding to be grouped into a "threaded view" in your email client, you must provide an e-mail "Reference" header, which acts as the key for grouping messages together.
+Headers can be added inside a rule by calling the `mailActions.addHeader()` method before calling the respective `mailActions.sendMail()` method.
+See the example below.
+
+```
+rule "Send Mail with a 'Reference' header; for threaded view in e-mail client"
+when
+    ...
+then
+    val mailActions = getActions("mail","mail:smtp:sampleserver")
+    mailActions.addHeader("Reference", "<unique-thread-identifier>")
+    mailActions.sendMail("mail@example.com", "Test subject", "Test message text")
+end
+```
+
+Note: in the case of the "Reference" header, the `<unique-thread-identifier>` has to be an ASCII string enclosed in angle brackets.

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/MailBuilder.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/MailBuilder.java
@@ -17,7 +17,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.activation.FileDataSource;
 import javax.mail.internet.AddressException;
@@ -47,6 +49,7 @@ public class MailBuilder {
     private String subject = "(no subject)";
     private String text = "";
     private String html = "";
+    private Map<String, String> headers = new HashMap<>();
 
     /**
      * Create a new MailBuilder
@@ -137,6 +140,11 @@ public class MailBuilder {
         return this;
     }
 
+    public MailBuilder addHeader(String name, String value) {
+        headers.put(name, value);
+        return this;
+    }
+
     /**
      * Build the Mail
      *
@@ -197,6 +205,8 @@ public class MailBuilder {
         if (!sender.isEmpty()) {
             mail.setFrom(sender);
         }
+
+        headers.forEach((name, value) -> mail.addHeader(name, value));
 
         return mail;
     }

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/MailBuilder.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/MailBuilder.java
@@ -140,7 +140,7 @@ public class MailBuilder {
         return this;
     }
 
-    public MailBuilder addHeader(String name, String value) {
+    public MailBuilder withHeader(String name, String value) {
         headers.put(name, value);
         return this;
     }

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
@@ -14,7 +14,9 @@ package org.openhab.binding.mail.internal.action;
 
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.mail.internet.AddressException;
 
@@ -44,6 +46,7 @@ public class SendMailActions implements ThingActions {
     private final Logger logger = LoggerFactory.getLogger(SendMailActions.class);
 
     private @Nullable SMTPHandler handler;
+    private Map<String, String> headers = new HashMap<>();
 
     @RuleAction(label = "@text/sendMessageActionLabel", description = "@text/sendMessageActionDescription")
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean sendMail(
@@ -89,6 +92,8 @@ public class SendMailActions implements ThingActions {
                     builder.withURLAttachment(urlString);
                 }
             }
+
+            headers.forEach((name, value) -> builder.addHeader(name, value));
 
             final SMTPHandler handler = this.handler;
             if (handler == null) {
@@ -167,6 +172,8 @@ public class SendMailActions implements ThingActions {
                 }
             }
 
+            headers.forEach((name, value) -> builder.addHeader(name, value));
+
             final SMTPHandler handler = this.handler;
             if (handler == null) {
                 logger.warn("Handler is null, cannot send mail.");
@@ -209,5 +216,19 @@ public class SendMailActions implements ThingActions {
     @Override
     public @Nullable ThingHandler getThingHandler() {
         return handler;
+    }
+
+    @RuleAction(label = "@text/addHeaderActionLabel", description = "@text/addHeaderActionDescription")
+    public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean addHeader(
+            @ActionInput(name = "name") @Nullable String name, @ActionInput(name = "value") @Nullable String value) {
+        if (name != null && !name.isEmpty()) {
+            if (value != null && !value.isEmpty()) {
+                headers.put(name, value);
+            } else {
+                headers.remove(name);
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
+++ b/bundles/org.openhab.binding.mail/src/main/java/org/openhab/binding/mail/internal/action/SendMailActions.java
@@ -93,7 +93,7 @@ public class SendMailActions implements ThingActions {
                 }
             }
 
-            headers.forEach((name, value) -> builder.addHeader(name, value));
+            headers.forEach((name, value) -> builder.withHeader(name, value));
 
             final SMTPHandler handler = this.handler;
             if (handler == null) {
@@ -172,7 +172,7 @@ public class SendMailActions implements ThingActions {
                 }
             }
 
-            headers.forEach((name, value) -> builder.addHeader(name, value));
+            headers.forEach((name, value) -> builder.withHeader(name, value));
 
             final SMTPHandler handler = this.handler;
             if (handler == null) {
@@ -230,5 +230,9 @@ public class SendMailActions implements ThingActions {
             return true;
         }
         return false;
+    }
+
+    public static boolean addHeader(ThingActions actions, @Nullable String name, @Nullable String value) {
+        return ((SendMailActions) actions).addHeader(name, value);
     }
 }

--- a/bundles/org.openhab.binding.mail/src/main/resources/OH-INF/i18n/mail.properties
+++ b/bundles/org.openhab.binding.mail/src/main/resources/OH-INF/i18n/mail.properties
@@ -16,3 +16,6 @@ sendHTMLAttachmentMessageActionDescription = Sends a HTML mail with an URL attac
 
 sendHTMLAttachmentsMessageActionLabel = send a HTML mail with several attachments
 sendHTMLAttachmentsMessageActionDescription = Sends a HTML mail with several URL attachments.
+
+addHeaderActionLabel = add a mail header
+addHeaderActionDescription = Adds a mail header to the mail message.

--- a/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
+++ b/bundles/org.openhab.binding.mail/src/test/java/org/openhab/binding/mail/MailBuilderTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Map;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
@@ -40,6 +41,11 @@ public class MailBuilderTest {
 
     private static final String TEST_STRING = "test";
     private static final String TEST_EMAIL = "foo@bar.zinga";
+
+    private static final String HEADER_1_KEY = "key_one";
+    private static final String HEADER_1_VAL = "value_one";
+    private static final String HEADER_2_KEY = "key_two";
+    private static final String HEADER_2_VAL = "value_two";
 
     @Test
     public void illegalToAddressThrowsException() {
@@ -90,5 +96,17 @@ public class MailBuilderTest {
 
         assertEquals(TEST_EMAIL, builder.build().getToAddresses().get(0).getAddress());
         assertEquals(2, builder.withRecipients(TEST_EMAIL).build().getToAddresses().size());
+    }
+
+    @Test
+    public void withHeaders() throws EmailException, MessagingException, IOException {
+        MailBuilder builder = new MailBuilder(TEST_EMAIL);
+        Email mail = builder.withHeader(HEADER_1_KEY, HEADER_1_VAL).withHeader(HEADER_2_KEY, HEADER_2_VAL).build();
+
+        Map<String, String> headers = mail.getHeaders();
+
+        assertEquals(2, headers.size());
+        assertEquals(HEADER_2_VAL, headers.get(HEADER_2_KEY));
+        assertEquals(HEADER_1_VAL, headers.get(HEADER_1_KEY));
     }
 }


### PR DESCRIPTION
**Background**
Previously e-mails sent by this binding could not be grouped into a "threaded view" in the user's email client, because the binding could not provide an e-mail "Reference" header (which is the key for message threading).

**Solution**
This PR allows one to (optionally) add e-mail headers such as, but not limited to, the "Reference" header.

**Example Rule**
```
rule "Send Mail with a Reference Header"
when
    ...
then
    val mailer = getActions("mail","mail:smtp:xyz")
    mailer.addHeader("Reference", "<unique-thread-identifier>")
    mailer.sendMail("joe@abc.com", "message-subject", "message-text")
end
```
Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
