### PR TITLE
[miele] Temperature channel improvements: UoM, categories and descriptions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -168,7 +168,7 @@
 /bundles/org.openhab.binding.meteoalerte/ @clinique
 /bundles/org.openhab.binding.meteoblue/ @9037568
 /bundles/org.openhab.binding.meteostick/ @cdjackson
-/bundles/org.openhab.binding.miele/ @kgoderis
+/bundles/org.openhab.binding.miele/ @kgoderis @jlaur
 /bundles/org.openhab.binding.mielecloud/ @BjoernLange
 /bundles/org.openhab.binding.mihome/ @pboos
 /bundles/org.openhab.binding.miio/ @marcelrv

--- a/bundles/org.openhab.binding.miele/README.md
+++ b/bundles/org.openhab.binding.miele/README.md
@@ -64,8 +64,8 @@ demo.items:
 ```
 String MieleFridgeState  (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:state"}
 Switch MieleFridgeSuperCool (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:supercool"}
-Number MieleFridgeCurrent (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:current"}
-Number MieleFridgeTarget (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:target"}
+Number:Temperature MieleFridgeCurrent (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:current"}
+Number:Temperature MieleFridgeTarget (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:target"}
 Contact MieleFridgeDoor (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:door"}
 Switch MieleFridgeStart (gMiele,gMieleFridge) {channel="miele:fridge:dilbeek:fridge:start"}
 ```

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
@@ -57,7 +57,7 @@ public class ExtendedDeviceStateUtil {
      * Convert string to Number:Temperature state with unit Celcius
      */
     public static State getTemperatureState(String s) throws NumberFormatException {
-        if (s.equals(TEMPERATURE_UNDEFINED)) {
+        if (TEMPERATURE_UNDEFINED.equals(s)) {
             return UnDefType.UNDEF;
         }
         int temperature = Integer.parseInt(s);

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtil.java
@@ -14,6 +14,11 @@ package org.openhab.binding.miele.internal;
 
 import java.nio.charset.StandardCharsets;
 
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+
 /**
  * The {@link ExtendedDeviceStateUtil} class contains utility methods for parsing
  * ExtendedDeviceState information
@@ -22,6 +27,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class ExtendedDeviceStateUtil {
     private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+    private static final String TEMPERATURE_UNDEFINED = "32768";
 
     /**
      * Convert byte array to hex representation.
@@ -45,5 +51,16 @@ public class ExtendedDeviceStateUtil {
      */
     public static byte[] stringToBytes(String input) {
         return input.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    /**
+     * Convert string to Number:Temperature state with unit Celcius
+     */
+    public static State getTemperatureState(String s) throws NumberFormatException {
+        if (s.equals(TEMPERATURE_UNDEFINED)) {
+            return UnDefType.UNDEF;
+        }
+        int temperature = Integer.parseInt(s);
+        return new QuantityType<>(temperature, SIUnits.CELSIUS);
     }
 }

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/MieleBindingConstants.java
@@ -58,8 +58,24 @@ public class MieleBindingConstants {
     public static final String MIELE_DEVICE_CLASS_FRIDGE_FREEZER = "FridgeFreezer";
 
     // Miele appliance states
+    public static final int STATE_UNKNOWN = 0;
+    public static final int STATE_OFF = 1;
+    public static final int STATE_STAND_BY = 2;
+    public static final int STATE_PROGRAMMED = 3;
+    public static final int STATE_WAITING_TO_START = 4;
+    public static final int STATE_RUNNING = 5;
+    public static final int STATE_PAUSED = 6;
+    public static final int STATE_END = 7;
+    public static final int STATE_FAILURE = 8;
+    public static final int STATE_ABORT = 9;
+    public static final int STATE_IDLE = 10;
+    public static final int STATE_RINSE_HOLD = 11;
+    public static final int STATE_SERVICE = 12;
     public static final int STATE_SUPER_FREEZING = 13;
     public static final int STATE_SUPER_COOLING = 14;
+    public static final int STATE_SUPER_HEATING = 15;
+    public static final int STATE_LOCKED = 145;
+    public static final int STATE_NOT_CONNECTED = 255;
 
     // Bridge config properties
     public static final String HOST = "ipAddress";

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -17,10 +17,11 @@ import static org.openhab.binding.miele.internal.MieleBindingConstants.SUPERCOOL
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
+import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
@@ -43,16 +44,16 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     COMPANY_ID("companyId", "companyId", StringType.class, true),
     STATE("state", "state", StringType.class, false),
     SUPERCOOL(null, SUPERCOOL_CHANNEL_ID, OnOffType.class, false),
-    FRIDGECURRENTTEMP("currentTemperature", "current", DecimalType.class, false) {
+    FRIDGECURRENTTEMP("currentTemperature", "current", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    FRIDGETARGETTEMP("targetTemperature", "target", DecimalType.class, false) {
+    FRIDGETARGETTEMP("targetTemperature", "target", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
@@ -140,6 +141,15 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
         }
 
         return null;
+    }
+
+    public State getTemperatureState(String s) {
+        try {
+            return ExtendedDeviceStateUtil.getTemperatureState(s);
+        } catch (Exception e) {
+            logger.error("An exception occurred while converting '{}' into a State", s);
+            return null;
+        }
     }
 
     public String getMieleEnum(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeChannelSelector.java
@@ -146,9 +146,9 @@ public enum FridgeChannelSelector implements ApplianceChannelSelector {
     public State getTemperatureState(String s) {
         try {
             return ExtendedDeviceStateUtil.getTemperatureState(s);
-        } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
-            return null;
+        } catch (NumberFormatException e) {
+            logger.warn("An exception occurred while converting '{}' into a State", s);
+            return UnDefType.UNDEF;
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -18,10 +18,11 @@ import static org.openhab.binding.miele.internal.MieleBindingConstants.SUPERFREE
 import java.lang.reflect.Method;
 import java.util.Map.Entry;
 
+import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
@@ -48,28 +49,28 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     FRIDGESTATE("fridgeState", "fridgestate", StringType.class, false),
     SUPERCOOL(null, SUPERCOOL_CHANNEL_ID, OnOffType.class, false),
     SUPERFREEZE(null, SUPERFREEZE_CHANNEL_ID, OnOffType.class, false),
-    FREEZERCURRENTTEMP("freezerCurrentTemperature", "freezercurrent", DecimalType.class, false) {
+    FREEZERCURRENTTEMP("freezerCurrentTemperature", "freezercurrent", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    FREEZERTARGETTEMP("freezerTargetTemperature", "freezertarget", DecimalType.class, false) {
+    FREEZERTARGETTEMP("freezerTargetTemperature", "freezertarget", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    FRIDGECURRENTTEMP("fridgeCurrentTemperature", "fridgecurrent", DecimalType.class, false) {
+    FRIDGECURRENTTEMP("fridgeCurrentTemperature", "fridgecurrent", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    FRIDGETARGETTEMP("fridgeTargetTemperature", "fridgetarget", DecimalType.class, false) {
+    FRIDGETARGETTEMP("fridgeTargetTemperature", "fridgetarget", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
@@ -158,6 +159,15 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
         }
 
         return null;
+    }
+
+    public State getTemperatureState(String s) {
+        try {
+            return ExtendedDeviceStateUtil.getTemperatureState(s);
+        } catch (Exception e) {
+            logger.error("An exception occurred while converting '{}' into a State", s);
+            return null;
+        }
     }
 
     public String getMieleEnum(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/FridgeFreezerChannelSelector.java
@@ -164,9 +164,9 @@ public enum FridgeFreezerChannelSelector implements ApplianceChannelSelector {
     public State getTemperatureState(String s) {
         try {
             return ExtendedDeviceStateUtil.getTemperatureState(s);
-        } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
-            return null;
+        } catch (NumberFormatException e) {
+            logger.warn("An exception occurred while converting '{}' into a State", s);
+            return UnDefType.UNDEF;
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -18,11 +18,12 @@ import java.util.Date;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
+import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DateTimeType;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
@@ -104,28 +105,28 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
             return getState(dateFormatter.format(date));
         }
     },
-    TARGET_TEMP("targetTemperature", "target", DecimalType.class, false) {
+    TARGET_TEMP("targetTemperature", "target", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    MEASURED_TEMP("measuredTemperature", "measured", DecimalType.class, false) {
+    MEASURED_TEMP("measuredTemperature", "measured", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    DEVICE_TEMP_ONE("deviceTemperature1", "temp1", DecimalType.class, false) {
+    DEVICE_TEMP_ONE("deviceTemperature1", "temp1", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
-    DEVICE_TEMP_TWO("deviceTemperature2", "temp2", DecimalType.class, false) {
+    DEVICE_TEMP_TWO("deviceTemperature2", "temp2", QuantityType.class, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false) {
@@ -214,6 +215,15 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
         }
 
         return null;
+    }
+
+    public State getTemperatureState(String s) {
+        try {
+            return ExtendedDeviceStateUtil.getTemperatureState(s);
+        } catch (Exception e) {
+            logger.error("An exception occurred while converting '{}' into a State", s);
+            return null;
+        }
     }
 
     public String getMieleEnum(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/OvenChannelSelector.java
@@ -220,9 +220,9 @@ public enum OvenChannelSelector implements ApplianceChannelSelector {
     public State getTemperatureState(String s) {
         try {
             return ExtendedDeviceStateUtil.getTemperatureState(s);
-        } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
-            return null;
+        } catch (NumberFormatException e) {
+            logger.warn("An exception occurred while converting '{}' into a State", s);
+            return UnDefType.UNDEF;
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -226,9 +226,9 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
     public State getTemperatureState(String s) {
         try {
             return ExtendedDeviceStateUtil.getTemperatureState(s);
-        } catch (Exception e) {
-            logger.error("An exception occurred while converting '{}' into a State", s);
-            return null;
+        } catch (NumberFormatException e) {
+            logger.warn("An exception occurred while converting '{}' into a State", s);
+            return UnDefType.UNDEF;
         }
     }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -23,9 +23,9 @@ import java.util.Map.Entry;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openhab.binding.miele.internal.ExtendedDeviceStateUtil;
 import org.openhab.binding.miele.internal.handler.MieleBridgeHandler.DeviceMetaData;
 import org.openhab.core.library.types.DateTimeType;
-import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
@@ -111,10 +111,10 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
             return getState(dateFormatter.format(date));
         }
     },
-    TARGET_TEMP("targetTemperature", "target", DecimalType.class, false, false) {
+    TARGET_TEMP("targetTemperature", "target", QuantityType.class, false, false) {
         @Override
         public State getState(String s, DeviceMetaData dmd) {
-            return getState(s);
+            return getTemperatureState(s);
         }
     },
     SPINNING_SPEED("spinningSpeed", "spinningspeed", StringType.class, false, false) {
@@ -221,6 +221,15 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
         }
 
         return null;
+    }
+
+    public State getTemperatureState(String s) {
+        try {
+            return ExtendedDeviceStateUtil.getTemperatureState(s);
+        } catch (Exception e) {
+            logger.error("An exception occurred while converting '{}' into a State", s);
+            return null;
+        }
     }
 
     public String getMieleEnum(String s, DeviceMetaData dmd) {

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineChannelSelector.java
@@ -126,7 +126,7 @@ public enum WashingMachineChannelSelector implements ApplianceChannelSelector {
             if ("256".equals(s)) {
                 return getState("Rinsing");
             }
-            return getState(Integer.toString((Integer.valueOf(s) * 10)));
+            return getState(Integer.toString((Integer.valueOf(s))));
         }
     },
     DOOR("signalDoor", "door", OpenClosedType.class, false, false) {

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -98,6 +98,22 @@
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 
+	<channel-type id="currentTemperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Current Temperature</label>
+		<description>Current temperature of the appliance</description>
+		<category>Temperature</category>
+		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+
+	<channel-type id="targetTemperature">
+		<item-type>Number:Temperature</item-type>
+		<label>Target Temperature</label>
+		<description>Target temperature to be reached by the appliance</description>
+		<category>Temperature</category>
+		<state readOnly="true" pattern="%.0f %unit%"/>
+	</channel-type>
+
 	<channel-type id="supercool">
 		<item-type>Switch</item-type>
 		<label>Super Cool</label>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -36,6 +36,7 @@
 		<item-type>DateTime</item-type>
 		<label>Start Time</label>
 		<description>Programmed start time of the program</description>
+		<category>Time</category>
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
@@ -43,6 +44,7 @@
 		<item-type>DateTime</item-type>
 		<label>Duration</label>
 		<description>Duration of the program running on the appliance</description>
+		<category>Time</category>
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
@@ -50,6 +52,7 @@
 		<item-type>DateTime</item-type>
 		<label>Elapsed Time</label>
 		<description>Time elapsed in the program running on the appliance</description>
+		<category>Time</category>
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
@@ -57,6 +60,7 @@
 		<item-type>DateTime</item-type>
 		<label>Finish Time</label>
 		<description>Time to finish the program running on the appliance</description>
+		<category>Time</category>
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -4,14 +4,14 @@
 	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-	<channel-type id="state" advanced="false">
+	<channel-type id="state">
 		<item-type>String</item-type>
 		<label>Status</label>
 		<description>Current status of the appliance</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="program" advanced="false">
+	<channel-type id="program">
 		<item-type>String</item-type>
 		<label>Program</label>
 		<description>Current program or function running on the appliance</description>
@@ -25,7 +25,7 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="phase" advanced="false">
+	<channel-type id="phase">
 		<item-type>String</item-type>
 		<label>Phase</label>
 		<description>Current phase of the program running on the appliance</description>
@@ -48,7 +48,7 @@
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
-	<channel-type id="elapsed" advanced="true">
+	<channel-type id="elapsed">
 		<item-type>DateTime</item-type>
 		<label>Elapsed Time</label>
 		<description>Time elapsed in the program running on the appliance</description>
@@ -56,7 +56,7 @@
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
-	<channel-type id="finish" advanced="true">
+	<channel-type id="finish">
 		<item-type>DateTime</item-type>
 		<label>Finish Time</label>
 		<description>Time to finish the program running on the appliance</description>
@@ -64,20 +64,20 @@
 		<state readOnly="true" pattern="%1$tH:%1$tM"></state>
 	</channel-type>
 
-	<channel-type id="door" advanced="false">
+	<channel-type id="door">
 		<item-type>Contact</item-type>
 		<label>Door</label>
 		<description>Current state of the door of the appliance</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="switch" advanced="false">
+	<channel-type id="switch">
 		<item-type>Switch</item-type>
 		<label>Switch</label>
 		<description>Switch the appliance on or off</description>
 	</channel-type>
 
-	<channel-type id="stop" advanced="false">
+	<channel-type id="stop">
 		<item-type>Switch</item-type>
 		<label>Stop</label>
 		<description>Stop the appliance</description>
@@ -98,42 +98,42 @@
 		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 
-	<channel-type id="supercool" advanced="false">
+	<channel-type id="supercool">
 		<item-type>Switch</item-type>
 		<label>Super Cool</label>
 		<description>Start Super Cooling</description>
 		<state readOnly="false"></state>
 	</channel-type>
 
-	<channel-type id="freezerstate" advanced="false">
+	<channel-type id="freezerstate">
 		<item-type>String</item-type>
 		<label>Status</label>
 		<description>Current status of the freezer compartment</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="fridgestate" advanced="false">
+	<channel-type id="fridgestate">
 		<item-type>String</item-type>
 		<label>Status</label>
 		<description>Current status of the fridge compartment</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="superfreeze" advanced="false">
+	<channel-type id="superfreeze">
 		<item-type>Switch</item-type>
 		<label>Super Freeze</label>
 		<description>Start Super Freezing</description>
 		<state readOnly="false"></state>
 	</channel-type>
 
-	<channel-type id="plates" advanced="false">
+	<channel-type id="plates">
 		<item-type>Number</item-type>
 		<label>Plates</label>
 		<description>Number of heating zones/plates on the hob</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="power" advanced="false">
+	<channel-type id="power">
 		<item-type>Number</item-type>
 		<label>Power Step</label>
 		<description>Power level of the heating zone/plate</description>
@@ -147,14 +147,14 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="time" advanced="true">
+	<channel-type id="time">
 		<item-type>String</item-type>
 		<label>Remaining Time</label>
 		<description>Remaining time of the heating zone/plate</description>
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="ventilation" advanced="false">
+	<channel-type id="ventilation">
 		<item-type>Number</item-type>
 		<label>Ventilation Power</label>
 		<description>Current ventilation power</description>
@@ -168,14 +168,14 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="powerConsumption" advanced="false">
+	<channel-type id="powerConsumption">
 		<item-type>Number:Power</item-type>
 		<label>Power Consumption</label>
 		<description>Power consumption by the currently running program on the appliance</description>
 		<state readOnly="true" pattern="%.1f %unit%"/>
 	</channel-type>
 
-	<channel-type id="waterConsumption" advanced="false">
+	<channel-type id="waterConsumption">
 		<item-type>Number:Volume</item-type>
 		<label>Water Consumption</label>
 		<description>Water consumption by the currently running program on the appliance</description>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -90,7 +90,7 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="temperature">
+	<channel-type id="temperature" advanced="true">
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
 		<description>Temperature reported by the appliance</description>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/channeltypes.xml
@@ -86,25 +86,12 @@
 		<state readOnly="true"></state>
 	</channel-type>
 
-	<channel-type id="target" advanced="true">
-		<item-type>Number</item-type>
-		<label>Target Temperature</label>
-		<description>Target temperature to be reached by the oven</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="measured" advanced="true">
-		<item-type>Number</item-type>
-		<label>Measured Temperature</label>
-		<description>Actual measured temperature in the oven</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="temp" advanced="true">
-		<item-type>Number</item-type>
+	<channel-type id="temperature">
+		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
-		<description>Program temperature in the oven</description>
-		<state readOnly="true"></state>
+		<description>Temperature reported by the appliance</description>
+		<category>Temperature</category>
+		<state readOnly="true" pattern="%.0f %unit%"/>
 	</channel-type>
 
 	<channel-type id="supercool" advanced="false">
@@ -112,13 +99,6 @@
 		<label>Super Cool</label>
 		<description>Start Super Cooling</description>
 		<state readOnly="false"></state>
-	</channel-type>
-
-	<channel-type id="current" advanced="false">
-		<item-type>Number</item-type>
-		<label>Current Temperature</label>
-		<description>Current temperature in the fridge</description>
-		<state readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="freezerstate" advanced="false">
@@ -140,34 +120,6 @@
 		<label>Super Freeze</label>
 		<description>Start Super Freezing</description>
 		<state readOnly="false"></state>
-	</channel-type>
-
-	<channel-type id="freezercurrent" advanced="false">
-		<item-type>Number</item-type>
-		<label>Current Temperature</label>
-		<description>Current temperature in the freezer compartment</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="freezertarget" advanced="true">
-		<item-type>Number</item-type>
-		<label>Target Temperature</label>
-		<description>Target temperature to be reached by the freezer compartment</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="fridgecurrent" advanced="false">
-		<item-type>Number</item-type>
-		<label>Current Temperature</label>
-		<description>Current temperature in the fridge compartment</description>
-		<state readOnly="true"></state>
-	</channel-type>
-
-	<channel-type id="fridgetarget" advanced="true">
-		<item-type>Number</item-type>
-		<label>Target Temperature</label>
-		<description>Target temperature to be reached by the fridge compartment</description>
-		<state readOnly="true"></state>
 	</channel-type>
 
 	<channel-type id="plates" advanced="false">

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
@@ -16,12 +16,10 @@
 		<channels>
 			<channel id="state" typeId="state"/>
 			<channel id="supercool" typeId="supercool"/>
-			<channel id="current" typeId="temperature">
-				<label>Current Temperature</label>
+			<channel id="current" typeId="currentTemperature">
 				<description>Current temperature in the fridge</description>
 			</channel>
-			<channel id="target" typeId="temperature">
-				<label>Target Temperature</label>
+			<channel id="target" typeId="targetTemperature">
 				<description>Target temperature to be reached by the fridge</description>
 			</channel>
 			<channel id="door" typeId="door"/>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridge.xml
@@ -16,8 +16,14 @@
 		<channels>
 			<channel id="state" typeId="state"/>
 			<channel id="supercool" typeId="supercool"/>
-			<channel id="current" typeId="current"/>
-			<channel id="target" typeId="target"/>
+			<channel id="current" typeId="temperature">
+				<label>Current Temperature</label>
+				<description>Current temperature in the fridge</description>
+			</channel>
+			<channel id="target" typeId="temperature">
+				<label>Target Temperature</label>
+				<description>Target temperature to be reached by the fridge</description>
+			</channel>
 			<channel id="door" typeId="door"/>
 			<channel id="start" typeId="switch"/>
 		</channels>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
@@ -19,10 +19,22 @@
 			<channel id="fridgestate" typeId="fridgestate"/>
 			<channel id="supercool" typeId="supercool"/>
 			<channel id="superfreeze" typeId="superfreeze"/>
-			<channel id="freezercurrent" typeId="freezercurrent"/>
-			<channel id="freezertarget" typeId="freezertarget"/>
-			<channel id="fridgecurrent" typeId="fridgecurrent"/>
-			<channel id="fridgetarget" typeId="fridgetarget"/>
+			<channel id="freezercurrent" typeId="temperature">
+				<label>Current Temperature</label>
+				<description>Current temperature in the freezer compartment</description>
+			</channel>
+			<channel id="freezertarget" typeId="temperature">
+				<label>Target Temperature</label>
+				<description>Target temperature to be reached by the freezer compartment</description>
+			</channel>
+			<channel id="fridgecurrent" typeId="temperature">
+				<label>Current Temperature</label>
+				<description>Current temperature in the fridge compartment</description>
+			</channel>
+			<channel id="fridgetarget" typeId="temperature">
+				<label>Target Temperature</label>
+				<description>Target temperature to be reached by the fridge compartment</description>
+			</channel>
 			<channel id="door" typeId="door"/>
 			<channel id="start" typeId="switch"/>
 		</channels>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/fridgefreezer.xml
@@ -19,20 +19,16 @@
 			<channel id="fridgestate" typeId="fridgestate"/>
 			<channel id="supercool" typeId="supercool"/>
 			<channel id="superfreeze" typeId="superfreeze"/>
-			<channel id="freezercurrent" typeId="temperature">
-				<label>Current Temperature</label>
+			<channel id="freezercurrent" typeId="currentTemperature">
 				<description>Current temperature in the freezer compartment</description>
 			</channel>
-			<channel id="freezertarget" typeId="temperature">
-				<label>Target Temperature</label>
+			<channel id="freezertarget" typeId="targetTemperature">
 				<description>Target temperature to be reached by the freezer compartment</description>
 			</channel>
-			<channel id="fridgecurrent" typeId="temperature">
-				<label>Current Temperature</label>
+			<channel id="fridgecurrent" typeId="currentTemperature">
 				<description>Current temperature in the fridge compartment</description>
 			</channel>
-			<channel id="fridgetarget" typeId="temperature">
-				<label>Target Temperature</label>
+			<channel id="fridgetarget" typeId="targetTemperature">
 				<description>Target temperature to be reached by the fridge compartment</description>
 			</channel>
 			<channel id="door" typeId="door"/>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
@@ -22,11 +22,10 @@
 			<channel id="duration" typeId="duration"/>
 			<channel id="elapsed" typeId="elapsed"/>
 			<channel id="finish" typeId="finish"/>
-			<channel id="target" typeId="temperature">
-				<label>Target Temperature</label>
+			<channel id="target" typeId="targetTemperature">
 				<description>Target temperature to be reached by the oven</description>
 			</channel>
-			<channel id="measured" typeId="temperature">
+			<channel id="measured" typeId="currentTemperature">
 				<label>Measured Temperature</label>
 				<description>Actual measured temperature in the oven</description>
 			</channel>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
@@ -22,10 +22,22 @@
 			<channel id="duration" typeId="duration"/>
 			<channel id="elapsed" typeId="elapsed"/>
 			<channel id="finish" typeId="finish"/>
-			<channel id="target" typeId="target"/>
-			<channel id="measured" typeId="measured"/>
-			<channel id="temp1" typeId="temp"/>
-			<channel id="temp2" typeId="temp"/>
+			<channel id="target" typeId="temperature">
+				<label>Target Temperature</label>
+				<description>Target temperature to be reached by the oven</description>
+			</channel>
+			<channel id="measured" typeId="temperature">
+				<label>Measured Temperature</label>
+				<description>Actual measured temperature in the oven</description>
+			</channel>
+			<channel id="temp1" typeId="temperature">
+				<label>Temperature</label>
+				<description>Program temperature in the oven</description>
+			</channel>
+			<channel id="temp2" typeId="temperature">
+				<label>Temperature</label>
+				<description>Program temperature in the oven</description>
+			</channel>
 			<channel id="door" typeId="door"/>
 			<channel id="stop" typeId="stop"/>
 			<channel id="switch" typeId="switch"/>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/oven.xml
@@ -30,11 +30,11 @@
 				<description>Actual measured temperature in the oven</description>
 			</channel>
 			<channel id="temp1" typeId="temperature">
-				<label>Temperature</label>
+				<label>Program Temperature 1</label>
 				<description>Program temperature in the oven</description>
 			</channel>
 			<channel id="temp2" typeId="temperature">
-				<label>Temperature</label>
+				<label>Program Temperature 2</label>
 				<description>Program temperature in the oven</description>
 			</channel>
 			<channel id="door" typeId="door"/>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -24,7 +24,7 @@
 			<channel id="finish" typeId="finish"/>
 			<channel id="door" typeId="door"/>
 			<channel id="switch" typeId="switch"/>
-			<channel id="target" typeId="temperature">
+			<channel id="target" typeId="targetTemperature">
 				<label>Temperature</label>
 				<description>Temperature of the selected program</description>
 			</channel>

--- a/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
+++ b/bundles/org.openhab.binding.miele/src/main/resources/OH-INF/thing/washingmachine.xml
@@ -24,7 +24,10 @@
 			<channel id="finish" typeId="finish"/>
 			<channel id="door" typeId="door"/>
 			<channel id="switch" typeId="switch"/>
-			<channel id="target" typeId="target"/>
+			<channel id="target" typeId="temperature">
+				<label>Temperature</label>
+				<description>Temperature of the selected program</description>
+			</channel>
 			<channel id="spinningspeed" typeId="spinningspeed"/>
 			<channel id="powerConsumption" typeId="powerConsumption"/>
 			<channel id="waterConsumption" typeId="waterConsumption"/>

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.types.UnDefType;
 
 /**
  * This class provides test cases for {@link
@@ -54,7 +55,17 @@ public class ExtendedDeviceStateUtilTest extends JavaTest {
     }
 
     @Test
+    public void getTemperatureStateMagicValueReturnsUndefined() throws NumberFormatException {
+        assertEquals(UnDefType.UNDEF, ExtendedDeviceStateUtil.getTemperatureState("32768"));
+    }
+
+    @Test
     public void getTemperatureStateNonNumericValueThrowsNumberFormatException() {
         assertThrows(NumberFormatException.class, () -> ExtendedDeviceStateUtil.getTemperatureState("A"));
+    }
+
+    @Test
+    public void getTemperatureStateNullValueThrowsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> ExtendedDeviceStateUtil.getTemperatureState(null));
     }
 }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
@@ -52,4 +52,9 @@ public class ExtendedDeviceStateUtilTest extends JavaTest {
     public void getTemperatureStateWellFormedValueReturnsQuantityType() throws NumberFormatException {
         assertEquals(new QuantityType<>(42, SIUnits.CELSIUS), ExtendedDeviceStateUtil.getTemperatureState("42"));
     }
+
+    @Test
+    public void getTemperatureStateNonNumericValueThrowsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> ExtendedDeviceStateUtil.getTemperatureState("A"));
+    }
 }

--- a/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
+++ b/bundles/org.openhab.binding.miele/src/test/java/org/openhab/binding/miele/internal/ExtendedDeviceStateUtilTest.java
@@ -15,6 +15,8 @@ package org.openhab.binding.miele.internal;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.test.java.JavaTest;
 
 /**
@@ -44,5 +46,10 @@ public class ExtendedDeviceStateUtilTest extends JavaTest {
         byte[] expected = new byte[] { (byte) 0x00, (byte) 0x80, (byte) 0x00 };
         byte[] actual = ExtendedDeviceStateUtil.stringToBytes("\u0000\u0080\u0000");
         assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void getTemperatureStateWellFormedValueReturnsQuantityType() throws NumberFormatException {
+        assertEquals(new QuantityType<>(42, SIUnits.CELSIUS), ExtendedDeviceStateUtil.getTemperatureState("42"));
     }
 }


### PR DESCRIPTION
This PR improves channels provided by the binding in different ways.

### Temperatures
- Changed type from **Number** to **Number:Temperature**.
- Now supports Unit of Measurement.
- Fixed descriptions for specific appliances. For example, previously target temperature channels were described as "Target temperature to be reached by the oven", but in fact applied also to fridge and washing machine.
- Special value 32768 °C is now correctly translated into **Undefined**.
- Added category **Temperature** for default icons.

### Spinning speed
For washing machines spinning speed was multiplied by 10. Probably mislead by description in response JSON:

```
                {
                    "Name": "spinningSpeed",
                    "Value": 1600,
                    "Polling": 0,
                    "Metadata": {
                        "Filter": "true",
                        "description": "Spinning speed divided by 10!, 0x00 = without spinning, 0xFF = rinse hold.",
                        "LocalizedID": "Spin Speed",
                        "LocalizedValue": "1600",
                        "access": "RE"
                    }
                },
```

16.000 is clearly not correct number of rotations per minute.

### Time
Added category **Time** for the following channels:
- start
- duration
- elapsed
- finish

**Elapsed** and **remaining** time channels are no longer marked as advanced.

### Next steps
See #11317. Should be linked by first commit, but isn't.

Added myself as binding maintainer, see #11321.