### PR TITLE
[nikohomecontrol] Prepare for translation

### DIFF
--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlBindingConstants.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/NikoHomeControlBindingConstants.java
@@ -31,6 +31,9 @@ public class NikoHomeControlBindingConstants {
 
     public static final String BINDING_ID = "nikohomecontrol";
 
+    // Listener threadname prefix
+    public static final String THREAD_NAME_PREFIX = "OH-" + BINDING_ID + "-";
+
     // List of all Thing Type UIDs
 
     // bridge

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlActionHandler.java
@@ -66,8 +66,8 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     public void handleCommand(ChannelUID channelUID, Command command) {
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Bridge communication not initialized when trying to execute action command " + actionId);
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "@text/offline.bridge-unitialized");
             return;
         }
 
@@ -107,15 +107,10 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
                 handleBrightnessCommand(command);
                 updateStatus(ThingStatus.ONLINE);
                 break;
-
             case CHANNEL_ROLLERSHUTTER:
                 handleRollershutterCommand(command);
                 updateStatus(ThingStatus.ONLINE);
                 break;
-
-            default:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Channel unknown " + channelUID.getId());
         }
     }
 
@@ -217,8 +212,6 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Connection with controller not started yet, could not initialize action " + actionId);
             return;
         }
 
@@ -226,14 +219,14 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "No connection with controller, could not initialize action " + actionId);
+                        "@text/offline.communication-error");
                 return;
             }
 
             NhcAction nhcAction = nhcComm.getActions().get(actionId);
             if (nhcAction == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Action " + actionId + " does not match an action in the controller");
+                        "@text/offline.configuration-error.actionId");
                 return;
             }
 
@@ -313,7 +306,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
                 break;
             default:
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Unknown action type " + actionType);
+                        "@text/offline.configuration-error.actionType " + actionType);
         }
     }
 
@@ -328,7 +321,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
     @Override
     public void actionRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Action " + actionId + " has been removed from the controller");
+                "@text/offline.configuration-error.actionRemoved");
     }
 
     private void restartCommunication(NikoHomeControlCommunication nhcComm) {
@@ -337,7 +330,8 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.communication-error");
             return;
         }
         // Also put the bridge back online
@@ -351,7 +345,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for action " + actionId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -362,7 +356,7 @@ public class NikoHomeControlActionHandler extends BaseThingHandler implements Nh
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for action " + actionId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler.java
@@ -141,7 +141,7 @@ public abstract class NikoHomeControlBridgeHandler extends BaseBridgeHandler imp
      */
     protected void bridgeOffline() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                "Error with bridge connection");
