### PR TITLE
[lifx] Add channels for controlling absolute color temperature in Kelvin

### DIFF
--- a/bundles/org.openhab.binding.lifx/README.md
+++ b/bundles/org.openhab.binding.lifx/README.md
@@ -43,14 +43,14 @@ The following table lists the thing types of the supported LIFX devices:
 The thing type determines the capability of a device and with that the possible ways of interacting with it.
 The following matrix lists the capabilities (channels) for each type:
 
-| Thing Type    | On/Off | Brightness | Color | Color Zone | Color Temperature | Color Temperature Zone | HEV Cycle | Infrared | Tile Effects |
-|---------------|:------:|:----------:|:-----:|:----------:|:-----------------:|:----------------------:|:---------:|:--------:|:------------:|
-| colorlight    |    X   |            |   X   |            |         X         |                        |           |          |              |
-| colorhevlight |    X   |            |   X   |            |         X         |                        |     X     |          |              |
-| colorirlight  |    X   |            |   X   |            |         X         |                        |           |     X    |              |
-| colormzlight  |    X   |            |   X   |      X     |         X         |            X           |           |          |              |
-| tilelight     |    X   |      X     |   X   |            |         X         |                        |           |          |       X      |
-| whitelight    |    X   |      X     |       |            |         X         |                        |           |          |              |
+| Thing Type    | On/Off | Brightness | Color | Color Zone | (Abs) Color Temperature | (Abs) Color Temperature Zone | HEV Cycle | Infrared | Tile Effects |
+|---------------|:------:|:----------:|:-----:|:----------:|:-----------------------:|:----------------------------:|:---------:|:--------:|:------------:|
+| colorlight    |    X   |            |   X   |            |            X            |                              |           |          |              |
+| colorhevlight |    X   |            |   X   |            |            X            |                              |     X     |          |              |
+| colorirlight  |    X   |            |   X   |            |            X            |                              |           |     X    |              |
+| colormzlight  |    X   |            |   X   |      X     |            X            |               X              |           |          |              |
+| tilelight     |    X   |      X     |   X   |            |            X            |                              |           |          |       X      |
+| whitelight    |    X   |      X     |       |            |            X            |                              |           |          |              |
 
 ## Discovery
 
@@ -85,17 +85,19 @@ Thing lifx:colorirlight:porch [ host="10.120.130.4", fadetime=0 ]
 
 All devices support some of the following channels:
 
-| Channel Type ID | Item Type | Description                                                                                                                                                      | Thing Types                                                                  |
-|-----------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| brightness      | Dimmer    | This channel supports adjusting the brightness value.                                                                                                            | whitelight                                                                   |
-| color           | Color     | This channel supports full color control with hue, saturation and brightness values.                                                                             | colorlight, colorhevlight, colorirlight, colormzlight, tilelight             |
-| colorzone       | Color     | This channel supports full zone color control with hue, saturation and brightness values.                                                                        | colormzlight                                                                 |
-| effect          | String    | This channel represents a type of light effect (e.g. for tile light: off, morph, flame)                                                                          | tilelight                                                                    |
-| hevcycle        | Switch    | This channel supports starting and stopping the HEV clean cycle.                                                                                                 | colorhevlight                                                                |
-| infrared        | Dimmer    | This channel supports adjusting the infrared value. *Note:* IR capable lights only activate their infrared LEDs when the brightness drops below a certain level. | colorirlight                                                                 |
-| signalstrength  | Number    | This channel represents signal strength with values 0, 1, 2, 3 or 4; 0 being worst strength and 4 being best strength.                                           | colorlight, colorhevlight, colorirlight, colormzlight, tilelight, whitelight |
-| temperature     | Dimmer    | This channel supports adjusting the color temperature from cold (0%) to warm (100%).                                                                             | colorlight, colorhevlight, colorirlight, colormzlight, tilelight, whitelight |
-| temperaturezone | Dimmer    | This channel supports adjusting the zone color temperature from cold (0%) to warm (100%).                                                                        | colormzlight                                                                 |
+| Channel Type ID    | Item Type | Description                                                                                                                                                      | Thing Types                                                                  |
+|--------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| abstemperature     | Number    | This channel supports adjusting the color temperature in Kelvin.                                                                                                 | colorlight, colorhevlight, colorirlight, colormzlight, tilelight, whitelight |
+| abstemperaturezone | Number    | This channel supports adjusting the zone color temperature in Kelvin.                                                                                            | colormzlight                                                                 |
+| brightness         | Dimmer    | This channel supports adjusting the brightness value.                                                                                                            | whitelight                                                                   |
+| color              | Color     | This channel supports full color control with hue, saturation and brightness values.                                                                             | colorlight, colorhevlight, colorirlight, colormzlight, tilelight             |
+| colorzone          | Color     | This channel supports full zone color control with hue, saturation and brightness values.                                                                        | colormzlight                                                                 |
+| effect             | String    | This channel represents a type of light effect (e.g. for tile light: off, morph, flame)                                                                          | tilelight                                                                    |
+| hevcycle           | Switch    | This channel supports starting and stopping the HEV clean cycle.                                                                                                 | colorhevlight                                                                |
+| infrared           | Dimmer    | This channel supports adjusting the infrared value. *Note:* IR capable lights only activate their infrared LEDs when the brightness drops below a certain level. | colorirlight                                                                 |
+| signalstrength     | Number    | This channel represents signal strength with values 0, 1, 2, 3 or 4; 0 being worst strength and 4 being best strength.                                           | colorlight, colorhevlight, colorirlight, colormzlight, tilelight, whitelight |
+| temperature        | Dimmer    | This channel supports adjusting the color temperature from cold (0%) to warm (100%).                                                                             | colorlight, colorhevlight, colorirlight, colormzlight, tilelight, whitelight |
+| temperaturezone    | Dimmer    | This channel supports adjusting the zone color temperature from cold (0%) to warm (100%).                                                                        | colormzlight                                                                 |
 
 The *color* and *brightness* channels have a "Power On Brightness" configuration option that is used to determine the brightness when a light is switched on.
 When it is left empty, the brightness of a light remains unchanged when a light is switched on or off.
