### PR TITLE
[WLED] Fix Nightlight sleep timer to use default time

### DIFF
--- a/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
+++ b/bundles/org.openhab.binding.wled/src/main/java/org/openhab/binding/wled/internal/WLedHandler.java
@@ -387,7 +387,7 @@ public class WLedHandler extends BaseThingHandler {
                 break;
             case CHANNEL_SLEEP:
                 if (OnOffType.ON.equals(command)) {
-                    sendGetRequest("/win&NL=1");
+                    sendGetRequest("/win&ND");
                 } else {
                     sendGetRequest("/win&NL=0");
                 }


### PR DESCRIPTION
[WLED] Fix Nightlight sleep timer to use default time

Based on WLED API (https://kno.wled.ge/interfaces/http-api/) current handler uses NL=1 so sleep timer is hard coded to 1 minute. Should be default (ND) to use configured time in WLED.