### PR TITLE
[openwebnet] added support for CEN/CEN+ scenarios (WHO=15/25)

### DIFF
--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -331,7 +331,7 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
 ```xtend
 rule "CEN+ virtual pressure from OH button"
 /* This rule triggers when the proxy item iCENPlusProxyItem is activated, for example from a button on WebUI/sitemap.
-When activated it sends a "virtual short pressure" of where=212, button=5 on the BUS 
+When activated it sends a "virtual short pressure" event (where=212, button=5) on the BUS 
 */
 when 
     Item iCENPlusProxyItem received command

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -119,14 +119,17 @@ Alternatively the ZigBee USB Gateway thing can be configured using the `.things`
 ### Configuring Devices
 
 Devices can be discovered automatically using an Inbox Scan after a gateway has been configured and connected.
+
 For any manually added device, you must configure:
 
 - the associated gateway (`Parent Bridge` menu)
 - the `where` config parameter (`OpenWebNet Device Address`):
-  - example for BUS/SCS device with WHERE address Point to Point `A=2 PL=4` --> `where="24"`
-  - example for BUS/SCS device with WHERE address Point to Point `A=03 PL=11` on local bus --> `where="0311#4#01"`
-  - example for BUS/SCS CEN+ scenario: add `2` before the configured scenario `5` --> `where="25"`
-  - example for ZigBee devices: `where=765432101#9`. The ID of the device (ADDR part) is usually written in hexadecimal on the device itself, for example `ID 0074CBB1`: convert to decimal (`7654321`) and add `01#9` at the end to obtain `where=765432101#9`. For 2-unit switch devices (`zb_on_off_switch2u`), last part should be `00#9`.
+    - example for BUS/SCS:
+        - light device with WHERE address Point to Point `A=2 PL=4` --> `where="24"`
+        - light device with WHERE address Point to Point `A=03 PL=11` on local bus --> `where="0311#4#01"`
+        - CEN scenario with WHERE address Point to Point `A=05 PL=12` --> `where="0512"`
+        - CEN+ configured scenario `5`: add a `2` before --> `where="25"`
+    - example for ZigBee devices: `where=765432101#9`. The ID of the device (ADDR part) is usually written in hexadecimal on the device itself, for example `ID 0074CBB1`: convert to decimal (`7654321`) and add `01#9` at the end to obtain `where=765432101#9`. For 2-unit switch devices (`zb_on_off_switch2u`), last part should be `00#9`.
  
 
 #### Configuring Thermo
@@ -136,14 +139,14 @@ In BTicino MyHOME Thermoregulation (WHO=4) each **zone** has associated a thermo
 Thermo zones can be configured defining a `bus_thermo_zone` Thing for each zone with the following parameters:
 
 - the `where` config parameter (`OpenWebNet Device Address`):
-  - example BUS/SCS Thermo zone `1` --> `where="1"` 
+    - example BUS/SCS Thermo zone `1` --> `where="1"` 
 - the `standAlone` config parameter (`boolean`, default: `true`): identifies if the zone is managed or not by a Central Unit (4 or 99 zones). `standAlone=true` means no Central Unit is present in the system.
 
 Temperature sensors can be configured defining a `bus_thermo_sensor` Thing with the following parameters:
 
 - the `where` config parameter (`OpenWebNet Device Address`):
-  - example sensor `5` of external zone `00` --> `where="500"`
-  - example: slave sensor `3` of zone `2` --> `where="302"`
+    - example sensor `5` of external zone `00` --> `where="500"`
+    - example: slave sensor `3` of zone `2` --> `where="302"`
 
 #### NOTE
 
@@ -193,7 +196,7 @@ It's possible to enter a value manually or set `shutterRun=AUTO` (default) to ca
 CEN/CEN+ are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers]): they handle events and do not have a state.
 
 A powerful feature is to be able to assign CEN or CEN+ commands to your physical wall switches and use the events they generate to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by physical BTicino switches.
