### PR TITLE
[feed] added channel for enclosure link on latest entry

### DIFF
--- a/bundles/org.openhab.binding.feed/README.md
+++ b/bundles/org.openhab.binding.feed/README.md
@@ -32,17 +32,18 @@ Optional configuration:
 
 The binding supports following channels
 
-| Channel Type ID    | Item Type | Description                                         |
-|--------------------|-----------|-----------------------------------------------------|
-| latest-title       | String    | Contains the title of the last feed entry.          |
-| latest-description | String    | Contains the description of the last feed entry.    |
-| latest-date        | DateTime  | Contains the published date of the last feed entry. |
-| latest-link        | String    | Contains the link of the last feed entry.           |
-| author             | String    | The name of the feed author, if author is present.  |
-| title              | String    | The title of the feed.                              |
-| description        | String    | Description of the feed.                            |
-| last-update        | DateTime  | The last update date of the feed.                   |
-| number-of-entries  | Number    | Number of entries in the feed.                      |
+| Channel Type ID    | Item Type | Description                                                                                               |
+|--------------------|-----------|-----------------------------------------------------------------------------------------------------------|
+| latest-title       | String    | Contains the title of the last feed entry.                                                                |
+| latest-description | String    | Contains the description of the last feed entry.                                                          |
+| latest-date        | DateTime  | Contains the published date of the last feed entry.                                                       |
+| latest-link        | String    | Contains the link of the last feed entry.                                                                 |
+| latest-enclosure   | String    | Contains the enclosure link (podcast) of the last feed entry, if enclosure is present (used in podcasts). |
+| author             | String    | The name of the feed author, if author is present.                                                        |
+| title              | String    | The title of the feed.                                                                                    |
+| description        | String    | Description of the feed.                                                                                  |
+| last-update        | DateTime  | The last update date of the feed.                                                                         |
+| number-of-entries  | Number    | Number of entries in the feed.                                                                            |
 
 ## Example
 
@@ -60,6 +61,7 @@ String latest_title           {channel="feed:feed:bbc:latest-title"}
 String latest_description     {channel="feed:feed:bbc:latest-description"}
 DateTime latest_date          {channel="feed:feed:bbc:latest-date"}
 String latest_link            {channel="feed:feed:bbc:latest-link"}
+String latest_enclosure       {channel="feed:feed:bbc:latest-enclosure"}
 Number number_of_entries      {channel="feed:feed:bbc:number-of-entries"}
 String description            {channel="feed:feed:bbc:description"}
 String author                 {channel="feed:feed:bbc:author"}

--- a/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/FeedBindingConstants.java
+++ b/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/FeedBindingConstants.java
@@ -20,6 +20,7 @@ import org.openhab.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Svilen Valkanov - Initial contribution
+ * @author Juergen Pabel - Added enclosure channel
  */
 @NonNullByDefault
 public class FeedBindingConstants {
@@ -49,6 +50,11 @@ public class FeedBindingConstants {
      * Contains the link to the last feed entry.
      */
     public static final String CHANNEL_LATEST_LINK = "latest-link";
+
+    /**
+     * Contains the enclosure link to the last feed entry.
+     */
+    public static final String CHANNEL_LATEST_ENCLOSURE = "latest-enclosure";
 
     /**
      * Description of the feed.

--- a/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/handler/FeedHandler.java
+++ b/bundles/org.openhab.binding.feed/src/main/java/org/openhab/binding/feed/internal/handler/FeedHandler.java
@@ -57,6 +57,7 @@ import com.rometools.rome.io.SyndFeedInput;
  * sent to one of the channels and for the regular updates of the feed data.
  *
  * @author Svilen Valkanov - Initial contribution
+ * @author Juergen Pabel - Added enclosure channel
  */
 @NonNullByDefault
 public class FeedHandler extends BaseThingHandler {
@@ -167,6 +168,13 @@ public class FeedHandler extends BaseThingHandler {
                     state = UnDefType.UNDEF;
                 } else {
                     state = new StringType(getValueSafely(latestEntry.getLink()));
+                }
+                break;
+            case CHANNEL_LATEST_ENCLOSURE:
+                if (latestEntry == null || latestEntry.getEnclosures().isEmpty()) {
+                    state = UnDefType.UNDEF;
+                } else {
+                    state = new StringType(getValueSafely(latestEntry.getEnclosures().get(0).getUrl()));
                 }
                 break;
             case CHANNEL_LATEST_PUBLISHED_DATE:

--- a/bundles/org.openhab.binding.feed/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.feed/src/main/resources/OH-INF/thing/thing-types.xml
@@ -20,6 +20,7 @@
 			<channel id="latest-description" typeId="latest-description"/>
 			<channel id="latest-date" typeId="latest-date"/>
 			<channel id="latest-link" typeId="latest-link"/>
+			<channel id="latest-enclosure" typeId="latest-enclosure"/>
 			<channel id="author" typeId="author"/>
 			<channel id="description" typeId="description"/>
 			<channel id="title" typeId="title"/>
@@ -68,6 +69,13 @@
 		<item-type>String</item-type>
 		<label>Latest Link</label>
 		<description>Contains the link of the last feed entry.</description>
+		<state readOnly="true" pattern="%s"/>
+	</channel-type>
+
+	<channel-type id="latest-enclosure">
+		<item-type>String</item-type>
+		<label>Latest Enclosure</label>
+		<description>Contains the first (if any) enclosure link of the last feed entry.</description>
 		<state readOnly="true" pattern="%s"/>
 	</channel-type>
 


### PR DESCRIPTION
[feed] added channel for enclosure link on latest entry

The feed plugin doesn't support (most) podcasts, as the audio link is provided in an enclosure tag; this PR adds the new channel "lastest-enclosure" to the thing. Albeit multiple enclosures are supported, this thing exposes only the first enclosure (if any at all - else the channel will be UNDEF). This covers the vast majority of podcasts sufficiently while minimizing the changes to the binding (a general re-refactoring/improvement of this binding would seem to be reasonable, though).

Recreated the PR for cleanliness sake (replaces https://github.com/openhab/openhab-addons/pull/11257/)