### PR TITLE
[milight] Fix minimum value for parameter repeat

### DIFF
--- a/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/v3.xml
+++ b/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/v3.xml
@@ -15,7 +15,7 @@
 				<description>You either need an IP/Hostname or the Bridge ID.</description>
 				<context>network-address</context>
 			</parameter>
-			<parameter name="repeat" type="integer" required="false" min="0" max="5">
+			<parameter name="repeat" type="integer" required="false" min="1" max="5">
 				<label>Repeat Commands</label>
 				<description>Usually the bridge receives all commands albeit UDP is used. But the actual bulbs might be slightly out
 					of bridge radio range and it sometimes helps to send commands multiple times.

--- a/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/v6.xml
+++ b/bundles/org.openhab.binding.milight/src/main/resources/OH-INF/thing/v6.xml
@@ -34,7 +34,7 @@
 				<context>password</context>
 				<default>0</default>
 			</parameter>
-			<parameter name="repeat" type="integer" required="false" min="0" max="5">
+			<parameter name="repeat" type="integer" required="false" min="1" max="5">
 				<label>Repeat Commands</label>
 				<description>Usually the bridge receives all commands albeit UDP is used. But the actual bulbs might be slightly out
 					of bridge radio range and it sometimes helps to send commands multiple times.


### PR DESCRIPTION
Minimum value "0" is invalid for repeat parameter, as this would mean no execution at all. See https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/protocol/QueuedSend.java#L84

Signed-off-by: Patrick Fink <mail@pfink.de>