### PR TITLE
[benqprojector] Update broken link in README

### DIFF
--- a/bundles/org.openhab.binding.benqprojector/README.md
+++ b/bundles/org.openhab.binding.benqprojector/README.md
@@ -3,7 +3,7 @@
 This binding is compatible with BenQ projectors that support the control protocol via the built-in ethernet port, serial port or USB to serial adapter.
 If your projector does not have built-in networking, you can connect to your projector's serial port via a TCP connection using a serial over IP device or by using`ser2net`.  
 
-The manufacturer's documentation for connecting to the projector and the control protocol can be found here: https://esupportdownload.benq.com/esupport/Projector/Control%20Protocols/LX9215/LX9215_RS232%20Control%20Guide_0_Windows7_Windows8_WinXP.pdf
+The manufacturer's guide for connecting to the projector and the control protocol can be found in this document: [LX9215_RS232 Control Guide_0_Windows7_Windows8_WinXP.pdf](https://esupportdownload.benq.com/esupport/Projector/Control%20Protocols/LX9215/LX9215_RS232%20Control%20Guide_0_Windows7_Windows8_WinXP.pdf)
 
 ## Supported Things
 


### PR DESCRIPTION
Fix the broken link in the README.