### PR TITLE
[heliosventilation] reference modbus.helioseasycontrols binding

### DIFF
--- a/bundles/org.openhab.binding.heliosventilation/README.md
+++ b/bundles/org.openhab.binding.heliosventilation/README.md
@@ -8,6 +8,8 @@ Setup the device as described in https://www.openhab.org/docs/administration/ser
 
 The binding will use the remote control address 15 for communication, so make sure that this is not assigned to a physically present remote control.
 
+For Helios ventilation devices supporting the easyControls web interface, a separate binding can be used: https://www.openhab.org/addons/bindings/modbus.helioseasycontrols/
+
 ## Supported Things
 
 There is only one thing type supported by this binding: a Helios Ventilation System KWL EC 200/300/500 Pro from Helios.

--- a/bundles/org.openhab.binding.heliosventilation/README.md
+++ b/bundles/org.openhab.binding.heliosventilation/README.md
@@ -8,7 +8,7 @@ Setup the device as described in https://www.openhab.org/docs/administration/ser
 
 The binding will use the remote control address 15 for communication, so make sure that this is not assigned to a physically present remote control.
 
-For Helios ventilation devices supporting the easyControls web interface, a separate binding can be used: https://www.openhab.org/addons/bindings/modbus.helioseasycontrols/
+For Helios ventilation devices supporting the easyControls web interface, the separate binding [Helios easyControls binding](https://www.openhab.org/addons/bindings/modbus.helioseasycontrols/) can be used.
 
 ## Supported Things
 


### PR DESCRIPTION
There are two binding supporting different types of Helios ventilation systems. Cross referencing the bindings in their descriptions should help users identify the right binding for their device.