### PR TITLE
[automower] Support for GPS coordinates provided by API

### DIFF
--- a/bundles/org.openhab.binding.automower/README.md
+++ b/bundles/org.openhab.binding.automower/README.md
@@ -40,87 +40,91 @@ With the default value of 10min this would mean ~4300 requests per month per sin
 
 ## Channels
 
-### Channel Group 'Mower Status'
+### Status Channels
 
-| channel                        | type     | access mode | description                                                                                                                                                                 |
-|--------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| status#mode                    | String   | R | The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                |
-| status#activity                | String   | R | The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                           |
-| status#state                   | String   | R | The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED_NONE, RESTRICTED_WEEK_SCHEDULE, RESTRICTED_PARK_OVERRIDE, RESTRICTED_SENSOR, RESTRICTED_DAILY_LIMIT, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP)  |
-| status#last-update             | DateTime | R | The time when the automower updated its states                                                                                                                   |
-| status#battery                 | Number   | R | The battery state of charge in percent                                                                                                                           |
-| status#error-code              | Number   | R | The current error code                                                                                                                                           |
-| status#error-timestamp         | DateTime | R | The timestamp when the current error occurred                                                                                                                    |
-| status#planner-next-start      | DateTime | R | The time for the next auto start. If the mower is charging then the value is the estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.                                                                  |
-| status#planner-override-action | String   | R | The action that overrides current planner operation.                                                                                                                                                                                                                  |
-| status#calendar-tasks          | String   | R | The JSON with the information about Automower planner.                                                                                                    |
+| channel                 | type     | access mode | description                                                                                                                                                                 |
+|-------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| mode                    | String   | R | The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                |
+| activity                | String   | R | The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                           |
+| state                   | String   | R | The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED_NONE, RESTRICTED_WEEK_SCHEDULE, RESTRICTED_PARK_OVERRIDE, RESTRICTED_SENSOR, RESTRICTED_DAILY_LIMIT, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP)  |
+| last-update             | DateTime | R | The time when the automower updated its states                                                                                                                   |
+| battery                 | Number   | R | The battery state of charge in percent                                                                                                                           |
+| error-code              | Number   | R | The current error code                                                                                                                                           |
+| error-timestamp         | DateTime | R | The timestamp when the current error occurred                                                                                                                    |
+| planner-next-start      | DateTime | R | The time for the next auto start. If the mower is charging then the value is the estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.                                                                  |
+| planner-override-action | String   | R | The action that overrides current planner operation.                                                                                                                                                                                                                  |
+| calendar-tasks          | String   | R | The JSON with the information about Automower planner.                                                                                                    |
 
-### Channel Group 'Mower Commmands'
+### Command Channels
 
-| channel                              | type     | access mode | description                                                                                                                                                                 |
-|--------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| commands#start                       | Number   | W | Starts the automower for a duration                     |
-| commands#resume_schedule             | Switch   | W | Resumes the Automower schedule                          |
-| commands#pause                       | Switch   | W | Pause the Automower                                     |
-| commands#park                        | Number   | W | Park the Automower for a duration                       |
-| commands#park_until_next_schedule    | Switch   | W | Park the Automower until next schedule                  |
-| commands#park_until_further_notice   | Switch   | W | Park the Automower until further notice.                |
+| channel                     | type     | access mode | description                                                                                                                                                                 |
+|-----------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| start                       | Number   | W | Starts the automower for a duration                     |
+| resume_schedule             | Switch   | W | Resumes the Automower schedule                          |
+| pause                       | Switch   | W | Pause the Automower                                     |
+| park                        | Number   | W | Park the Automower for a duration                       |
+| park_until_next_schedule    | Switch   | W | Park the Automower until next schedule                  |
+| park_until_further_notice   | Switch   | W | Park the Automower until further notice.                |
 
-### Channel Group 'Mower Positions'
+### Position Channels
 
