### PR TITLE
[Luxtronik] Fix possible out ouf bound error for older heatpumps

### DIFF
--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/HeatpumpConnector.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/HeatpumpConnector.java
@@ -71,7 +71,7 @@ public class HeatpumpConnector {
             // the thermal energies can be unreasonably high in some cases, probably due to a sign bug in the firmware
             // trying to correct this issue here
             for (int i = 151; i <= 154; i++) {
-                if (heatpumpValues.length >= i && heatpumpValues[i] >= 214748364) {
+                if (heatpumpValues.length > i && heatpumpValues[i] >= 214748364) {
                     heatpumpValues[i] -= 214748364;
                 }
             }

--- a/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/HeatpumpConnector.java
+++ b/bundles/org.openhab.binding.luxtronikheatpump/src/main/java/org/openhab/binding/luxtronikheatpump/internal/HeatpumpConnector.java
@@ -71,7 +71,7 @@ public class HeatpumpConnector {
             // the thermal energies can be unreasonably high in some cases, probably due to a sign bug in the firmware
             // trying to correct this issue here
             for (int i = 151; i <= 154; i++) {
-                if (heatpumpValues[i] >= 214748364) {
+                if (heatpumpValues.length >= i && heatpumpValues[i] >= 214748364) {
                     heatpumpValues[i] -= 214748364;
                 }
             }


### PR DESCRIPTION
As reported on the forum some older heatpumps seem to serve less than 154 socket channels, causing a out of bounds error.

See https://community.openhab.org/t/migration-of-novelan-luxtronic-binding-to-openhab2/70743/132?u=sgiehl