### PR TITLE
Fix/remove outdated "Default Tags"

### DIFF
--- a/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.danfossairunit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -201,7 +201,8 @@
 		<label>Humidity</label>
 		<category>Humidity</category>
 		<tags>
-			<tag>CurrentHumidity</tag>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
 		</tags>
 		<state pattern="%.0f %%" readOnly="true" min="0" max="100">
 		</state>

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/group-thing-types.xml
@@ -29,7 +29,8 @@
 		<label>All On</label>
 		<description>"On" if all lights in this group are "On", otherwise "Off".</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Status</tag>
+			<tag>Light</tag>
 		</tags>
 		<state readOnly="true"/>
 	</channel-type>
@@ -39,7 +40,8 @@
 		<label>Any On</label>
 		<description>"On" if any light in this group is "On", otherwise "Off".</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Status</tag>
+			<tag>Light</tag>
 		</tags>
 		<state readOnly="true"/>
 	</channel-type>
@@ -48,7 +50,8 @@
 		<item-type>String</item-type>
 		<label>Recall Scene</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
+++ b/bundles/org.openhab.binding.deconz/src/main/resources/OH-INF/thing/light-thing-types.xml
@@ -167,7 +167,8 @@
 		<item-type>String</item-type>
 		<label>Effect Channel</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -175,7 +176,8 @@
 		<item-type>Number</item-type>
 		<label>Effect Speed Channel</label>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<state min="0" max="10" step="1"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.dmx/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.dmx/src/main/resources/OH-INF/thing/channels.xml
@@ -10,7 +10,8 @@
 			channel, the values is used for ALL DMX channels.</description>
 		<category>DimmableLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 	<!-- Color Temperature -->
@@ -20,7 +21,8 @@
 		<description>Relative intensity of two adjacent DMX channels</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 	<!-- Color Channel -->
@@ -31,7 +33,8 @@
 			color will be re-use in 3-channel groups.</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 	<!-- Switch Channel -->

--- a/bundles/org.openhab.binding.feican/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.feican/src/main/resources/OH-INF/thing/channels.xml
@@ -11,7 +11,8 @@
 		</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.homeconnect/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.homeconnect/src/main/resources/OH-INF/thing/thing-types.xml
@@ -758,7 +758,8 @@
 		<description>This setting describes the custom color state of the ambient light.</description>
 		<category>Colorpicker</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<state readOnly="false"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.lghombot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.lghombot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -108,9 +108,6 @@
 		<item-type>Switch</item-type>
 		<label>Clean</label>
 		<description>Start cleaning / return home.</description>
-		<tags>
-			<tag>Switchable</tag>
-		</tags>
 	</channel-type>
 	<channel-type id="startType">
 		<item-type>Switch</item-type>

--- a/bundles/org.openhab.binding.linuxinput/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.linuxinput/src/main/resources/OH-INF/thing/thing-types.xml
@@ -40,9 +40,6 @@
 		<item-type>Switch</item-type>
 		<label>Device Grab</label>
 		<category>Switch</category>
-		<tags>
-			<tag>Switchable</tag>
-		</tags>
 	</channel-type>
 
 	<channel-group-type id="keypresses">

--- a/bundles/org.openhab.binding.mihome/src/main/resources/OH-INF/thing/channel.xml
+++ b/bundles/org.openhab.binding.mihome/src/main/resources/OH-INF/thing/channel.xml
@@ -29,7 +29,8 @@
 			light on and off.</description>
 		<category>DimmableLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<state max="100" min="0" step="1" pattern="%d %%" readOnly="false"></state>
 	</channel-type>
@@ -49,7 +50,8 @@
 		<description>Control the color of light.</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -58,6 +60,7 @@
 		<label>Color Temperature</label>
 		<description>Allows to control the color temperature of light.</description>
 		<tags>
+			<tag>Control</tag>
 			<tag>ColorTemperature</tag>
 		</tags>
 		<state pattern="%d K"/>

--- a/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/channels.xml
@@ -46,8 +46,8 @@
 		</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>ColorLighting</tag>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -57,7 +57,8 @@
 		<description>The brightness can be set in 16 steps for RGBW/White leds and in 64 steps for RGBWW leds</description>
 		<category>Light</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 		<state min="0" max="100" step="1" pattern="%d"></state>
 	</channel-type>

--- a/bundles/org.openhab.binding.millheat/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.millheat/src/main/resources/OH-INF/thing/channels.xml
@@ -9,7 +9,8 @@
 		<label>Current Temperature</label>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
@@ -18,7 +19,8 @@
 		<label>Temperature Comfort Mode</label>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" min="5" max="35" step="1"/>
 	</channel-type>
@@ -27,7 +29,8 @@
 		<label>Temperature Sleep Mode</label>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" min="5" max="35" step="1"/>
 	</channel-type>
@@ -37,7 +40,8 @@
 		<description>Set temperature away mode</description>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" min="5" max="35" step="1"/>
 	</channel-type>
@@ -46,7 +50,8 @@
 		<label>Target Temperature</label>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" min="5" max="35" step="1"/>
 	</channel-type>
@@ -55,7 +60,8 @@
 		<label>Target Temperature</label>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" readOnly="true" min="5" max="35" step="1"/>
 	</channel-type>
@@ -121,7 +127,8 @@
 		<label>Target Temperature Vacation</label>
 		<category>Heating</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%d %unit%" min="5" max="35" step="1"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -225,7 +225,8 @@
 		<description>Temperature measured by thermostat</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