-| channel              | type     | access mode | description                                                                                                                                                                 |
-|----------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| positions#position01 | Location | R | GPS Position 01 |
-| positions#position02 | Location | R | GPS Position 02 |
-| positions#position03 | Location | R | GPS Position 03 |
-| positions#position04 | Location | R | GPS Position 04 |
-| positions#position05 | Location | R | GPS Position 05 |
-| positions#position06 | Location | R | GPS Position 06 |
-| positions#position07 | Location | R | GPS Position 07 |
-| positions#position08 | Location | R | GPS Position 08 |
-| positions#position09 | Location | R | GPS Position 09 |
-| positions#position10 | Location | R | GPS Position 10 |
-| positions#position11 | Location | R | GPS Position 11 |
-| positions#position12 | Location | R | GPS Position 12 |
-| positions#position13 | Location | R | GPS Position 13 |
-| positions#position14 | Location | R | GPS Position 14 |
-| positions#position15 | Location | R | GPS Position 15 |
-| positions#position16 | Location | R | GPS Position 16 |
-| positions#position17 | Location | R | GPS Position 17 |
-| positions#position18 | Location | R | GPS Position 18 |
-| positions#position19 | Location | R | GPS Position 19 |
-| positions#position20 | Location | R | GPS Position 20 |
-| positions#position21 | Location | R | GPS Position 21 |
-| positions#position22 | Location | R | GPS Position 22 |
-| positions#position23 | Location | R | GPS Position 23 |
-| positions#position24 | Location | R | GPS Position 24 |
-| positions#position25 | Location | R | GPS Position 25 |
-| positions#position26 | Location | R | GPS Position 26 |
-| positions#position27 | Location | R | GPS Position 27 |
-| positions#position28 | Location | R | GPS Position 28 |
-| positions#position29 | Location | R | GPS Position 29 |
-| positions#position30 | Location | R | GPS Position 30 |
-| positions#position31 | Location | R | GPS Position 31 |
-| positions#position32 | Location | R | GPS Position 32 |
-| positions#position33 | Location | R | GPS Position 33 |
-| positions#position34 | Location | R | GPS Position 34 |
-| positions#position35 | Location | R | GPS Position 35 |
-| positions#position36 | Location | R | GPS Position 36 |
-| positions#position37 | Location | R | GPS Position 37 |
-| positions#position38 | Location | R | GPS Position 38 |
-| positions#position39 | Location | R | GPS Position 39 |
-| positions#position40 | Location | R | GPS Position 40 |
-| positions#position41 | Location | R | GPS Position 41 |
-| positions#position42 | Location | R | GPS Position 42 |
-| positions#position43 | Location | R | GPS Position 43 |
-| positions#position44 | Location | R | GPS Position 44 |
-| positions#position45 | Location | R | GPS Position 45 |
-| positions#position46 | Location | R | GPS Position 46 |
-| positions#position47 | Location | R | GPS Position 47 |
-| positions#position48 | Location | R | GPS Position 48 |
-| positions#position49 | Location | R | GPS Position 49 |
-| positions#position50 | Location | R | GPS Position 50 |
-| positions#last-position | Location | R | Last GPS Position |
+These channels hold the last 50 GPS positions recorded by the Automower, thus describing the path it followed.
+Position 01 is the latest recorded position, the other positions are pushed back, thus removing the previous position 50 from the list because it is replaced by the previous position 49.
+Channel `last-position` is always identical with channel `position01` and thus provides more convenient access if only the latest GPS information is required by the user.
+
+| channel    | type     | access mode | description                                                                                                                                                                 |
+|------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| position01 | Location | R | GPS Position 01 |
+| position02 | Location | R | GPS Position 02 |
+| position03 | Location | R | GPS Position 03 |
+| position04 | Location | R | GPS Position 04 |
+| position05 | Location | R | GPS Position 05 |
+| position06 | Location | R | GPS Position 06 |
+| position07 | Location | R | GPS Position 07 |
+| position08 | Location | R | GPS Position 08 |
+| position09 | Location | R | GPS Position 09 |
+| position10 | Location | R | GPS Position 10 |
+| position11 | Location | R | GPS Position 11 |
+| position12 | Location | R | GPS Position 12 |
+| position13 | Location | R | GPS Position 13 |
+| position14 | Location | R | GPS Position 14 |
+| position15 | Location | R | GPS Position 15 |
+| position16 | Location | R | GPS Position 16 |
+| position17 | Location | R | GPS Position 17 |
+| position18 | Location | R | GPS Position 18 |
+| position19 | Location | R | GPS Position 19 |
+| position20 | Location | R | GPS Position 20 |
+| position21 | Location | R | GPS Position 21 |
+| position22 | Location | R | GPS Position 22 |
+| position23 | Location | R | GPS Position 23 |
+| position24 | Location | R | GPS Position 24 |
+| position25 | Location | R | GPS Position 25 |
+| position26 | Location | R | GPS Position 26 |
+| position27 | Location | R | GPS Position 27 |
+| position28 | Location | R | GPS Position 28 |
+| position29 | Location | R | GPS Position 29 |
+| position30 | Location | R | GPS Position 30 |
+| position31 | Location | R | GPS Position 31 |
+| position32 | Location | R | GPS Position 32 |
+| position33 | Location | R | GPS Position 33 |
+| position34 | Location | R | GPS Position 34 |
+| position35 | Location | R | GPS Position 35 |
+| position36 | Location | R | GPS Position 36 |
+| position37 | Location | R | GPS Position 37 |
+| position38 | Location | R | GPS Position 38 |
+| position39 | Location | R | GPS Position 39 |
+| position40 | Location | R | GPS Position 40 |
+| position41 | Location | R | GPS Position 41 |
+| position42 | Location | R | GPS Position 42 |
+| position43 | Location | R | GPS Position 43 |
+| position44 | Location | R | GPS Position 44 |
+| position45 | Location | R | GPS Position 45 |
+| position46 | Location | R | GPS Position 46 |
+| position47 | Location | R | GPS Position 47 |
+| position48 | Location | R | GPS Position 48 |
+| position49 | Location | R | GPS Position 49 |
+| position50 | Location | R | GPS Position 50 |
+| last-position | Location | R | Last GPS Position (identical with positions#position01) |
 
 
 ## Actions
@@ -149,25 +153,25 @@ The following actions are available for `automower`things:
 
 ### automower.items
 
-	String Automower_Mode               "Mode [%s]"                   { channel="automower:automower:mybridge:myAutomower:status#mode" }
-	String Automower_Activity           "Activity [%s]"         	     { channel="automower:automower:mybridge:myAutomower:status#activity" }
-	String Automower_State              "State [%s]"            	     { channel="automower:automower:mybridge:myAutomower:status#state" }
-	DateTime Automower_Last_Update      "Last Update"    	     { channel="automower:automower:mybridge:myAutomower:status#last-update" }
-	Number Automower_Battery            "Battery [%d %%]"                { channel="automower:automower:mybridge:myAutomower:status#battery" }
-	Number Automower_Error_Code         "Error Code [%d]"             { channel="automower:automower:mybridge:myAutomower:status#error-code" }
-	DateTime Automower_Error_Time       "Error Time"             { channel="automower:automower:mybridge:myAutomower:status#error-timestamp" }
-	String Automower_Override_Action    "Override Action [%s]"        { channel="automower:automower:mybridge:myAutomower:status#planner-override-action" }
-	DateTime Automower_Next_Start_Time  "Next Start Time"        { channel="automower:automower:mybridge:myAutomower:status#planner-next-start" }
-	String Automower_Calendar_Tasks     "Planned Tasks [%s]"          { channel="automower:automower:mybridge:myAutomower:status#calendar-tasks" }
+	String Automower_Mode               "Mode [%s]"                   { channel="automower:automower:mybridge:myAutomower:mode" }
+	String Automower_Activity           "Activity [%s]"         	     { channel="automower:automower:mybridge:myAutomower:activity" }
+	String Automower_State              "State [%s]"            	     { channel="automower:automower:mybridge:myAutomower:state" }
+	DateTime Automower_Last_Update      "Last Update"    	     { channel="automower:automower:mybridge:myAutomower:last-update" }
+	Number Automower_Battery            "Battery [%d %%]"                { channel="automower:automower:mybridge:myAutomower:battery" }
+	Number Automower_Error_Code         "Error Code [%d]"             { channel="automower:automower:mybridge:myAutomower:error-code" }
+	DateTime Automower_Error_Time       "Error Time"             { channel="automower:automower:mybridge:myAutomower:error-timestamp" }
+	String Automower_Override_Action    "Override Action [%s]"        { channel="automower:automower:mybridge:myAutomower:planner-override-action" }
+	DateTime Automower_Next_Start_Time  "Next Start Time"        { channel="automower:automower:mybridge:myAutomower:planner-next-start" }
+	String Automower_Calendar_Tasks     "Planned Tasks [%s]"          { channel="automower:automower:mybridge:myAutomower:calendar-tasks" }
 
-	Number Automower_Command_Start               "Start mowing for duration [%d min]"    { channel="automower:automower:mybridge:myAutomower:commands#start" }
-	Switch Automower_Command_Resume              "Resume the schedule"          { channel="automower:automower:mybridge:myAutomower:commands#resume_schedule" }
-	Switch Automower_Command_Pause               "Pause the automower"          { channel="automower:automower:mybridge:myAutomower:commands#pause" }
-	Number Automower_Command_Park                "Park for duration [%d min]"            { channel="automower:automower:mybridge:myAutomower:commands#park" }
-	Switch Automower_Command_Park_Next_Schedule  "Park until next schedule"     { channel="automower:automower:mybridge:myAutomower:commands#park_until_next_schedule" }
-	Switch Automower_Command_Park_Notice         "Park until further notice"    { channel="automower:automower:mybridge:myAutomower:commands#park_until_further_notice" }
+	Number Automower_Command_Start               "Start mowing for duration [%d min]"    { channel="automower:automower:mybridge:myAutomower:start" }
+	Switch Automower_Command_Resume              "Resume the schedule"          { channel="automower:automower:mybridge:myAutomower:resume_schedule" }
+	Switch Automower_Command_Pause               "Pause the automower"          { channel="automower:automower:mybridge:myAutomower:pause" }
+	Number Automower_Command_Park                "Park for duration [%d min]"            { channel="automower:automower:mybridge:myAutomower:park" }
+	Switch Automower_Command_Park_Next_Schedule  "Park until next schedule"     { channel="automower:automower:mybridge:myAutomower:park_until_next_schedule" }
+	Switch Automower_Command_Park_Notice         "Park until further notice"    { channel="automower:automower:mybridge:myAutomower:park_until_further_notice" }
 
-    Location Automower_Last_Position    "Last Position" { channel="automower:automower:mybridge:myAutomower:positions#last-position" }
+    Location Automower_Last_Position    "Last Position" { channel="automower:automower:mybridge:myAutomower:last-position" }
    
 
 ### automower.sitemap

--- a/bundles/org.openhab.binding.automower/README.md
+++ b/bundles/org.openhab.binding.automower/README.md
@@ -40,25 +40,87 @@ With the default value of 10min this would mean ~4300 requests per month per sin
 
 ## Channels
 
+### Channel Group 'Mower Status'
 
-| channel                 | type     | access mode | description                                                                                                                                                                 |
-|-------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| mower-status#mode                     | String   | R | The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                |
-| mower-status#activity                 | String   | R | The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                           |
-| mower-status#state                   | String   | R | The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED_NONE, RESTRICTED_WEEK_SCHEDULE, RESTRICTED_PARK_OVERRIDE, RESTRICTED_SENSOR, RESTRICTED_DAILY_LIMIT, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP)  |
-| mower-status#last-update              | DateTime | R | The time when the automower updated its states                                                                                                                   |
-| mower-status#battery                  | Number   | R | The battery state of charge in percent                                                                                                                           |
-| mower-status#error-code               | Number   | R | The current error code                                                                                                                                           |
-| mower-status#error-timestamp         | DateTime | R | The timestamp when the current error occurred                                                                                                                    |
-| mower-status#planner-next-start      | DateTime | R | The time for the next auto start. If the mower is charging then the value is the estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.                                                                  |
-| mower-status#planner-override-action | String   | R | The action that overrides current planner operation.                                                                                                                                                                                                                  |
-| mower-status#calendar-tasks          | String   | R | The JSON with the information about Automower planner.                                                                                                    |
-| mower#start                       | Number   | W | Starts the automower for a duration                     |
-| mower#resume_schedule             | Switch   | W | Resumes the Automower schedule                          |
-| mower#pause                       | Switch   | W | Pause the Automower                                     |
-| mower#park                        | Number   | W | Park the Automower for a duration                       |
-| mower#park_until_next_schedule    | Switch   | W | Park the Automower until next schedule                  |
-| mower#park_until_further_notice   | Switch   | W | Park the Automower until further notice.                |
+| channel                        | type     | access mode | description                                                                                                                                                                 |
+|--------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| status#mode                    | String   | R | The current mode (MAIN_AREA, SECONDARY_AREA, HOME, DEMO, UNKNOWN)                                                                                                |
+| status#activity                | String   | R | The current activity (UNKNOWN, NOT_APPLICABLE, MOWING, GOING_HOME, CHARGING, LEAVING, PARKED_IN_CS, STOPPED_IN_GARDEN)                                           |
+| status#state                   | String   | R | The current state (UNKNOWN, NOT_APPLICABLE, PAUSED, IN_OPERATION, WAIT_UPDATING, WAIT_POWER_UP, RESTRICTED_NONE, RESTRICTED_WEEK_SCHEDULE, RESTRICTED_PARK_OVERRIDE, RESTRICTED_SENSOR, RESTRICTED_DAILY_LIMIT, OFF, STOPPED, ERROR, FATAL_ERROR, ERROR_AT_POWER_UP)  |
+| status#last-update             | DateTime | R | The time when the automower updated its states                                                                                                                   |
+| status#battery                 | Number   | R | The battery state of charge in percent                                                                                                                           |
+| status#error-code              | Number   | R | The current error code                                                                                                                                           |
+| status#error-timestamp         | DateTime | R | The timestamp when the current error occurred                                                                                                                    |
+| status#planner-next-start      | DateTime | R | The time for the next auto start. If the mower is charging then the value is the estimated time when it will be leaving the charging station. If the mower is about to start now, the value is NULL.                                                                  |
+| status#planner-override-action | String   | R | The action that overrides current planner operation.                                                                                                                                                                                                                  |
+| status#calendar-tasks          | String   | R | The JSON with the information about Automower planner.                                                                                                    |
+
+### Channel Group 'Mower Commmands'
+
+| channel                              | type     | access mode | description                                                                                                                                                                 |
+|--------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| commands#start                       | Number   | W | Starts the automower for a duration                     |
+| commands#resume_schedule             | Switch   | W | Resumes the Automower schedule                          |
+| commands#pause                       | Switch   | W | Pause the Automower                                     |
+| commands#park                        | Number   | W | Park the Automower for a duration                       |
+| commands#park_until_next_schedule    | Switch   | W | Park the Automower until next schedule                  |
+| commands#park_until_further_notice   | Switch   | W | Park the Automower until further notice.                |
+
+### Channel Group 'Mower Positions'
+
+| channel              | type     | access mode | description                                                                                                                                                                 |
+|----------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| positions#position01 | Location | R | GPS Position 01 |
+| positions#position02 | Location | R | GPS Position 02 |
+| positions#position03 | Location | R | GPS Position 03 |
+| positions#position04 | Location | R | GPS Position 04 |
+| positions#position05 | Location | R | GPS Position 05 |
+| positions#position06 | Location | R | GPS Position 06 |
+| positions#position07 | Location | R | GPS Position 07 |
+| positions#position08 | Location | R | GPS Position 08 |
+| positions#position09 | Location | R | GPS Position 09 |
+| positions#position10 | Location | R | GPS Position 10 |
+| positions#position11 | Location | R | GPS Position 11 |
+| positions#position12 | Location | R | GPS Position 12 |
+| positions#position13 | Location | R | GPS Position 13 |
+| positions#position14 | Location | R | GPS Position 14 |
+| positions#position15 | Location | R | GPS Position 15 |
+| positions#position16 | Location | R | GPS Position 16 |
+| positions#position17 | Location | R | GPS Position 17 |
+| positions#position18 | Location | R | GPS Position 18 |
+| positions#position19 | Location | R | GPS Position 19 |
+| positions#position20 | Location | R | GPS Position 20 |
+| positions#position21 | Location | R | GPS Position 21 |
+| positions#position22 | Location | R | GPS Position 22 |
+| positions#position23 | Location | R | GPS Position 23 |
+| positions#position24 | Location | R | GPS Position 24 |
+| positions#position25 | Location | R | GPS Position 25 |
+| positions#position26 | Location | R | GPS Position 26 |
+| positions#position27 | Location | R | GPS Position 27 |
+| positions#position28 | Location | R | GPS Position 28 |
+| positions#position29 | Location | R | GPS Position 29 |
+| positions#position30 | Location | R | GPS Position 30 |
+| positions#position31 | Location | R | GPS Position 31 |
+| positions#position32 | Location | R | GPS Position 32 |
+| positions#position33 | Location | R | GPS Position 33 |
+| positions#position34 | Location | R | GPS Position 34 |
+| positions#position35 | Location | R | GPS Position 35 |
+| positions#position36 | Location | R | GPS Position 36 |
+| positions#position37 | Location | R | GPS Position 37 |
+| positions#position38 | Location | R | GPS Position 38 |
+| positions#position39 | Location | R | GPS Position 39 |
+| positions#position40 | Location | R | GPS Position 40 |
+| positions#position41 | Location | R | GPS Position 41 |
+| positions#position42 | Location | R | GPS Position 42 |
+| positions#position43 | Location | R | GPS Position 43 |
+| positions#position44 | Location | R | GPS Position 44 |
+| positions#position45 | Location | R | GPS Position 45 |
+| positions#position46 | Location | R | GPS Position 46 |
+| positions#position47 | Location | R | GPS Position 47 |
+| positions#position48 | Location | R | GPS Position 48 |
+| positions#position49 | Location | R | GPS Position 49 |
+| positions#position50 | Location | R | GPS Position 50 |
+| positions#last-position | Location | R | Last GPS Position |
 
 
 ## Actions
@@ -87,23 +149,26 @@ The following actions are available for `automower`things:
 
 ### automower.items
 
-	String Automower_Mode               "Mode [%s]"                   { channel="automower:automower:mybridge:myAutomower:mower-status#mode" }
-	String Automower_Activity           "Activity [%s]"         	     { channel="automower:automower:mybridge:myAutomower:mower-status#activity" }
-	String Automower_State              "State [%s]"            	     { channel="automower:automower:mybridge:myAutomower:mower-status#state" }
-	DateTime Automower_Last_Update      "Last Update"    	     { channel="automower:automower:mybridge:myAutomower:mower-status#last-update" }
-	Number Automower_Battery            "Battery [%d %%]"                { channel="automower:automower:mybridge:myAutomower:mower-status#battery" }
-	Number Automower_Error_Code         "Error Code [%d]"             { channel="automower:automower:mybridge:myAutomower:mower-status#error-code" }
-	DateTime Automower_Error_Time       "Error Time"             { channel="automower:automower:mybridge:myAutomower:mower-status#error-timestamp" }
-	String Automower_Override_Action    "Override Action [%s]"        { channel="automower:automower:mybridge:myAutomower:mower-status#planner-override-action" }
-	DateTime Automower_Next_Start_Time  "Next Start Time"        { channel="automower:automower:mybridge:myAutomower:mower-status#planner-next-start" }
-	String Automower_Calendar_Tasks     "Planned Tasks [%s]"          { channel="automower:automower:mybridge:myAutomower:mower-status#calendar-tasks" }
+	String Automower_Mode               "Mode [%s]"                   { channel="automower:automower:mybridge:myAutomower:status#mode" }
+	String Automower_Activity           "Activity [%s]"         	     { channel="automower:automower:mybridge:myAutomower:status#activity" }
+	String Automower_State              "State [%s]"            	     { channel="automower:automower:mybridge:myAutomower:status#state" }
+	DateTime Automower_Last_Update      "Last Update"    	     { channel="automower:automower:mybridge:myAutomower:status#last-update" }
+	Number Automower_Battery            "Battery [%d %%]"                { channel="automower:automower:mybridge:myAutomower:status#battery" }
+	Number Automower_Error_Code         "Error Code [%d]"             { channel="automower:automower:mybridge:myAutomower:status#error-code" }
+	DateTime Automower_Error_Time       "Error Time"             { channel="automower:automower:mybridge:myAutomower:status#error-timestamp" }
+	String Automower_Override_Action    "Override Action [%s]"        { channel="automower:automower:mybridge:myAutomower:status#planner-override-action" }
+	DateTime Automower_Next_Start_Time  "Next Start Time"        { channel="automower:automower:mybridge:myAutomower:status#planner-next-start" }
+	String Automower_Calendar_Tasks     "Planned Tasks [%s]"          { channel="automower:automower:mybridge:myAutomower:status#calendar-tasks" }
 
-	Number Automower_Command_Start               "Start mowing for duration [%d min]"    { channel="automower:automower:mybridge:myAutomower:mower#start" }
-	Switch Automower_Command_Resume              "Resume the schedule"          { channel="automower:automower:mybridge:myAutomower:mower#resume_schedule" }
-	Switch Automower_Command_Pause               "Pause the automower"          { channel="automower:automower:mybridge:myAutomower:mower#pause" }
-	Number Automower_Command_Park                "Park for duration [%d min]"            { channel="automower:automower:mybridge:myAutomower:mower#park" }
-	Switch Automower_Command_Park_Next_Schedule  "Park until next schedule"     { channel="automower:automower:mybridge:myAutomower:mower#park_until_next_schedule" }
-	Switch Automower_Command_Park_Notice         "Park until further notice"    { channel="automower:automower:mybridge:myAutomower:mower#park_until_further_notice" }
+	Number Automower_Command_Start               "Start mowing for duration [%d min]"    { channel="automower:automower:mybridge:myAutomower:commands#start" }
+	Switch Automower_Command_Resume              "Resume the schedule"          { channel="automower:automower:mybridge:myAutomower:commands#resume_schedule" }
+	Switch Automower_Command_Pause               "Pause the automower"          { channel="automower:automower:mybridge:myAutomower:commands#pause" }
+	Number Automower_Command_Park                "Park for duration [%d min]"            { channel="automower:automower:mybridge:myAutomower:commands#park" }
+	Switch Automower_Command_Park_Next_Schedule  "Park until next schedule"     { channel="automower:automower:mybridge:myAutomower:commands#park_until_next_schedule" }
+	Switch Automower_Command_Park_Notice         "Park until further notice"    { channel="automower:automower:mybridge:myAutomower:commands#park_until_further_notice" }
+
+    Location Automower_Last_Position    "Last Position" { channel="automower:automower:mybridge:myAutomower:positions#last-position" }
+   
 
 ### automower.sitemap
 

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -35,7 +35,8 @@ public class AutomowerBindingConstants {
     public static final ThingTypeUID THING_TYPE_AUTOMOWER = new ThingTypeUID(BINDING_ID, "automower");
 
     // List of all status Channel ids
-    public static final String GROUP_STATUS = "status#";
+    public static final String GROUP_STATUS = ""; // no channel group in use at the moment, we'll possibly introduce
+                                                  // this in a future release
     public static final String CHANNEL_STATUS_NAME = GROUP_STATUS + "name";
     public static final String CHANNEL_STATUS_MODE = GROUP_STATUS + "mode";
     public static final String CHANNEL_STATUS_ACTIVITY = GROUP_STATUS + "activity";
@@ -49,7 +50,9 @@ public class AutomowerBindingConstants {
     public static final String CHANNEL_CALENDAR_TASKS = GROUP_STATUS + "calendar-tasks";
 
     // Position Channels ids
-    public static final String GROUP_POSITIONS = "positions#";
+    public static final String GROUP_POSITIONS = ""; // no channel group in use at the moment, we'll possibly
+                                                     // introduce
+    // this in a future release
     public static final String LAST_POSITION = GROUP_POSITIONS + "last-position";
     public static final ArrayList<String> CHANNEL_POSITIONS = new ArrayList<String>(
             List.of(GROUP_POSITIONS + "position01", GROUP_POSITIONS + "position02", GROUP_POSITIONS + "position03",
@@ -71,7 +74,8 @@ public class AutomowerBindingConstants {
                     GROUP_POSITIONS + "position49", GROUP_POSITIONS + "position50"));
 
     // Command Channel ids
-    public static final String GROUP_COMMANDS = "commands#";
+    public static final String GROUP_COMMANDS = ""; // no channel group in use at the moment, we'll possibly introduce
+                                                    // this in a future release
     public static final String CHANNEL_COMMAND_START = GROUP_COMMANDS + "start";
     public static final String CHANNEL_COMMAND_RESUME_SCHEDULE = GROUP_COMMANDS + "resume_schedule";
     public static final String CHANNEL_COMMAND_PAUSE = GROUP_COMMANDS + "pause";

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -50,6 +50,7 @@ public class AutomowerBindingConstants {
 
     // Position Channels ids
     public static final String GROUP_POSITIONS = "positions#";
+    public static final String LAST_POSITION = GROUP_POSITIONS + "last-position";
     public static final ArrayList<String> CHANNEL_POSITIONS = new ArrayList<String>(
             List.of(GROUP_POSITIONS + "position01", GROUP_POSITIONS + "position02", GROUP_POSITIONS + "position03",
                     GROUP_POSITIONS + "position04", GROUP_POSITIONS + "position05", GROUP_POSITIONS + "position06",

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -65,7 +65,7 @@ public class AutomowerBindingConstants {
                     GROUP_POSITIONS + "position31", GROUP_POSITIONS + "position32", GROUP_POSITIONS + "position33",
                     GROUP_POSITIONS + "position34", GROUP_POSITIONS + "position35", GROUP_POSITIONS + "position36",
                     GROUP_POSITIONS + "position37", GROUP_POSITIONS + "position38", GROUP_POSITIONS + "position39",
-                    GROUP_POSITIONS + "position00", GROUP_POSITIONS + "position41", GROUP_POSITIONS + "position42",
+                    GROUP_POSITIONS + "position40", GROUP_POSITIONS + "position41", GROUP_POSITIONS + "position42",
                     GROUP_POSITIONS + "position43", GROUP_POSITIONS + "position44", GROUP_POSITIONS + "position45",
                     GROUP_POSITIONS + "position46", GROUP_POSITIONS + "position47", GROUP_POSITIONS + "position48",
                     GROUP_POSITIONS + "position49", GROUP_POSITIONS + "position50"));

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/AutomowerBindingConstants.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.binding.automower.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
 
@@ -31,26 +34,49 @@ public class AutomowerBindingConstants {
     // generic thing types
     public static final ThingTypeUID THING_TYPE_AUTOMOWER = new ThingTypeUID(BINDING_ID, "automower");
 
-    // List of all Channel ids
-    public static final String CHANNEL_STATUS_NAME = "name";
-    public static final String CHANNEL_STATUS_MODE = "mode";
-    public static final String CHANNEL_STATUS_ACTIVITY = "activity";
-    public static final String CHANNEL_STATUS_STATE = "state";
-    public static final String CHANNEL_STATUS_LAST_UPDATE = "last-update";
-    public static final String CHANNEL_STATUS_BATTERY = "battery";
-    public static final String CHANNEL_STATUS_ERROR_CODE = "error-code";
-    public static final String CHANNEL_STATUS_ERROR_TIMESTAMP = "error-timestamp";
-    public static final String CHANNEL_PLANNER_NEXT_START = "planner-next-start";
-    public static final String CHANNEL_PLANNER_OVERRIDE_ACTION = "planner-override-action";
-    public static final String CHANNEL_CALENDAR_TASKS = "calendar-tasks";
+    // List of all status Channel ids
+    public static final String GROUP_STATUS = "status#";
+    public static final String CHANNEL_STATUS_NAME = GROUP_STATUS + "name";
+    public static final String CHANNEL_STATUS_MODE = GROUP_STATUS + "mode";
+    public static final String CHANNEL_STATUS_ACTIVITY = GROUP_STATUS + "activity";
+    public static final String CHANNEL_STATUS_STATE = GROUP_STATUS + "state";
+    public static final String CHANNEL_STATUS_LAST_UPDATE = GROUP_STATUS + "last-update";
+    public static final String CHANNEL_STATUS_BATTERY = GROUP_STATUS + "battery";
+    public static final String CHANNEL_STATUS_ERROR_CODE = GROUP_STATUS + "error-code";
+    public static final String CHANNEL_STATUS_ERROR_TIMESTAMP = GROUP_STATUS + "error-timestamp";
+    public static final String CHANNEL_PLANNER_NEXT_START = GROUP_STATUS + "planner-next-start";
+    public static final String CHANNEL_PLANNER_OVERRIDE_ACTION = GROUP_STATUS + "planner-override-action";
+    public static final String CHANNEL_CALENDAR_TASKS = GROUP_STATUS + "calendar-tasks";
 
-    // Command channels
-    public static final String CHANNEL_COMMAND_START = "start";
-    public static final String CHANNEL_COMMAND_RESUME_SCHEDULE = "resume_schedule";
-    public static final String CHANNEL_COMMAND_PAUSE = "pause";
-    public static final String CHANNEL_COMMAND_PARK = "park";
-    public static final String CHANNEL_COMMAND_PARK_UNTIL_NEXT_SCHEDULE = "park_until_next_schedule";
-    public static final String CHANNEL_COMMAND_PARK_UNTIL_NOTICE = "park_until_further_notice";
+    // Position Channels ids
+    public static final String GROUP_POSITIONS = "positions#";
+    public static final ArrayList<String> CHANNEL_POSITIONS = new ArrayList<String>(
+            List.of(GROUP_POSITIONS + "position01", GROUP_POSITIONS + "position02", GROUP_POSITIONS + "position03",
+                    GROUP_POSITIONS + "position04", GROUP_POSITIONS + "position05", GROUP_POSITIONS + "position06",
+                    GROUP_POSITIONS + "position07", GROUP_POSITIONS + "position08", GROUP_POSITIONS + "position09",
+                    GROUP_POSITIONS + "position10", GROUP_POSITIONS + "position11", GROUP_POSITIONS + "position12",
+                    GROUP_POSITIONS + "position13", GROUP_POSITIONS + "position14", GROUP_POSITIONS + "position15",
+                    GROUP_POSITIONS + "position16", GROUP_POSITIONS + "position17", GROUP_POSITIONS + "position18",
+                    GROUP_POSITIONS + "position19", GROUP_POSITIONS + "position20", GROUP_POSITIONS + "position21",
+                    GROUP_POSITIONS + "position22", GROUP_POSITIONS + "position23", GROUP_POSITIONS + "position24",
+                    GROUP_POSITIONS + "position25", GROUP_POSITIONS + "position26", GROUP_POSITIONS + "position27",
+                    GROUP_POSITIONS + "position28", GROUP_POSITIONS + "position29", GROUP_POSITIONS + "position30",
+                    GROUP_POSITIONS + "position31", GROUP_POSITIONS + "position32", GROUP_POSITIONS + "position33",
+                    GROUP_POSITIONS + "position34", GROUP_POSITIONS + "position35", GROUP_POSITIONS + "position36",
+                    GROUP_POSITIONS + "position37", GROUP_POSITIONS + "position38", GROUP_POSITIONS + "position39",
+                    GROUP_POSITIONS + "position00", GROUP_POSITIONS + "position41", GROUP_POSITIONS + "position42",
+                    GROUP_POSITIONS + "position43", GROUP_POSITIONS + "position44", GROUP_POSITIONS + "position45",
+                    GROUP_POSITIONS + "position46", GROUP_POSITIONS + "position47", GROUP_POSITIONS + "position48",
+                    GROUP_POSITIONS + "position49", GROUP_POSITIONS + "position50"));
+
+    // Command Channel ids
+    public static final String GROUP_COMMANDS = "commands#";
+    public static final String CHANNEL_COMMAND_START = GROUP_COMMANDS + "start";
+    public static final String CHANNEL_COMMAND_RESUME_SCHEDULE = GROUP_COMMANDS + "resume_schedule";
+    public static final String CHANNEL_COMMAND_PAUSE = GROUP_COMMANDS + "pause";
+    public static final String CHANNEL_COMMAND_PARK = GROUP_COMMANDS + "park";
+    public static final String CHANNEL_COMMAND_PARK_UNTIL_NEXT_SCHEDULE = GROUP_COMMANDS + "park_until_next_schedule";
+    public static final String CHANNEL_COMMAND_PARK_UNTIL_NOTICE = GROUP_COMMANDS + "park_until_further_notice";
 
     // Automower properties
     public static final String AUTOMOWER_ID = "mowerId";

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/MowerData.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/MowerData.java
@@ -83,6 +83,6 @@ public class MowerData {
     }
 
     public Position getLastPosition() {
-        return !this.positions.isEmpty() ? this.positions.get(this.positions.size() - 1) : null;
+        return !this.positions.isEmpty() ? this.positions.get(0) : null;
     }
 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/MowerData.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/MowerData.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
 
+import java.util.ArrayList;
+
 /**
  * @author Markus Pfleger - Initial contribution
  */
@@ -22,6 +24,7 @@ public class MowerData {
     private Calendar calendar;
     private Planner planner;
     private Metadata metadata;
+    private ArrayList<Position> positions = new ArrayList<Position>();
 
     public System getSystem() {
         return system;
@@ -69,5 +72,17 @@ public class MowerData {
 
     public void setMetadata(Metadata metadata) {
         this.metadata = metadata;
+    }
+
+    public void addPosition(Position position) {
+        this.positions.add(position);
+    }
+
+    public ArrayList<Position> getPositions() {
+        return this.positions;
+    }
+
+    public Position getLastPosition() {
+        return !this.positions.isEmpty() ? this.positions.get(this.positions.size() - 1) : null;
     }
 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
+
+/**
+ * @author Bernhard Bauer - Adding support for positions
+ */
+public class Position {
+    private double latitude;
+    private double longitude;
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(double latitude) {
+        this.latitude = latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(double longitude) {
+        this.longitude = longitude;
+    }
+
+}

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
@@ -34,5 +34,4 @@ public class Position {
     public void setLongitude(double longitude) {
         this.longitude = longitude;
     }
-
 }

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/rest/api/automowerconnect/dto/Position.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.automower.internal.rest.api.automowerconnect.dto;
 
 /**
- * @author Bernhard Bauer - Adding support for positions
+ * @author Bernhard Bauer - Initial contribution
  */
 public class Position {
     private double latitude;

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerCommand.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerCommand.java
@@ -17,11 +17,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 
 /**
  * @author Markus Pfleger - Initial contribution
  */
+@NonNullByDefault
 public enum AutomowerCommand {
     START("Start", "mower#start"),
     RESUME_SCHEDULE("ResumeSchedule", "mower#resume_schedule"),

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerHandler.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerHandler.java
@@ -16,6 +16,7 @@ import static org.openhab.binding.automower.internal.AutomowerBindingConstants.*
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -34,12 +35,14 @@ import org.openhab.binding.automower.internal.actions.AutomowerActions;
 import org.openhab.binding.automower.internal.bridge.AutomowerBridge;
 import org.openhab.binding.automower.internal.bridge.AutomowerBridgeHandler;
 import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.Mower;
+import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.Position;
 import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.RestrictedReason;
 import org.openhab.binding.automower.internal.rest.api.automowerconnect.dto.State;
 import org.openhab.binding.automower.internal.rest.exceptions.AutomowerCommunicationException;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PointType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.Units;
@@ -313,6 +316,13 @@ public class AutomowerHandler extends BaseThingHandler {
 
             updateState(CHANNEL_CALENDAR_TASKS,
                     new StringType(gson.toJson(mower.getAttributes().getCalendar().getTasks())));
+
+            ArrayList<Position> positions = mower.getAttributes().getPositions();
+            for (int i = 0; i < positions.size(); i++) {
+                updateState(CHANNEL_POSITIONS.get(i), new PointType(new DecimalType(positions.get(i).getLatitude()),
+                        new DecimalType(positions.get(i).getLongitude())));
+
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerHandler.java
+++ b/bundles/org.openhab.binding.automower/src/main/java/org/openhab/binding/automower/internal/things/AutomowerHandler.java
@@ -317,6 +317,9 @@ public class AutomowerHandler extends BaseThingHandler {
             updateState(CHANNEL_CALENDAR_TASKS,
                     new StringType(gson.toJson(mower.getAttributes().getCalendar().getTasks())));
 
+            updateState(LAST_POSITION,
+                    new PointType(new DecimalType(mower.getAttributes().getLastPosition().getLatitude()),
+                            new DecimalType(mower.getAttributes().getLastPosition().getLongitude())));
             ArrayList<Position> positions = mower.getAttributes().getPositions();
             for (int i = 0; i < positions.size(); i++) {
                 updateState(CHANNEL_POSITIONS.get(i), new PointType(new DecimalType(positions.get(i).getLatitude()),

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -44,25 +44,11 @@
 		<label>Automower</label>
 		<description>An automatic lawn mower</description>
 
-		<channels>
-			<channel id="name" typeId="nameType"/>
-			<channel id="mode" typeId="modeType"/>
-			<channel id="activity" typeId="activityType"/>
-			<channel id="state" typeId="stateType"/>
-			<channel id="last-update" typeId="lastUpdateType"/>
-			<channel id="battery" typeId="system.battery-level"/>
-			<channel id="error-code" typeId="errorCodeType"/>
-			<channel id="error-timestamp" typeId="errorTimestampType"/>
-			<channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
-			<channel id="planner-override-action" typeId="plannerOverrideActionType"/>
-			<channel id="calendar-tasks" typeId="calendarTasksType"/>
-			<channel id="start" typeId="start"/>
-			<channel id="resume_schedule" typeId="resumeSchedule"/>
-			<channel id="pause" typeId="pause"/>
-			<channel id="park" typeId="park"/>
-			<channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
-			<channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
-		</channels>
+        <channel-groups>
+            <channel-group id="status" typeId="statusGroup"/>
+            <channel-group id="positions" typeId="positionsGroup"/>
+            <channel-group id="commands" typeId="commandsGroup"/>
+        </channel-groups>
 
 		<properties>
 			<property name="mowerId">N/A</property>
@@ -84,6 +70,94 @@
 		</config-description>
 
 	</thing-type>
+
+    <channel-group-type id="statusGroup">
+        <label>Mower Status</label>
+        <description>Status information about the mower</description>
+        <channels>
+            <channel id="name" typeId="nameType"/>
+            <channel id="mode" typeId="modeType"/>
+            <channel id="activity" typeId="activityType"/>
+            <channel id="state" typeId="stateType"/>
+            <channel id="last-update" typeId="lastUpdateType"/>
+            <channel id="battery" typeId="system.battery-level"/>
+            <channel id="error-code" typeId="errorCodeType"/>
+            <channel id="error-timestamp" typeId="errorTimestampType"/>
+            <channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
+            <channel id="planner-override-action" typeId="plannerOverrideActionType"/>
+            <channel id="calendar-tasks" typeId="calendarTasksType"/>
+        </channels>
+    </channel-group-type>
+    
+    <channel-group-type id="positionsGroup">
+        <label>Mower Positions</label>
+        <description>Waypoints of the mower's activity</description>
+        <channels>
+            <channel id="position01" typeId="positionType"/>
+            <channel id="position02" typeId="positionType"/>
+            <channel id="position03" typeId="positionType"/>
+            <channel id="position04" typeId="positionType"/>
+            <channel id="position05" typeId="positionType"/>
+            <channel id="position06" typeId="positionType"/>
+            <channel id="position07" typeId="positionType"/>
+            <channel id="position08" typeId="positionType"/>
+            <channel id="position09" typeId="positionType"/>
+            <channel id="position10" typeId="positionType"/>
+            <channel id="position11" typeId="positionType"/>
+            <channel id="position12" typeId="positionType"/>
+            <channel id="position13" typeId="positionType"/>
+            <channel id="position14" typeId="positionType"/>
+            <channel id="position15" typeId="positionType"/>
+            <channel id="position16" typeId="positionType"/>
+            <channel id="position17" typeId="positionType"/>
+            <channel id="position18" typeId="positionType"/>
+            <channel id="position19" typeId="positionType"/>
+            <channel id="position20" typeId="positionType"/>
+            <channel id="position21" typeId="positionType"/>
+            <channel id="position22" typeId="positionType"/>
+            <channel id="position23" typeId="positionType"/>
+            <channel id="position24" typeId="positionType"/>
+            <channel id="position25" typeId="positionType"/>
+            <channel id="position26" typeId="positionType"/>
+            <channel id="position27" typeId="positionType"/>
+            <channel id="position28" typeId="positionType"/>
+            <channel id="position29" typeId="positionType"/>
+            <channel id="position30" typeId="positionType"/>
+            <channel id="position31" typeId="positionType"/>
+            <channel id="position32" typeId="positionType"/>
+            <channel id="position33" typeId="positionType"/>
+            <channel id="position34" typeId="positionType"/>
+            <channel id="position35" typeId="positionType"/>
+            <channel id="position36" typeId="positionType"/>
+            <channel id="position37" typeId="positionType"/>
+            <channel id="position38" typeId="positionType"/>
+            <channel id="position39" typeId="positionType"/>
+            <channel id="position40" typeId="positionType"/>
+            <channel id="position41" typeId="positionType"/>
+            <channel id="position42" typeId="positionType"/>
+            <channel id="position43" typeId="positionType"/>
+            <channel id="position44" typeId="positionType"/>
+            <channel id="position45" typeId="positionType"/>
+            <channel id="position46" typeId="positionType"/>
+            <channel id="position47" typeId="positionType"/>
+            <channel id="position48" typeId="positionType"/>
+            <channel id="position49" typeId="positionType"/>
+            <channel id="position50" typeId="positionType"/>
+        </channels>
+    </channel-group-type>
+
+    <channel-group-type id="commandsGroup">
+        <label>Mower Commands</label>
+        <description>Commands that can be sent to the mower</description>
+        <channels>
+            <channel id="start" typeId="start"/>
+            <channel id="resume_schedule" typeId="resumeSchedule"/>
+            <channel id="pause" typeId="pause"/>
+            <channel id="park" typeId="park"/>
+            <channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
+            <channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
+        </channels>
+    </channel-group-type>
 
 	<channel-type id="nameType">
 		<item-type>String</item-type>
@@ -200,6 +274,13 @@
 		<description>The channel providing a JSON with the information about the planner tasks.</description>
 		<state readOnly="true"/>
 	</channel-type>
+	
+	<channel-type id="positionType">
+        <item-type>Point</item-type>
+        <label>GPS Position</label>
+        <description>The channel providing a waypoint of the mower's activity.</description>
+        <state readOnly="true"/>
+    </channel-type>
 
 	<channel-type id="start">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -44,11 +44,11 @@
 		<label>Automower</label>
 		<description>An automatic lawn mower</description>
 
-        <channel-groups>
-            <channel-group id="status" typeId="statusGroup"/>
-            <channel-group id="positions" typeId="positionsGroup"/>
-            <channel-group id="commands" typeId="commandsGroup"/>
-        </channel-groups>
+		<channel-groups>
+			<channel-group id="status" typeId="statusGroup"/>
+			<channel-group id="positions" typeId="positionsGroup"/>
+			<channel-group id="commands" typeId="commandsGroup"/>
+		</channel-groups>
 
 		<properties>
 			<property name="mowerId">N/A</property>
@@ -71,94 +71,96 @@
 
 	</thing-type>
 
-    <channel-group-type id="statusGroup">
-        <label>Mower Status</label>
-        <description>Status information about the mower</description>
-        <channels>
-            <channel id="name" typeId="nameType"/>
-            <channel id="mode" typeId="modeType"/>
-            <channel id="activity" typeId="activityType"/>
-            <channel id="state" typeId="stateType"/>
-            <channel id="last-update" typeId="lastUpdateType"/>
-            <channel id="battery" typeId="system.battery-level"/>
-            <channel id="error-code" typeId="errorCodeType"/>
-            <channel id="error-timestamp" typeId="errorTimestampType"/>
-            <channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
-            <channel id="planner-override-action" typeId="plannerOverrideActionType"/>
-            <channel id="calendar-tasks" typeId="calendarTasksType"/>
-        </channels>
-    </channel-group-type>
-    
-    <channel-group-type id="positionsGroup">
-        <label>Mower Positions</label>
-        <description>Waypoints of the mower's activity</description>
-        <channels>
-            <channel id="last-position" typeId="positionType"><description>Last Position</description></channel>
-            <channel id="position01" typeId="positionType"/>
-            <channel id="position02" typeId="positionType"/>
-            <channel id="position03" typeId="positionType"/>
-            <channel id="position04" typeId="positionType"/>
-            <channel id="position05" typeId="positionType"/>
-            <channel id="position06" typeId="positionType"/>
-            <channel id="position07" typeId="positionType"/>
-            <channel id="position08" typeId="positionType"/>
-            <channel id="position09" typeId="positionType"/>
-            <channel id="position10" typeId="positionType"/>
-            <channel id="position11" typeId="positionType"/>
-            <channel id="position12" typeId="positionType"/>
-            <channel id="position13" typeId="positionType"/>
-            <channel id="position14" typeId="positionType"/>
-            <channel id="position15" typeId="positionType"/>
-            <channel id="position16" typeId="positionType"/>
-            <channel id="position17" typeId="positionType"/>
-            <channel id="position18" typeId="positionType"/>
-            <channel id="position19" typeId="positionType"/>
-            <channel id="position20" typeId="positionType"/>
-            <channel id="position21" typeId="positionType"/>
-            <channel id="position22" typeId="positionType"/>
-            <channel id="position23" typeId="positionType"/>
-            <channel id="position24" typeId="positionType"/>
-            <channel id="position25" typeId="positionType"/>
-            <channel id="position26" typeId="positionType"/>
-            <channel id="position27" typeId="positionType"/>
-            <channel id="position28" typeId="positionType"/>
-            <channel id="position29" typeId="positionType"/>
-            <channel id="position30" typeId="positionType"/>
-            <channel id="position31" typeId="positionType"/>
-            <channel id="position32" typeId="positionType"/>
-            <channel id="position33" typeId="positionType"/>
-            <channel id="position34" typeId="positionType"/>
-            <channel id="position35" typeId="positionType"/>
-            <channel id="position36" typeId="positionType"/>
-            <channel id="position37" typeId="positionType"/>
-            <channel id="position38" typeId="positionType"/>
-            <channel id="position39" typeId="positionType"/>
-            <channel id="position40" typeId="positionType"/>
-            <channel id="position41" typeId="positionType"/>
-            <channel id="position42" typeId="positionType"/>
-            <channel id="position43" typeId="positionType"/>
-            <channel id="position44" typeId="positionType"/>
-            <channel id="position45" typeId="positionType"/>
-            <channel id="position46" typeId="positionType"/>
-            <channel id="position47" typeId="positionType"/>
-            <channel id="position48" typeId="positionType"/>
-            <channel id="position49" typeId="positionType"/>
-            <channel id="position50" typeId="positionType"/>
-        </channels>
-    </channel-group-type>
+	<channel-group-type id="statusGroup">
+		<label>Mower Status</label>
+		<description>Status information about the mower</description>
+		<channels>
+			<channel id="name" typeId="nameType"/>
+			<channel id="mode" typeId="modeType"/>
+			<channel id="activity" typeId="activityType"/>
+			<channel id="state" typeId="stateType"/>
+			<channel id="last-update" typeId="lastUpdateType"/>
+			<channel id="battery" typeId="system.battery-level"/>
+			<channel id="error-code" typeId="errorCodeType"/>
+			<channel id="error-timestamp" typeId="errorTimestampType"/>
+			<channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
+			<channel id="planner-override-action" typeId="plannerOverrideActionType"/>
+			<channel id="calendar-tasks" typeId="calendarTasksType"/>
+		</channels>
+	</channel-group-type>
 
-    <channel-group-type id="commandsGroup">
-        <label>Mower Commands</label>
-        <description>Commands that can be sent to the mower</description>
-        <channels>
-            <channel id="start" typeId="start"/>
-            <channel id="resume_schedule" typeId="resumeSchedule"/>
-            <channel id="pause" typeId="pause"/>
-            <channel id="park" typeId="park"/>
-            <channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
-            <channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
-        </channels>
-    </channel-group-type>
+	<channel-group-type id="positionsGroup">
+		<label>Mower Positions</label>
+		<description>Waypoints of the mower's activity</description>
+		<channels>
+			<channel id="last-position" typeId="positionType">
+				<description>Last Position</description>
+			</channel>
+			<channel id="position01" typeId="positionType"/>
+			<channel id="position02" typeId="positionType"/>
+			<channel id="position03" typeId="positionType"/>
+			<channel id="position04" typeId="positionType"/>
+			<channel id="position05" typeId="positionType"/>
+			<channel id="position06" typeId="positionType"/>
+			<channel id="position07" typeId="positionType"/>
+			<channel id="position08" typeId="positionType"/>
+			<channel id="position09" typeId="positionType"/>
+			<channel id="position10" typeId="positionType"/>
+			<channel id="position11" typeId="positionType"/>
+			<channel id="position12" typeId="positionType"/>
+			<channel id="position13" typeId="positionType"/>
+			<channel id="position14" typeId="positionType"/>
+			<channel id="position15" typeId="positionType"/>
+			<channel id="position16" typeId="positionType"/>
+			<channel id="position17" typeId="positionType"/>
+			<channel id="position18" typeId="positionType"/>
+			<channel id="position19" typeId="positionType"/>
+			<channel id="position20" typeId="positionType"/>
+			<channel id="position21" typeId="positionType"/>
+			<channel id="position22" typeId="positionType"/>
+			<channel id="position23" typeId="positionType"/>
+			<channel id="position24" typeId="positionType"/>
+			<channel id="position25" typeId="positionType"/>
+			<channel id="position26" typeId="positionType"/>
+			<channel id="position27" typeId="positionType"/>
+			<channel id="position28" typeId="positionType"/>
+			<channel id="position29" typeId="positionType"/>
+			<channel id="position30" typeId="positionType"/>
+			<channel id="position31" typeId="positionType"/>
+			<channel id="position32" typeId="positionType"/>
+			<channel id="position33" typeId="positionType"/>
+			<channel id="position34" typeId="positionType"/>
+			<channel id="position35" typeId="positionType"/>
+			<channel id="position36" typeId="positionType"/>
+			<channel id="position37" typeId="positionType"/>
+			<channel id="position38" typeId="positionType"/>
+			<channel id="position39" typeId="positionType"/>
+			<channel id="position40" typeId="positionType"/>
+			<channel id="position41" typeId="positionType"/>
+			<channel id="position42" typeId="positionType"/>
+			<channel id="position43" typeId="positionType"/>
+			<channel id="position44" typeId="positionType"/>
+			<channel id="position45" typeId="positionType"/>
+			<channel id="position46" typeId="positionType"/>
+			<channel id="position47" typeId="positionType"/>
+			<channel id="position48" typeId="positionType"/>
+			<channel id="position49" typeId="positionType"/>
+			<channel id="position50" typeId="positionType"/>
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="commandsGroup">
+		<label>Mower Commands</label>
+		<description>Commands that can be sent to the mower</description>
+		<channels>
+			<channel id="start" typeId="start"/>
+			<channel id="resume_schedule" typeId="resumeSchedule"/>
+			<channel id="pause" typeId="pause"/>
+			<channel id="park" typeId="park"/>
+			<channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
+			<channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
+		</channels>
+	</channel-group-type>
 
 	<channel-type id="nameType">
 		<item-type>String</item-type>
@@ -275,13 +277,13 @@
 		<description>The channel providing a JSON with the information about the planner tasks.</description>
 		<state readOnly="true"/>
 	</channel-type>
-	
+
 	<channel-type id="positionType">
-        <item-type>Point</item-type>
-        <label>GPS Position</label>
-        <description>The channel providing a waypoint of the mower's activity.</description>
-        <state readOnly="true"/>
-    </channel-type>
+		<item-type>Point</item-type>
+		<label>GPS Position</label>
+		<description>The channel providing a waypoint of the mower's activity.</description>
+		<state readOnly="true"/>
+	</channel-type>
 
 	<channel-type id="start">
 		<item-type>Number</item-type>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -43,12 +43,83 @@
 
 		<label>Automower</label>
 		<description>An automatic lawn mower</description>
-
-		<channel-groups>
-			<channel-group id="status" typeId="statusGroup"/>
-			<channel-group id="positions" typeId="positionsGroup"/>
-			<channel-group id="commands" typeId="commandsGroup"/>
-		</channel-groups>
+		
+		<channels>
+		    <!-- Status -->
+            <channel id="name" typeId="nameType"/>
+            <channel id="mode" typeId="modeType"/>
+            <channel id="activity" typeId="activityType"/>
+            <channel id="state" typeId="stateType"/>
+            <channel id="last-update" typeId="lastUpdateType"/>
+            <channel id="battery" typeId="system.battery-level"/>
+            <channel id="error-code" typeId="errorCodeType"/>
+            <channel id="error-timestamp" typeId="errorTimestampType"/>
+            <channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
+            <channel id="planner-override-action" typeId="plannerOverrideActionType"/>
+            <channel id="calendar-tasks" typeId="calendarTasksType"/>
+            <!-- Commands -->
+            <channel id="start" typeId="start"/>
+            <channel id="resume_schedule" typeId="resumeSchedule"/>
+            <channel id="pause" typeId="pause"/>
+            <channel id="park" typeId="park"/>
+            <channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
+            <channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
+            
+            <!-- Positions -->
+            <channel id="last-position" typeId="positionType">
+                <description>Last Position</description>
+            </channel>
+            <channel id="position01" typeId="positionType"/>
+            <channel id="position02" typeId="positionType"/>
+            <channel id="position03" typeId="positionType"/>
+            <channel id="position04" typeId="positionType"/>
+            <channel id="position05" typeId="positionType"/>
+            <channel id="position06" typeId="positionType"/>
+            <channel id="position07" typeId="positionType"/>
+            <channel id="position08" typeId="positionType"/>
+            <channel id="position09" typeId="positionType"/>
+            <channel id="position10" typeId="positionType"/>
+            <channel id="position11" typeId="positionType"/>
+            <channel id="position12" typeId="positionType"/>
+            <channel id="position13" typeId="positionType"/>
+            <channel id="position14" typeId="positionType"/>
+            <channel id="position15" typeId="positionType"/>
+            <channel id="position16" typeId="positionType"/>
+            <channel id="position17" typeId="positionType"/>
+            <channel id="position18" typeId="positionType"/>
+            <channel id="position19" typeId="positionType"/>
+            <channel id="position20" typeId="positionType"/>
+            <channel id="position21" typeId="positionType"/>
+            <channel id="position22" typeId="positionType"/>
+            <channel id="position23" typeId="positionType"/>
+            <channel id="position24" typeId="positionType"/>
+            <channel id="position25" typeId="positionType"/>
+            <channel id="position26" typeId="positionType"/>
+            <channel id="position27" typeId="positionType"/>
+            <channel id="position28" typeId="positionType"/>
+            <channel id="position29" typeId="positionType"/>
+            <channel id="position30" typeId="positionType"/>
+            <channel id="position31" typeId="positionType"/>
+            <channel id="position32" typeId="positionType"/>
+            <channel id="position33" typeId="positionType"/>
+            <channel id="position34" typeId="positionType"/>
+            <channel id="position35" typeId="positionType"/>
+            <channel id="position36" typeId="positionType"/>
+            <channel id="position37" typeId="positionType"/>
+            <channel id="position38" typeId="positionType"/>
+            <channel id="position39" typeId="positionType"/>
+            <channel id="position40" typeId="positionType"/>
+            <channel id="position41" typeId="positionType"/>
+            <channel id="position42" typeId="positionType"/>
+            <channel id="position43" typeId="positionType"/>
+            <channel id="position44" typeId="positionType"/>
+            <channel id="position45" typeId="positionType"/>
+            <channel id="position46" typeId="positionType"/>
+            <channel id="position47" typeId="positionType"/>
+            <channel id="position48" typeId="positionType"/>
+            <channel id="position49" typeId="positionType"/>
+            <channel id="position50" typeId="positionType"/>
+        </channels>
 
 		<properties>
 			<property name="mowerId">N/A</property>
@@ -71,96 +142,6 @@
 
 	</thing-type>
 
-	<channel-group-type id="statusGroup">
-		<label>Mower Status</label>
-		<description>Status information about the mower</description>
-		<channels>
-			<channel id="name" typeId="nameType"/>
-			<channel id="mode" typeId="modeType"/>
-			<channel id="activity" typeId="activityType"/>
-			<channel id="state" typeId="stateType"/>
-			<channel id="last-update" typeId="lastUpdateType"/>
-			<channel id="battery" typeId="system.battery-level"/>
-			<channel id="error-code" typeId="errorCodeType"/>
-			<channel id="error-timestamp" typeId="errorTimestampType"/>
-			<channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
-			<channel id="planner-override-action" typeId="plannerOverrideActionType"/>
-			<channel id="calendar-tasks" typeId="calendarTasksType"/>
-		</channels>
-	</channel-group-type>
-
-	<channel-group-type id="positionsGroup">
-		<label>Mower Positions</label>
-		<description>Waypoints of the mower's activity</description>
-		<channels>
-			<channel id="last-position" typeId="positionType">
-				<description>Last Position</description>
-			</channel>
-			<channel id="position01" typeId="positionType"/>
-			<channel id="position02" typeId="positionType"/>
-			<channel id="position03" typeId="positionType"/>
-			<channel id="position04" typeId="positionType"/>
-			<channel id="position05" typeId="positionType"/>
-			<channel id="position06" typeId="positionType"/>
-			<channel id="position07" typeId="positionType"/>
-			<channel id="position08" typeId="positionType"/>
-			<channel id="position09" typeId="positionType"/>
-			<channel id="position10" typeId="positionType"/>
-			<channel id="position11" typeId="positionType"/>
-			<channel id="position12" typeId="positionType"/>
-			<channel id="position13" typeId="positionType"/>
-			<channel id="position14" typeId="positionType"/>
-			<channel id="position15" typeId="positionType"/>
-			<channel id="position16" typeId="positionType"/>
-			<channel id="position17" typeId="positionType"/>
-			<channel id="position18" typeId="positionType"/>
-			<channel id="position19" typeId="positionType"/>
-			<channel id="position20" typeId="positionType"/>
-			<channel id="position21" typeId="positionType"/>
-			<channel id="position22" typeId="positionType"/>
-			<channel id="position23" typeId="positionType"/>
-			<channel id="position24" typeId="positionType"/>
-			<channel id="position25" typeId="positionType"/>
-			<channel id="position26" typeId="positionType"/>
-			<channel id="position27" typeId="positionType"/>
-			<channel id="position28" typeId="positionType"/>
-			<channel id="position29" typeId="positionType"/>
-			<channel id="position30" typeId="positionType"/>
-			<channel id="position31" typeId="positionType"/>
-			<channel id="position32" typeId="positionType"/>
-			<channel id="position33" typeId="positionType"/>
-			<channel id="position34" typeId="positionType"/>
-			<channel id="position35" typeId="positionType"/>
-			<channel id="position36" typeId="positionType"/>
-			<channel id="position37" typeId="positionType"/>
-			<channel id="position38" typeId="positionType"/>
-			<channel id="position39" typeId="positionType"/>
-			<channel id="position40" typeId="positionType"/>
-			<channel id="position41" typeId="positionType"/>
-			<channel id="position42" typeId="positionType"/>
-			<channel id="position43" typeId="positionType"/>
-			<channel id="position44" typeId="positionType"/>
-			<channel id="position45" typeId="positionType"/>
-			<channel id="position46" typeId="positionType"/>
-			<channel id="position47" typeId="positionType"/>
-			<channel id="position48" typeId="positionType"/>
-			<channel id="position49" typeId="positionType"/>
-			<channel id="position50" typeId="positionType"/>
-		</channels>
-	</channel-group-type>
-
-	<channel-group-type id="commandsGroup">
-		<label>Mower Commands</label>
-		<description>Commands that can be sent to the mower</description>
-		<channels>
-			<channel id="start" typeId="start"/>
-			<channel id="resume_schedule" typeId="resumeSchedule"/>
-			<channel id="pause" typeId="pause"/>
-			<channel id="park" typeId="park"/>
-			<channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
-			<channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
-		</channels>
-	</channel-group-type>
 
 	<channel-type id="nameType">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -93,6 +93,7 @@
         <label>Mower Positions</label>
         <description>Waypoints of the mower's activity</description>
         <channels>
+            <channel id="last-position" typeId="positionType"><description>Last Position</description></channel>
             <channel id="position01" typeId="positionType"/>
             <channel id="position02" typeId="positionType"/>
             <channel id="position03" typeId="positionType"/>

--- a/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.automower/src/main/resources/OH-INF/thing/thing-types.xml
@@ -43,83 +43,83 @@
 
 		<label>Automower</label>
 		<description>An automatic lawn mower</description>
-		
+
 		<channels>
-		    <!-- Status -->
-            <channel id="name" typeId="nameType"/>
-            <channel id="mode" typeId="modeType"/>
-            <channel id="activity" typeId="activityType"/>
-            <channel id="state" typeId="stateType"/>
-            <channel id="last-update" typeId="lastUpdateType"/>
-            <channel id="battery" typeId="system.battery-level"/>
-            <channel id="error-code" typeId="errorCodeType"/>
-            <channel id="error-timestamp" typeId="errorTimestampType"/>
-            <channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
-            <channel id="planner-override-action" typeId="plannerOverrideActionType"/>
-            <channel id="calendar-tasks" typeId="calendarTasksType"/>
-            <!-- Commands -->
-            <channel id="start" typeId="start"/>
-            <channel id="resume_schedule" typeId="resumeSchedule"/>
-            <channel id="pause" typeId="pause"/>
-            <channel id="park" typeId="park"/>
-            <channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
-            <channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
-            
-            <!-- Positions -->
-            <channel id="last-position" typeId="positionType">
-                <description>Last Position</description>
-            </channel>
-            <channel id="position01" typeId="positionType"/>
-            <channel id="position02" typeId="positionType"/>
-            <channel id="position03" typeId="positionType"/>
-            <channel id="position04" typeId="positionType"/>
-            <channel id="position05" typeId="positionType"/>
-            <channel id="position06" typeId="positionType"/>
-            <channel id="position07" typeId="positionType"/>
-            <channel id="position08" typeId="positionType"/>
-            <channel id="position09" typeId="positionType"/>
-            <channel id="position10" typeId="positionType"/>
-            <channel id="position11" typeId="positionType"/>
-            <channel id="position12" typeId="positionType"/>
-            <channel id="position13" typeId="positionType"/>
-            <channel id="position14" typeId="positionType"/>
-            <channel id="position15" typeId="positionType"/>
-            <channel id="position16" typeId="positionType"/>
-            <channel id="position17" typeId="positionType"/>
-            <channel id="position18" typeId="positionType"/>
-            <channel id="position19" typeId="positionType"/>
-            <channel id="position20" typeId="positionType"/>
-            <channel id="position21" typeId="positionType"/>
-            <channel id="position22" typeId="positionType"/>
-            <channel id="position23" typeId="positionType"/>
-            <channel id="position24" typeId="positionType"/>
-            <channel id="position25" typeId="positionType"/>
-            <channel id="position26" typeId="positionType"/>
-            <channel id="position27" typeId="positionType"/>
-            <channel id="position28" typeId="positionType"/>
-            <channel id="position29" typeId="positionType"/>
-            <channel id="position30" typeId="positionType"/>
-            <channel id="position31" typeId="positionType"/>
-            <channel id="position32" typeId="positionType"/>
-            <channel id="position33" typeId="positionType"/>
-            <channel id="position34" typeId="positionType"/>
-            <channel id="position35" typeId="positionType"/>
-            <channel id="position36" typeId="positionType"/>
-            <channel id="position37" typeId="positionType"/>
-            <channel id="position38" typeId="positionType"/>
-            <channel id="position39" typeId="positionType"/>
-            <channel id="position40" typeId="positionType"/>
-            <channel id="position41" typeId="positionType"/>
-            <channel id="position42" typeId="positionType"/>
-            <channel id="position43" typeId="positionType"/>
-            <channel id="position44" typeId="positionType"/>
-            <channel id="position45" typeId="positionType"/>
-            <channel id="position46" typeId="positionType"/>
-            <channel id="position47" typeId="positionType"/>
-            <channel id="position48" typeId="positionType"/>
-            <channel id="position49" typeId="positionType"/>
-            <channel id="position50" typeId="positionType"/>
-        </channels>
+			<!-- Status -->
+			<channel id="name" typeId="nameType"/>
+			<channel id="mode" typeId="modeType"/>
+			<channel id="activity" typeId="activityType"/>
+			<channel id="state" typeId="stateType"/>
+			<channel id="last-update" typeId="lastUpdateType"/>
+			<channel id="battery" typeId="system.battery-level"/>
+			<channel id="error-code" typeId="errorCodeType"/>
+			<channel id="error-timestamp" typeId="errorTimestampType"/>
+			<channel id="planner-next-start" typeId="plannerNextStartTimestampType"/>
+			<channel id="planner-override-action" typeId="plannerOverrideActionType"/>
+			<channel id="calendar-tasks" typeId="calendarTasksType"/>
+			<!-- Commands -->
+			<channel id="start" typeId="start"/>
+			<channel id="resume_schedule" typeId="resumeSchedule"/>
+			<channel id="pause" typeId="pause"/>
+			<channel id="park" typeId="park"/>
+			<channel id="park_until_next_schedule" typeId="parkUntilNextSchedule"/>
+			<channel id="park_until_further_notice" typeId="parkUntilFurtherNotice"/>
+
+			<!-- Positions -->
+			<channel id="last-position" typeId="positionType">
+				<description>Last Position</description>
+			</channel>
+			<channel id="position01" typeId="positionType"/>
+			<channel id="position02" typeId="positionType"/>
+			<channel id="position03" typeId="positionType"/>
+			<channel id="position04" typeId="positionType"/>
+			<channel id="position05" typeId="positionType"/>
+			<channel id="position06" typeId="positionType"/>
+			<channel id="position07" typeId="positionType"/>
+			<channel id="position08" typeId="positionType"/>
+			<channel id="position09" typeId="positionType"/>
+			<channel id="position10" typeId="positionType"/>
+			<channel id="position11" typeId="positionType"/>
+			<channel id="position12" typeId="positionType"/>
+			<channel id="position13" typeId="positionType"/>
+			<channel id="position14" typeId="positionType"/>
+			<channel id="position15" typeId="positionType"/>
+			<channel id="position16" typeId="positionType"/>
+			<channel id="position17" typeId="positionType"/>
+			<channel id="position18" typeId="positionType"/>
+			<channel id="position19" typeId="positionType"/>
+			<channel id="position20" typeId="positionType"/>
+			<channel id="position21" typeId="positionType"/>
+			<channel id="position22" typeId="positionType"/>
+			<channel id="position23" typeId="positionType"/>
+			<channel id="position24" typeId="positionType"/>
+			<channel id="position25" typeId="positionType"/>
+			<channel id="position26" typeId="positionType"/>
+			<channel id="position27" typeId="positionType"/>
+			<channel id="position28" typeId="positionType"/>
+			<channel id="position29" typeId="positionType"/>
+			<channel id="position30" typeId="positionType"/>
+			<channel id="position31" typeId="positionType"/>
+			<channel id="position32" typeId="positionType"/>
+			<channel id="position33" typeId="positionType"/>
+			<channel id="position34" typeId="positionType"/>
+			<channel id="position35" typeId="positionType"/>
+			<channel id="position36" typeId="positionType"/>
+			<channel id="position37" typeId="positionType"/>
+			<channel id="position38" typeId="positionType"/>
+			<channel id="position39" typeId="positionType"/>
+			<channel id="position40" typeId="positionType"/>
+			<channel id="position41" typeId="positionType"/>
+			<channel id="position42" typeId="positionType"/>
+			<channel id="position43" typeId="positionType"/>
+			<channel id="position44" typeId="positionType"/>
+			<channel id="position45" typeId="positionType"/>
+			<channel id="position46" typeId="positionType"/>
+			<channel id="position47" typeId="positionType"/>
+			<channel id="position48" typeId="positionType"/>
+			<channel id="position49" typeId="positionType"/>
+			<channel id="position50" typeId="positionType"/>
+		</channels>
 
 		<properties>
 			<property name="mowerId">N/A</property>


### PR DESCRIPTION
This PR adds support for the GPS coordinates provided by the Husqvarna Automower Connect API.
When requested the latest 'Mower Data' via the API the last 50 GPS positions are also provided.
They can be useful to visualize the mower's path or identify his last position in case of an error.

Considering the large number of additional channels, this PR introduces also some channel groups to structure the channels and separate the GPS channels from the rest.