### PR TITLE
[openhabcloud] Add api token option for local openhab connection

### DIFF
--- a/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
+++ b/bundles/org.openhab.io.openhabcloud/src/main/java/org/openhab/io/openhabcloud/internal/CloudService.java
@@ -72,6 +72,7 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
 
     private static final String CFG_EXPOSE = "expose";
     private static final String CFG_BASE_URL = "baseURL";
+    private static final String CFG_API_TOKEN = "apiToken";
     private static final String CFG_MODE = "mode";
     private static final String SECRET_FILE_NAME = "openhabcloud" + File.separator + "secret";
     private static final String DEFAULT_URL = "https://myopenhab.org/";
@@ -86,6 +87,7 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
     public static String clientVersion = null;
     private CloudClient cloudClient;
     private String cloudBaseUrl = null;
+    private String localApiToken = null;
     private final HttpClient httpClient;
     protected final ItemRegistry itemRegistry;
     protected final EventPublisher eventPublisher;
@@ -207,6 +209,10 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
             cloudBaseUrl = DEFAULT_URL;
         }
 
+        if (config.get(CFG_API_TOKEN) != null) {
+            localApiToken = (String) config.get(CFG_API_TOKEN);
+        }
+
         exposedItems = new HashSet<>();
         Object expCfg = config.get(CFG_EXPOSE);
         if (expCfg instanceof String) {
@@ -242,7 +248,7 @@ public class CloudService implements ActionService, CloudClientListener, EventSu
 
         String localBaseUrl = "http://localhost:" + localPort;
         cloudClient = new CloudClient(httpClient, InstanceUUID.get(), getSecret(), cloudBaseUrl, localBaseUrl,
-                remoteAccessEnabled, exposedItems);
+                localApiToken, remoteAccessEnabled, exposedItems);
         cloudClient.setOpenHABVersion(OpenHAB.getVersion());
         cloudClient.connect();
         cloudClient.setListener(this);

--- a/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/config/config.xml
@@ -24,5 +24,12 @@
 			<description>Base URL for the openHAB Cloud server</description>
 			<default>https://myopenhab.org/</default>
 		</parameter>
+		<parameter name="apiToken" type="text" required="false">
+			<label>API Token</label>
+			<description>API Token for local openHAB server (might be neccessary when deactivated default user role for
+				unauthenticated users)</description>
+			<default></default>
+			<advanced>true</advanced>
+		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.io.openhabcloud/src/main/resources/OH-INF/config/config.xml
@@ -28,8 +28,8 @@
 			<label>API Token</label>
 			<description>API Token for local openHAB server (might be neccessary when deactivated default user role for
 				unauthenticated users)</description>
-			<default></default>
 			<advanced>true</advanced>
+			<context>password</context>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>


### PR DESCRIPTION
I had the same problem as @DejanBukovec in #8979 and found a solution that worked for me and was quite simple. 

My solution simply adds an API token to any forwarded API request that goes to the local openHAB instance and makes this API token configurable in the UI settings.

But I would say that it is rather a kind of a workaround. So whether this should go into the productive addon I cannot decide. 

I mainly wanted to share my code, so that others with the same problem, do not have to do it again...

There is also one thing that bothers me about my solution, but I haven't found a solution for it unfortunately
...my first time working on openHAB's source code...
The API token remains permanently visible in the UI settings. Doesn't bother me that much personally, but I think this should be changed.

