### PR TITLE
[unifi] Fix thing configuration reload after changes

### DIFF
--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiBaseThingHandler.java
@@ -59,6 +59,7 @@ public abstract class UniFiBaseThingHandler<E, C> extends BaseThingHandler {
         }
         if (bridge.getStatus() == OFFLINE) {
             updateStatus(OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE, "The UniFi Controller is currently offline.");
+            return;
         }
         // mgb: derive the config class from the generic type
         Class<?> clazz = (Class<?>) (((ParameterizedType) getClass().getGenericSuperclass())

--- a/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiClientThingHandler.java
+++ b/bundles/org.openhab.binding.unifi/src/main/java/org/openhab/binding/unifi/internal/handler/UniFiClientThingHandler.java
@@ -76,9 +76,7 @@ public class UniFiClientThingHandler extends UniFiBaseThingHandler<UniFiClient, 
             return;
         }
         this.config = config;
-        if (thing.getStatus() == INITIALIZING) {
-            updateStatus(ONLINE);
-        }
+        updateStatus(ONLINE);
     }
 
     private static boolean belongsToSite(UniFiClient client, String siteName) {


### PR DESCRIPTION
Fixes #11407

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix reloading of configuration after changing things, for example setting a new **considerHome** value. Previously this didn't have effect for any thing already online.