### PR TITLE
[miele] Fix supercool/superfreeze for fridges/fridge-freezers

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
@@ -39,7 +39,7 @@ public class ExtendedDeviceStateUtil {
 
     /**
      * Convert string consisting of 8 bit characters to byte array.
-     * Note: This simple operation has been extracted and pure here to document
+     * Note: This simple operation has been extracted and put here to document
      * and ensure correct behavior for 8 bit characters that should be turned
      * into single bytes without any UTF-8 encoding.
      */

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -36,6 +36,7 @@ public class MieleBindingConstants {
 
     // Shared Channel ID's
     public static final String SUPERCOOL_CHANNEL_ID = "supercool";
+    public static final String SUPERFREEZE_CHANNEL_ID = "superfreeze";
     public static final String POWER_CONSUMPTION_CHANNEL_ID = "powerConsumption";
     public static final String WATER_CONSUMPTION_CHANNEL_ID = "waterConsumption";
 
@@ -54,6 +55,11 @@ public class MieleBindingConstants {
     // Miele devices classes
     public static final String MIELE_DEVICE_CLASS_COFFEE_SYSTEM = "CoffeeSystem";
     public static final String MIELE_DEVICE_CLASS_FRIDGE = "Fridge";
+    public static final String MIELE_DEVICE_CLASS_FRIDGE_FREEZER = "FridgeFreezer";
+
+    // Miele appliance states
+    public static final int STATE_SUPER_FREEZING = 13;
+    public static final int STATE_SUPER_COOLING = 14;
 
     // Bridge config properties
     public static final String HOST = "ipAddress";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -32,8 +32,10 @@ public class MieleBindingConstants {
     public static final String PROTOCOL_PROPERTY_NAME = "protocol";
     public static final String SERIAL_NUMBER_PROPERTY_NAME = "serialNumber";
     public static final String EXTENDED_DEVICE_STATE_PROPERTY_NAME = "extendedDeviceState";
+    public static final String STATE_PROPERTY_NAME = "state";
 
     // Shared Channel ID's
+    public static final String SUPERCOOL_CHANNEL_ID = "supercool";
     public static final String POWER_CONSUMPTION_CHANNEL_ID = "powerConsumption";
     public static final String WATER_CONSUMPTION_CHANNEL_ID = "waterConsumption";
 
@@ -51,6 +53,7 @@ public class MieleBindingConstants {
 
     // Miele devices classes
     public static final String MIELE_DEVICE_CLASS_COFFEE_SYSTEM = "CoffeeSystem";
+    public static final String MIELE_DEVICE_CLASS_FRIDGE = "Fridge";
 
     // Bridge config properties
     public static final String HOST = "ipAddress";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceChannelSelector.java
@@ -14,7 +14,6 @@ package org.openhab.binding.miele.internal.handler;
 
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.types.State;
-import org.openhab.core.types.Type;
 
 /**
  * The {@link ApplianceChannelSelector} class defines a common interface for
@@ -62,9 +61,4 @@ public interface ApplianceChannelSelector {
      * @param dmd - the device meta data
      */
     State getState(String s, DeviceMetaData dmd);
-
-    /**
-     * Returns "compatible" Type for this datapoint
-     */
-    Class<? extends Type> getTypeClass();
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/ApplianceStatusListener.java
@@ -52,14 +52,14 @@ public interface ApplianceStatusListener {
     void onAppliancePropertyChanged(String serialNumber, DeviceProperty dp);
 
     /**
-     * This method us called whenever an appliance is removed.
+     * This method is called whenever an appliance is removed.
      *
      * @param appliance The XGW homedevice definition of the appliance that was removed
      */
     void onApplianceRemoved(HomeDevice appliance);
 
     /**
-     * This method us called whenever an appliance is added.
+     * This method is called whenever an appliance is added.
      *
      * @param appliance The XGW homedevice definition of the appliance that was removed
      */

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/CoffeeMachineChannelSelector.java
@@ -90,11 +90,6 @@ public enum CoffeeMachineChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishwasherChannelSelector.java
@@ -161,11 +161,6 @@ public enum DishwasherChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
+import static org.openhab.binding.miele.internal.MieleBindingConstants.SUPERCOOL_CHANNEL_ID;
+
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
@@ -40,7 +42,7 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     BRAND_ID("brandId", "brandId", StringType.class, true),
     COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE("state", "state", StringType.class, false),
-    SUPERCOOL(null, "supercool", OnOffType.class, false),
+    SUPERCOOL(null, SUPERCOOL_CHANNEL_ID, OnOffType.class, false),
     FRIDGECURRENTTEMP("currentTemperature", "current", DecimalType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -100,11 +100,6 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
+import static org.openhab.binding.miele.internal.MieleBindingConstants.SUPERCOOL_CHANNEL_ID;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.SUPERFREEZE_CHANNEL_ID;
+
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
@@ -43,8 +46,8 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     STATE("state", "state", StringType.class, false),
     FREEZERSTATE("freezerState", "freezerstate", StringType.class, false),
     FRIDGESTATE("fridgeState", "fridgestate", StringType.class, false),
-    SUPERCOOL(null, "supercool", OnOffType.class, false),
-    SUPERFREEZE(null, "superfreeze", OnOffType.class, false),
+    SUPERCOOL(null, SUPERCOOL_CHANNEL_ID, OnOffType.class, false),
+    SUPERFREEZE(null, SUPERFREEZE_CHANNEL_ID, OnOffType.class, false),
     FREEZERCURRENTTEMP("freezerCurrentTemperature", "freezercurrent", DecimalType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -117,11 +117,6 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -37,8 +37,6 @@ import com.google.gson.JsonElement;
  */
 public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> {
 
-    private static final int STATE_SUPER_COOLING = 14;
-
     private final Logger logger = LoggerFactory.getLogger(FridgeHandler.class);
 
     public FridgeHandler(Thing thing) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeHandler.java
@@ -12,15 +12,16 @@
  */
 package org.openhab.binding.miele.internal.handler;
 
-import static org.openhab.binding.miele.internal.MieleBindingConstants.APPLIANCE_ID;
-import static org.openhab.binding.miele.internal.MieleBindingConstants.PROTOCOL_PROPERTY_NAME;
+import static org.openhab.binding.miele.internal.MieleBindingConstants.*;
 
 import org.openhab.binding.miele.internal.FullyQualifiedApplianceIdentifier;
+import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceProperty;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +37,12 @@ import com.google.gson.JsonElement;
  */
 public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> {
 
+    private static final int STATE_SUPER_COOLING = 14;
+
     private final Logger logger = LoggerFactory.getLogger(FridgeHandler.class);
 
     public FridgeHandler(Thing thing) {
-        super(thing, FridgeChannelSelector.class, "Fridge");
+        super(thing, FridgeChannelSelector.class, MIELE_DEVICE_CLASS_FRIDGE);
     }
 
     @Override
@@ -88,5 +91,20 @@ public class FridgeHandler extends MieleApplianceHandler<FridgeChannelSelector> 
                     "An error occurred while trying to set the read-only variable associated with channel '{}' to '{}'",
                     channelID, command.toString());
         }
+    }
+
+    @Override
+    protected void onAppliancePropertyChanged(DeviceProperty dp) {
+        super.onAppliancePropertyChanged(dp);
+
+        if (!dp.Name.equals(STATE_PROPERTY_NAME)) {
+            return;
+        }
+
+        // Supercool is not exposed directly as property, but can be deduced from state.
+        ChannelUID channelUid = new ChannelUID(getThing().getUID(), SUPERCOOL_CHANNEL_ID);
+        State state = dp.Value.equals(String.valueOf(STATE_SUPER_COOLING)) ? OnOffType.ON : OnOffType.OFF;
+        logger.trace("Update state of {} to {} through '{}'", channelUid, state, dp.Name);
+        updateState(channelUid, state);
     }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HobChannelSelector.java
@@ -120,11 +120,6 @@ public enum HobChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/HoodChannelSelector.java
@@ -87,11 +87,6 @@ public enum HoodChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleApplianceHandler.java
@@ -192,7 +192,7 @@ public abstract class MieleApplianceHandler<E extends Enum<E> & ApplianceChannel
         this.onAppliancePropertyChanged(dp);
     }
 
-    private void onAppliancePropertyChanged(DeviceProperty dp) {
+    protected void onAppliancePropertyChanged(DeviceProperty dp) {
         try {
             DeviceMetaData dmd = null;
             if (dp.Metadata == null) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -281,7 +281,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                                     listener.onApplianceStateChanged(applianceIdentifier, dco);
                                                 }
                                             } catch (Exception e) {
-                                                logger.debug("An exception occurred while quering an appliance : '{}'",
+                                                logger.debug("An exception occurred while querying an appliance : '{}'",
                                                         e.getMessage());
                                             }
                                         }
@@ -600,7 +600,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
     /**
      * This method is called whenever the connection to the given {@link MieleBridge} is resumed.
      *
-     * @param bridge the hue bridge the connection is resumed to
+     * @param bridge the Miele bridge the connection is resumed to
      */
     public void onConnectionResumed() {
         updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/MieleBridgeHandler.java
@@ -387,7 +387,7 @@ public class MieleBridgeHandler extends BaseBridgeHandler {
                                             break;
                                         }
                                         case "value": {
-                                            dp.Value = subparts[1];
+                                            dp.Value = StringUtils.trim(StringUtils.strip(subparts[1]));
                                             break;
                                         }
                                         case "id": {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -176,11 +176,6 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/TumbleDryerChannelSelector.java
@@ -158,11 +158,6 @@ public enum TumbleDryerChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -183,11 +183,6 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     }
 
     @Override
-    public Class<? extends Type> getTypeClass() {
-        return typeClass;
-    }
-
-    @Override
     public boolean isProperty() {
         return isProperty;
     }

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -108,10 +108,10 @@
 	</channel-type>
 
 	<channel-type id="supercool" advanced="false">
-		<item-type>String</item-type>
+		<item-type>Switch</item-type>
 		<label>Super Cool</label>
 		<description>Start Super Cooling</description>
-		<state readOnly="true"></state>
+		<state readOnly="false"></state>
 	</channel-type>
 
 	<channel-type id="current" advanced="false">
@@ -136,10 +136,10 @@
 	</channel-type>
 
 	<channel-type id="superfreeze" advanced="false">
-		<item-type>String</item-type>
+		<item-type>Switch</item-type>
 		<label>Super Freeze</label>
 		<description>Start Super Freezing</description>
-		<state readOnly="true"></state>
+		<state readOnly="false"></state>
 	</channel-type>
 
 	<channel-type id="freezercurrent" advanced="false">


### PR DESCRIPTION
Fix channels **supercool** and **superfreeze** for fridges/fridge-freezers.

Both channels were declared as read-only strings, but should have been writable switches, and are in fact handled as switches in handleCommand:

```
case SUPERCOOL: {
    if (command.equals(OnOffType.ON)) {
        result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "startSuperCooling");
    } else if (command.equals(OnOffType.OFF)) {
        result = bridgeHandler.invokeOperation(applianceIdentifier, modelID, "stopSuperCooling");
    }
```

Furthermore, the channels were not updated according to current operation of the fridge/fridge-freezer. This fix enables two-way synchronization of the supercool/superfreeze state by using the **state** property.

See more details in linked issue.

## Testing
Tested with fridge.

Initial sitemap:
![image](https://user-images.githubusercontent.com/19519842/135168357-97a6b90a-116e-4064-ae94-f6223f1bd074.png)

Enable:
![image](https://user-images.githubusercontent.com/19519842/135168431-ab8ded21-5da3-43ff-beeb-e57021f43c41.png)

Verify state in Miele app:
![image](https://user-images.githubusercontent.com/19519842/135168479-0c8fd0d2-182c-4551-9d2b-e0637c573f15.png)

Disable:
![image](https://user-images.githubusercontent.com/19519842/135168515-34fced23-d896-4bbe-b4f4-16fb026d1e73.png)

Verify state in sitemap:
![image](https://user-images.githubusercontent.com/19519842/135168357-97a6b90a-116e-4064-ae94-f6223f1bd074.png)

## Pull request note
This fix was provided as part of some planned channel quality improvements. See #11317 for intentions/possible next steps.

Fixes #11320 

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>