### PR TITLE
Bump library netty.io to 4.1.68.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <eea.version>2.2.1</eea.version>
     <jackson.version>2.12.3</jackson.version>
     <karaf.version>4.3.3</karaf.version>
-    <netty.version>4.1.63.Final</netty.version>
+    <netty.version>4.1.68.Final</netty.version>
     <okhttp.version>3.14.9</okhttp.version>
     <sat.version>0.11.1</sat.version>
     <spotless.version>2.0.3</spotless.version>


### PR DESCRIPTION
Update to latest Netty which has 2 security fixes in it.

https://netty.io/news/2021/09/09/4-1-68-Final.html

Signed-off-by: Matthew Skinner <matt@pcmus.com>