### PR TITLE
Remove deprecated XStream.setupDefaultSecurity calls

### DIFF
--- a/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
+++ b/bundles/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/CcuGateway.java
@@ -63,7 +63,6 @@ public class CcuGateway extends AbstractHomematicGateway {
             HttpClient httpClient) {
         super(id, config, gatewayAdapter, httpClient);
 
-        XStream.setupDefaultSecurity(xStream);
         xStream.allowTypesByWildcard(new String[] { HmDevice.class.getPackageName() + ".**" });
         xStream.setClassLoader(CcuGateway.class.getClassLoader());
         xStream.autodetectAnnotations(true);

--- a/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryService.java
+++ b/bundles/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/pchkdiscovery/LcnPchkDiscoveryService.java
@@ -146,7 +146,6 @@ public class LcnPchkDiscoveryService extends AbstractDiscoveryService {
 
     ServicesResponse xmlToServiceResponse(String response) {
         XStream xstream = new XStream(new StaxDriver());
-        XStream.setupDefaultSecurity(xstream);
         xstream.allowTypesByWildcard(new String[] { ServicesResponse.class.getPackageName() + ".**" });
         xstream.setClassLoader(getClass().getClassLoader());
         xstream.autodetectAnnotations(true);

--- a/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
+++ b/bundles/org.openhab.binding.lutron/src/main/java/org/openhab/binding/lutron/internal/xml/DbXmlInfoReader.java
@@ -59,7 +59,6 @@ public class DbXmlInfoReader {
     }
 
     private void configureSecurity(XStream xstream) {
-        XStream.setupDefaultSecurity(xstream);
         xstream.allowTypesByWildcard(new String[] { Project.class.getPackageName() + ".**" });
     }
 


### PR DESCRIPTION
The XStream.setupDefaultSecurity method is deprecated since XStream 1.4.18.
It no longer does anything, because this is the default in newer XStream versions.