@@ -107,9 +109,9 @@ If both "Power on brightness" and "Power On Color" configuration options are def
 
 The *temperature* channels have a "Power On Temperature" configuration option that is used to determine the color temperature when a light is switched on. When it is left empty, the color temperature of a light remains unchanged when a light is switched on or off.
 
-MultiZone lights (*colormzlight*) have several channels (e.g. *colorzone0*, *temperaturezone0*, etc.) that allow for controlling specific zones of the light.
-Changing the *color* and *temperature* channels will update the states of all zones.
-The *color* and *temperature* channels of MultiZone lights always return the same state as *colorzone0*, *temperaturezone0*.
+MultiZone lights (*colormzlight*) have several channels (e.g. *colorzone0*, *temperaturezone0*, *abstemperaturezone0*, etc.) that allow for controlling specific zones of the light.
+Changing the *color*, *temperature* and *abstemperature* channels will update the states of all zones.
+The *color*, *temperature* and *abstemperature* channels of MultiZone lights always return the same state as *colorzone0*, *temperaturezone0*, *abstemperaturezone0*.
 
 The *hevcycle* channels have an optional "HEV Cycle Duration" configuration option that can be used to override the cycle duration configured in the light. 
 
@@ -174,36 +176,44 @@ Thing lifx:whitelight:kitchen [ deviceId="D073D5D4D4D4", fadetime=150 ]
 // Living
 Color Living_Color { channel="lifx:colorlight:living:color" }
 Dimmer Living_Temperature { channel="lifx:colorlight:living:temperature" }
+Number Living_Abs_Temperature { channel="lifx:colorlight:living:abstemperature" }
 
 // Living2 (alternative approach)
 Color Living2_Color { channel="lifx:colorlight:living2:color" }
 Switch Living2_Switch { channel="lifx:colorlight:living2:color" }
 Dimmer Living2_Dimmer { channel="lifx:colorlight:living2:color" }
 Dimmer Living2_Temperature { channel="lifx:colorlight:living2:temperature" }
+Number Living2_Abs_Temperature { channel="lifx:colorlight:living2:abstemperature" }
 
 // Desk
 Color Desk_Color { channel="lifx:colorhevlight:desk:color" }
 Dimmer Desk_Temperature { channel="lifx:colorhevlight:desk:temperature" }
+Number Desk_Abs_Temperature { channel="lifx:colorhevlight:desk:abstemperature" }
 Switch Desk_HEV_Cycle { channel="lifx:colorhevlight:desk:hevcycle" }
 
 // Porch
 Color Porch_Color { channel="lifx:colorirlight:porch:color" }
 Dimmer Porch_Infrared { channel="lifx:colorirlight:porch:infrared" }
 Dimmer Porch_Temperature { channel="lifx:colorirlight:porch:temperature" }
+Number Porch_Abs_Temperature { channel="lifx:colorirlight:porch:abstemperature" }
 Number Porch_Signal_Strength { channel="lifx:colorirlight:porch:signalstrength" }
 
 // Ceiling
 Color Ceiling_Color { channel="lifx:colormzlight:ceiling:color" }
 Dimmer Ceiling_Temperature { channel="lifx:colormzlight:ceiling:temperature" }
+Number Ceiling_Abs_Temperature { channel="lifx:colormzlight:ceiling:abstemperature" }
 Color Ceiling_Color_Zone_0 { channel="lifx:colormzlight:ceiling:colorzone0" }
 Dimmer Ceiling_Temperature_Zone_0 { channel="lifx:colormzlight:ceiling:temperaturezone0" }
+Number Ceiling_Abs_Temperature_Zone_0 { channel="lifx:colormzlight:ceiling:abstemperaturezone0" }
 Color Ceiling_Color_Zone_15 { channel="lifx:colormzlight:ceiling:colorzone15" }
 Dimmer Ceiling_Temperature_Zone_15 { channel="lifx:colormzlight:ceiling:temperaturezone15" }
+Number Ceiling_Abs_Temperature_Zone_15 { channel="lifx:colormzlight:ceiling:abstemperaturezone15" }
 
 // Kitchen
 Switch Kitchen_Toggle { channel="lifx:whitelight:kichen:brightness" }
 Dimmer Kitchen_Brightness { channel="lifx:whitelight:kitchen:brightness" }
 Dimmer Kitchen_Temperature { channel="lifx:whitelight:kitchen:temperature" }