+                "@text/offline.communication-error");
     }
 
     /**

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -53,8 +53,8 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
             nhcComm = new NikoHomeControlCommunication1(this, scheduler);
             startCommunication();
         } else {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    "Cannot resolve bridge IP with hostname " + config.addr);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                    "@text/offline.configuration-error.ip");
         }
     }
 

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler1.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.handler;
 
+import static org.openhab.binding.nikohomecontrol.internal.NikoHomeControlBindingConstants.THREAD_NAME_PREFIX;
+
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +52,8 @@ public class NikoHomeControlBridgeHandler1 extends NikoHomeControlBridgeHandler 
         logger.debug("bridge handler host {}, port {}", addr, port);
 
         if (addr != null) {
-            nhcComm = new NikoHomeControlCommunication1(this, scheduler);
+            String eventThreadName = THREAD_NAME_PREFIX + thing.getUID().getAsString();
+            nhcComm = new NikoHomeControlCommunication1(this, scheduler, eventThreadName);
             startCommunication();
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlBridgeHandler2.java
@@ -69,14 +69,15 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
                 // advanced configuration, skipping token validation.
                 // This behavior would allow the same logic to be used (with profile UUID) as before token validation
                 // was introduced.
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, "Token is empty");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
+                        "@text/offline.configuration-error.tokenEmpty");
                 return;
             }
         } else {
             Date now = new Date();
             if (expiryDate.before(now)) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR,
-                        "Hobby api token has expired");
+                        "@text/offline.configuration-error.tokenExpired");
                 return;
             }
         }
@@ -90,7 +91,7 @@ public class NikoHomeControlBridgeHandler2 extends NikoHomeControlBridgeHandler 
         } catch (CertificateException e) {
             // this should not happen unless there is a programming error
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR,
-                    "Not able to set SSL context");
+                    "@text/offline.communication-error");
             return;
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlEnergyMeterHandler.java
@@ -64,7 +64,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
             return;
         }
 
-        if (command == REFRESH) {
+        if (REFRESH.equals(command)) {
             energyMeterEvent(nhcEnergyMeter.getPower());
         }
     }
@@ -77,8 +77,6 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Connection with controller not started yet, could not initialize energy meter " + energyMeterId);
             return;
         }
 
@@ -87,14 +85,14 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "No connection with controller, could not initialize energy meter " + energyMeterId);
+                        "@text/offline.communication-error");
                 return;
             }
 
             NhcEnergyMeter nhcEnergyMeter = nhcComm.getEnergyMeters().get(energyMeterId);
             if (nhcEnergyMeter == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Energy meter " + energyMeterId + " does not match a energy meter in the controller");
+                        "@text/offline.configuration-error.energyMeterId");
                 return;
             }
 
@@ -163,7 +161,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
     @Override
     public void energyMeterRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Energy meter " + energyMeterId + " has been removed from the controller");
+                "@text/offline.configuration-error.energyMeterRemoved");
     }
 
     @Override
@@ -172,8 +170,8 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
     public void channelLinked(ChannelUID channelUID) {
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Bridge communication not initialized when trying to start energy meter " + energyMeterId);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.communication-error");
             return;
         }
 
@@ -194,8 +192,8 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
     public void channelUnlinked(ChannelUID channelUID) {
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Bridge communication not initialized when trying to stop energy meter " + energyMeterId);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.communication-error");
             return;
         }
 
@@ -220,7 +218,8 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.communication-error");
             return;
         }
         // Also put the bridge back online
@@ -234,7 +233,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for energy meter " + energyMeterId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -245,7 +244,7 @@ public class NikoHomeControlEnergyMeterHandler extends BaseThingHandler implemen
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for energy meter " + energyMeterId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/handler/NikoHomeControlThermostatHandler.java
@@ -68,9 +68,8 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
     public void handleCommand(ChannelUID channelUID, Command command) {
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                    "Bridge communication not initialized when trying to execute thermostat command on "
-                            + thermostatId);
+            updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
+                    "@text/offline.bridge-unitialized");
             return;
         }
 
@@ -143,10 +142,6 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
                 }
                 updateStatus(ThingStatus.ONLINE);
                 break;
-
-            default:
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "Channel unknown " + channelUID.getId());
         }
     }
 
@@ -159,8 +154,6 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
 
         NikoHomeControlCommunication nhcComm = getCommunication();
         if (nhcComm == null) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                    "Connection with controller not started yet, could not initialize thermostat " + thermostatId);
             return;
         }
 
@@ -169,14 +162,14 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         scheduler.submit(() -> {
             if (!nhcComm.communicationActive()) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
-                        "No connection with controller, could not initialize thermostat " + thermostatId);
+                        "@text/offline.communication-error");
                 return;
             }
 
             NhcThermostat nhcThermostat = nhcComm.getThermostats().get(thermostatId);
             if (nhcThermostat == null) {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                        "Thermostat " + thermostatId + " does not match a thermostat in the controller");
+                        "@text/offline.configuration-error.thermostatId");
                 return;
             }
 
@@ -288,7 +281,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
     @Override
     public void thermostatRemoved() {
         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                "Thermostat " + thermostatId + " has been removed from the controller");
+                "@text/offline.configuration-error.thermostatRemoved");
     }
 
     private void restartCommunication(NikoHomeControlCommunication nhcComm) {
@@ -297,7 +290,8 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         nhcComm.restartCommunication();
         // If still not active, take thing offline and return.
         if (!nhcComm.communicationActive()) {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Communication error");
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "@text/offline.communication-error");
             return;
         }
         // Also put the bridge back online
@@ -311,7 +305,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         NikoHomeControlBridgeHandler nhcBridgeHandler = getBridgeHandler();
         if (nhcBridgeHandler == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for thermostat " + thermostatId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlCommunication nhcComm = nhcBridgeHandler.getCommunication();
@@ -322,7 +316,7 @@ public class NikoHomeControlThermostatHandler extends BaseThingHandler implement
         Bridge nhcBridge = getBridge();
         if (nhcBridge == null) {
             updateStatus(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED,
-                    "No bridge initialized for thermostat " + thermostatId);
+                    "@text/offline.bridge-unitialized");
             return null;
         }
         NikoHomeControlBridgeHandler nhcBridgeHandler = (NikoHomeControlBridgeHandler) nhcBridge.getHandler();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
@@ -117,7 +117,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
 
         } catch (IOException | InterruptedException e) {
             stopCommunication();
-            handler.controllerOffline("Error initializing communication");
+            handler.controllerOffline("@text/offline.communication-error");
         }
     }
 
@@ -227,7 +227,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
             logger.debug("resend json {}", json);
             nhcOut.println(json);
             if (nhcOut.checkError()) {
-                handler.controllerOffline("Error resending message");
+                handler.controllerOffline("@text/offline.communication-error");
             }
         }
     }

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc1/NikoHomeControlCommunication1.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.nikohomecontrol.internal.protocol.nhc1;
 
+import static org.openhab.binding.nikohomecontrol.internal.NikoHomeControlBindingConstants.THREAD_NAME_PREFIX;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -56,6 +58,8 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
 
     private Logger logger = LoggerFactory.getLogger(NikoHomeControlCommunication1.class);
 
+    private String eventThreadName = THREAD_NAME_PREFIX + "";
+
     private final NhcSystemInfo1 systemInfo = new NhcSystemInfo1();
     private final Map<String, NhcLocation1> locations = new ConcurrentHashMap<>();
 
@@ -77,9 +81,11 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
      * Niko Home Control IP-interface.
      *
      */
