### PR TITLE
[tr064] fix incorrectly reported decibel values for DSL Noise Margin and Attenuation

### DIFF
--- a/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/soap/SOAPValueConverter.java
+++ b/bundles/org.openhab.binding.tr064/src/main/java/org/openhab/binding/tr064/internal/soap/SOAPValueConverter.java
@@ -201,6 +201,20 @@ public class SOAPValueConverter {
     }
 
     /**
+     * post processor for decibel values (which are served as deca decibel)
+     *
+     * @param state the channel value in deca decibel
+     * @param channelConfig channel config of the channel
+     * @return the state converted to decibel
+     */
+    @SuppressWarnings("unused")
+    private State processDecaDecibel(State state, Tr064ChannelConfig channelConfig) {
+        Float value = state.as(DecimalType.class).floatValue() / 10;
+
+        return new QuantityType(value.toString() + " dB");
+    }
+
+    /**
      * post processor for answering machine new messages channel
      *
      * @param state the message list URL

--- a/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.openhab.binding.tr064/src/main/resources/channels.xml
@@ -284,25 +284,25 @@
 		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
-		<getAction name="GetInfo" argument="NewDownstreamNoiseMargin"/>
+		<getAction name="GetInfo" argument="NewDownstreamNoiseMargin" postProcessor="processDecaDecibel"/>
 	</channel>
 	<channel name="dslUpstreamNoiseMargin" label="DSL Upstream Noise Margin">
 		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
-		<getAction name="GetInfo" argument="NewUpstreamNoiseMargin"/>
+		<getAction name="GetInfo" argument="NewUpstreamNoiseMargin" postProcessor="processDecaDecibel"/>
 	</channel>
 	<channel name="dslDownstreamAttenuation" label="DSL Downstream Attenuation">
 		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
-		<getAction name="GetInfo" argument="NewDownstreamAttenuation"/>
+		<getAction name="GetInfo" argument="NewDownstreamAttenuation" postProcessor="processDecaDecibel"/>
 	</channel>
 	<channel name="dslUpstreamAttenuation" label="DSL Upstream Attenuation">
 		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
-		<getAction name="GetInfo" argument="NewUpstreamAttenuation"/>
+		<getAction name="GetInfo" argument="NewUpstreamAttenuation" postProcessor="processDecaDecibel"/>
 	</channel>
 	<channel name="dslFECErrors" label="DSL FEC Errors">
 		<item type="Number:Dimensionless"/>


### PR DESCRIPTION
As reported in #10783, the decibel values reported for the DSL Noise Margin and DSL Attenuation channels are currently reported with a 10 times too high value.

I tried simply using `dadB` (deca-decibel) as unit in the `channels.xml`, but that doesn't work an results in an Exception like `java.lang.IllegalArgumentException: Invalid Quantity value: 150 dadB`

So guess using a post processor might be the most easiest solution to "fix" those values.

fixes #10783