+Number Kitchen_Abs_Temperature { channel="lifx:whitelight:kitchen:abstemperature" }
 ```
 
 ### demo.sitemap:
@@ -216,6 +226,7 @@ sitemap demo label="Main Menu"
         Slider item=Living_Color
         Colorpicker item=Living_Color
         Slider item=Living_Temperature
+        Slider item=Living_Abs_Temperature
     }
 
     Frame label="Living2" {
@@ -223,6 +234,7 @@ sitemap demo label="Main Menu"
         Slider item=Living2_Dimmer
         Colorpicker item=Living2_Color
         Slider item=Living2_Temperature
+        Slider item=Living2_Abs_Temperature
     }
 
     Frame label="Desk" {
@@ -230,6 +242,7 @@ sitemap demo label="Main Menu"
         Slider item=Desk_Color
         Colorpicker item=Desk_Color
         Slider item=Desk_Temperature
+        Slider item=Desk_Abs_Temperature
         Switch item=Desk_HEV_Cycle
     }
 
@@ -238,6 +251,7 @@ sitemap demo label="Main Menu"
         Slider item=Porch_Color
         Colorpicker item=Porch_Color
         Slider item=Porch_Temperature
+        Slider item=Porch_Abs_Temperature
         Slider item=Porch_Infrared
         Text item=Porch_Signal_Strength
     }
@@ -247,16 +261,20 @@ sitemap demo label="Main Menu"
         Slider item=Ceiling_Color
         Colorpicker item=Ceiling_Color
         Slider item=Ceiling_Temperature
+        Slider item=Ceiling_Abs_Temperature
         Colorpicker item=Ceiling_Color_Zone_0
         Slider item=Ceiling_Temperature_Zone_0
+        Slider item=Ceiling_Abs_Temperature_Zone_0
         Colorpicker item=Ceiling_Color_Zone_15
         Slider item=Ceiling_Temperature_Zone_15
+        Slider item=Ceiling_Abs_Temperature_Zone_15
     }
 
     Frame label="Kitchen" {
         Switch item=Kitchen_Toggle
         Slider item=Kitchen_Brightness
         Slider item=Kitchen_Temperature
+        Slider item=Kitchen_Abs_Temperature
     }
 }
 ```

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxBindingConstants.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxBindingConstants.java
@@ -62,19 +62,12 @@ public class LifxBindingConstants {
     public static final String CHANNEL_TEMPERATURE_ZONE = "temperaturezone";
 
     // List of all Channel Type UIDs
-    public static final ChannelTypeUID CHANNEL_TYPE_ABS_TEMPERATURE = new ChannelTypeUID(BINDING_ID,
-            CHANNEL_ABS_TEMPERATURE);
-    public static final ChannelTypeUID CHANNEL_TYPE_ABS_TEMPERATURE_ZONE = new ChannelTypeUID(BINDING_ID,
-            CHANNEL_ABS_TEMPERATURE_ZONE);
     public static final ChannelTypeUID CHANNEL_TYPE_BRIGHTNESS = new ChannelTypeUID(BINDING_ID, CHANNEL_BRIGHTNESS);
     public static final ChannelTypeUID CHANNEL_TYPE_COLOR = new ChannelTypeUID(BINDING_ID, CHANNEL_COLOR);
-    public static final ChannelTypeUID CHANNEL_TYPE_COLOR_ZONE = new ChannelTypeUID(BINDING_ID, CHANNEL_COLOR_ZONE);
     public static final ChannelTypeUID CHANNEL_TYPE_EFFECT = new ChannelTypeUID(BINDING_ID, CHANNEL_EFFECT);
     public static final ChannelTypeUID CHANNEL_TYPE_HEV_CYCLE = new ChannelTypeUID(BINDING_ID, CHANNEL_HEV_CYCLE);
     public static final ChannelTypeUID CHANNEL_TYPE_INFRARED = new ChannelTypeUID(BINDING_ID, CHANNEL_INFRARED);
     public static final ChannelTypeUID CHANNEL_TYPE_TEMPERATURE = new ChannelTypeUID(BINDING_ID, CHANNEL_TEMPERATURE);
-    public static final ChannelTypeUID CHANNEL_TYPE_TEMPERATURE_ZONE = new ChannelTypeUID(BINDING_ID,
-            CHANNEL_TEMPERATURE_ZONE);
 
     // List of options for effect channel
     public static final String CHANNEL_TYPE_EFFECT_OPTION_OFF = "off";

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxBindingConstants.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxBindingConstants.java
@@ -49,6 +49,8 @@ public class LifxBindingConstants {
     public static final PercentType DEFAULT_BRIGHTNESS = PercentType.HUNDRED;
 
     // List of all Channel IDs
+    public static final String CHANNEL_ABS_TEMPERATURE = "abstemperature";
+    public static final String CHANNEL_ABS_TEMPERATURE_ZONE = "abstemperaturezone";
     public static final String CHANNEL_BRIGHTNESS = "brightness";
     public static final String CHANNEL_COLOR = "color";
     public static final String CHANNEL_COLOR_ZONE = "colorzone";
@@ -60,10 +62,15 @@ public class LifxBindingConstants {
     public static final String CHANNEL_TEMPERATURE_ZONE = "temperaturezone";
 
     // List of all Channel Type UIDs
+    public static final ChannelTypeUID CHANNEL_TYPE_ABS_TEMPERATURE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_ABS_TEMPERATURE);
+    public static final ChannelTypeUID CHANNEL_TYPE_ABS_TEMPERATURE_ZONE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_ABS_TEMPERATURE_ZONE);
     public static final ChannelTypeUID CHANNEL_TYPE_BRIGHTNESS = new ChannelTypeUID(BINDING_ID, CHANNEL_BRIGHTNESS);
     public static final ChannelTypeUID CHANNEL_TYPE_COLOR = new ChannelTypeUID(BINDING_ID, CHANNEL_COLOR);
     public static final ChannelTypeUID CHANNEL_TYPE_COLOR_ZONE = new ChannelTypeUID(BINDING_ID, CHANNEL_COLOR_ZONE);
     public static final ChannelTypeUID CHANNEL_TYPE_EFFECT = new ChannelTypeUID(BINDING_ID, CHANNEL_EFFECT);
+    public static final ChannelTypeUID CHANNEL_TYPE_HEV_CYCLE = new ChannelTypeUID(BINDING_ID, CHANNEL_HEV_CYCLE);
     public static final ChannelTypeUID CHANNEL_TYPE_INFRARED = new ChannelTypeUID(BINDING_ID, CHANNEL_INFRARED);
     public static final ChannelTypeUID CHANNEL_TYPE_TEMPERATURE = new ChannelTypeUID(BINDING_ID, CHANNEL_TEMPERATURE);
     public static final ChannelTypeUID CHANNEL_TYPE_TEMPERATURE_ZONE = new ChannelTypeUID(BINDING_ID,

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactory.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactory.java
@@ -24,6 +24,8 @@ import org.openhab.core.thing.ThingUID;
 @NonNullByDefault
 public interface LifxChannelFactory {
 
+    Channel createAbsTemperatureZoneChannel(ThingUID thingUID, int index);
+
     Channel createColorZoneChannel(ThingUID thingUID, int index);
 
     Channel createTemperatureZoneChannel(ThingUID thingUID, int index);

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactoryImpl.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactoryImpl.java
@@ -14,23 +14,14 @@ package org.openhab.binding.lifx.internal;
 
 import static org.openhab.binding.lifx.internal.LifxBindingConstants.*;
 
-import java.util.Locale;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.i18n.LocaleProvider;
-import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.DefaultSystemChannelTypeProvider;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
-import org.osgi.framework.Bundle;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link LifxChannelFactoryImpl} creates dynamic LIFX channels.
@@ -41,83 +32,22 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = LifxChannelFactory.class)
 public class LifxChannelFactoryImpl implements LifxChannelFactory {
 
-    private static final String ABS_TEMPERATURE_ZONE_LABEL_KEY = "channel-type.lifx.abstemperaturezone.label";
-    private static final String ABS_TEMPERATURE_ZONE_DESCRIPTION_KEY = "channel-type.lifx.abstemperaturezone.description";
-
-    private static final String COLOR_ZONE_LABEL_KEY = "channel-type.lifx.colorzone.label";
-    private static final String COLOR_ZONE_DESCRIPTION_KEY = "channel-type.lifx.colorzone.description";
-
-    private static final String TEMPERATURE_ZONE_LABEL_KEY = "channel-type.lifx.temperaturezone.label";
-    private static final String TEMPERATURE_ZONE_DESCRIPTION_KEY = "channel-type.lifx.temperaturezone.description";
-
-    private @NonNullByDefault({}) Bundle bundle;
-    private @NonNullByDefault({}) TranslationProvider i18nProvider;
-    private @NonNullByDefault({}) LocaleProvider localeProvider;
-
     @Override
     public Channel createAbsTemperatureZoneChannel(ThingUID thingUID, int index) {
-        String label = getText(ABS_TEMPERATURE_ZONE_LABEL_KEY, index);
-        String description = getText(ABS_TEMPERATURE_ZONE_DESCRIPTION_KEY, index);
         return ChannelBuilder
                 .create(new ChannelUID(thingUID, CHANNEL_ABS_TEMPERATURE_ZONE + index), CoreItemFactory.NUMBER)
-                .withType(CHANNEL_TYPE_ABS_TEMPERATURE_ZONE).withLabel(label).withDescription(description).build();
+                .withType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS).build();
     }
 
     @Override
     public Channel createColorZoneChannel(ThingUID thingUID, int index) {
-        String label = getText(COLOR_ZONE_LABEL_KEY, index);
-        String description = getText(COLOR_ZONE_DESCRIPTION_KEY, index);
         return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_COLOR_ZONE + index), CoreItemFactory.COLOR)
