### PR TITLE
[verisure] Keep refreshing after RuntimeException

### DIFF
--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/VerisureSession.java
@@ -109,7 +109,7 @@ public class VerisureSession {
 
     public boolean initialize(@Nullable String authstring, @Nullable String pinCode, String userName, String password) {
         if (authstring != null) {
-            this.authstring = authstring.substring(0);
+            this.authstring = authstring;
             this.pinCode = pinCode;
             this.userName = userName;
             this.password = password;

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/dto/VerisureBaseThingDTO.java
@@ -272,7 +272,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             this.climates = climates;
         }
 
-        public List<DoorWindow> getDoorWindows() {
+        public @Nullable List<DoorWindow> getDoorWindows() {
             return doorWindows;
         }
 
@@ -284,11 +284,11 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             return eventLog;
         }
 
-        public List<CommunicationState> getCommunicationState() {
+        public @Nullable List<CommunicationState> getCommunicationState() {
             return communicationState;
         }
 
-        public List<Mouse> getMice() {
+        public @Nullable List<Mouse> getMice() {
             return mice;
         }
 
@@ -296,7 +296,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             this.mice = mice;
         }
 
-        public List<Doorlock> getDoorlocks() {
+        public @Nullable List<Doorlock> getDoorlocks() {
             return doorlocks;
         }
 
@@ -304,7 +304,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             this.doorlocks = doorlocks;
         }
 
-        public List<Smartplug> getSmartplugs() {
+        public @Nullable List<Smartplug> getSmartplugs() {
             return smartplugs;
         }
 
@@ -312,7 +312,7 @@ public abstract class VerisureBaseThingDTO implements VerisureThingDTO {
             this.smartplugs = smartplugs;
         }
 
-        public List<UserTracking> getUserTrackings() {
+        public @Nullable List<UserTracking> getUserTrackings() {
             return userTrackings;
         }
 

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureBridgeHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureBridgeHandler.java
@@ -110,9 +110,9 @@ public class VerisureBridgeHandler extends BaseBridgeHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "Refresh time is lower than min value of 10!");
         } else {
-            try {
-                authstring = "j_username=" + config.username;
-                scheduler.execute(() -> {
+            authstring = "j_username=" + config.username;
+            scheduler.execute(() -> {
+                try {
                     if (session == null) {
                         logger.debug("Session is null, let's create a new one");
                         session = new VerisureSession(this.httpClient);
@@ -123,15 +123,15 @@ public class VerisureBridgeHandler extends BaseBridgeHandler {
                         if (!session.initialize(authstring, pinCode, config.username, config.password)) {
                             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_REGISTERING_ERROR,
                                     "Failed to login to Verisure, please check your account settings! Is MFA activated?");
-                            return;
                         }
-                        startAutomaticRefresh(config.refresh);
                     }
-                });
-            } catch (RuntimeException e) {
-                logger.warn("Failed to initialize: {}", e.getMessage());
-                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-            }
+                } catch (RuntimeException e) {
+                    logger.warn("Failed to initialize: {}", e.getMessage());
+                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
+                } finally {
+                    startAutomaticRefresh(config.refresh);
+                }
+            });
         }
     }
 

--- a/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureBridgeHandler.java
+++ b/bundles/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/internal/handler/VerisureBridgeHandler.java
@@ -112,25 +112,19 @@ public class VerisureBridgeHandler extends BaseBridgeHandler {
         } else {
             authstring = "j_username=" + config.username;
             scheduler.execute(() -> {
-                try {
-                    if (session == null) {
-                        logger.debug("Session is null, let's create a new one");
-                        session = new VerisureSession(this.httpClient);
-                    }
-                    VerisureSession session = this.session;
-                    updateStatus(ThingStatus.UNKNOWN);
-                    if (session != null) {
-                        if (!session.initialize(authstring, pinCode, config.username, config.password)) {
-                            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.HANDLER_REGISTERING_ERROR,
-                                    "Failed to login to Verisure, please check your account settings! Is MFA activated?");
-                        }
-                    }
-                } catch (RuntimeException e) {
-                    logger.warn("Failed to initialize: {}", e.getMessage());
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-                } finally {
-                    startAutomaticRefresh(config.refresh);
+                if (session == null) {
+                    logger.debug("Session is null, let's create a new one");
+                    session = new VerisureSession(this.httpClient);
                 }
+                VerisureSession session = this.session;
+                updateStatus(ThingStatus.UNKNOWN);
+                if (session != null) {
+                    if (!session.initialize(authstring, pinCode, config.username, config.password)) {
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                                "Failed to login to Verisure, please check your account settings! Is MFA activated?");
+                    }
+                }
+                startAutomaticRefresh(config.refresh);
             });
         }
     }
@@ -172,8 +166,7 @@ public class VerisureBridgeHandler extends BaseBridgeHandler {
         logger.debug("Refresh and update status!");
         VerisureSession session = this.session;
         if (session != null) {
-            boolean success = session.refresh();
-            if (success) {
+            if (session.refresh()) {
                 updateStatus(ThingStatus.ONLINE);
             } else {
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);


### PR DESCRIPTION
Fix for #11396 - Runtime exception not caught causing periodic refresh to stop.

The binding does not handle a RuntimeException correctly which leads to that the binding stops to refresh, which this PR fixes.

Signed-off-by: Jan Gustafsson jannegpriv@gmail.com

