### PR TITLE
[unifi] Fix online channel update after client is disconnected

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/api/model/UniFiController.java
@@ -135,7 +135,7 @@ public class UniFiController {
         synchronized (this) {
             sitesCache = getSites();
             devicesCache = getDevices();
-            clientsCache = getClients();
+            updateClients();
             insightsCache = getInsights();
         }
     }
@@ -263,27 +263,23 @@ public class UniFiController {
         return cache;
     }
 
-    private UniFiClientCache getClients() throws UniFiException {
-        UniFiClientCache cache = new UniFiClientCache();
+    private void updateClients() throws UniFiException {
         Collection<UniFiSite> sites = sitesCache.values();
         for (UniFiSite site : sites) {
-            cache.putAll(getClients(site));
+            updateClients(site);
         }
-        return cache;
     }
 
-    private UniFiClientCache getClients(UniFiSite site) throws UniFiException {
+    private void updateClients(UniFiSite site) throws UniFiException {
         UniFiControllerRequest<UniFiClient[]> req = newRequest(UniFiClient[].class);
         req.setAPIPath("/api/s/" + site.getName() + "/stat/sta");
         UniFiClient[] clients = executeRequest(req);
-        UniFiClientCache cache = new UniFiClientCache();
         if (clients != null) {
             logger.debug("Found {} UniFi Client(s): {}", clients.length, lazyFormatAsList(clients));
             for (UniFiClient client : clients) {
-                cache.put(client);
+                clientsCache.put(client);
             }
         }
-        return cache;
     }
 
     private UniFiClientCache getInsights() throws UniFiException {


### PR DESCRIPTION
Fixes #7001

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix problem with online channel never being updated to **OFF** after client disconnects. This was most likely introduced by Uni-Fi Controller 5.12.35.

Problem could be solved in different ways. In this PR I fixed it by keeping clients in the cache after they are no longer connected to the access point. A different approach could be to fix it through the insights cache, which might seem more correct at first glance. However, it would get messy (also) as the IP address is simply not available anymore (at least since 5.12.35). So the insights cache would need to be correlated with the client cache to add this information while it's still available, for example through **mac** or **_id**.

The chosen approach here is quite simple as `cache.put` will replace any existing client with same key (it's implemented as HashMap). So instead of flushing the entire cache after each call, clients are replaced one by one.