-                .withType(CHANNEL_TYPE_COLOR_ZONE).withLabel(label).withDescription(description).build();
+                .withType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_COLOR).build();
     }
 
     @Override
     public Channel createTemperatureZoneChannel(ThingUID thingUID, int index) {
-        String label = getText(TEMPERATURE_ZONE_LABEL_KEY, index);
-        String description = getText(TEMPERATURE_ZONE_DESCRIPTION_KEY, index);
         return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_TEMPERATURE_ZONE + index), CoreItemFactory.DIMMER)
-                .withType(CHANNEL_TYPE_TEMPERATURE_ZONE).withLabel(label).withDescription(description).build();
-    }
-
-    private @Nullable String getDefaultText(String key) {
-        return i18nProvider.getText(bundle, key, key, Locale.ENGLISH);
-    }
-
-    private String getText(String key, Object... arguments) {
-        Locale locale = localeProvider != null ? localeProvider.getLocale() : Locale.ENGLISH;
-        if (i18nProvider == null) {
-            return key;
-        }
-
-        String text = i18nProvider.getText(bundle, key, getDefaultText(key), locale, arguments);
-        return text != null ? text : key;
-    }
-
-    @Activate
-    protected void activate(ComponentContext componentContext) {
-        this.bundle = componentContext.getBundleContext().getBundle();
-    }
-
-    @Deactivate
-    protected void deactivate(ComponentContext componentContext) {
-        this.bundle = null;
-    }
-
-    @Reference
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = i18nProvider;
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = null;
-    }
-
-    @Reference
-    protected void setLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
-    }
-
-    protected void unsetLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = null;
+                .withType(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE).build();
     }
 }

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactoryImpl.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/LifxChannelFactoryImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingUID;
@@ -40,6 +41,9 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = LifxChannelFactory.class)
 public class LifxChannelFactoryImpl implements LifxChannelFactory {
 
+    private static final String ABS_TEMPERATURE_ZONE_LABEL_KEY = "channel-type.lifx.abstemperaturezone.label";
+    private static final String ABS_TEMPERATURE_ZONE_DESCRIPTION_KEY = "channel-type.lifx.abstemperaturezone.description";
+
     private static final String COLOR_ZONE_LABEL_KEY = "channel-type.lifx.colorzone.label";
     private static final String COLOR_ZONE_DESCRIPTION_KEY = "channel-type.lifx.colorzone.description";
 
@@ -51,10 +55,19 @@ public class LifxChannelFactoryImpl implements LifxChannelFactory {
     private @NonNullByDefault({}) LocaleProvider localeProvider;
 
     @Override
+    public Channel createAbsTemperatureZoneChannel(ThingUID thingUID, int index) {
+        String label = getText(ABS_TEMPERATURE_ZONE_LABEL_KEY, index);
+        String description = getText(ABS_TEMPERATURE_ZONE_DESCRIPTION_KEY, index);
+        return ChannelBuilder
+                .create(new ChannelUID(thingUID, CHANNEL_ABS_TEMPERATURE_ZONE + index), CoreItemFactory.NUMBER)
+                .withType(CHANNEL_TYPE_ABS_TEMPERATURE_ZONE).withLabel(label).withDescription(description).build();
+    }
+
+    @Override
     public Channel createColorZoneChannel(ThingUID thingUID, int index) {
         String label = getText(COLOR_ZONE_LABEL_KEY, index);
         String description = getText(COLOR_ZONE_DESCRIPTION_KEY, index);
-        return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_COLOR_ZONE + index), "Color")
+        return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_COLOR_ZONE + index), CoreItemFactory.COLOR)
                 .withType(CHANNEL_TYPE_COLOR_ZONE).withLabel(label).withDescription(description).build();
     }
 
