### PR TITLE
[xmppclient] Set dependencies in the pom.xml to provided

### DIFF
--- a/bundles/org.openhab.binding.xmppclient/pom.xml
+++ b/bundles/org.openhab.binding.xmppclient/pom.xml
@@ -23,37 +23,37 @@
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-java7</artifactId>
       <version>${smack.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-extensions</artifactId>
       <version>${smack.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-im</artifactId>
       <version>${smack.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-tcp</artifactId>
       <version>${smack.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
       <artifactId>smack-experimental</artifactId>
       <version>${smack.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.minidns</groupId>
       <artifactId>minidns-core</artifactId>
       <version>0.3.3</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
As asked by @fwolter in https://github.com/openhab/openhab-addons/pull/11247

I set all the dependencies in the pom.xml to provided for all the one which exists in features.xml, because it's okay to add a transitive dependency to features.xml, but not to the pom.xml
