### PR TITLE
[pushsafer] Added support to send an Image directly

### DIFF
--- a/bundles/org.openhab.binding.pushsafer/README.md
+++ b/bundles/org.openhab.binding.pushsafer/README.md
@@ -47,8 +47,23 @@ The parameter `message` is **mandatory**, the `title` parameter defaults to what
 
 - `sendPushsaferMonospaceMessage(String message, @Nullable String title)` - This method is used to send a monospace message.
 
-- `sendPushsaferAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType, @Nullable String authentication)` - This method is used to send a message with an image attachment. It takes a local path or url to the image attachment (parameter `attachment` **mandatory**), an optional `contentType` to define the content-type of the attachment (default: `"jpeg"`, possible values: `"jpeg"`, `"png"`, `"gif"`) and an optional `authentication` for the given URL to define the authentication if needed (default: `""`, example: `"user:password"`).
+- `sendPushsaferAttachmentMessage(String message, @Nullable String title, String attachment, @Nullable String contentType, @Nullable String authentication)` - This method is used to send a message with an image attachment. It takes a local path or URL to the image attachment (parameter `attachment` **mandatory**), an optional `contentType` to define the content-type of the attachment (default: `"jpeg"`, possible values: `"jpeg"`, `"png"`, `"gif"`) and an optional `authentication` for the given URL to define the credentials to authenticate a user if needed (default: `""`, example: `"user:password"`).
 
 - `sendPushsaferURLMessage(String message, @Nullable String title, String url, @Nullable String urlTitle)` - This method is used to send a message with an URL. A supplementary `url` to show with the message and a `urlTitle` for the URL, otherwise just the URL is shown.
 
 - `sendPushsaferPriorityMessage(String message, @Nullable String title, @Nullable Integer priority)` - This method is used to send a priority message. Parameter `priority` is the priority (`-2`, `-1`, `0`, `1`, `2`) to be used (default: `2`).
+
+## Example
+
+demo.rules
+
+```java
+```java
+val actions = getActions("pushsafer", "pushsafer:pushsafer-account:account")
+// send message with attachment
+actions.sendPushsaferAttachmentMessage("Hello World!", "openHAB", "/path/to/my-local-image.png", "png", null)
+actions.sendPushsaferAttachmentMessage("Hello World!", "openHAB", "https://www.openhab.org/openhab-logo-square.png", "png", "user:password")
+actions.sendPushsaferAttachmentMessage("Hello World!", "openHAB", "data:[<media type>][;base64],<data>", null, null)
+// in case you want to send the content of an Image Item (RawType)
+actions.sendPushsaferAttachmentMessage("Hello World!", "openHAB", myImageItem.state.toFullString, null, null)
+```

--- a/bundles/org.openhab.binding.pushsafer/src/main/java/org/openhab/binding/pushsafer/internal/connection/PushsaferMessageBuilder.java
+++ b/bundles/org.openhab.binding.pushsafer/src/main/java/org/openhab/binding/pushsafer/internal/connection/PushsaferMessageBuilder.java
@@ -310,9 +310,10 @@ public class PushsaferMessageBuilder {
         body.addFieldPart(MESSAGE_KEY_TIME2LIVE, new StringContentProvider(String.valueOf(time2live)), null);
 
         if (attachment != null) {
+            String localAttachment = attachment;
             final String encodedString;
             try {
-                if (attachment.startsWith("http")) {
+                if (localAttachment.startsWith("http")) {
                     Properties headers = new Properties();
                     headers.put("User-Agent", "Mozilla/5.0");
                     if (!authentication.isBlank()) {
@@ -324,7 +325,9 @@ public class PushsaferMessageBuilder {
                         throw new IllegalArgumentException(
                                 String.format("Skip sending the message as content '%s' does not exist.", attachment));
                     }
-                    encodedString = "data:" + contentType + ";base64," + content;
+                    encodedString = "data:image/" + contentType + ";base64," + content;
+                } else if (localAttachment.startsWith("data:")) {
+                    encodedString = localAttachment;
                 } else {
                     File file = new File(attachment);
                     if (!file.exists()) {

--- a/bundles/org.openhab.binding.pushsafer/src/main/resources/OH-INF/i18n/pushsafer.properties
+++ b/bundles/org.openhab.binding.pushsafer/src/main/resources/OH-INF/i18n/pushsafer.properties
@@ -30,9 +30,9 @@ sendPushsaferMonospaceMessageActionDescription = This method is used to send a m
 sendPushsaferAttachmentMessageActionLabel = send a plain text message with an image attachment
 sendPushsaferAttachmentMessageActionDescription = This method is used to send a message with an image attachment.
 sendPushsaferMessageActionInputAttachmentLabel = Image Attachment
-sendPushsaferMessageActionInputAttachmentDescription = A local path or url to the image.
+sendPushsaferMessageActionInputAttachmentDescription = A local path or URL to the image.
 sendPushsaferMessageActionInputContentTypeLabel = Image Type
-sendPushsaferMessageActionInputContentTypeDescription = The image type of the attachment. Defaults to "jpeg", possible values "jpeg,png,gif".
+sendPushsaferMessageActionInputContentTypeDescription = The image type of the attachment. Defaults to "jpeg", possible values "jpeg" ,"png" or "gif".
 sendPushsaferMessageActionInputAuthenticationLabel = Authentication
 sendPushsaferMessageActionInputAuthenticationDescription = Basic access authentication for HTTP(S) requests. Default: "", Example: "user:password".
 

--- a/bundles/org.openhab.binding.pushsafer/src/main/resources/OH-INF/i18n/pushsafer_de.properties
+++ b/bundles/org.openhab.binding.pushsafer/src/main/resources/OH-INF/i18n/pushsafer_de.properties
@@ -73,7 +73,7 @@ sendPushsaferAttachmentMessageActionDescription = Action zum Versenden einer Tex
 sendPushsaferMessageActionInputAttachmentLabel = Bild-Anhang
 sendPushsaferMessageActionInputAttachmentDescription = Lokaler Pfad oder URL zum Anhang.
 sendPushsaferMessageActionInputContentTypeLabel = Bild-Typ
-sendPushsaferMessageActionInputContentTypeDescription = Der Bild-Typ für den Anhang. Default: "jpeg", mögliche Werte "jpeg,png,gif".
+sendPushsaferMessageActionInputContentTypeDescription = Der Bild-Typ für den Anhang. Default: "jpeg", mögliche Werte "jpeg", "png" oder "gif".
 sendPushsaferMessageActionInputAuthenticationLabel = Authentifizierung
 sendPushsaferMessageActionInputAuthenticationDescription = Basisauthentifizierung für HTTP(S) Aufrufe. Default: "", Beispiel: "user:passwort".
 


### PR DESCRIPTION
- Fixed content type for binary image
- Added support to send an Image directly

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