@@ -62,7 +75,7 @@ public class LifxChannelFactoryImpl implements LifxChannelFactory {
     public Channel createTemperatureZoneChannel(ThingUID thingUID, int index) {
         String label = getText(TEMPERATURE_ZONE_LABEL_KEY, index);
         String description = getText(TEMPERATURE_ZONE_DESCRIPTION_KEY, index);
-        return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_TEMPERATURE_ZONE + index), "Dimmer")
+        return ChannelBuilder.create(new ChannelUID(thingUID, CHANNEL_TEMPERATURE_ZONE + index), CoreItemFactory.DIMMER)
                 .withType(CHANNEL_TYPE_TEMPERATURE_ZONE).withLabel(label).withDescription(description).build();
     }
 

--- a/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxMessageUtil.java
+++ b/bundles/org.openhab.binding.lifx/src/main/java/org/openhab/binding/lifx/internal/util/LifxMessageUtil.java
@@ -102,6 +102,16 @@ public final class LifxMessageUtil {
         return new PercentType(value);
     }
 
+    public static int commandToKelvin(DecimalType temperature, TemperatureRange temperatureRange) {
+        return temperature instanceof PercentType ? percentTypeToKelvin((PercentType) temperature, temperatureRange)
+                : decimalTypeToKelvin(temperature, temperatureRange);
+    }
+
+    public static int decimalTypeToKelvin(DecimalType temperature, TemperatureRange temperatureRange) {
+        return Math.round(Math.min(Math.max(temperature.intValue(), temperatureRange.getMinimum()),
+                temperatureRange.getMaximum()));
+    }
+
     public static int percentTypeToKelvin(PercentType temperature, TemperatureRange temperatureRange) {
         return Math.round(
                 temperatureRange.getMaximum() - (temperature.floatValue() * (temperatureRange.getRange() / 100)));

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx.properties
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx.properties
@@ -19,29 +19,21 @@ thing-type.config.lifx.light.fadetime.label = Fade Time
 thing-type.config.lifx.light.fadetime.description = The time to fade to the new color value (in ms).
 
 # channel types
-channel-type.lifx.abstemperature.label = Temperature
-channel-type.lifx.abstemperature.description = Sets the color temperature of the light in Kelvin
-channel-type.lifx.abstemperaturezone.label = Temperature Zone {0}
-channel-type.lifx.abstemperaturezone.description = Sets the zone {0} color temperature of the light in Kelvin
 channel-type.lifx.brightness.label = Brightness
-channel-type.lifx.brightness.description = Sets the brightness of the light
+channel-type.lifx.brightness.description = Controls the brightness and switches the light on and off
 channel-type.lifx.color.label = Color
-channel-type.lifx.color.description = Selects the color of the light
-channel-type.lifx.colorzone.label = Color Zone {0}
-channel-type.lifx.colorzone.description = Selects the zone {0} color of the light
+channel-type.lifx.color.description = Controls the color of the light
 channel-type.lifx.effect.label = Effect
-channel-type.lifx.effect.description = Sets the effect of the light
+channel-type.lifx.effect.description = Controls the effect of the light
 channel-type.lifx.effect.state.option.off = Off
 channel-type.lifx.effect.state.option.morph = Morph
 channel-type.lifx.effect.state.option.flame = Flame
 channel-type.lifx.hevcycle.label = HEV Cycle
 channel-type.lifx.hevcycle.description = Controls the HEV clean cycle of the light
 channel-type.lifx.infrared.label = Infrared
-channel-type.lifx.infrared.description = Sets the infrared of the light
-channel-type.lifx.temperature.label = Temperature
-channel-type.lifx.temperature.description = Sets the color temperature of the light from 0 (cold) to 100 (warm)
-channel-type.lifx.temperaturezone.label = Temperature Zone {0}
-channel-type.lifx.temperaturezone.description = Sets the zone {0} color temperature of the light from 0 (cold) to 100 (warm)
+channel-type.lifx.infrared.description = Controls the infrared level of the light
+channel-type.lifx.temperature.label = Color Temperature
+channel-type.lifx.temperature.description = Controls the color temperature of the light from 0 (cold) to 100 (warm)
 
 # channel type configuration
 channel-type.config.lifx.brightness.powerOnBrightness.label = Power On Brightness

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx.properties
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx.properties
@@ -19,6 +19,10 @@ thing-type.config.lifx.light.fadetime.label = Fade Time
 thing-type.config.lifx.light.fadetime.description = The time to fade to the new color value (in ms).
 
 # channel types
+channel-type.lifx.abstemperature.label = Temperature
+channel-type.lifx.abstemperature.description = Sets the color temperature of the light in Kelvin
+channel-type.lifx.abstemperaturezone.label = Temperature Zone {0}
+channel-type.lifx.abstemperaturezone.description = Sets the zone {0} color temperature of the light in Kelvin
 channel-type.lifx.brightness.label = Brightness
 channel-type.lifx.brightness.description = Sets the brightness of the light
 channel-type.lifx.color.label = Color
@@ -35,9 +39,9 @@ channel-type.lifx.hevcycle.description = Controls the HEV clean cycle of the lig
 channel-type.lifx.infrared.label = Infrared
 channel-type.lifx.infrared.description = Sets the infrared of the light
 channel-type.lifx.temperature.label = Temperature
-channel-type.lifx.temperature.description = Sets the temperature of the light
+channel-type.lifx.temperature.description = Sets the color temperature of the light from 0 (cold) to 100 (warm)
 channel-type.lifx.temperaturezone.label = Temperature Zone {0}
-channel-type.lifx.temperaturezone.description = Sets the zone {0} temperature of the light
+channel-type.lifx.temperaturezone.description = Sets the zone {0} color temperature of the light from 0 (cold) to 100 (warm)
 
 # channel type configuration
 channel-type.config.lifx.brightness.powerOnBrightness.label = Power On Brightness

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx_nl.properties
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx_nl.properties
@@ -19,6 +19,10 @@ thing-type.config.lifx.light.fadetime.label = Vervagingsduur
 thing-type.config.lifx.light.fadetime.description = De tijdsduur van het vervagen naar een nieuwe kleur (in ms).
 
 # channel types
+channel-type.lifx.abstemperature.label = Temperatuur
+channel-type.lifx.abstemperature.description = Bepaalt de kleurtemperatuur van de lamp in Kelvin
+channel-type.lifx.abstemperaturezone.label = Temperatuur Zone {0}
+channel-type.lifx.abstemperaturezone.description = Bepaalt de kleurtemperatuur van lampzone {0} in Kelvin
 channel-type.lifx.brightness.label = Helderheid
 channel-type.lifx.brightness.description = Bepaalt de helderheid van de lamp
 channel-type.lifx.color.label = Kleur
@@ -35,9 +39,9 @@ channel-type.lifx.hevcycle.description = Bedient de HEV schoonmaakcylcus van de 
 channel-type.lifx.infrared.label = Infrarood
 channel-type.lifx.infrared.description = Bepaalt het infraroodniveau van de lamp
 channel-type.lifx.temperature.label = Temperatuur
-channel-type.lifx.temperature.description = Bepaalt de kleurtemperatuur van de lamp
+channel-type.lifx.temperature.description = Bepaalt de kleurtemperatuur van de lamp van 0 (koud) naar 100 (warm)
 channel-type.lifx.temperaturezone.label = Temperatuur Zone {0}
-channel-type.lifx.temperaturezone.description = Bepaalt de kleurtemperatuur van lampzone {0}
+channel-type.lifx.temperaturezone.description = Bepaalt de kleurtemperatuur van lampzone {0} van 0 (koud) naar 100 (warm)
 
 # channel type configuration
 channel-type.config.lifx.brightness.powerOnBrightness.label = Inschakelhelderheid

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx_nl.properties
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/i18n/lifx_nl.properties
@@ -19,29 +19,21 @@ thing-type.config.lifx.light.fadetime.label = Vervagingsduur
 thing-type.config.lifx.light.fadetime.description = De tijdsduur van het vervagen naar een nieuwe kleur (in ms).
 
 # channel types
-channel-type.lifx.abstemperature.label = Temperatuur
-channel-type.lifx.abstemperature.description = Bepaalt de kleurtemperatuur van de lamp in Kelvin
-channel-type.lifx.abstemperaturezone.label = Temperatuur Zone {0}
-channel-type.lifx.abstemperaturezone.description = Bepaalt de kleurtemperatuur van lampzone {0} in Kelvin
 channel-type.lifx.brightness.label = Helderheid
-channel-type.lifx.brightness.description = Bepaalt de helderheid van de lamp
+channel-type.lifx.brightness.description = Bepaalt de helderheid en schakelt het licht aan en uit
 channel-type.lifx.color.label = Kleur
-channel-type.lifx.color.description = Bepaalt de kleur van de lamp
-channel-type.lifx.colorzone.label = Kleur Zone {0}
-channel-type.lifx.colorzone.description = Bepaalt de kleur van lampzone {0}
+channel-type.lifx.color.description = Bepaalt de kleur van het licht
 channel-type.lifx.effect.label = Effect
 channel-type.lifx.effect.description = Bepaalt het lichteffect
 channel-type.lifx.effect.state.option.off = Uit
 channel-type.lifx.effect.state.option.morph = Morph
 channel-type.lifx.effect.state.option.flame = Vlam
 channel-type.lifx.hevcycle.label = HEV Cyclus
-channel-type.lifx.hevcycle.description = Bedient de HEV schoonmaakcylcus van de lamp
+channel-type.lifx.hevcycle.description = Bedient de HEV schoonmaakcyclus van de lamp
 channel-type.lifx.infrared.label = Infrarood
 channel-type.lifx.infrared.description = Bepaalt het infraroodniveau van de lamp
-channel-type.lifx.temperature.label = Temperatuur
-channel-type.lifx.temperature.description = Bepaalt de kleurtemperatuur van de lamp van 0 (koud) naar 100 (warm)
-channel-type.lifx.temperaturezone.label = Temperatuur Zone {0}
-channel-type.lifx.temperaturezone.description = Bepaalt de kleurtemperatuur van lampzone {0} van 0 (koud) naar 100 (warm)
+channel-type.lifx.temperature.label = Kleurtemperatuur
+channel-type.lifx.temperature.description = Bepaalt de kleurtemperatuur van het licht van 0 (koud) tot 100 (warm)
 
 # channel type configuration
 channel-type.config.lifx.brightness.powerOnBrightness.label = Inschakelhelderheid

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/channel.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/channel.xml
@@ -4,13 +4,38 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
+	<channel-type id="abstemperature" advanced="true">
+		<item-type>Number</item-type>
+		<label>Temperature</label>
+		<description>Sets the color temperature of the light in Kelvin</description>
+		<category>ColorLight</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>ColorTemperature</tag>
+		</tags>
+		<state min="1500" max="9000" step="1" pattern="%.0f K"/>
+	</channel-type>
+
+	<channel-type id="abstemperaturezone" advanced="true">
+		<item-type>Number</item-type>
+		<label>Temperature Zone</label>
+		<description>Sets the zone color temperature of the light in Kelvin</description>
+		<category>ColorLight</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>ColorTemperature</tag>
+		</tags>
+		<state min="1500" max="9000" step="1" pattern="%.0f K"/>
+	</channel-type>
+
 	<channel-type id="brightness">
 		<item-type>Dimmer</item-type>
 		<label>Brightness</label>
 		<description>Sets the brightness of the light</description>
 		<category>DimmableLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<config-description-ref uri="channel-type:lifx:brightness"/>
 	</channel-type>
@@ -21,7 +46,8 @@
 		<description>Selects the color of the light</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<config-description-ref uri="channel-type:lifx:color"/>
 	</channel-type>
@@ -32,7 +58,8 @@
 		<description>Selects the zone color of the light</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -40,6 +67,10 @@
 		<item-type>Switch</item-type>
 		<label>HEV Cycle</label>
 		<description>Controls the HEV clean cycle of the light</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Light</tag>
+		</tags>
 		<config-description-ref uri="channel-type:lifx:hevcycle"/>
 	</channel-type>
 
@@ -47,27 +78,43 @@
 		<item-type>Dimmer</item-type>
 		<label>Infrared</label>
 		<description>Sets the infrared of the light</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Light</tag>
+		</tags>
 	</channel-type>
 
 	<channel-type id="temperature">
 		<item-type>Dimmer</item-type>
 		<label>Temperature</label>
-		<description>Sets the temperature of the light</description>
+		<description>Sets the color temperature of the light from 0 (cold) to 100 (warm)</description>
 		<category>ColorLight</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>ColorTemperature</tag>
+		</tags>
 		<config-description-ref uri="channel-type:lifx:temperature"/>
 	</channel-type>
 
 	<channel-type id="temperaturezone" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Temperature Zone</label>
-		<description>Sets the zone temperature of the light</description>
+		<description>Sets the zone color temperature of the light from 0 (cold) to 100 (warm)</description>
 		<category>ColorLight</category>
+		<tags>
+			<tag>Control</tag>
+			<tag>ColorTemperature</tag>
+		</tags>
 	</channel-type>
 
 	<channel-type id="effect">
 		<item-type>String</item-type>
 		<label>Effect</label>
 		<description>Sets the effect of the light</description>
+		<tags>
+			<tag>Control</tag>
+			<tag>Light</tag>
+		</tags>
 		<state>
 			<options>
 				<option value="off">Off</option>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/channel.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/channel.xml
@@ -4,34 +4,10 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<channel-type id="abstemperature" advanced="true">
-		<item-type>Number</item-type>
-		<label>Temperature</label>
-		<description>Sets the color temperature of the light in Kelvin</description>
-		<category>ColorLight</category>
-		<tags>
-			<tag>Control</tag>
-			<tag>ColorTemperature</tag>
-		</tags>
-		<state min="1500" max="9000" step="1" pattern="%.0f K"/>
-	</channel-type>
-
-	<channel-type id="abstemperaturezone" advanced="true">
-		<item-type>Number</item-type>
-		<label>Temperature Zone</label>
-		<description>Sets the zone color temperature of the light in Kelvin</description>
-		<category>ColorLight</category>
-		<tags>
-			<tag>Control</tag>
-			<tag>ColorTemperature</tag>
-		</tags>
-		<state min="1500" max="9000" step="1" pattern="%.0f K"/>
-	</channel-type>
-
 	<channel-type id="brightness">
 		<item-type>Dimmer</item-type>
 		<label>Brightness</label>
-		<description>Sets the brightness of the light</description>
+		<description>Controls the brightness and switches the light on and off</description>
 		<category>DimmableLight</category>
 		<tags>
 			<tag>Control</tag>
@@ -43,24 +19,13 @@
 	<channel-type id="color">
 		<item-type>Color</item-type>
 		<label>Color</label>
-		<description>Selects the color of the light</description>
+		<description>Controls the color of the light</description>
 		<category>ColorLight</category>
 		<tags>
 			<tag>Control</tag>
 			<tag>Light</tag>
 		</tags>
 		<config-description-ref uri="channel-type:lifx:color"/>
-	</channel-type>
-
-	<channel-type id="colorzone" advanced="true">
-		<item-type>Color</item-type>
-		<label>Color Zone</label>
-		<description>Selects the zone color of the light</description>
-		<category>ColorLight</category>
-		<tags>
-			<tag>Control</tag>
-			<tag>Light</tag>
-		</tags>
 	</channel-type>
 
 	<channel-type id="hevcycle">
@@ -77,7 +42,7 @@
 	<channel-type id="infrared">
 		<item-type>Dimmer</item-type>
 		<label>Infrared</label>
-		<description>Sets the infrared of the light</description>
+		<description>Controls the infrared level of the light</description>
 		<tags>
 			<tag>Control</tag>
 			<tag>Light</tag>
@@ -86,8 +51,8 @@
 
 	<channel-type id="temperature">
 		<item-type>Dimmer</item-type>
-		<label>Temperature</label>
-		<description>Sets the color temperature of the light from 0 (cold) to 100 (warm)</description>
+		<label>Color Temperature</label>
+		<description>Controls the color temperature of the light from 0 (cold) to 100 (warm)</description>
 		<category>ColorLight</category>
 		<tags>
 			<tag>Control</tag>
@@ -96,21 +61,10 @@
 		<config-description-ref uri="channel-type:lifx:temperature"/>
 	</channel-type>
 
-	<channel-type id="temperaturezone" advanced="true">
-		<item-type>Dimmer</item-type>
-		<label>Temperature Zone</label>
-		<description>Sets the zone color temperature of the light from 0 (cold) to 100 (warm)</description>
-		<category>ColorLight</category>
-		<tags>
-			<tag>Control</tag>
-			<tag>ColorTemperature</tag>
-		</tags>
-	</channel-type>
-
 	<channel-type id="effect">
 		<item-type>String</item-type>
 		<label>Effect</label>
-		<description>Sets the effect of the light</description>
+		<description>Controls the effect of the light</description>
 		<tags>
 			<tag>Control</tag>
 			<tag>Light</tag>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="hevcycle" typeId="hevcycle"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorhevlight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="hevcycle" typeId="hevcycle"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="infrared" typeId="infrared"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorirlight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="infrared" typeId="infrared"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colorlight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/colormzlight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 			<channel id="effect" typeId="effect"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/tilelight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="color" typeId="color"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 			<channel id="effect" typeId="effect"/>
 		</channels>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/whitelight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/whitelight.xml
@@ -9,6 +9,7 @@
 		<channels>
 			<channel id="brightness" typeId="brightness"/>
 			<channel id="temperature" typeId="temperature"/>
+			<channel id="abstemperature" typeId="abstemperature"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>

--- a/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/whitelight.xml
+++ b/bundles/org.openhab.binding.lifx/src/main/resources/OH-INF/thing/whitelight.xml
@@ -9,7 +9,7 @@
 		<channels>
 			<channel id="brightness" typeId="brightness"/>
 			<channel id="temperature" typeId="temperature"/>
-			<channel id="abstemperature" typeId="abstemperature"/>
+			<channel id="abstemperature" typeId="system.color-temperature-abs"/>
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 		</channels>
 		<representation-property>macAddress</representation-property>


### PR DESCRIPTION
Adds an 'abstemperature' channel to all Thing Types for controlling the absolute color temperature in Kelvin.
MultiZone lights also have 'abstemperaturezone' channels that allow for controlling the color temperature of a zone in Kelvin.
These channels make it easier to use the same color temperature with lights that have a different color temperature range.
Furthermore the channel type tags have been updated which simplifies using the generated items with the semantic model.