### PR TITLE
[systeminfo] Fix heap graph too high on axis.

### DIFF
--- a/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
+++ b/bundles/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/handler/SysteminfoHandler.java
@@ -294,8 +294,8 @@ public class SysteminfoHandler extends BaseThingHandler {
                     state = new QuantityType<>(Runtime.getRuntime().freeMemory(), Units.BYTE);
                     break;
                 case CHANNEL_MEMORY_USED_HEAP_PERCENT:
-                    state = new DecimalType((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 100
-                            / Runtime.getRuntime().maxMemory());
+                    state = new DecimalType((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
+                            * 100 / Runtime.getRuntime().maxMemory());
                     break;
                 case CHANNEL_DISPLAY_INFORMATION:
                     state = systeminfo.getDisplayInformation(deviceIndex);


### PR DESCRIPTION
Was calculating the “used heap” based on max heap size and not on the currently allocated size.

Signed-off-by: Matthew Skinner <matt@pcmus.com>