-    public NikoHomeControlCommunication1(NhcControllerEvent handler, ScheduledExecutorService scheduler) {
+    public NikoHomeControlCommunication1(NhcControllerEvent handler, ScheduledExecutorService scheduler,
+            String eventThreadName) {
         super(handler);
         this.scheduler = scheduler;
+        this.eventThreadName = eventThreadName;
 
         // When we set up this object, we want to get the proper gson adapter set up once
         GsonBuilder gsonBuilder = new GsonBuilder();
@@ -113,7 +119,7 @@ public class NikoHomeControlCommunication1 extends NikoHomeControlCommunication 
 
             // Start Niko Home Control event listener. This listener will act on all messages coming from
             // IP-interface.
-            (new Thread(this::runNhcEvents)).start();
+            (new Thread(this::runNhcEvents, eventThreadName)).start();
 
         } catch (IOException | InterruptedException e) {
             stopCommunication();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/java/org/openhab/binding/nikohomecontrol/internal/protocol/nhc2/NikoHomeControlCommunication2.java
@@ -778,8 +778,7 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
             mqttConnection.connectionPublish(topic, gsonMessage);
 
         } catch (MqttException e) {
-            String message = e.getMessage();
-            message = (message != null) ? message : "Communication error";
+            String message = e.getLocalizedMessage();
 
             logger.debug("sending command failed, trying to restart communication");
             restartCommunication();
@@ -791,12 +790,12 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
                     logger.debug("failed to restart communication");
                 }
             } catch (MqttException e1) {
-                message = e1.getMessage();
-                message = (message != null) ? message : "Communication error";
+                message = e1.getLocalizedMessage();
 
                 logger.debug("error resending device command");
             }
             if (!communicationActive()) {
+                message = (message != null) ? message : "@text/offline.communication-error";
                 connectionLost(message);
             }
         }
