### PR TITLE
[systeminfo] Add 2 new channels for Java heap

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/README.md
+++ b/bundles/org.openhab.binding.systeminfo/README.md
@@ -1,6 +1,6 @@
 # Systeminfo Binding
 
-System information Binding provides operating system and hardware information including:
+The system information binding provides operating system and hardware information including:
 
 -   Operating system name, version and manufacturer;
 -   CPU average load for last 1, 5, 15 minutes, name, description, number of physical and logical cores, running threads number, system uptime;
@@ -14,7 +14,7 @@ System information Binding provides operating system and hardware information in
 -   Network IP,name and adapter name, mac, data sent and received, packets sent and received;
 -   Process information - size of RAM memory used, CPU load, process name, path, number of threads.
 
-The binding uses [OSHI](https://github.com/oshi/oshi) API to access this information regardless of the underlying platform and does not need any native parts.
+The binding uses the [OSHI](https://github.com/oshi/oshi) library to access this information regardless of the underlying OS and hardware.
 
 ## Supported Things
 
@@ -28,8 +28,7 @@ The thing has the following properties:
 -   `os_version` - The version of the operating system
 -   `os_family` - The family of the operating system
 
-If multiple storage or display devices support is needed, new thing type has to be defined.
-This is workaround until [this issue](https://github.com/eclipse/smarthome/issues/588) is resolved and it is possible to add dynamically channels to DSL defined thing.
+If multiple storage or display devices support is needed, a new thing type has to be defined.
 
 ## Discovery
 
@@ -37,12 +36,8 @@ The discovery service implementation tries to resolve the computer name.
 If the resolving process fails, the computer name is set to "Unknown".
 In both cases it creates a Discovery Result with thing type  **computer**.
 
-When [this issue](https://github.com/eclipse/smarthome/issues/1118) is resolved it will be possible to implement creation of dynamic channels (e.g. the binding will scan how much storage devices are present and create channel groups for them).
+It will be possible to implement creation of dynamic channels (e.g. the binding will scan how many storage devices are present and create channel groups for them).
 At the moment this is not supported.
-
-## Binding configuration
-
-No binding configuration required.
 
 ## Thing configuration
 
@@ -57,13 +52,14 @@ That means that by default configuration:
 
 *   channels with priority set to 'High' are updated every second
 *   channels with priority set to 'Medium' are updated every minute
-*   channels with priority set to 'Low' are updated only at initialization or at Refresh command.
+*   channels with priority set to 'Low' are updated only at initialization or if the `REFRESH` command is sent to the channel.
 
 For more info see [channel configuration](#channel-configuration)
 
 ## Channels
 
-The binding support several channel group. Each channel group, contains one or more channels.
+The binding support several channel group.
+Each channel group, contains one or more channels.
 In the list below, you can find, how are channel group and channels id`s related.
 
 **thing** `computer`
@@ -137,7 +133,8 @@ The binding introduces the following channels:
 | packetsReceived    | Number of packets received                                       | Number              | Medium           | True     |
 | dataSent           | Data sent in MB                                                  | Number              | Medium           | True     |
 | dataReceived       | Data received in MB                                              | Number              | Medium           | True     |
-
+| availableHeap      | How many bytes are free out of the currently committed heap      | Number:DataAmount   | Medium           | True     |
+| usedHeapPercent    | How much of the MAX heap size is actually used in %              | Number:Dimensionless| Medium           | False    |
 
 ## Channel configuration
 
@@ -167,20 +164,7 @@ If you find an issue with a support for a specific hardware or software architec
 Your problem might have be already reported and solved!
 Feel free to open a new issue there with the log message and the and information about your software or hardware configuration.
 
-After the issue is resolved the binding has to be [updated](#updating-this-binding).
-
 For a general problem with the binding report the issue directly to openHAB.
-
-## Updating this binding
-
-OSHI project has a good support and regularly updates the library with fixes to issues and new features.
-
-In order to update the version used in the binding, follow these easy steps:
-
--   Go to the [OSHI GitHub repo](https://github.com/oshi/oshi) and download the newest version available of the module oshi-core or download the jar from the [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Coshi-). Check if the versions of the OSHI dependencies as well (jna and jna-platform) are changed;
--   Replace the jars in lib folder;
--   Modify the .classpath file with the new versions of the jars;
--   Modify the header Bundle-ClassPath in the META-INF/MANIFEST.MF.
 
 ## Example
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoBindingConstants.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoBindingConstants.java
@@ -82,6 +82,16 @@ public class SysteminfoBindingConstants {
     public static final String CHANNEL_MEMORY_USED_PERCENT = "memory#usedPercent";
 
     /**
+     * Percents of the used heap
+     */
+    public static final String CHANNEL_MEMORY_USED_HEAP_PERCENT = "memory#usedHeapPercent";
+
+    /**
+     * Bytes used in the heap
+     */
+    public static final String CHANNEL_MEMORY_HEAP_AVAILABLE = "memory#availableHeap";
+
+    /**
      * Total size of swap memory
      */
     public static final String CHANNEL_SWAP_TOTAL = "swap#total";

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
@@ -294,7 +294,8 @@ public class SysteminfoHandler extends BaseThingHandler {
                     state = new QuantityType<>(Runtime.getRuntime().freeMemory(), Units.BYTE);
                     break;
                 case CHANNEL_MEMORY_USED_HEAP_PERCENT:
-                    state = new DecimalType(Runtime.getRuntime().freeMemory() * 100 / Runtime.getRuntime().maxMemory());
+                    state = new DecimalType((Runtime.getRuntime().maxMemory() - Runtime.getRuntime().freeMemory()) * 100
+                            / Runtime.getRuntime().maxMemory());
                     break;
                 case CHANNEL_DISPLAY_INFORMATION:
                     state = systeminfo.getDisplayInformation(deviceIndex);

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
@@ -28,6 +28,9 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.systeminfo.internal.model.DeviceNotFoundException;
 import org.openhab.binding.systeminfo.internal.model.SysteminfoInterface;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -106,12 +109,9 @@ public class SysteminfoHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        logger.debug("Start initializing!");
-
         if (instantiateSysteminfoLibrary() && isConfigurationValid() && updateProperties()) {
             groupChannelsByPriority();
             scheduleUpdates();
-            logger.debug("Thing is successfully initialized!");
             updateStatus(ThingStatus.ONLINE);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_INITIALIZING_ERROR,
@@ -290,6 +290,12 @@ public class SysteminfoHandler extends BaseThingHandler {
 
         try {
             switch (channelID) {
+                case CHANNEL_MEMORY_HEAP_AVAILABLE:
+                    state = new QuantityType<>(Runtime.getRuntime().freeMemory(), Units.BYTE);
+                    break;
+                case CHANNEL_MEMORY_USED_HEAP_PERCENT:
+                    state = new DecimalType(Runtime.getRuntime().freeMemory() * 100 / Runtime.getRuntime().maxMemory());
+                    break;
                 case CHANNEL_DISPLAY_INFORMATION:
                     state = systeminfo.getDisplayInformation(deviceIndex);
                     break;

--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/model/OSHISysteminfo.java
@@ -16,7 +16,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
@@ -339,7 +338,10 @@ public class OSHISysteminfo implements SysteminfoInterface {
     @Override
     public @Nullable DecimalType getSensorsFanSpeed(int index) throws DeviceNotFoundException {
         int[] fanSpeeds = sensors.getFanSpeeds();
-        int speed = getDevice(ArrayUtils.toObject(fanSpeeds), index);
+        int speed = 0;// 0 means unable to measure speed
+        if (index < fanSpeeds.length) {
+            speed = fanSpeeds[index];
+        }
         return speed > 0 ? new DecimalType(speed) : null;
     }
 

--- a/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/thing/channels.xml
@@ -16,6 +16,8 @@
 			<channel id="used" typeId="used"/>
 			<channel id="availablePercent" typeId="availablePercent"/>
 			<channel id="usedPercent" typeId="usedPercent"/>
+			<channel id="availableHeap" typeId="availableHeap"/>
+			<channel id="usedHeapPercent" typeId="usedHeapPercent"/>
 		</channels>
 	</channel-group-type>
 
@@ -124,6 +126,22 @@
 			<channel id="path" typeId="path_process"/>
 		</channels>
 	</channel-group-type>
+
+	<channel-type id="availableHeap">
+		<item-type>Number:DataAmount</item-type>
+		<label>Available Heap</label>
+		<description>How much data is available in the Java heap.</description>
+		<state pattern="%.1f %unit%" readOnly="true"/>
+		<config-description-ref uri="channel-type:systeminfo:mediumpriority"/>
+	</channel-type>
+
+	<channel-type id="usedHeapPercent">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Used Heap Percent</label>
+		<description>How much data in percent has been used from the max size the Java heap can grow to.</description>
+		<state pattern="%.1f %%" readOnly="true"/>
+		<config-description-ref uri="channel-type:systeminfo:mediumpriority"/>
+	</channel-type>
 
 	<channel-type id="path_process">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.systeminfo/src/main/resources/OH-INF/thing/channels.xml
@@ -127,7 +127,7 @@
 		</channels>
 	</channel-group-type>
 
-	<channel-type id="availableHeap">
+	<channel-type id="availableHeap" advanced="true">
 		<item-type>Number:DataAmount</item-type>
 		<label>Available Heap</label>
 		<description>How much data is available in the Java heap.</description>


### PR DESCRIPTION
* Add 2 extra channels for tracking the Java heap sizes.
* Refactor to remove use of a apache.commons lib
* Clean up the readme and some logging.

Precompiled jar can be downloaded here:
http://pcmus.com/openhab/sysinfo/

Signed-off-by: Matthew Skinner <matt@pcmus.com>