### PR TITLE
[sunspec modbus] fix thing example

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/README.md
+++ b/bundles/org.openhab.binding.modbus.sunspec/README.md
@@ -190,7 +190,7 @@ Supported by: all inverter things
 
 ```
 Bridge modbus:tcp:modbusBridgeName [ host="hostname|ip", port=502, id=1, enableDiscovery=true ]
-Thing modbus:inverter-single-phase:bridge:se4000h "SE4000h" (modbus:tcp:modbusBridgeName) [ address=40069, length=52, refresh=15 ]
+Thing modbus:inverter-single-phase:bridge:myInverter "SE4000h" (modbus:tcp:modbusBridgeName) [ address=40069, length=52, refresh=15 ]
 ```
 
 Note: Make sure that refresh, port and id values are numerical, without quotes.


### PR DESCRIPTION
The Thing definition in () in l193 references the *name* that was assigned in l192, correct?
So they should match (they didn't). And "bridge" isn't quite a clever name in examples so I changed that in the first place.
Or do I misunderstand the mapping here ?

Signed-off-by: Markus Storm <markus.storm@gmx.net>