@@ -862,8 +861,8 @@ public class NikoHomeControlCommunication2 extends NikoHomeControlCommunication
     public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
         if (error != null) {
             logger.debug("Connection state: {}", state, error);
-            String message = error.getMessage();
-            message = (message != null) ? message : "Error communicating with the controller";
+            String message = error.getLocalizedMessage();
+            message = (message != null) ? message : "@text/offline.communication-error";
             if (!MqttConnectionState.CONNECTING.equals(state)) {
                 // This is a connection loss, try to restart
                 restartCommunication();

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/binding/binding.xml
@@ -3,6 +3,6 @@
 	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-	<name>Niko Home Control Binding</name>
-	<description>This is the binding for the Niko Home Control system</description>
+	<name>@text/bindingName</name>
+	<description>@text/bindingDescription</description>
 </binding:binding>

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/i18n/nikohomecontrol.properties
@@ -1,0 +1,120 @@
+# binding
+bindingName = Niko Home Control Binding
+bindingDescription = This is the binding for the Niko Home Control system
+
+# bridge types
+bridgeLabel = Niko Home Control I Bridge
+bridgeDescription = This bridge represents a Niko Home Control I IP-interface
+
+bridge2Label = Niko Home Control II Bridge
+bridge2Description = This bridge represents a Niko Home Control II Connected Controller or Wireless Smart Hub
+
+bridgeConfigAddressLabel = IP or Host Name
+bridgeConfigAddressDescription = IP Address of Niko Home Control IP-interface
+bridge2ConfigAddressDescription = IP Address of Connected Controller or Wireless Smart Hub
+
+bridgeConfigPortLabel = Bridge Port
+bridgeConfigPortDescription = Port to communicate with Niko Home Control IP-interface, default 8000
+bridge2ConfigPortDescription = Port for secure MQTT communication with Connected Controller or Wireless Smart Hub, default 8884
+
+bridge2ConfigProfileLabel = Profile
+bridge2ConfigProfileDescription = Profile used in Niko Home Control II for hobby API
+
+bridge2ConfigPasswordLabel = API Token
+bridge2ConfigPasswordDescription = Token for Niko Home Control II hobby API, should not be empty. This token will have to be renewed after expiration (1 year after creation)
+
+bridgeConfigRefreshLabel = Refresh Interval
+bridgeConfigRefreshDescription = Refresh interval for connection with Niko Home Control IP-interface (min), default 300. If set to 0 or left empty, no refresh will be scheduled
+bridge2ConfigRefreshDescription = Refresh interval for connection with Connected Controller or Wireless Smart Hub (min), default 300. If set to 0 or left empty, no refresh will be scheduled
+
+# thing types
+pushButtonLabel = Pushbutton
+pushButtonDescription = Pushbutton type action in Niko Home Control
+
+onOffLabel = Switch
+onOffDescription = On/Off type action in Niko Home Control
+
+dimmerLabel = Dimmer
+dimmerDescription = Dimmer type action in Niko Home Control
+
+blindLabel = Shutter
+blindDescription = Rollershutter type action in Niko Home Control
+
+thermostatLabel = Thermostat
+thermostatDescription = Thermostat in the Niko Home Control system
+
+energyMeterLabel = Energy Meter
+energyMeterDescription = Energy meter in the Niko Home Control system
+
+actionConfigActionIdLabel = Action ID
+actionConfigActionIdDescription = Niko Home Control action ID
+
+dimmerConfigStepLabel = Step Value
+dimmerConfigStepDescription = Step value used for increase/decrease of dimmer brightness, default 10%
+
+blindConfigInvertLabel = Invert Direction
+blindConfigInvertDescription = Invert rollershutter direction
+
+thermostatConfigThermostatIdLabel = Thermostat ID
+thermostatConfigThermostatIdDescription = Niko Home Control Thermostat ID
+
+thermostatConfigOverruleTimeLabel = Overrule Time
+thermostatConfigOverruleTimeDescription = Default overrule duration in minutes when an overrule temperature is set without providing overrule \
+                    time, 60 minutes by default
+
+energyMeterConfigEnergyMeterIdLabel = Energy Meter ID
+energyMeterConfigEnergyMeterIdDescription = Niko Home Control Energy Meter ID
+
+#channel types
+channelButtonLabel = Button
+channelButtonDescription = Pushbutton control for action in Niko Home Control
+
+channelRollershutterLabel = Rollershutter
+channelRollershutterDescription = Rollershutter control for rollershutter action in Niko Home Control
+
+channelMeasuredLabel = Measured
+channelMeasuredDescription = Temperature measured by thermostat
+
+channelSetpointLabel = Setpoint
+channelSetpointDescription = Setpoint temperature of thermostat
+
+channelOverruletimeLabel = Overrule Time
+channelOverruletimeDescription = Time duration for overruling thermostat target temperature in min.
+
+channelModeLabel = Mode
+channelModeDescription = Thermostat mode
+channelModeOption0 = day
+channelModeOption1 = night
+channelModeOption2 = eco
+channelModeOption3 = off
+channelModeOption4 = cool
+channelModeOption5 = prog 1
+channelModeOption6 = prog 2
+channelModeOption7 = prog 3
+
+channelPowerLabel = Power
+channelPowerDescription = Momentary power consumption/production (positive is consumption)
+
+channelAlarmLabel = Alarm
+channelAlarmDescription = Alarm from Niko Home Control
+
+channelNoticeLabel = Notice
+channelNoticeDescription = Notice from Niko Home Control
+
+# thing status messages
+offline.configuration-error.ip = Cannot resolve bridge IP with given host name
+offline.configuration-error.tokenEmpty = Hobby API token is empty
+offline.configuration-error.tokenExpired = Hobby API token has expired
+
+offline.configuration-error.actionId = Configured action ID does not match an action in controller
+offline.configuration-error.actionType = Unsupported action type
+offline.configuration-error.actionRemoved = Action has been removed from controller
+
+offline.configuration-error.energyMeterId = Configured energy meter ID does not match an energy meter in controller
+offline.configuration-error.energyMeterRemoved = Energy meter has been removed from controller
+
+offline.configuration-error.thermostatId = Configured thermostat ID does not match an thermostat in controller
+offline.configuration-error.thermostatRemoved = Thermostat has been removed from controller
+
+offline.communication-error = Error communicating with controller
+offline.bridge-unitialized = Bridge not initialized

--- a/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nikohomecontrol/src/main/resources/OH-INF/thing/thing-types.xml
@@ -5,70 +5,67 @@
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="bridge">
-		<label>Niko Home Control I Bridge</label>
-		<description>This bridge represents a Niko Home Control I IP-interface</description>
+		<label>@text/bridgeLabel</label>
+		<description>@text/bridgeDescription</description>
 		<channels>
 			<channel id="alarm" typeId="alarm"/>
 			<channel id="notice" typeId="notice"/>
 		</channels>
 		<config-description>
 			<parameter name="addr" type="text" required="true">
-				<label>IP or Host Name</label>
-				<description>IP Address of Niko Home Control IP-interface</description>
+				<label>@text/bridgeConfigAddressLabel</label>
+				<description>@text/bridgeConfigAddressDescription</description>
 				<advanced>false</advanced>
 				<context>network-address</context>
 			</parameter>
 			<parameter name="port" type="integer">
-				<label>Bridge Port</label>
-				<description>Port to communicate with Niko Home Control IP-interface, default 8000</description>
+				<label>@text/bridgeConfigPortLabel</label>
+				<description>@text/bridgeConfigPortDescription</description>
 				<default>8000</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="refresh" type="integer">
-				<label>Refresh Interval</label>
-				<description>Refresh interval for connection with Niko Home Control IP-interface (min), default 300. If set to 0 or
-					left empty, no refresh will be scheduled</description>
+				<label>@text/bridgeConfigRefreshLabel</label>
+				<description>@text/bridgeConfigRefreshDescription</description>
 				<default>300</default>
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>
 	<bridge-type id="bridge2">
-		<label>Niko Home Control II Bridge</label>
-		<description>This bridge represents a Niko Home Control II Connected Controller</description>
+		<label>@text/bridge2Label</label>
+		<description>@text/bridge2Description</description>
 		<channels>
 			<channel id="alarm" typeId="alarm"/>
 			<channel id="notice" typeId="notice"/>
 		</channels>
 		<config-description>
 			<parameter name="addr" type="text" required="true">
-				<label>IP or Host Name</label>
-				<description>IP Address of Connected Controller</description>
+				<label>@text/bridgeConfigAddressLabel</label>
+				<description>@text/bridge2ConfigAddressDescription</description>
 				<advanced>false</advanced>
 				<context>network-address</context>
 			</parameter>
 			<parameter name="port" type="integer">
-				<label>Bridge Port</label>
-				<description>Port for secure MQTT communication with Connected Controller, default 8884</description>
+				<label>@text/bridgeConfigPortLabel</label>
+				<description>@text/bridge2ConfigPortDescription</description>
 				<default>8884</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="profile" type="text">
-				<label>Profile</label>
-				<description>Profile used in Niko Home Control II for hobby API</description>
+				<label>@text/bridge2ConfigProfileLabel</label>
+				<description>@text/bridge2ConfigProfileDescription</description>
 				<default>hobby</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="password" type="text" required="true">
-				<label>API Token</label>
-				<description>Token for Niko Home Control II hobby API, should not be empty. This token will have to be renewed after
-					expiration (1 year after creation)</description>
+				<label>@text/bridge2ConfigPasswordLabel</label>
+				<description>@text/bridge2ConfigPasswordDescription</description>
 				<context>password</context>
 			</parameter>
 			<parameter name="refresh" type="integer">
-				<label>Refresh Interval</label>
-				<description>Refresh interval for connection with Connected Controller (min), default 300. If set to 0 or left
-					empty, no refresh will be scheduled</description>
+				<label>@text/bridgeConfigRefreshLabel</label>
+				<description>@text/bridge2ConfigRefreshDescription</description>
 				<default>300</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -80,15 +77,15 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Pushbutton</label>
-		<description>Pushbutton type action in Niko Home Control</description>
+		<label>@text/pushButtonLabel</label>
+		<description>@text/pushButtonDescription</description>
 		<channels>
 			<channel id="button" typeId="button"/>
 		</channels>
 		<config-description>
 			<parameter name="actionId" type="text" required="true">
-				<label>Action ID</label>
-				<description>Niko Home Control action ID</description>
+				<label>@text/actionConfigActionIdLabel</label>
+				<description>@text/actionConfigActionIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 		</config-description>
@@ -98,15 +95,15 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Switch</label>
-		<description>On/Off type action in Niko Home Control</description>
+		<label>@text/onOffLabel</label>
+		<description>@text/onOffDescription</description>
 		<channels>
 			<channel id="switch" typeId="system.power"/>
 		</channels>
 		<config-description>
 			<parameter name="actionId" type="text" required="true">
-				<label>Action ID</label>
-				<description>Niko Home Control action ID</description>
+                <label>@text/actionConfigActionIdLabel</label>
+                <description>@text/actionConfigActionIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 		</config-description>
@@ -116,20 +113,20 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Dimmer</label>
-		<description>Dimmer type action in Niko Home Control</description>
+		<label>@text/dimmerLabel</label>
+		<description>@text/dimmerDescription</description>
 		<channels>
 			<channel id="brightness" typeId="system.brightness"/>
 		</channels>
 		<config-description>
 			<parameter name="actionId" type="text" required="true">
-				<label>Action ID</label>
-				<description>Niko Home Control action ID</description>
+                <label>@text/actionConfigActionIdLabel</label>
+                <description>@text/actionConfigActionIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 			<parameter name="step" type="integer">
-				<label>Step Value</label>
-				<description>Step value used for increase/decrease of dimmer brightness, default 10%</description>
+				<label>@text/dimmerConfigStepLabel</label>
+				<description>@text/dimmerConfigStepValue</description>
 				<default>10</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -140,20 +137,20 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Shutter</label>
-		<description>Rollershutter type action in Niko Home Control</description>
+		<label>@text/blindLabel</label>
+		<description>@text/blindDescription</description>
 		<channels>
 			<channel id="rollershutter" typeId="rollershutter"/>
 		</channels>
 		<config-description>
 			<parameter name="actionId" type="text" required="true">
-				<label>Action ID</label>
-				<description>Niko Home Control action ID</description>
+                <label>@text/actionConfigActionIdLabel</label>
+                <description>@text/actionConfigActionIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 			<parameter name="invert" type="boolean">
-				<label>Invert Direction</label>
-				<description>Invert rollershutter direction</description>
+				<label>@text/blindConfigInvertLabel</label>
+				<description>@text/blindConfigInvertDescription</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -164,8 +161,8 @@
 			<bridge-type-ref id="bridge"/>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Thermostat</label>
-		<description>Thermostat in the Niko Home Control system</description>
+		<label>@textThermostatLabel</label>
+		<description>@textThermostatDescription</description>
 		<channels>
 			<channel id="measured" typeId="measured"/>
 			<channel id="mode" typeId="mode"/>
@@ -174,14 +171,13 @@
 		</channels>
 		<config-description>
 			<parameter name="thermostatId" type="text" required="true">
-				<label>Thermostat ID</label>
-				<description>Niko Home Control Thermostat ID</description>
+				<label>@text/thermostatConfigThermostatIdLabel</label>
+				<description>@text/thermostatConfigThermostatIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 			<parameter name="overruleTime" type="integer">
-				<label>Overrule Time</label>
-				<description>Default overrule duration in minutes when an overrule temperature is set without providing overrule
-					time, 60 minutes by default</description>
+				<label>@text/thermostatConfigOverruleTimeLabel</label>
+				<description>@text/thermostatConfigOverruleTimeDescription</description>
 				<default>60</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -191,15 +187,15 @@
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="bridge2"/>
 		</supported-bridge-type-refs>
-		<label>Energy Meter</label>
-		<description>Energy meter in the Niko Home Control system</description>
+		<label>@text/energyMeterLabel</label>
+		<description>@text/energyMeterDescription</description>
 		<channels>
 			<channel id="power" typeId="power"/>
 		</channels>
 		<config-description>
 			<parameter name="energyMeterId" type="text" required="true">
-				<label>Energy Meter ID</label>
-				<description>Niko Home Control Energy Meter ID</description>
+				<label>@text/energyMeterConfigEnergyMeterIdLabel</label>
+				<description>@text/energyMeterConfigEnergyMeterIdDescription</description>
 				<advanced>false</advanced>
 			</parameter>
 		</config-description>
@@ -207,22 +203,22 @@
 
 	<channel-type id="button">
 		<item-type>Switch</item-type>
-		<label>Button</label>
-		<description>Pushbutton control for action in Niko Home Control</description>
+		<label>@text/channelButtonLabel</label>
+		<description>@text/channelButtonDescription</description>
 		<category>Switch</category>
 		<autoUpdatePolicy>veto</autoUpdatePolicy>
 	</channel-type>
 	<channel-type id="rollershutter">
 		<item-type>Rollershutter</item-type>
-		<label>Rollershutter</label>
-		<description>Rollershutter control for rollershutter action in Niko Home Control</description>
+		<label>@text/channelRollershutterLabel</label>
+		<description>@text/channelRollershutterDescription</description>
 		<category>Blinds</category>
 	</channel-type>
 
 	<channel-type id="measured">
 		<item-type>Number:Temperature</item-type>
-		<label>Measured</label>
-		<description>Temperature measured by thermostat</description>
+		<label>@text/channelMeasuredLabel</label>
+		<description>@text/channelMeasuredDescription</description>
 		<category>Temperature</category>
 		<tags>
 			<tag>Measurement</tag>
@@ -232,8 +228,8 @@
 	</channel-type>
 	<channel-type id="setpoint">
 		<item-type>Number:Temperature</item-type>
-		<label>Setpoint</label>
-		<description>Setpoint temperature of thermostat</description>
+		<label>@text/channelSetpointLabel</label>
+		<description>@text/channelSetpointDescription</description>
 		<category>Temperature</category>
 		<tags>
 			<tag>Setpoint</tag>
@@ -243,33 +239,33 @@
 	</channel-type>
 	<channel-type id="overruletime">
 		<item-type>Number</item-type>
-		<label>Overrule Time</label>
-		<description>Time duration for overruling thermostat target temperature in min.</description>
+		<label>@text/channelOverruletimeLabel</label>
+		<description>@text/channelOverruletimeDescription</description>
 		<category>Number</category>
 		<state min="0" max="1440" step="5"/>
 	</channel-type>
 	<channel-type id="mode">
 		<item-type>Number</item-type>
-		<label>Mode</label>
-		<description>Thermostat mode</description>
+		<label>@text/channelModeLabel</label>
+		<description>@text/channelModeDescription</description>
 		<category>Number</category>
 		<state>
 			<options>
-				<option value="0">day</option>
-				<option value="1">night</option>
-				<option value="2">eco</option>
-				<option value="3">off</option>
-				<option value="4">cool</option>
-				<option value="5">prog 1</option>
-				<option value="6">prog 2</option>
-				<option value="7">prog 3</option>
+				<option value="0">@text/channelModeOption0</option>
+				<option value="1">@text/channelModeOption1</option>
+				<option value="2">@text/channelModeOption2</option>
+				<option value="3">@text/channelModeOption3</option>
+				<option value="4">@text/channelModeOption4</option>
+				<option value="5">@text/channelModeOption5</option>
+				<option value="6">@text/channelModeOption6</option>
+				<option value="7">@text/channelModeOption7</option>
 			</options>
 		</state>
 	</channel-type>
 	<channel-type id="power">
 		<item-type>Number:Power</item-type>
-		<label>Power</label>
-		<description>Momentary power consumption/production (positive is consumption)</description>
+		<label>@text/channelPowerLabel</label>
+		<description>@text/channelPowerDescription</description>
 		<category>Number</category>
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
@@ -277,13 +273,13 @@
 
 	<channel-type id="alarm">
 		<kind>trigger</kind>
-		<label>Alarm</label>
-		<description>Alarm from Niko Home Control</description>
+		<label>@text/channelAlarmLabel</label>
+		<description>@text/channelAlarmDescription</description>
 	</channel-type>
 	<channel-type id="notice">
 		<kind>trigger</kind>
-		<label>Notice</label>
-		<description>Notice from Niko Home Control</description>
+		<label>@text/channelNoticeLabel</label>
+		<description>@text/channelNoticeDescription</description>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
- Externalize strings to properties file to allow translation as a next step.
- Give listener thread a name.


