### PR TITLE
[bluetooth.enoceanble] Prevent that channels are triggered multiple times per click

### DIFF
--- a/bundles/org.openhab.binding.bluetooth.enoceanble/src/main/java/org/openhab/binding/bluetooth/enoceanble/internal/EnoceanBlePtm215Event.java
+++ b/bundles/org.openhab.binding.bluetooth.enoceanble/src/main/java/org/openhab/binding/bluetooth/enoceanble/internal/EnoceanBlePtm215Event.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.bluetooth.enoceanble.internal;
 
+import java.nio.ByteBuffer;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -30,9 +32,15 @@ public class EnoceanBlePtm215Event {
     private static final byte BUTTON2_DIR2 = 0x2;
 
     private final byte byteState;
+    private final int sequence;
 
     public EnoceanBlePtm215Event(byte[] manufacturerData) {
         byteState = manufacturerData[6];
+
+        byte[] sequenceBytes = new byte[] { manufacturerData[5], manufacturerData[4], manufacturerData[3],
+                manufacturerData[2] };
+        ByteBuffer sequenceBytesBuffered = ByteBuffer.wrap(sequenceBytes); // big-endian by default
+        sequence = sequenceBytesBuffered.getInt();
     }
 
     public boolean isPressed() {
@@ -59,9 +67,13 @@ public class EnoceanBlePtm215Event {
         return (byteState & flag) == flag;
     }
 
+    public int getSequence() {
+        return sequence;
+    }
+
     @Override
     public String toString() {
         return "Button " + (isButton1() ? 1 : 2) + " Dir " + (isDir1() ? 1 : 2) + " "
-                + (isPressed() ? "PRESSED" : "RELEASED");
+                + (isPressed() ? "PRESSED" : "RELEASED") + " (seq. " + this.sequence + ")";
     }
 }

--- a/bundles/org.openhab.binding.bluetooth.enoceanble/src/main/java/org/openhab/binding/bluetooth/enoceanble/internal/EnoceanBleRockerHandler.java
+++ b/bundles/org.openhab.binding.bluetooth.enoceanble/src/main/java/org/openhab/binding/bluetooth/enoceanble/internal/EnoceanBleRockerHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 public class EnoceanBleRockerHandler extends BeaconBluetoothHandler {
 
     private final Logger logger = LoggerFactory.getLogger(EnoceanBleRockerHandler.class);
+    private int lastSequence = Integer.MIN_VALUE;
 
     public EnoceanBleRockerHandler(Thing thing) {
         super(thing);
@@ -44,7 +45,12 @@ public class EnoceanBleRockerHandler extends BeaconBluetoothHandler {
             if (manufacturerData != null && manufacturerData.length > 0) {
                 EnoceanBlePtm215Event event = new EnoceanBlePtm215Event(manufacturerData);
                 logger.debug("Parsed manufacturer data to PTM215B event: {}", event);
-                triggerChannel(resolveChannel(event), resolveTriggerEvent(event));
+                synchronized (this) {
+                    if (event.getSequence() > lastSequence) {
+                        lastSequence = event.getSequence();
+                        triggerChannel(resolveChannel(event), resolveTriggerEvent(event));
+                    }
+                }
             }
         } catch (IllegalStateException e) {
             logger.warn("PTM215B event could not be parsed correctly, exception occured:", e);


### PR DESCRIPTION
**Bugfix**

Rockers are transmitting each event up to 3 times repeteadly, currently this also triggers the channels up to 3 times, even though there is actually just one event. Each BLE transmission contains a sequence number which increases per event, not per transmission. The PR uses the sequence number to prevent that the same event triggers the channel multiple times.

Signed-off-by: Patrick Fink <mail@pfink.de>
