### PR TITLE
[miele] Fix reading of water/power consumption on some appliance models/configurations

### DIFF
--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/DishWasherHandler.java
@@ -46,7 +46,7 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
 
     private static final int POWER_CONSUMPTION_BYTE_POSITION = 16;
     private static final int WATER_CONSUMPTION_BYTE_POSITION = 18;
-    private static final int EXTENDED_STATE_SIZE_BYTES = 24;
+    private static final int EXTENDED_STATE_MIN_SIZE_BYTES = 19;
 
     private final Logger logger = LoggerFactory.getLogger(DishWasherHandler.class);
 
@@ -97,8 +97,8 @@ public class DishWasherHandler extends MieleApplianceHandler<DishwasherChannelSe
     }
 
     public void onApplianceExtendedStateChanged(byte[] extendedDeviceState) {
-        if (extendedDeviceState.length != EXTENDED_STATE_SIZE_BYTES) {
-            logger.error("Unexpected size of extended state: {}", extendedDeviceState);
+        if (extendedDeviceState.length < EXTENDED_STATE_MIN_SIZE_BYTES) {
+            logger.warn("Unexpected size of extended state: {}", extendedDeviceState);
             return;
         }
 

--- a/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
+++ b/bundles/org.openhab.binding.miele/src/main/java/org/openhab/binding/miele/internal/handler/WashingMachineHandler.java
@@ -46,7 +46,7 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
 
     private static final int POWER_CONSUMPTION_BYTE_POSITION = 51;
     private static final int WATER_CONSUMPTION_BYTE_POSITION = 53;
-    private static final int EXTENDED_STATE_SIZE_BYTES = 59;
+    private static final int EXTENDED_STATE_MIN_SIZE_BYTES = 54;
 
     private final Logger logger = LoggerFactory.getLogger(WashingMachineHandler.class);
 
@@ -98,8 +98,8 @@ public class WashingMachineHandler extends MieleApplianceHandler<WashingMachineC
     }
 
     public void onApplianceExtendedStateChanged(byte[] extendedDeviceState) {
-        if (extendedDeviceState.length != EXTENDED_STATE_SIZE_BYTES) {
-            logger.error("Unexpected size of extended state: {}", extendedDeviceState);
+        if (extendedDeviceState.length < EXTENDED_STATE_MIN_SIZE_BYTES) {
+            logger.warn("Unexpected size of extended state: {}", extendedDeviceState);
             return;
         }
 


### PR DESCRIPTION
Fixes #11416

Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

Fix too strict validation of ExtendedDeviceState number of bytes.

Changed also to log too few bytes as warnings as this implies only that appliance doesn't provide enough information for channels to be supported/updated.