-See [openwebnet.rules](#openwebnet-rules) for an example on how to define rules that trigger on CEN/CEN+ push buttons events.
+See [openwebnet.rules](#openwebnet-rules) for an example on how to define rules that trigger on CEN/CEN+ buttons events.
 
 It's also possible to send *virtual pressure* events on the BUS, for example to enable the activation of MH202 scenarios from openHAB.
 See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for an example on how to use the `virtualPress` action connected to a pushbutton on a sitemap.

--- a/bundles/org.openhab.binding.openwebnet/README.md
+++ b/bundles/org.openhab.binding.openwebnet/README.md
@@ -198,22 +198,22 @@ CEN/CEN+ are [TRIGGER channels](https://www.openhab.org/docs/configuration/rules
 A powerful feature is to be able to assign CEN or CEN+ commands to your physical wall switches and use the events they generate to trigger rules in openHAB: this way openHAB becomes a very powerful scenario manager activated by physical BTicino switches.
 See [openwebnet.rules](#openwebnet-rules) for an example on how to define rules that trigger on CEN/CEN+ buttons events.
 
-It's also possible to send *virtual pressure* events on the BUS, for example to enable the activation of MH202 scenarios from openHAB.
+It's also possible to send *virtual press* events on the BUS, for example to enable the activation of MH202 scenarios from openHAB.
 See [openwebnet.sitemap](#openwebnet-sitemap) & [openwebnet.rules](#openwebnet-rules) sections for an example on how to use the `virtualPress` action connected to a pushbutton on a sitemap.
 
 - channels are named `button#X` where `X` is the button number on the Scenario Control device
 - in the .thing file configuration you can specify the `buttons` parameter to define a comma-separated list of buttons numbers [0-31] configured for the scenario device, example: `buttons=1,2,4`
 - possible events are:
     - for CEN:
-        - `START_PRESSURE` - sent when you start pressing the button
-        - `SHORT_PRESSURE` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
-        - `EXTENDED_PRESSURE` - sent if you keep the button pressed longer than 0,5sec; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
-        - `RELEASE_EXTENDED_PRESSURE` - sent once when you finally release the button after having it pressed longer than 0,5sec
+        - `START_PRESS` - sent when you start pressing the button
+        - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
+        - `EXTENDED_PRESS` - sent if you keep the button pressed longer than 0,5sec; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
+        - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
     - for CEN+:
-        - `SHORT_PRESSURE` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
-        - `START_EXTENDED_PRESSURE` - sent once as soon as you keep the button pressed longer than 0,5sec
-        - `EXTENDED_PRESSURE` - sent after `START_EXTENDED_PRESSURE` if you keep the button pressed longer; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
-        - `RELEASE_EXTENDED_PRESSURE` - sent once when you finally release the button after having it pressed longer than 0,5sec
+        - `SHORT_PRESS` - sent if you pressed the button shorter than 0,5sec (sent at the moment when you release it)
+        - `START_EXTENDED_PRESS` - sent once as soon as you keep the button pressed longer than 0,5sec
+        - `EXTENDED_PRESS` - sent after `START_EXTENDED_PRESS` if you keep the button pressed longer; will be sent again every 0,5sec as long as you hold pressed (good for dimming rules)
+        - `RELEASE_EXTENDED_PRESS` - sent once when you finally release the button after having it pressed longer than 0,5sec
 
 
 ## Full Example
@@ -329,31 +329,31 @@ sitemap openwebnet label="OpenWebNet Binding Example Sitemap"
 ### openwebnet.rules
 
 ```xtend
-rule "CEN+ virtual pressure from OH button"
+rule "CEN+ virtual press from OH button"
 /* This rule triggers when the proxy item iCENPlusProxyItem is activated, for example from a button on WebUI/sitemap.
-When activated it sends a "virtual short pressure" event (where=212, button=5) on the BUS 
+When activated it sends a "virtual short press" event (where=212, button=5) on the BUS 
 */
 when 
     Item iCENPlusProxyItem received command
 then
     val actions = getActions("openwebnet","openwebnet:bus_cenplus_scenario_control:mybridge:212")
-    actions.virtualPress("SHORT_PRESSURE", 5)
+    actions.virtualPress("SHORT_PRESS", 5)
 end
 
 
 rule "CEN dimmer increase"
-// A "start pressure" event on CEN where=51, button=4 will increase dimmer%
+// A "start press" event on CEN where=51, button=4 will increase dimmer%
 when
-    Channel "openwebnet:bus_cen_scenario_control:mybridge:51:button#4" triggered START_PRESSURE
+    Channel "openwebnet:bus_cen_scenario_control:mybridge:51:button#4" triggered START_PRESS
 then
     sendCommand(iLR_dimmer, INCREASE)  
 end
 
 
 rule "CEN dimmer decrease"
-// A "release extended pressure" event on CEN where=51, button=4 will decrease dimmer%
+// A "release extended press" event on CEN where=51, button=4 will decrease dimmer%
 when
-    Channel "openwebnet:bus_cen_scenario_control:mybridge:51:button#4" triggered RELEASE_EXTENDED_PRESSURE
+    Channel "openwebnet:bus_cen_scenario_control:mybridge:51:button#4" triggered RELEASE_EXTENDED_PRESS
 then
     sendCommand(iLR_dimmer, DECREASE)  
 end

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.6.0-SNAPSHOT</version>
+      <version>0.6.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/pom.xml
+++ b/bundles/org.openhab.binding.openwebnet/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.openwebnet4j</groupId>
       <artifactId>openwebnet4j</artifactId>
-      <version>0.5.3</version>
+      <version>0.6.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -126,9 +126,10 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_ACTUATORS = "actuators";
     // energy management
     public static final String CHANNEL_POWER = "power";
-    // scenario button
+    // scenario button channels
     public static final String CHANNEL_SCENARIO_BUTTON = "button#";
-    public static final String CHANNEL_TYPE_SCENARIO_BUTTON = "cenButtonEvent";
+    public static final String CHANNEL_TYPE_CEN_BUTTON_EVENT = "cenButtonEvent";
+    public static final String CHANNEL_TYPE_CEN_PLUS_BUTTON_EVENT = "cenPlusButtonEvent";
 
     // devices config properties
     public static final String CONFIG_PROPERTY_WHERE = "where";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetBindingConstants.java
@@ -59,6 +59,12 @@ public class OpenWebNetBindingConstants {
     public static final String THING_LABEL_BUS_THERMO_SENSOR = "Thermo Sensor";
     public static final ThingTypeUID THING_TYPE_BUS_THERMO_ZONE = new ThingTypeUID(BINDING_ID, "bus_thermo_zone");
     public static final String THING_LABEL_BUS_THERMO_ZONE = "Thermo Zone";
+    public static final ThingTypeUID THING_TYPE_BUS_CEN_SCENARIO_CONTROL = new ThingTypeUID(BINDING_ID,
+            "bus_cen_scenario_control");
+    public static final String THING_LABEL_BUS_CEN_SCENARIO_CONTROL = "CEN Control";
+    public static final ThingTypeUID THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL = new ThingTypeUID(BINDING_ID,
+            "bus_cenplus_scenario_control");
+    public static final String THING_LABEL_BUS_CENPLUS_SCENARIO_CONTROL = "CEN+ Control";
 
     // ZIGBEE
     public static final ThingTypeUID THING_TYPE_ZB_ON_OFF_SWITCH = new ThingTypeUID(BINDING_ID, "zb_on_off_switch");
@@ -81,24 +87,22 @@ public class OpenWebNetBindingConstants {
     // ## Automation
     public static final Set<ThingTypeUID> AUTOMATION_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_ZB_AUTOMATION,
             THING_TYPE_BUS_AUTOMATION);
-
     // ## Thermoregulation
     public static final Set<ThingTypeUID> THERMOREGULATION_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_THERMO_ZONE,
             THING_TYPE_BUS_THERMO_SENSOR);
-
     // ## Energy Management
     public static final Set<ThingTypeUID> ENERGY_MANAGEMENT_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_ENERGY_METER);
-
+    // ## CEN/CEN+ Scenario
+    public static final Set<ThingTypeUID> SCENARIO_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_BUS_CEN_SCENARIO_CONTROL,
+            THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL);
     // ## Groups
     public static final Set<ThingTypeUID> DEVICE_SUPPORTED_THING_TYPES = Stream
             .of(LIGHTING_SUPPORTED_THING_TYPES, AUTOMATION_SUPPORTED_THING_TYPES,
                     THERMOREGULATION_SUPPORTED_THING_TYPES, ENERGY_MANAGEMENT_SUPPORTED_THING_TYPES,
-                    GENERIC_SUPPORTED_THING_TYPES)
+                    SCENARIO_SUPPORTED_THING_TYPES, GENERIC_SUPPORTED_THING_TYPES)
             .flatMap(Collection::stream).collect(Collectors.toCollection(HashSet::new));
-
     public static final Set<ThingTypeUID> BRIDGE_SUPPORTED_THING_TYPES = Set.of(THING_TYPE_ZB_GATEWAY,
             THING_TYPE_BUS_GATEWAY);
-
     public static final Set<ThingTypeUID> ALL_SUPPORTED_THING_TYPES = Stream
             .of(DEVICE_SUPPORTED_THING_TYPES, BRIDGE_SUPPORTED_THING_TYPES).flatMap(Collection::stream)
             .collect(Collectors.toCollection(HashSet::new));
@@ -109,10 +113,8 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_SWITCH_01 = "switch_01";
     public static final String CHANNEL_SWITCH_02 = "switch_02";
     public static final String CHANNEL_BRIGHTNESS = "brightness";
-
     // automation
     public static final String CHANNEL_SHUTTER = "shutter";
-
     // thermo
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_FUNCTION = "function";
@@ -122,18 +124,19 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_CONDITIONING_VALVES = "conditioningValves";
     public static final String CHANNEL_HEATING_VALVES = "heatingValves";
     public static final String CHANNEL_ACTUATORS = "actuators";
-
     // energy management
     public static final String CHANNEL_POWER = "power";
+    // scenario button
+    public static final String CHANNEL_SCENARIO_BUTTON = "button#";
+    public static final String CHANNEL_TYPE_SCENARIO_BUTTON = "cenButtonEvent";
 
     // devices config properties
     public static final String CONFIG_PROPERTY_WHERE = "where";
     public static final String CONFIG_PROPERTY_SHUTTER_RUN = "shutterRun";
-
+    public static final String CONFIG_PROPERTY_SCENARIO_BUTTONS = "buttons";
     // BUS gw config properties
     public static final String CONFIG_PROPERTY_HOST = "host";
     public static final String CONFIG_PROPERTY_SERIAL_PORT = "serialPort";
-
     // properties
     public static final String PROPERTY_OWNID = "ownId";
     public static final String PROPERTY_ZIGBEEID = "zigbeeid";

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/OpenWebNetHandlerFactory.java
@@ -21,6 +21,7 @@ import org.openhab.binding.openwebnet.internal.handler.OpenWebNetBridgeHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetEnergyHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetGenericHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetLightingHandler;
+import org.openhab.binding.openwebnet.internal.handler.OpenWebNetScenarioHandler;
 import org.openhab.binding.openwebnet.internal.handler.OpenWebNetThermoregulationHandler;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
@@ -70,6 +71,9 @@ public class OpenWebNetHandlerFactory extends BaseThingHandlerFactory {
         } else if (OpenWebNetThermoregulationHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
             logger.debug("creating NEW THERMO Handler");
             return new OpenWebNetThermoregulationHandler(thing);
+        } else if (OpenWebNetScenarioHandler.SUPPORTED_THING_TYPES.contains(thing.getThingTypeUID())) {
+            logger.debug("creating NEW SCENARIO Handler");
+            return new OpenWebNetScenarioHandler(thing);
         }
         logger.warn("ThingType {} is not supported by this binding", thing.getThingTypeUID());
         return null;

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/actions/OpenWebNetCENActions.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/actions/OpenWebNetCENActions.java
@@ -50,22 +50,22 @@ public class OpenWebNetCENActions implements ThingActions {
         return scenarioHandler;
     }
 
-    @RuleAction(label = "virtualPress", description = "Virtual pressure of the push button")
+    @RuleAction(label = "virtualPress", description = "Virtual press of the push button")
     public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean virtualPress(
-            @ActionInput(name = "pressure", label = "pressure", description = "Type of pressure") @Nullable String pressure,
+            @ActionInput(name = "press", label = "press", description = "Type of press") @Nullable String press,
             @ActionInput(name = "button", label = "button", description = "Button number") int button) {
         OpenWebNetScenarioHandler handler = scenarioHandler;
         if (handler == null) {
             logger.warn("openwebnet OpenWebNetCENActions: scenarioHandler is null!");
             return false;
         }
-        if (pressure == null) {
-            logger.warn("openwebnet OpenWebNetCENActions: pressure parameter is null!");
+        if (press == null) {
+            logger.warn("openwebnet OpenWebNetCENActions: press parameter is null!");
             return false;
         }
         CEN msg = null;
         try {
-            msg = handler.pressureStrToMessage(pressure, button);
+            msg = handler.pressStrToMessage(press, button);
             Response res = handler.send(msg);
             if (res != null) {
                 logger.debug("Sent virtualPress '{}' to gateway. Response: {}", msg, res.getResponseMessages());
@@ -83,9 +83,9 @@ public class OpenWebNetCENActions implements ThingActions {
     }
 
     // legacy delegate methods
-    public static void virtualPress(@Nullable ThingActions actions, @Nullable String pressure, int button) {
+    public static void virtualPress(@Nullable ThingActions actions, @Nullable String press, int button) {
         if (actions instanceof OpenWebNetCENActions) {
-            ((OpenWebNetCENActions) actions).virtualPress(pressure, button);
+            ((OpenWebNetCENActions) actions).virtualPress(press, button);
         } else {
             throw new IllegalArgumentException("Instance is not an OpenWebNetCENActions class.");
         }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/actions/OpenWebNetCENActions.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/actions/OpenWebNetCENActions.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.actions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.openwebnet.internal.handler.OpenWebNetScenarioHandler;
+import org.openhab.core.automation.annotation.ActionInput;
+import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.RuleAction;
+import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.thing.binding.ThingActionsScope;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openwebnet4j.communication.OWNException;
+import org.openwebnet4j.communication.Response;
+import org.openwebnet4j.message.CEN;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OpenWebNetCENActions} defines CEN/CEN+ actions for the openwebnet binding.
+ *
+ * @author Massimo Valla - Initial contribution
+ */
+
+@ThingActionsScope(name = "openwebnet")
+@NonNullByDefault
+public class OpenWebNetCENActions implements ThingActions {
+
+    private final Logger logger = LoggerFactory.getLogger(OpenWebNetCENActions.class);
+    private @Nullable OpenWebNetScenarioHandler scenarioHandler;
+
+    @Override
+    public void setThingHandler(@Nullable ThingHandler handler) {
+        this.scenarioHandler = (OpenWebNetScenarioHandler) handler;
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return scenarioHandler;
+    }
+
+    @RuleAction(label = "virtualPress", description = "Virtual pressure of the push button")
+    public @ActionOutput(name = "success", type = "java.lang.Boolean") Boolean virtualPress(
+            @ActionInput(name = "pressure", label = "pressure", description = "Type of pressure") @Nullable String pressure,
+            @ActionInput(name = "button", label = "button", description = "Button number") int button) {
+        OpenWebNetScenarioHandler handler = scenarioHandler;
+        if (handler == null) {
+            logger.warn("openwebnet OpenWebNetCENActions: scenarioHandler is null!");
+            return false;
+        }
+        if (pressure == null) {
+            logger.warn("openwebnet OpenWebNetCENActions: pressure parameter is null!");
+            return false;
+        }
+        CEN msg = null;
+        try {
+            msg = handler.pressureStrToMessage(pressure, button);
+            Response res = handler.send(msg);
+            if (res != null) {
+                logger.debug("Sent virtualPress '{}' to gateway. Response: {}", msg, res.getResponseMessages());
+                return res.isSuccess();
+            } else {
+                logger.debug("virtual press action returned null response");
+            }
+        } catch (IllegalArgumentException e) {
+            logger.warn("cannot execute virtual press action for thing {}: {}", handler.getThing().getUID(),
+                    e.getMessage());
+        } catch (OWNException e) {
+            logger.warn("exception while sending virtual press message '{}' to gateway: {}", msg, e.getMessage());
+        }
+        return false;
+    }
+
+    // legacy delegate methods
+    public static void virtualPress(@Nullable ThingActions actions, @Nullable String pressure, int button) {
+        if (actions instanceof OpenWebNetCENActions) {
+            ((OpenWebNetCENActions) actions).virtualPress(pressure, button);
+        } else {
+            throw new IllegalArgumentException("Instance is not an OpenWebNetCENActions class.");
+        }
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -153,6 +153,18 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService
                 deviceWho = Who.ENERGY_MANAGEMENT;
                 break;
             }
+            case SCENARIO_CONTROL: {
+                thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_CEN_SCENARIO_CONTROL;
+                thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_CEN_SCENARIO_CONTROL;
+                deviceWho = Who.CEN_SCENARIO_SCHEDULER;
+                break;
+            }
+            case MULTIFUNCTION_SCENARIO_CONTROL: {
+                thingTypeUID = OpenWebNetBindingConstants.THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL;
+                thingLabel = OpenWebNetBindingConstants.THING_LABEL_BUS_CENPLUS_SCENARIO_CONTROL;
+                deviceWho = Who.CEN_PLUS_SCENARIO_SCHEDULER;
+                break;
+            }
             default:
                 logger.warn("Device type {} is not supported, default to GENERIC device (WHERE={})", deviceType, where);
                 if (where instanceof WhereZigBee) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetBridgeHandler.java
@@ -48,6 +48,7 @@ import org.openwebnet4j.communication.OWNAuthException;
 import org.openwebnet4j.communication.OWNException;
 import org.openwebnet4j.message.Automation;
 import org.openwebnet4j.message.BaseOpenMessage;
+import org.openwebnet4j.message.CEN;
 import org.openwebnet4j.message.EnergyManagement;
 import org.openwebnet4j.message.FrameException;
 import org.openwebnet4j.message.GatewayMgmt;
@@ -308,7 +309,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         }
         // we support these types only
         if (baseMsg instanceof Lighting || baseMsg instanceof Automation || baseMsg instanceof EnergyManagement
-                || baseMsg instanceof Thermoregulation) {
+                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN) {
             BaseOpenMessage bmsg = baseMsg;
             if (baseMsg instanceof Lighting) {
                 What what = baseMsg.getWhat();
@@ -419,7 +420,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
         BaseOpenMessage baseMsg = (BaseOpenMessage) msg;
         // let's try to get the Thing associated with this message...
         if (baseMsg instanceof Lighting || baseMsg instanceof Automation || baseMsg instanceof EnergyManagement
-                || baseMsg instanceof Thermoregulation) {
+                || baseMsg instanceof Thermoregulation || baseMsg instanceof CEN) {
             String ownId = ownIdFromMessage(baseMsg);
             logger.debug("ownIdFromMessage({}) --> {}", baseMsg, ownId);
             OpenWebNetThingHandler deviceHandler = registeredDevices.get(ownId);

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetEnergyHandler.java
@@ -107,20 +107,23 @@ public class OpenWebNetEnergyHandler extends OpenWebNetThingHandler {
                         "subscribeToActivePowerChanges() Refreshing subscription for the next {}min for WHERE={} to active power changes notification",
                         ENERGY_SUBSCRIPTION_PERIOD, deviceWhere);
             }
-
-            try {
-                bridgeHandler.gateway.send(EnergyManagement.setActivePowerNotificationsTime(deviceWhere.value(),
-                        ENERGY_SUBSCRIPTION_PERIOD));
-                isFirstSchedulerLaunch = false;
-            } catch (Exception e) {
-                if (isFirstSchedulerLaunch) {
-                    logger.warn(
-                            "subscribeToActivePowerChanges() For WHERE={} could not subscribe to active power changes notifications. Exception={}",
-                            deviceWhere, e.getMessage());
-                } else {
-                    logger.warn(
-                            "subscribeToActivePowerChanges() Unable to refresh subscription to active power changes notifications for WHERE={}. Exception={}",
-                            deviceWhere, e.getMessage());
+            Where w = deviceWhere;
+            if (w == null) {
+                logger.warn("subscribeToActivePowerChanges() WHERE=null. Skipping");
+            } else {
+                try {
+                    send(EnergyManagement.setActivePowerNotificationsTime(w.value(), ENERGY_SUBSCRIPTION_PERIOD));
+                    isFirstSchedulerLaunch = false;
+                } catch (Exception e) {
+                    if (isFirstSchedulerLaunch) {
+                        logger.warn(
+                                "subscribeToActivePowerChanges() For WHERE={} could not subscribe to active power changes notifications. Exception={}",
+                                w, e.getMessage());
+                    } else {
+                        logger.warn(
+                                "subscribeToActivePowerChanges() Unable to refresh subscription to active power changes notifications for WHERE={}. Exception={}",
+                                w, e.getMessage());
+                    }
                 }
             }
         }, 0, ENERGY_SUBSCRIPTION_PERIOD - 1, TimeUnit.MINUTES);
@@ -129,9 +132,9 @@ public class OpenWebNetEnergyHandler extends OpenWebNetThingHandler {
     @Override
     public void dispose() {
         if (notificationSchedule != null) {
+            ScheduledFuture<?> ns = notificationSchedule;
+            ns.cancel(false);
             logger.debug("dispose() scheduler stopped.");
-
-            notificationSchedule.cancel(false);
         }
         super.dispose();
     }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.openwebnet.internal.handler;
+
+import static org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants.*;
+
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.openwebnet.internal.OpenWebNetBindingConstants;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.type.ChannelKind;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.types.Command;
+import org.openwebnet4j.message.BaseOpenMessage;
+import org.openwebnet4j.message.CEN;
+import org.openwebnet4j.message.CENScenario;
+import org.openwebnet4j.message.CENScenario.CENPressure;
+import org.openwebnet4j.message.FrameException;
+import org.openwebnet4j.message.Where;
+import org.openwebnet4j.message.WhereLightAutom;
+import org.openwebnet4j.message.Who;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OpenWebNetScenarioHandler} is responsible for handling commands/messages for CEN/CEN+ Scenarios. It
+ * extends the abstract {@link OpenWebNetThingHandler}.
+ *
+ * @author Massimo Valla - Initial contribution
+ */
+@NonNullByDefault
+public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OpenWebNetScenarioHandler.class);
+
+    private interface PressureEvent {
+        @Override
+        public String toString();
+    }
+
+    private enum CENPressureEvent implements PressureEvent {
+        START_PRESSURE("START_PRESSURE"),
+        SHORT_PRESSURE("SHORT_PRESSURE"),
+        EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
+        RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
+
+        private final String pressure;
+
+        CENPressureEvent(final String pr) {
+            this.pressure = pr;
+        }
+
+        @Override
+        public String toString() {
+            return pressure;
+        }
+    }
+
+    private boolean isCENPlus = false;
+
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.SCENARIO_SUPPORTED_THING_TYPES;
+
+    public OpenWebNetScenarioHandler(Thing thing) {
+        super(thing);
+        logger.debug("==OWN:ScenarioHandler== constructor");
+        if (OpenWebNetBindingConstants.THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL.equals(thing.getThingTypeUID())) {
+            isCENPlus = true;
+            logger.debug("==OWN:ScenarioHandler== CEN+ device for thing: {}", getThing().getUID());
+        }
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        logger.debug("==OWN:ScenarioHandler== initialize() thing={}", thing.getUID());
+        Object buttonsConfig = getConfig().get(CONFIG_PROPERTY_SCENARIO_BUTTONS);
+        if (buttonsConfig != null) {
+            Set<Integer> buttons = csvStringToSetInt((String) buttonsConfig);
+            if (!buttons.isEmpty()) {
+                ThingBuilder thingBuilder = editThing();
+                Channel ch;
+                for (Integer i : buttons) {
+                    ch = thing.getChannel(CHANNEL_SCENARIO_BUTTON + i);
+                    if (ch == null) {
+                        thingBuilder.withChannel(buttonToChannel(i));
+                        logger.debug("==OWN:ScenarioHandler== added channel {} to thing: {}", i, getThing().getUID());
+                    }
+                }
+                updateThing(thingBuilder.build());
+            } else {
+                logger.warn("==OWN:ScenarioHandler== invalid config parameter buttons='{}' for thing {}", buttonsConfig,
+                        thing.getUID());
+            }
+        }
+    }
+
+    @Override
+    protected String ownIdPrefix() {
+        if (isCENPlus) {
+            return Who.CEN_PLUS_SCENARIO_SCHEDULER.value().toString();
+        } else {
+            return Who.CEN_SCENARIO_SCHEDULER.value().toString();
+        }
+    }
+
+    @Override
+    protected void handleMessage(BaseOpenMessage msg) {
+        super.handleMessage(msg);
+        logger.debug("==OWN:ScenarioHandler== handleMessage() for thing: {}", thing.getUID());
+        if (msg.isCommand()) {
+            triggerChannel((CEN) msg);
+        } else {
+            logger.debug("==OWN:ScenarioHandler== handleMessage() Ignoring unsupported DIM for thing {}. Frame={}",
+                    getThing().getUID(), msg);
+        }
+    }
+
+    private void triggerChannel(CEN cenMsg) {
+        logger.debug("==OWN:ScenarioHandler== triggerChannel() for thing: {}", thing.getUID());
+        Integer buttonNumber;
+        try {
+            buttonNumber = cenMsg.getButtonNumber();
+        } catch (FrameException e) {
+            logger.warn("==OWN:ScenarioHandler== cannot read CEN/CEN+ button. Ignoring message {}", cenMsg);
+            return;
+        }
+        if (buttonNumber == null || buttonNumber < 0 || buttonNumber > 31) {
+            logger.warn("==OWN:ScenarioHandler== invalid CEN/CEN+ button number: {}. Ignoring message {}", buttonNumber,
+                    cenMsg);
+            return;
+        }
+        Channel ch = thing.getChannel(CHANNEL_SCENARIO_BUTTON + buttonNumber);
+        if (ch == null) { // we have found a new button for this device, let's add a new channel for the button
+            ThingBuilder thingBuilder = editThing();
+            ch = buttonToChannel(buttonNumber);
+            thingBuilder.withChannel(ch);
+            updateThing(thingBuilder.build());
+            logger.info("==OWN:ScenarioHandler== added new channel {} to thing {}", ch.getUID(), getThing().getUID());
+        }
+        final Channel channel = ch;
+        PressureEvent pressureEv = null;
+        if (cenMsg instanceof CENScenario) {
+            CENPressure cenPr = null;
+            try {
+                cenPr = ((CENScenario) cenMsg).getButtonPressure();
+            } catch (FrameException e) {
+                // TODO
+            }
+            if (cenPr == null) {
+                logger.warn("==OWN:ScenarioHandler== invalid CENPressure. Frame: {}", cenMsg);
+                return;
+            }
+            switch (cenPr) {
+                case START_PRESSURE:
+                    pressureEv = CENPressureEvent.START_PRESSURE;
+                    break;
+                case RELEASE_SHORT_PRESSURE:
+                    pressureEv = CENPressureEvent.SHORT_PRESSURE;
+                    break;
+                case EXTENDED_PRESSURE:
+                    pressureEv = CENPressureEvent.EXTENDED_PRESSURE;
+                    break;
+                case RELEASE_EXTENDED_PRESSURE:
+                    pressureEv = CENPressureEvent.RELEASE_EXTENDED_PRESSURE;
+                    break;
+                default:
+                    logger.warn("==OWN:ScenarioHandler== unsupported CENPressure. Frame: {}", cenMsg);
+            }
+        } else {
+            // TODO same for CENPlus
+        }
+        if (pressureEv != null) {
+            triggerChannel(channel.getUID(), pressureEv.toString());
+        }
+    }
+
+    private Channel buttonToChannel(int buttonNumber) {
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(BINDING_ID, CHANNEL_TYPE_SCENARIO_BUTTON);
+        return ChannelBuilder
+                .create(new ChannelUID(getThing().getUID(), CHANNEL_SCENARIO_BUTTON + buttonNumber), "String")
+                .withType(channelTypeUID).withKind(ChannelKind.TRIGGER).withLabel("Button " + buttonNumber).build();
+    }
+
+    /*
+     * private Integer channelToButton(ChannelUID channel) {
+     * try {
+     * return Integer.parseInt(channel.getId().substring(channel.getId().lastIndexOf("_") + 1));
+     * } catch (NumberFormatException nfe) {
+     * logger.warn("==OWN:ScenarioHandler== channelToButton() Exception: {}", nfe.getMessage());
+     * return null;
+     * }
+     * }
+     */
+    private static Set<Integer> csvStringToSetInt(String s) {
+        TreeSet<Integer> intSet = new TreeSet<Integer>();
+        if (s != null) {
+            String sNorm = s.replaceAll("\\s", "");
+            Scanner sc = new Scanner(sNorm);
+            sc.useDelimiter(",");
+            while (sc.hasNextInt()) {
+                intSet.add(sc.nextInt());
+            }
+            sc.close();
+        }
+        return intSet;
+    }
+
+    @Override
+    protected void handleChannelCommand(ChannelUID channel, Command command) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected void refreshDevice(boolean refreshAll) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected Where buildBusWhere(String wStr) throws IllegalArgumentException {
+        return new WhereLightAutom(wStr);
+    }
+
+    @Override
+    protected void requestChannelState(ChannelUID channel) {
+        // TODO Auto-generated method stub
+    }
+}

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -61,56 +61,54 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(OpenWebNetScenarioHandler.class);
 
-    private interface PressureEvent {
+    private interface PressEvent {
         @Override
         public String toString();
     }
 
-    private enum CENPressureEvent implements PressureEvent {
-        CEN_EVENT_START_PRESSURE("START_PRESSURE"),
-        CEN_EVENT_SHORT_PRESSURE("SHORT_PRESSURE"),
-        CEN_EVENT_EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
-        CEN_EVENT_RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
+    private enum CENPressEvent implements PressEvent {
+        CEN_EVENT_START_PRESS("START_PRESS"),
+        CEN_EVENT_SHORT_PRESS("SHORT_PRESS"),
+        CEN_EVENT_EXTENDED_PRESS("EXTENDED_PRESS"),
+        CEN_EVENT_RELEASE_EXTENDED_PRESS("RELEASE_EXTENDED_PRESS");
 
-        private final String pressure;
+        private final String press;
 
-        CENPressureEvent(final String pr) {
-            this.pressure = pr;
+        CENPressEvent(final String pr) {
+            this.press = pr;
         }
 
-        public static @Nullable CENPressureEvent fromValue(String s) {
-            Optional<CENPressureEvent> event = Arrays.stream(values()).filter(val -> s.equals(val.pressure))
-                    .findFirst();
+        public static @Nullable CENPressEvent fromValue(String s) {
+            Optional<CENPressEvent> event = Arrays.stream(values()).filter(val -> s.equals(val.press)).findFirst();
             return event.orElse(null);
         }
 
         @Override
         public String toString() {
-            return pressure;
+            return press;
         }
     }
 
-    private enum CENPlusPressureEvent implements PressureEvent {
-        CENPLUS_EVENT_SHORT_PRESSURE("SHORT_PRESSURE"),
-        CENPLUS_EVENT_START_EXTENDED_PRESSURE("START_EXTENDED_PRESSURE"),
-        CENPLUS_EVENT_EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
-        CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
+    private enum CENPlusPressEvent implements PressEvent {
+        CENPLUS_EVENT_SHORT_PRESS("SHORT_PRESS"),
+        CENPLUS_EVENT_START_EXTENDED_PRESS("START_EXTENDED_PRESS"),
+        CENPLUS_EVENT_EXTENDED_PRESS("EXTENDED_PRESS"),
+        CENPLUS_EVENT_RELEASE_EXTENDED_PRESS("RELEASE_EXTENDED_PRESS");
 
-        private final String pressure;
+        private final String press;
 
-        CENPlusPressureEvent(final String pr) {
-            this.pressure = pr;
+        CENPlusPressEvent(final String pr) {
+            this.press = pr;
         }
 
-        public static @Nullable CENPlusPressureEvent fromValue(String s) {
-            Optional<CENPlusPressureEvent> event = Arrays.stream(values()).filter(val -> s.equals(val.pressure))
-                    .findFirst();
+        public static @Nullable CENPlusPressEvent fromValue(String s) {
+            Optional<CENPlusPressEvent> event = Arrays.stream(values()).filter(val -> s.equals(val.press)).findFirst();
             return event.orElse(null);
         }
 
         @Override
         public String toString() {
-            return pressure;
+            return press;
         }
     }
 
@@ -196,58 +194,58 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
             logger.info("added new channel {} to thing {}", ch.getUID(), getThing().getUID());
         }
         final Channel channel = ch;
-        PressureEvent pressureEv = null;
-        Pressure pressure = null;
+        PressEvent pressEv = null;
+        Pressure press = null;
         try {
-            pressure = cenMsg.getButtonPressure();
+            press = cenMsg.getButtonPressure();
         } catch (FrameException e) {
-            logger.warn("invalid CEN/CEN+ Pressure. Ignoring message {}", cenMsg);
+            logger.warn("invalid CEN/CEN+ Press. Ignoring message {}", cenMsg);
             return;
         }
-        if (pressure == null) {
-            logger.warn("invalid CEN/CEN+ Pressure. Ignoring message {}", cenMsg);
+        if (press == null) {
+            logger.warn("invalid CEN/CEN+ Press. Ignoring message {}", cenMsg);
             return;
         }
 
         if (cenMsg instanceof CENScenario) {
-            switch ((CENPressure) pressure) {
+            switch ((CENPressure) press) {
                 case START_PRESSURE:
-                    pressureEv = CENPressureEvent.CEN_EVENT_START_PRESSURE;
+                    pressEv = CENPressEvent.CEN_EVENT_START_PRESS;
                     break;
                 case RELEASE_SHORT_PRESSURE:
-                    pressureEv = CENPressureEvent.CEN_EVENT_SHORT_PRESSURE;
+                    pressEv = CENPressEvent.CEN_EVENT_SHORT_PRESS;
                     break;
                 case EXTENDED_PRESSURE:
-                    pressureEv = CENPressureEvent.CEN_EVENT_EXTENDED_PRESSURE;
+                    pressEv = CENPressEvent.CEN_EVENT_EXTENDED_PRESS;
                     break;
                 case RELEASE_EXTENDED_PRESSURE:
-                    pressureEv = CENPressureEvent.CEN_EVENT_RELEASE_EXTENDED_PRESSURE;
+                    pressEv = CENPressEvent.CEN_EVENT_RELEASE_EXTENDED_PRESS;
                     break;
                 default:
-                    logger.warn("unsupported CENPressure. Ignoring message {}", cenMsg);
+                    logger.warn("unsupported CENPress. Ignoring message {}", cenMsg);
                     return;
             }
         } else {
-            switch ((CENPlusPressure) pressure) {
+            switch ((CENPlusPressure) press) {
                 case SHORT_PRESSURE:
-                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_SHORT_PRESSURE;
+                    pressEv = CENPlusPressEvent.CENPLUS_EVENT_SHORT_PRESS;
                     break;
                 case START_EXTENDED_PRESSURE:
-                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_START_EXTENDED_PRESSURE;
+                    pressEv = CENPlusPressEvent.CENPLUS_EVENT_START_EXTENDED_PRESS;
                     break;
                 case EXTENDED_PRESSURE:
-                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_EXTENDED_PRESSURE;
+                    pressEv = CENPlusPressEvent.CENPLUS_EVENT_EXTENDED_PRESS;
                     break;
                 case RELEASE_EXTENDED_PRESSURE:
-                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE;
+                    pressEv = CENPlusPressEvent.CENPLUS_EVENT_RELEASE_EXTENDED_PRESS;
                     break;
                 default:
-                    logger.warn("unsupported CENPlusPressure. Ignoring message {}", cenMsg);
+                    logger.warn("unsupported CENPlusPress. Ignoring message {}", cenMsg);
                     return;
             }
         }
 
-        triggerChannel(channel.getUID(), pressureEv.toString());
+        triggerChannel(channel.getUID(), pressEv.toString());
     }
 
     private Channel buttonToChannel(int buttonNumber) {
@@ -263,53 +261,53 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
     }
 
     /**
-     * Construct a CEN/CEN+ virtual pressure message for this device given a pressureString and button number
+     * Construct a CEN/CEN+ virtual press message for this device given a pressString and button number
      *
-     * @param pressureString one START_PRESSURE, SHORT_PRESSURE etc.
+     * @param pressString one START_PRESS, SHORT_PRESS etc.
      * @param button number [0-31]
      * @return CEN message
-     * @throws IllegalArgumentException if button number or pressureString are invalid
+     * @throws IllegalArgumentException if button number or pressString are invalid
      */
-    public CEN pressureStrToMessage(String pressureString, int button) throws IllegalArgumentException {
+    public CEN pressStrToMessage(String pressString, int button) throws IllegalArgumentException {
         Where w = deviceWhere;
         if (w == null) {
-            throw new IllegalArgumentException("pressureStrToMessage: deviceWhere is null");
+            throw new IllegalArgumentException("pressStrToMessage: deviceWhere is null");
         }
         if (isCENPlus) {
-            CENPlusPressureEvent prEvent = CENPlusPressureEvent.fromValue(pressureString);
+            CENPlusPressEvent prEvent = CENPlusPressEvent.fromValue(pressString);
             if (prEvent != null) {
                 switch (prEvent) {
-                    case CENPLUS_EVENT_SHORT_PRESSURE:
+                    case CENPLUS_EVENT_SHORT_PRESS:
                         return CENPlusScenario.virtualShortPressure(w.value(), button);
-                    case CENPLUS_EVENT_START_EXTENDED_PRESSURE:
+                    case CENPLUS_EVENT_START_EXTENDED_PRESS:
                         return CENPlusScenario.virtualStartExtendedPressure(w.value(), button);
-                    case CENPLUS_EVENT_EXTENDED_PRESSURE:
+                    case CENPLUS_EVENT_EXTENDED_PRESS:
                         return CENPlusScenario.virtualExtendedPressure(w.value(), button);
-                    case CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE:
+                    case CENPLUS_EVENT_RELEASE_EXTENDED_PRESS:
                         return CENPlusScenario.virtualReleaseExtendedPressure(w.value(), button);
                     default:
-                        throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+                        throw new IllegalArgumentException("unsupported press type: " + pressString);
                 }
             } else {
-                throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+                throw new IllegalArgumentException("unsupported press type: " + pressString);
             }
         } else {
-            CENPressureEvent prEvent = CENPressureEvent.fromValue(pressureString);
+            CENPressEvent prEvent = CENPressEvent.fromValue(pressString);
             if (prEvent != null) {
                 switch (prEvent) {
-                    case CEN_EVENT_START_PRESSURE:
+                    case CEN_EVENT_START_PRESS:
                         return CENScenario.virtualStartPressure(w.value(), button);
-                    case CEN_EVENT_SHORT_PRESSURE:
+                    case CEN_EVENT_SHORT_PRESS:
                         return CENScenario.virtualReleaseShortPressure(w.value(), button);
-                    case CEN_EVENT_EXTENDED_PRESSURE:
+                    case CEN_EVENT_EXTENDED_PRESS:
                         return CENScenario.virtualExtendedPressure(w.value(), button);
-                    case CEN_EVENT_RELEASE_EXTENDED_PRESSURE:
+                    case CEN_EVENT_RELEASE_EXTENDED_PRESS:
                         return CENScenario.virtualReleaseExtendedPressure(w.value(), button);
                     default:
-                        throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+                        throw new IllegalArgumentException("unsupported press type: " + pressString);
                 }
             } else {
-                throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+                throw new IllegalArgumentException("unsupported press type: " + pressString);
             }
         }
     }
@@ -328,7 +326,7 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void handleChannelCommand(ChannelUID channel, Command command) {
-        logger.info("CEN/CEN+ channels are trigger channels and do not handle commands");
+        logger.warn("CEN/CEN+ channels are trigger channels and do not handle commands");
     }
 
     @Override

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -249,7 +249,6 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
         }
 
         triggerChannel(channel.getUID(), pressureEv.toString());
-
     }
 
     private Channel buttonToChannel(int buttonNumber) {

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -38,6 +38,9 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openwebnet4j.message.BaseOpenMessage;
 import org.openwebnet4j.message.CEN;
+import org.openwebnet4j.message.CEN.Pressure;
+import org.openwebnet4j.message.CENPlusScenario;
+import org.openwebnet4j.message.CENPlusScenario.CENPlusPressure;
 import org.openwebnet4j.message.CENScenario;
 import org.openwebnet4j.message.CENScenario.CENPressure;
 import org.openwebnet4j.message.FrameException;
@@ -63,11 +66,11 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
         public String toString();
     }
 
-    public enum CENPressureEvent implements PressureEvent {
-        START_PRESSURE("START_PRESSURE"),
-        SHORT_PRESSURE("SHORT_PRESSURE"),
-        EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
-        RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
+    private enum CENPressureEvent implements PressureEvent {
+        CEN_EVENT_START_PRESSURE("START_PRESSURE"),
+        CEN_EVENT_SHORT_PRESSURE("SHORT_PRESSURE"),
+        CEN_EVENT_EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
+        CEN_EVENT_RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
 
         private final String pressure;
 
@@ -87,23 +90,47 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
         }
     }
 
+    private enum CENPlusPressureEvent implements PressureEvent {
+        CENPLUS_EVENT_SHORT_PRESSURE("SHORT_PRESSURE"),
+        CENPLUS_EVENT_START_EXTENDED_PRESSURE("START_EXTENDED_PRESSURE"),
+        CENPLUS_EVENT_EXTENDED_PRESSURE("EXTENDED_PRESSURE"),
+        CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE("RELEASE_EXTENDED_PRESSURE");
+
+        private final String pressure;
+
+        CENPlusPressureEvent(final String pr) {
+            this.pressure = pr;
+        }
+
+        public static @Nullable CENPlusPressureEvent fromValue(String s) {
+            Optional<CENPlusPressureEvent> event = Arrays.stream(values()).filter(val -> s.equals(val.pressure))
+                    .findFirst();
+            return event.orElse(null);
+        }
+
+        @Override
+        public String toString() {
+            return pressure;
+        }
+    }
+
     private boolean isCENPlus = false;
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.SCENARIO_SUPPORTED_THING_TYPES;
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = OpenWebNetBindingConstants.SCENARIO_SUPPORTED_THING_TYPES;
 
     public OpenWebNetScenarioHandler(Thing thing) {
         super(thing);
-        logger.debug("==OWN:ScenarioHandler== constructor");
         if (OpenWebNetBindingConstants.THING_TYPE_BUS_CENPLUS_SCENARIO_CONTROL.equals(thing.getThingTypeUID())) {
             isCENPlus = true;
-            logger.debug("==OWN:ScenarioHandler== CEN+ device for thing: {}", getThing().getUID());
+            logger.debug("created CEN+ device for thing: {}", getThing().getUID());
+        } else {
+            logger.debug("created CEN device for thing: {}", getThing().getUID());
         }
     }
 
     @Override
     public void initialize() {
         super.initialize();
-        logger.debug("==OWN:ScenarioHandler== initialize() thing={}", thing.getUID());
         Object buttonsConfig = getConfig().get(CONFIG_PROPERTY_SCENARIO_BUTTONS);
         if (buttonsConfig != null) {
             Set<Integer> buttons = csvStringToSetInt((String) buttonsConfig);
@@ -114,13 +141,12 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
                     ch = thing.getChannel(CHANNEL_SCENARIO_BUTTON + i);
                     if (ch == null) {
                         thingBuilder.withChannel(buttonToChannel(i));
-                        logger.debug("==OWN:ScenarioHandler== added channel {} to thing: {}", i, getThing().getUID());
+                        logger.debug("added channel {} to thing: {}", i, getThing().getUID());
                     }
                 }
                 updateThing(thingBuilder.build());
             } else {
-                logger.warn("==OWN:ScenarioHandler== invalid config parameter buttons='{}' for thing {}", buttonsConfig,
-                        thing.getUID());
+                logger.warn("invalid config parameter buttons='{}' for thing {}", buttonsConfig, thing.getUID());
             }
         }
     }
@@ -142,27 +168,24 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
     @Override
     protected void handleMessage(BaseOpenMessage msg) {
         super.handleMessage(msg);
-        logger.debug("==OWN:ScenarioHandler== handleMessage() for thing: {}", thing.getUID());
         if (msg.isCommand()) {
             triggerChannel((CEN) msg);
         } else {
-            logger.debug("==OWN:ScenarioHandler== handleMessage() Ignoring unsupported DIM for thing {}. Frame={}",
-                    getThing().getUID(), msg);
+            logger.debug("handleMessage() Ignoring unsupported DIM for thing {}. Frame={}", getThing().getUID(), msg);
         }
     }
 
     private void triggerChannel(CEN cenMsg) {
-        logger.debug("==OWN:ScenarioHandler== triggerChannel() for thing: {}", thing.getUID());
+        logger.debug("triggerChannel() for thing: {}", thing.getUID());
         Integer buttonNumber;
         try {
             buttonNumber = cenMsg.getButtonNumber();
         } catch (FrameException e) {
-            logger.warn("==OWN:ScenarioHandler== cannot read CEN/CEN+ button. Ignoring message {}", cenMsg);
+            logger.warn("cannot read CEN/CEN+ button. Ignoring message {}", cenMsg);
             return;
         }
         if (buttonNumber == null || buttonNumber < 0 || buttonNumber > 31) {
-            logger.warn("==OWN:ScenarioHandler== invalid CEN/CEN+ button number: {}. Ignoring message {}", buttonNumber,
-                    cenMsg);
+            logger.warn("invalid CEN/CEN+ button number: {}. Ignoring message {}", buttonNumber, cenMsg);
             return;
         }
         Channel ch = thing.getChannel(CHANNEL_SCENARIO_BUTTON + buttonNumber);
@@ -171,47 +194,71 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
             ch = buttonToChannel(buttonNumber);
             thingBuilder.withChannel(ch);
             updateThing(thingBuilder.build());
-            logger.info("==OWN:ScenarioHandler== added new channel {} to thing {}", ch.getUID(), getThing().getUID());
+            logger.info("added new channel {} to thing {}", ch.getUID(), getThing().getUID());
         }
         final Channel channel = ch;
         PressureEvent pressureEv = null;
+        Pressure pressure = null;
+        try {
+            pressure = cenMsg.getButtonPressure();
+        } catch (FrameException e) {
+            logger.warn("invalid CEN/CEN+ Pressure. Ignoring message {}", cenMsg);
+            return;
+        }
+        if (pressure == null) {
+            logger.warn("invalid CEN/CEN+ Pressure. Ignoring message {}", cenMsg);
+            return;
+        }
+
         if (cenMsg instanceof CENScenario) {
-            CENPressure cenPr = null;
-            try {
-                cenPr = ((CENScenario) cenMsg).getButtonPressure();
-            } catch (FrameException e) {
-                // TODO
-            }
-            if (cenPr == null) {
-                logger.warn("==OWN:ScenarioHandler== invalid CENPressure. Frame: {}", cenMsg);
-                return;
-            }
-            switch (cenPr) {
+            switch ((CENPressure) pressure) {
                 case START_PRESSURE:
-                    pressureEv = CENPressureEvent.START_PRESSURE;
+                    pressureEv = CENPressureEvent.CEN_EVENT_START_PRESSURE;
                     break;
                 case RELEASE_SHORT_PRESSURE:
-                    pressureEv = CENPressureEvent.SHORT_PRESSURE;
+                    pressureEv = CENPressureEvent.CEN_EVENT_SHORT_PRESSURE;
                     break;
                 case EXTENDED_PRESSURE:
-                    pressureEv = CENPressureEvent.EXTENDED_PRESSURE;
+                    pressureEv = CENPressureEvent.CEN_EVENT_EXTENDED_PRESSURE;
                     break;
                 case RELEASE_EXTENDED_PRESSURE:
-                    pressureEv = CENPressureEvent.RELEASE_EXTENDED_PRESSURE;
+                    pressureEv = CENPressureEvent.CEN_EVENT_RELEASE_EXTENDED_PRESSURE;
                     break;
                 default:
-                    logger.warn("==OWN:ScenarioHandler== unsupported CENPressure. Frame: {}", cenMsg);
+                    logger.warn("unsupported CENPressure. Ignoring message {}", cenMsg);
+                    return;
             }
         } else {
-            // TODO same for CENPlus
+            switch ((CENPlusPressure) pressure) {
+                case SHORT_PRESSURE:
+                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_SHORT_PRESSURE;
+                    break;
+                case START_EXTENDED_PRESSURE:
+                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_START_EXTENDED_PRESSURE;
+                    break;
+                case EXTENDED_PRESSURE:
+                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_EXTENDED_PRESSURE;
+                    break;
+                case RELEASE_EXTENDED_PRESSURE:
+                    pressureEv = CENPlusPressureEvent.CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE;
+                    break;
+                default:
+                    logger.warn("unsupported CENPlusPressure. Ignoring message {}", cenMsg);
+                    return;
+            }
         }
-        if (pressureEv != null) {
-            triggerChannel(channel.getUID(), pressureEv.toString());
-        }
+
+        triggerChannel(channel.getUID(), pressureEv.toString());
+
     }
 
     private Channel buttonToChannel(int buttonNumber) {
-        ChannelTypeUID channelTypeUID = new ChannelTypeUID(BINDING_ID, CHANNEL_TYPE_SCENARIO_BUTTON);
+        ChannelTypeUID channelTypeUID;
+        if (isCENPlus) {
+            channelTypeUID = new ChannelTypeUID(BINDING_ID, CHANNEL_TYPE_CEN_PLUS_BUTTON_EVENT);
+        } else {
+            channelTypeUID = new ChannelTypeUID(BINDING_ID, CHANNEL_TYPE_CEN_BUTTON_EVENT);
+        }
         return ChannelBuilder
                 .create(new ChannelUID(getThing().getUID(), CHANNEL_SCENARIO_BUTTON + buttonNumber), "String")
                 .withType(channelTypeUID).withKind(ChannelKind.TRIGGER).withLabel("Button " + buttonNumber).build();
@@ -231,18 +278,34 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
             throw new IllegalArgumentException("pressureStrToMessage: deviceWhere is null");
         }
         if (isCENPlus) {
-            throw new IllegalArgumentException("CEN+ unsupported");
+            CENPlusPressureEvent prEvent = CENPlusPressureEvent.fromValue(pressureString);
+            if (prEvent != null) {
+                switch (prEvent) {
+                    case CENPLUS_EVENT_SHORT_PRESSURE:
+                        return CENPlusScenario.virtualShortPressure(w.value(), button);
+                    case CENPLUS_EVENT_START_EXTENDED_PRESSURE:
+                        return CENPlusScenario.virtualStartExtendedPressure(w.value(), button);
+                    case CENPLUS_EVENT_EXTENDED_PRESSURE:
+                        return CENPlusScenario.virtualExtendedPressure(w.value(), button);
+                    case CENPLUS_EVENT_RELEASE_EXTENDED_PRESSURE:
+                        return CENPlusScenario.virtualReleaseExtendedPressure(w.value(), button);
+                    default:
+                        throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+                }
+            } else {
+                throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
+            }
         } else {
             CENPressureEvent prEvent = CENPressureEvent.fromValue(pressureString);
             if (prEvent != null) {
                 switch (prEvent) {
-                    case START_PRESSURE:
+                    case CEN_EVENT_START_PRESSURE:
                         return CENScenario.virtualStartPressure(w.value(), button);
-                    case SHORT_PRESSURE:
+                    case CEN_EVENT_SHORT_PRESSURE:
                         return CENScenario.virtualReleaseShortPressure(w.value(), button);
-                    case EXTENDED_PRESSURE:
+                    case CEN_EVENT_EXTENDED_PRESSURE:
                         return CENScenario.virtualExtendedPressure(w.value(), button);
-                    case RELEASE_EXTENDED_PRESSURE:
+                    case CEN_EVENT_RELEASE_EXTENDED_PRESSURE:
                         return CENScenario.virtualReleaseExtendedPressure(w.value(), button);
                     default:
                         throw new IllegalArgumentException("unsupported pressure type: " + pressureString);
@@ -253,16 +316,6 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
         }
     }
 
-    /*
-     * private Integer channelToButton(ChannelUID channel) {
-     * try {
-     * return Integer.parseInt(channel.getId().substring(channel.getId().lastIndexOf("_") + 1));
-     * } catch (NumberFormatException nfe) {
-     * logger.warn("==OWN:ScenarioHandler== channelToButton() Exception: {}", nfe.getMessage());
-     * return null;
-     * }
-     * }
-     */
     private static Set<Integer> csvStringToSetInt(String s) {
         TreeSet<Integer> intSet = new TreeSet<Integer>();
         String sNorm = s.replaceAll("\\s", "");
@@ -277,12 +330,12 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void handleChannelCommand(ChannelUID channel, Command command) {
-        // TODO Auto-generated method stub
+        logger.info("CEN/CEN+ channels are trigger channels and do not handle commands");
     }
 
     @Override
     protected void refreshDevice(boolean refreshAll) {
-        // TODO Auto-generated method stub
+        logger.debug("CEN/CEN+ channels are trigger channels and do not have state");
     }
 
     @Override
@@ -292,6 +345,6 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
 
     @Override
     protected void requestChannelState(ChannelUID channel) {
-        // TODO Auto-generated method stub
+        logger.debug("CEN/CEN+ channels are trigger channels and do not have state");
     }
 }

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -176,7 +176,6 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
     }
 
     private void triggerChannel(CEN cenMsg) {
-        logger.debug("triggerChannel() for thing: {}", thing.getUID());
         Integer buttonNumber;
         try {
             buttonNumber = cenMsg.getButtonNumber();

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetScenarioHandler.java
@@ -45,7 +45,7 @@ import org.openwebnet4j.message.CENScenario;
 import org.openwebnet4j.message.CENScenario.CENPressure;
 import org.openwebnet4j.message.FrameException;
 import org.openwebnet4j.message.Where;
-import org.openwebnet4j.message.WhereLightAutom;
+import org.openwebnet4j.message.WhereCEN;
 import org.openwebnet4j.message.Who;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -340,7 +340,7 @@ public class OpenWebNetScenarioHandler extends OpenWebNetThingHandler {
 
     @Override
     protected Where buildBusWhere(String wStr) throws IllegalArgumentException {
-        return new WhereLightAutom(wStr);
+        return new WhereCEN(wStr);
     }
 
     @Override

--- a/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
+++ b/bundles/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/handler/OpenWebNetThingHandler.java
@@ -165,7 +165,7 @@ public abstract class OpenWebNetThingHandler extends BaseThingHandler {
     /**
      * Helper method to send OWN messages from ThingHandlers
      */
-    protected @Nullable Response send(OpenMessage msg) throws OWNException {
+    public @Nullable Response send(OpenMessage msg) throws OWNException {
         OpenWebNetBridgeHandler bh = bridgeHandler;
         if (bh != null) {
             OpenGateway gw = bh.gateway;

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAutomation.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusAutomation.xml
@@ -38,7 +38,7 @@
 			</parameter>
 
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
@@ -12,6 +12,8 @@
 		<label>CEN+ Scenario Control</label>
 		<description>A OpenWebNet BUS/SCS CEN+ Scenario Control device. BTicino models: HC/HD/HS/L/N/NT4680</description>
 
+		<!-- channels are created dynamically based on configured buttons -->
+
 		<properties>
 			<property name="vendor">BTicino/Legrand</property>
 			<property name="model">BTI-HC/HD/HS/L/N/NT4680</property>
@@ -27,10 +29,9 @@
 					buttons=1,2,4
 				</description>
 			</parameter>
-			<parameter name="where" type="text">
-				<label>OpenWebNet Device Address (WHERE)</label>
-				<description>Use 2+N[0-2047]; example Control 5 --> WHERE=25</description>
-				<required>true</required>
+			<parameter name="where" type="text" required="true">
+				<label>OpenWebNet Device Address (where)</label>
+				<description>Use 2+N[0-2047]. Example: scenario control 5 --> WHERE=25</description>
 			</parameter>
 		</config-description>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
@@ -24,13 +24,13 @@
 
 		<config-description>
 			<parameter name="buttons" type="text">
-				<label>Configured buttons</label>
+				<label>Configured Buttons</label>
 				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device, example:
 					buttons=1,2,4
 				</description>
 			</parameter>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Use 2+N[0-2047]. Example: scenario control 5 --> WHERE=25</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENPlusScenarioControl.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="openwebnet"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Thing for BUS CEN+ Scenario Control (BTicino HC/HD/HS/L/N/NT4680) -->
+	<thing-type id="bus_cenplus_scenario_control">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bus_gateway"/>
+		</supported-bridge-type-refs>
+		<label>CEN+ Scenario Control</label>
+		<description>A OpenWebNet BUS/SCS CEN+ Scenario Control device. BTicino models: HC/HD/HS/L/N/NT4680</description>
+
+		<properties>
+			<property name="vendor">BTicino/Legrand</property>
+			<property name="model">BTI-HC/HD/HS/L/N/NT4680</property>
+			<property name="ownDeviceType">273</property>
+		</properties>
+
+		<representation-property>ownId</representation-property>
+
+		<config-description>
+			<parameter name="buttons" type="text">
+				<label>Configured buttons</label>
+				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device, example:
+					buttons=1,2,4
+				</description>
+			</parameter>
+			<parameter name="where" type="text">
+				<label>OpenWebNet Device Address (WHERE)</label>
+				<description>Use 2+N[0-2047]; example Control 5 --> WHERE=25</description>
+				<required>true</required>
+			</parameter>
+		</config-description>
+
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
@@ -25,12 +25,12 @@
 
 		<config-description>
 			<parameter name="buttons" type="text">
-				<label>Configured buttons</label>
+				<label>Configured Buttons</label>
 				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example:
 					buttons=1,2,4</description>
 			</parameter>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: A/PL address: A=1 PL=3 --> WHERE=13. On local bus: WHERE=13#4#01</description>
 			</parameter>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusCENScenarioControl.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="openwebnet"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Thing for BUS CEN Scenario Control (BTicino HC/HD/HS/L/N/NT4680) -->
+	<thing-type id="bus_cen_scenario_control">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bus_gateway"/>
+		</supported-bridge-type-refs>
+
+		<label>CEN Scenario Control</label>
+		<description>A OpenWebNet BUS/SCS CEN Scenario Control device. BTicino models: HC/HD/HS/L/N/NT4680</description>
+
+		<!-- channels are created dynamically based on configured buttons -->
+
+		<properties>
+			<property name="vendor">BTicino/Legrand</property>
+			<property name="model">BTI-HC/HD/HS/L/N/NT4680</property>
+			<property name="ownDeviceType">2</property>
+		</properties>
+
+		<representation-property>ownId</representation-property>
+
+		<config-description>
+			<parameter name="buttons" type="text">
+				<label>Configured buttons</label>
+				<description>List (comma separated) of buttons numbers [0-31] configured for this scenario device. Example:
+					buttons=1,2,4</description>
+			</parameter>
+			<parameter name="where" type="text" required="true">
+				<label>OpenWebNet Device Address (where)</label>
+				<description>Example: A/PL address: A=1 PL=3 --> WHERE=13. On local bus: WHERE=13#4#01</description>
+			</parameter>
+
+		</config-description>
+
+	</thing-type>
+</thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusDimmer.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusDimmer.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusEnergyMeter.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusEnergyMeter.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Address</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: 5N with N=[1-255]</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusOnOffSwitch.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusOnOffSwitch.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: A/PL address: A=1 PL=3 --> where=13. On local bus: where=13#4#01</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoSensor.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoSensor.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: sensor 3 of zone 2 --> where=302. Sensor 5 of external zone 00 --> where=500</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoZone.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/BusThermoZone.xml
@@ -36,7 +36,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>Example: zone 2 --> where=2.</description>
 			</parameter>
 

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBAutomation.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBAutomation.xml
@@ -37,7 +37,7 @@
 				<default>AUTO</default>
 			</parameter>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>It identifies one ZigBee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBDimmer.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBDimmer.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>It identifies one ZigBee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch.xml
@@ -27,7 +27,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>It identifies one ZigBee device. Example: 765432101#9</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch2Units.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/ZBOnOffSwitch2Units.xml
@@ -28,7 +28,7 @@
 
 		<config-description>
 			<parameter name="where" type="text" required="true">
-				<label>OpenWebNet Device Address (where)</label>
+				<label>OpenWebNet Address (where)</label>
 				<description>It identifies one ZigBee device. Example: 765432100#9 (use unit=00 at the end)</description>
 			</parameter>
 		</config-description>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -178,4 +178,19 @@
 		<category>Energy</category>
 		<state readOnly="true" pattern="%.0f %unit%"></state>
 	</channel-type>
+
+	<!-- CEN/CEN+ trigger channels -->
+	<channel-type id="cenButtonEvent">
+		<kind>trigger</kind>
+		<label>CEN Button Event</label>
+		<event>
+			<options>
+				<option value="START_PRESSURE">start pressure</option>
+				<option value="SHORT_PRESSURE">release after short pressure</option>
+				<option value="EXTENDED_PRESSURE">extended pressure (repeated until release)</option>
+				<option value="RELEASE_EXTENDED_PRESSURE">release after extended pressure</option>
+			</options>
+		</event>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -193,4 +193,16 @@
 		</event>
 	</channel-type>
 
+	<channel-type id="cenPlusButtonEvent">
+		<kind>trigger</kind>
+		<label>CEN+ Button Event</label>
+		<event>
+			<options>
+				<option value="SHORT_PRESSURE">short pressure</option>
+				<option value="START_EXTENDED_PRESSURE">start of extended pressure</option>
+				<option value="EXTENDED_PRESSURE">extended pressure (repeated until release)</option>
+				<option value="RELEASE_EXTENDED_PRESSURE">release after extended pressure</option>
+			</options>
+		</event>
+	</channel-type>
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.openwebnet/src/main/resources/OH-INF/thing/channels.xml
@@ -185,10 +185,10 @@
 		<label>CEN Button Event</label>
 		<event>
 			<options>
-				<option value="START_PRESSURE">start pressure</option>
-				<option value="SHORT_PRESSURE">release after short pressure</option>
-				<option value="EXTENDED_PRESSURE">extended pressure (repeated until release)</option>
-				<option value="RELEASE_EXTENDED_PRESSURE">release after extended pressure</option>
+				<option value="START_PRESS">start press</option>
+				<option value="SHORT_PRESS">release after short press</option>
+				<option value="EXTENDED_PRESS">extended press (repeated until release)</option>
+				<option value="RELEASE_EXTENDED_PRESS">release after extended press</option>
 			</options>
 		</event>
 	</channel-type>
@@ -198,10 +198,10 @@
 		<label>CEN+ Button Event</label>
 		<event>
 			<options>
-				<option value="SHORT_PRESSURE">short pressure</option>
-				<option value="START_EXTENDED_PRESSURE">start of extended pressure</option>
-				<option value="EXTENDED_PRESSURE">extended pressure (repeated until release)</option>
-				<option value="RELEASE_EXTENDED_PRESSURE">release after extended pressure</option>
+				<option value="SHORT_PRESS">short press</option>
+				<option value="START_EXTENDED_PRESS">start of extended press</option>
+				<option value="EXTENDED_PRESS">extended press (repeated until release)</option>
+				<option value="RELEASE_EXTENDED_PRESS">release after extended press</option>
 			</options>
 		</event>
 	</channel-type>


### PR DESCRIPTION
This PR adds support for CEN/CEN+ scenarios (WHO=15/25) to the [openwebnet] binding.
With this addition BTicino BUS scenarios (WHO=15/25) can be detected and activated from OH3, enabling OH3 to work as a scenario manager for a BTicino installation, allowing for example to control other OH3-controlled devices from a bticino scenario button.
Configuration for new things and channel has been added to the add-on README.
Testing of this new addition by some users has been positive [as discussed here](https://community.openhab.org/t/openwebnet-adding-cen-cen-support-to-oh3/126882/).
Closes #11003. 