@@ -235,7 +236,8 @@
 		<description>Setpoint temperature of thermostat</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state min="0" max="100" step="0.5" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -11,7 +11,8 @@
 		<description>Switch the power ON and OFF</description>
 		<category>Light</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Switch</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -22,7 +23,8 @@
 		<description>Control the brightness and switch the light ON and OFF</description>
 		<category>DimmableLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -44,7 +46,8 @@
 		<description>Current temperature (read only)</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
@@ -68,7 +71,8 @@
 		<description>Setpoint temperature (read/write)</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state pattern="%.1f %unit%" step="0.5"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.playstation/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.playstation/src/main/resources/OH-INF/thing/thing-types.xml
@@ -47,18 +47,12 @@
 		<item-type>Switch</item-type>
 		<label>PlayStation 3 Power</label>
 		<description>Shows if PlayStation 3 is On or Off.</description>
-		<tags>
-			<tag>Switchable</tag>
-		</tags>
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="power-channel">
 		<item-type>Switch</item-type>
 		<label>PlayStation 4 Power</label>
 		<description>Shows if PlayStation 4 is On or in Standby/Off.</description>
-		<tags>
-			<tag>Switchable</tag>
-		</tags>
 	</channel-type>
 	<channel-type id="application-channel">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.qbus/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.qbus/src/main/resources/OH-INF/thing/thing-types.xml
@@ -175,7 +175,8 @@
 		<description>Temperature Measured by Thermostat</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
@@ -186,7 +187,8 @@
 		<description>Setpoint Temperature of Thermostat</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>TargetTemperature</tag>
+			<tag>Setpoint</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state min="0" max="100" step="0.5" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.sensibo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.sensibo/src/main/resources/OH-INF/thing/channels.xml
@@ -9,7 +9,8 @@
 		<label>Current Temperature</label>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
@@ -18,16 +19,14 @@
 		<label>Current Humidity</label>
 		<category>Humidity</category>
 		<tags>
-			<tag>CurrentHumidity</tag>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 	<channel-type id="masterSwitch">
 		<item-type>Switch</item-type>
 		<label>Master Switch</label>
-		<tags>
-			<tag>Switchable</tag>
-		</tags>
 	</channel-type>
 	<channel-type id="timer">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/device.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/device.xml
@@ -100,7 +100,8 @@
 		<description>Internal device temperature, helps to detect overheating due to installation issues</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.0f %unit%">
 		</state>

--- a/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/sensor.xml
+++ b/bundles/org.openhab.binding.shelly/src/main/resources/OH-INF/thing/sensor.xml
@@ -217,7 +217,8 @@
 		<description>Temperature from the sensor</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
@@ -228,7 +229,8 @@
 		<description>Temperature from the external sensor</description>
 		<category>Temperature</category>
 		<tags>
-			<tag>CurrentTemperature</tag>
+			<tag>Measurement</tag>
+			<tag>Temperature</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
@@ -239,7 +241,8 @@
 		<description>Relative humidity in % (0..100%) from external sensor</description>
 		<category>Humidity</category>
 		<tags>
-			<tag>CurrentHumidity</tag>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%">
 		</state>
@@ -249,7 +252,8 @@
 		<label>Humidity</label>
 		<description>Relative humidity in % (0..100%)</description>
 		<tags>
-			<tag>CurrentHumidity</tag>
+			<tag>Measurement</tag>
+			<tag>Humidity</tag>
 		</tags>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.touchwand/src/main/resources/OH-INF/thing/switch.xml
+++ b/bundles/org.openhab.binding.touchwand/src/main/resources/OH-INF/thing/switch.xml
@@ -22,7 +22,8 @@
 		</description>
 		<category>Light</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Switch</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.wled/src/main/resources/OH-INF/thing/thing-types.xml
@@ -57,7 +57,8 @@
 		<description>Allows you to exit FX mode and use the LEDS like a normal light</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.yeelight/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.yeelight/src/main/resources/OH-INF/thing/channels.xml
@@ -14,7 +14,8 @@
 		</description>
 		<category>DimmableLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -25,7 +26,8 @@
 		<description>The color channel allows to control the color of a light.</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -36,6 +38,7 @@
 		<description>The CT channel allows to control the CT of a light.</description>
 		<category>DimmableCT</category>
 		<tags>
+			<tag>Control</tag>
 			<tag>ColorTemperature</tag>
 		</tags>
 	</channel-type>
@@ -54,7 +57,8 @@
 		<description>The color channel allows to control the color of a light.</description>
 		<category>ColorLight</category>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Control</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 
@@ -64,7 +68,8 @@
 		<description>The nightlight channel allows to switch to nightlight mode.
 		</description>
 		<tags>
-			<tag>Lighting</tag>
+			<tag>Switch</tag>
+			<tag>Light</tag>
 		</tags>
 	</channel-type>
 


### PR DESCRIPTION
There used to be the following "Default Tags" which are no longer used in the current semantic model:

* Lighting
* Switchable
* CurrentTemperature
* TargetTemperature
* CurrentHumidity

See:

* https://www.openhab.org/docs/developer/bindings/thing-xml.html#default-tags
* https://www.openhab.org/docs/tutorial/model.html#semantic-model

---

I also fixed this for the LIFX Binding in https://github.com/openhab/openhab-addons/pull/11309.